### PR TITLE
feat(multi-voice): multi-voice granular synthesis + numpy cache fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,14 +37,14 @@ CACHEDIR := cache
 # --- Flags configurabili ---
 AUTOKILL ?= true
 AUTOPEN ?= true
-AUTOVISUAL ?= true
+AUTOVISUAL ?= false
 SHOWSTATIC ?= true
 FILE ?= PGE_test
 TEST ?= false
 PRECLEAN ?=true
 STEMS ?= true
-RENDERER ?= csound
-REAPER ?= false
+RENDERER ?= numpy
+REAPER ?= true
 REAPER_PATH ?= Project.rpp
 # Include moduli
 include make/test.mk

--- a/configs/PGE_test.yml
+++ b/configs/PGE_test.yml
@@ -7,7 +7,7 @@ streams:
     onset: 0.0
     duration: 5
     #time_scale: .3
-    sample: "pino2.wav"
+    sample: 
     #range_always_active:
     distribution_mode: 'gaussian'
     #fill_factor: [[0,.3],[.1,4], cycle]
@@ -39,4 +39,19 @@ streams:
     onset: 20.0
     duration: 5.0
     sample: "pino.wav"
-    
+  - stream_id: "stream5"
+    onset: 0.0
+    duration: 10.0
+    sample: "001-0-27_9.wav"
+    density: 3
+    distribution: 
+      type: cubic
+      points:
+        - [0.0, 0.0]
+        - [5.0, 1.0]
+        - [10.0, 0.0]
+    distribution_mode: "gaussian"
+    pan: 
+      - [[[0, -3600.0], [100, 3600.0]], 10.0, 4]
+    time_mode: "normalized"
+    pitch:      

--- a/configs/PGE_testVoices.yml
+++ b/configs/PGE_testVoices.yml
@@ -1,0 +1,322 @@
+composition:
+  title: "test voices"
+
+streams:
+
+  # ==========================================================================
+  # SEZIONE 1 — STRATEGIE SINGOLE
+  # ==========================================================================
+
+  # --- PITCH ---
+
+  - stream_id: "pitch_step"
+    onset: 0.0
+    duration: 6.0
+    sample: "pino2.wav"
+    density: 8
+    grain:
+      duration: 0.08
+    voices:
+      num_voices: 4
+      pitch:
+        strategy: step
+        step: 3.0
+
+  - stream_id: "pitch_range"
+    onset: 8.0
+    duration: 6.0
+    sample: "pino2.wav"
+    density: 8
+    grain:
+      duration: 0.08
+    voices:
+      num_voices: 4
+      pitch:
+        strategy: range
+        semitone_range: 12.0
+
+  - stream_id: "pitch_chord_dom7"
+    onset: 16.0
+    duration: 6.0
+    sample: "pino2.wav"
+    density: 8
+    grain:
+      duration: 0.08
+    voices:
+      num_voices: 4
+      pitch:
+        strategy: chord
+        chord: "dom7"
+
+  - stream_id: "pitch_stochastic"
+    onset: 24.0
+    duration: 6.0
+    sample: "pino2.wav"
+    density: 8
+    grain:
+      duration: 0.08
+    voices:
+      num_voices: 4
+      pitch:
+        strategy: stochastic
+        semitone_range: 6.0
+
+  # --- ONSET ---
+
+  - stream_id: "onset_linear"
+    onset: 32.0
+    duration: 6.0
+    sample: "pino2.wav"
+    density: 8
+    grain:
+      duration: 0.08
+    voices:
+      num_voices: 4
+      onset_offset:
+        strategy: linear
+        step: 0.08
+
+  - stream_id: "onset_geometric"
+    onset: 40.0
+    duration: 6.0
+    sample: "pino2.wav"
+    density: 8
+    grain:
+      duration: 0.08
+    voices:
+      num_voices: 4
+      onset_offset:
+        strategy: geometric
+        step: 0.05
+        base: 2.0
+
+  - stream_id: "onset_stochastic"
+    onset: 48.0
+    duration: 6.0
+    sample: "pino2.wav"
+    density: 8
+    grain:
+      duration: 0.08
+    voices:
+      num_voices: 4
+      onset_offset:
+        strategy: stochastic
+        max_offset: 0.2
+
+  # --- POINTER ---
+
+  - stream_id: "pointer_linear"
+    onset: 56.0
+    duration: 6.0
+    sample: "pino2.wav"
+    density: 8
+    grain:
+      duration: 0.08
+    voices:
+      num_voices: 4
+      pointer:
+        strategy: linear
+        step: 0.05
+
+  - stream_id: "pointer_stochastic"
+    onset: 64.0
+    duration: 6.0
+    sample: "pino2.wav"
+    density: 8
+    grain:
+      duration: 0.08
+    voices:
+      num_voices: 4
+      pointer:
+        strategy: stochastic
+        pointer_range: 0.1
+
+  # --- PAN ---
+
+  - stream_id: "pan_linear"
+    onset: 72.0
+    duration: 6.0
+    sample: "pino2.wav"
+    density: 8
+    grain:
+      duration: 0.08
+    voices:
+      num_voices: 4
+      pan:
+        strategy: linear
+        spread: 60.0
+
+  # ==========================================================================
+  # SEZIONE 2 — COPPIE DI STRATEGIE
+  # ==========================================================================
+
+  # --- pitch_step + onset_linear ---
+  - stream_id: "step_onset"
+    onset: 82.0
+    duration: 6.0
+    sample: "pino2.wav"
+    density: 8
+    grain:
+      duration: 0.08
+    voices:
+      num_voices: 4
+      pitch:
+        strategy: step
+        step: 3.0
+      onset_offset:
+        strategy: linear
+        step: 0.08
+
+  # --- pitch_chord + onset_stochastic ---
+  - stream_id: "chord_onset_stoch"
+    onset: 90.0
+    duration: 6.0
+    sample: "pino2.wav"
+    density: 8
+    grain:
+      duration: 0.08
+    voices:
+      num_voices: 4
+      pitch:
+        strategy: chord
+        chord: "dom7"
+      onset_offset:
+        strategy: stochastic
+        max_offset: 0.15
+
+  # --- pitch_step + pointer_linear ---
+  - stream_id: "step_pointer"
+    onset: 98.0
+    duration: 6.0
+    sample: "pino2.wav"
+    density: 8
+    grain:
+      duration: 0.08
+    voices:
+      num_voices: 4
+      pitch:
+        strategy: step
+        step: 4.0
+      pointer:
+        strategy: linear
+        step: 0.05
+
+  # --- pitch_chord + pointer_stochastic ---
+  - stream_id: "chord_pointer_stoch"
+    onset: 106.0
+    duration: 6.0
+    sample: "pino2.wav"
+    density: 8
+    grain:
+      duration: 0.08
+    voices:
+      num_voices: 4
+      pitch:
+        strategy: chord
+        chord: "maj7"
+      pointer:
+        strategy: stochastic
+        pointer_range: 0.08
+
+  # --- pitch_step + pan_linear ---
+  - stream_id: "step_pan"
+    onset: 114.0
+    duration: 6.0
+    sample: "pino2.wav"
+    density: 8
+    grain:
+      duration: 0.08
+    voices:
+      num_voices: 4
+      pitch:
+        strategy: step
+        step: 3.0
+      pan:
+        strategy: linear
+        spread: 60.0
+
+  # --- onset_linear + pointer_linear ---
+  - stream_id: "onset_pointer"
+    onset: 122.0
+    duration: 6.0
+    sample: "pino2.wav"
+    density: 8
+    grain:
+      duration: 0.08
+    voices:
+      num_voices: 4
+      onset_offset:
+        strategy: linear
+        step: 0.08
+      pointer:
+        strategy: linear
+        step: 0.05
+
+  # --- onset_stochastic + pan_linear ---
+  - stream_id: "onset_stoch_pan"
+    onset: 130.0
+    duration: 6.0
+    sample: "pino2.wav"
+    density: 8
+    grain:
+      duration: 0.08
+    voices:
+      num_voices: 4
+      onset_offset:
+        strategy: stochastic
+        max_offset: 0.15
+      pan:
+        strategy: linear
+        spread: 60.0
+
+  # --- pointer_linear + pan_linear ---
+  - stream_id: "pointer_pan"
+    onset: 138.0
+    duration: 6.0
+    sample: "pino2.wav"
+    density: 8
+    grain:
+      duration: 0.08
+    voices:
+      num_voices: 4
+      pointer:
+        strategy: linear
+        step: 0.05
+      pan:
+        strategy: linear
+        spread: 60.0
+
+  # --- pitch_range + onset_geometric ---
+  - stream_id: "range_geometric"
+    onset: 146.0
+    duration: 6.0
+    sample: "pino2.wav"
+    density: 8
+    grain:
+      duration: 0.08
+    voices:
+      num_voices: 4
+      pitch:
+        strategy: range
+        semitone_range: 12.0
+      onset_offset:
+        strategy: geometric
+        step: 0.05
+        base: 2.0
+
+  # --- pitch_stochastic + pan_linear ---
+  - stream_id: "stoch_pitch_pan"
+    onset: 154.0
+    duration: 6.0
+    sample: "pino2.wav"
+    density: 8
+    grain:
+      duration: 0.08
+    voices:
+      num_voices: 4
+      pitch:
+        strategy: stochastic
+        semitone_range: 6.0
+      pan:
+        strategy: linear
+        spread: 60.0

--- a/make/build.mk
+++ b/make/build.mk
@@ -99,11 +99,15 @@ ifeq ($(RENDERER), numpy)
 PYFLAGS += --show-static
 PYFLAGS += --per-stream
 
+ifeq ($(CACHE), true)
+PYFLAGS += --cache --cache-dir $(CACHEDIR)
+endif
+
 .PHONY: all
 all: $(ALL_PRE) stems-build
 
 .PHONY: stems-build
-stems-build: venv-setup $(SFDIR)
+stems-build: venv-setup $(SFDIR) $(CACHEDIR)
 	@echo "[NUMPY][STEMS] Rendering diretto YAML → AIF (nessun .sco, nessun csound)..."
 	$(PYTHON_VENV) $(INCDIR)/main.py $(YMLDIR)/$(FILE).yml $(SFDIR)/$(FILE).aif --renderer numpy $(PYFLAGS)
 	$(autopen_stems)

--- a/src/controllers/voice_manager.py
+++ b/src/controllers/voice_manager.py
@@ -1,0 +1,168 @@
+# src/controllers/voice_manager.py
+"""
+voice_manager.py
+
+VoiceManager — orchestratore delle strategy di voce nella sintesi granulare
+multi-voice.
+
+Responsabilità:
+- Ricevere le strategy per ogni dimensione (pitch, pointer, onset, pan)
+- Pre-computare VoiceConfig per ogni voice_index 0..max_voices-1
+- Esporre get_voice_config(voice_index) → VoiceConfig
+- Garantire che voce 0 abbia sempre VoiceConfig(0, 0, 0, 0)
+
+NON è responsabilità di VoiceManager:
+- La logica time-varying di num_voices (→ Stream.generate_grains)
+- La variazione per-grano (→ PitchController + mod_range)
+- Il calcolo dell'onset assoluto (→ Stream._create_grain)
+
+Design:
+- Tutte le strategy sono opzionali: se non fornite, offset = 0.0
+- VoiceConfig è frozen (immutabile)
+- Pre-computazione all'init: O(max_voices) upfront, O(1) in generate_grains
+
+Layering pointer (da design doc):
+  pointer_final = base_pointer(t)        # PointerController
+               + voice_pointer_offset    # VoicePointerStrategy (qui)
+               + grain_jitter(t)         # mod_range per-grano
+"""
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+from strategies.voice_pitch_strategy import VoicePitchStrategy
+from strategies.voice_onset_strategy import VoiceOnsetStrategy
+from strategies.voice_pointer_strategy import VoicePointerStrategy
+from strategies.voice_pan_strategy import VoicePanStrategy
+
+
+# =============================================================================
+# VOICE CONFIG
+# =============================================================================
+
+@dataclass(frozen=True)
+class VoiceConfig:
+    """
+    Configurazione immutabile per una singola voce.
+
+    Tutti i valori sono offset rispetto alla voce 0 (riferimento).
+    Voce 0 ha sempre tutti i campi a 0.0.
+
+    Attributes:
+        pitch_offset:   offset in semitoni
+        pointer_offset: offset normalizzato sulla posizione nel sample
+        pan_offset:     offset in gradi rispetto al pan base dello stream
+        onset_offset:   offset in secondi rispetto all'onset base
+    """
+    pitch_offset: float
+    pointer_offset: float
+    pan_offset: float
+    onset_offset: float
+
+
+# =============================================================================
+# VOICE MANAGER
+# =============================================================================
+
+class VoiceManager:
+    """
+    Orchestratore delle strategy di voce.
+
+    Pre-computa VoiceConfig per ogni voice_index 0..max_voices-1
+    combinando le quattro strategy indipendenti.
+
+    Args:
+        max_voices:       numero massimo di voci (>= 1)
+        pitch_strategy:   VoicePitchStrategy opzionale
+        onset_strategy:   VoiceOnsetStrategy opzionale
+        pointer_strategy: VoicePointerStrategy opzionale
+        pan_strategy:     VoicePanStrategy opzionale
+        pan_spread:       spread in gradi per la pan strategy (default 0.0)
+
+    Esempio:
+        vm = VoiceManager(
+            max_voices=4,
+            pitch_strategy=ChordPitchStrategy(chord="dom7"),
+            onset_strategy=LinearOnsetStrategy(step=0.05),
+        )
+        config = vm.get_voice_config(2)
+        # config.pitch_offset == 7.0 (terza nota di dom7)
+        # config.onset_offset == 0.10
+    """
+
+    def __init__(
+        self,
+        max_voices: int,
+        pitch_strategy: Optional[VoicePitchStrategy] = None,
+        onset_strategy: Optional[VoiceOnsetStrategy] = None,
+        pointer_strategy: Optional[VoicePointerStrategy] = None,
+        pan_strategy: Optional[VoicePanStrategy] = None,
+        pan_spread: float = 0.0,
+    ):
+        self.max_voices = max_voices
+        self._pitch_strategy = pitch_strategy
+        self._onset_strategy = onset_strategy
+        self._pointer_strategy = pointer_strategy
+        self._pan_strategy = pan_strategy
+        self._pan_spread = pan_spread
+
+        # Pre-computa tutti i VoiceConfig all'init
+        self.voice_configs: List[VoiceConfig] = [
+            self._compute(i) for i in range(max_voices)
+        ]
+
+    def _compute(self, voice_index: int) -> VoiceConfig:
+        """Calcola VoiceConfig per un voice_index dato."""
+        if voice_index == 0:
+            return VoiceConfig(0.0, 0.0, 0.0, 0.0)
+
+        pitch = (
+            self._pitch_strategy.get_pitch_offset(voice_index, self.max_voices)
+            if self._pitch_strategy is not None
+            else 0.0
+        )
+        onset = (
+            self._onset_strategy.get_onset_offset(voice_index, self.max_voices)
+            if self._onset_strategy is not None
+            else 0.0
+        )
+        pointer = (
+            self._pointer_strategy.get_pointer_offset(voice_index, self.max_voices)
+            if self._pointer_strategy is not None
+            else 0.0
+        )
+        pan = (
+            self._pan_strategy.get_pan_offset(
+                voice_index=voice_index,
+                num_voices=self.max_voices,
+                spread=self._pan_spread,
+            )
+            if self._pan_strategy is not None
+            else 0.0
+        )
+
+        return VoiceConfig(
+            pitch_offset=pitch,
+            pointer_offset=pointer,
+            pan_offset=pan,
+            onset_offset=onset,
+        )
+
+    def get_voice_config(self, voice_index: int) -> VoiceConfig:
+        """
+        Restituisce il VoiceConfig pre-computato per voice_index.
+
+        Args:
+            voice_index: indice della voce (0-based, < max_voices)
+
+        Returns:
+            VoiceConfig immutabile
+
+        Raises:
+            IndexError: se voice_index >= max_voices
+        """
+        if voice_index >= self.max_voices or voice_index < 0:
+            raise IndexError(
+                f"voice_index {voice_index} fuori range [0, {self.max_voices - 1}]"
+            )
+        return self.voice_configs[voice_index]

--- a/src/core/stream.py
+++ b/src/core/stream.py
@@ -25,6 +25,11 @@ from shared.utils import get_sample_duration
 from parameters.parameter_schema import STREAM_PARAMETER_SCHEMA
 from parameters.parameter_orchestrator import ParameterOrchestrator
 from core.stream_config import StreamConfig, StreamContext
+from controllers.voice_manager import VoiceManager, VoiceConfig
+from strategies.voice_pitch_strategy import VoicePitchStrategyFactory
+from strategies.voice_onset_strategy import VoiceOnsetStrategyFactory
+from strategies.voice_pointer_strategy import VoicePointerStrategyFactory
+from strategies.voice_pan_strategy import VoicePanStrategyFactory
 from dataclasses import fields
 
 
@@ -56,10 +61,12 @@ class Stream:
         self._init_stream_parameters(params, config)
         # === 6. CONTROLLER (riceve config) ===
         self._init_controllers(params, config)
-        # === 7. RIFERIMENTI CSOUND (assegnati da Generator) ===
+        # === 7. VOICE MANAGER ===
+        self._init_voice_manager(params, config)
+        # === 8. RIFERIMENTI CSOUND (assegnati da Generator) ===
         self.sample_table_num: Optional[int] = None
         self.envelope_table_num: Optional[int] = None
-        # === 8. STATO ===
+        # === 9. STATO ===
         self.voices: List[List[Grain]] = []
         self.grains: List[Grain] = []  # backward compatibility
         self.generated = False
@@ -128,6 +135,102 @@ class Stream:
             config=config
         )    
             
+    def _init_voice_manager(self, params: dict, config: StreamConfig) -> None:
+        """
+        Costruisce VoiceManager dal blocco YAML 'voices:'.
+
+        YAML supportato:
+            voices:
+              num_voices: 4
+              pitch:
+                strategy: chord
+                chord: "dom7"
+              onset_offset:
+                strategy: linear
+                step: 0.05
+              pointer:
+                strategy: stochastic
+                pointer_range: 0.1
+              pan:
+                strategy: linear
+                spread: 60.0
+
+        - voices assente → VoiceManager(max_voices=1)
+        - strategy stochastiche: stream_id iniettato automaticamente
+        - spread estratto dal blocco pan
+        """
+        from parameters.parameter import Parameter
+        from parameters.parameter_definitions import GRANULAR_PARAMETERS
+
+        v = params.get('voices', {})
+        if not v:
+            # Senza blocco voices, valori di default (nessun config necessario)
+            self._num_voices = Parameter('num_voices', 1.0, GRANULAR_PARAMETERS['num_voices'])
+            self._scatter = Parameter('scatter', 0.0, GRANULAR_PARAMETERS['scatter'])
+            self._voice_manager = VoiceManager(max_voices=1)
+            return
+
+        from parameters.parser import GranularParser
+        parser = GranularParser(config)
+
+        raw_num_voices = v.get('num_voices', 1)
+
+        # Estrae max_voices per pre-computare tutti i VoiceConfig all'init.
+        # Se num_voices è un Envelope, max_voices = picco dei breakpoints.
+        if isinstance(raw_num_voices, list):
+            max_voices = int(max(bp[1] for bp in raw_num_voices))
+        else:
+            max_voices = int(raw_num_voices)
+
+        # Parsa num_voices e scatter come Parameter (supportano Envelope time-varying).
+        self._num_voices = parser.parse_parameter('num_voices', raw_num_voices)
+        self._scatter = parser.parse_parameter('scatter', v.get('scatter', 0.0))
+
+        # --- PITCH ---
+        pitch_strategy = None
+        if 'pitch' in v:
+            kw = dict(v['pitch'])
+            name = kw.pop('strategy')
+            if name == 'stochastic':
+                kw['stream_id'] = self.stream_id
+            pitch_strategy = VoicePitchStrategyFactory.create(name, **kw)
+
+        # --- ONSET ---
+        onset_strategy = None
+        if 'onset_offset' in v:
+            kw = dict(v['onset_offset'])
+            name = kw.pop('strategy')
+            if name == 'stochastic':
+                kw['stream_id'] = self.stream_id
+            onset_strategy = VoiceOnsetStrategyFactory.create(name, **kw)
+
+        # --- POINTER ---
+        pointer_strategy = None
+        if 'pointer' in v:
+            kw = dict(v['pointer'])
+            name = kw.pop('strategy')
+            if name == 'stochastic':
+                kw['stream_id'] = self.stream_id
+            pointer_strategy = VoicePointerStrategyFactory.create(name, **kw)
+
+        # --- PAN ---
+        pan_strategy = None
+        pan_spread = 0.0
+        if 'pan' in v:
+            kw = dict(v['pan'])
+            name = kw.pop('strategy')
+            pan_spread = float(kw.pop('spread', 0.0))
+            pan_strategy = VoicePanStrategyFactory.create(name)
+
+        self._voice_manager = VoiceManager(
+            max_voices=max_voices,
+            pitch_strategy=pitch_strategy,
+            onset_strategy=onset_strategy,
+            pointer_strategy=pointer_strategy,
+            pan_strategy=pan_strategy,
+            pan_spread=pan_spread,
+        )
+
     def _init_grain_reverse(self, params: dict) -> None:
         """
         Inizializza parametri reverse del grano.
@@ -177,69 +280,110 @@ class Stream:
     
     def generate_grains(self) -> List[List[Grain]]:
         """
-        Genera grani per tutte le voices.
-        
-        Algoritmo:
-        2. Per ogni voice (0 a max_voices-1):
-           - Mantiene il proprio current_onset
-           - Verifica se è attiva (voice_index < active_voices)
-           - Se attiva: genera grano con parametri calcolati
-           - Sempre: avanza current_onset per mantenere la "fase"
-        
+        Genera grani per tutte le voci.
+
+        Per ogni tick temporale, genera un grano per ogni voce attiva.
+        La densità complessiva è density × num_voices (ogni voce ha il
+        proprio loop temporale indipendente con lo stesso inter-onset).
+
         Returns:
-            List[List[Grain]]: grani organizzati per voce
+            List[List[Grain]]: grani organizzati per voce (voce 0 = riferimento)
         """
-        # Reset stato
-        self.voices = []
-        self.grains = []
-        voice_grains: List[Grain] = []                
-        # 2. Loop per ogni voice
-        current_onset = 0.0
-        
-        # Loop temporale per questa voice
-        while current_onset < self.duration:
-            elapsed_time = current_onset
-            grain_dur = self.grain_duration.get_value(elapsed_time)
-            grain = self._create_grain(elapsed_time, grain_dur)
-            voice_grains.append(grain)
-            inter_onset = self._density.calculate_inter_onset(elapsed_time,grain_dur)
-            current_onset += inter_onset
-        self.voices = [voice_grains]
-        self.grains = voice_grains
+        max_v = self._voice_manager.max_voices
+
+        # Struttura per raccogliere grani per voce (pre-allocata per max_voices)
+        all_voice_grains: List[List[Grain]] = [[] for _ in range(max_v)]
+
+        # Cursore temporale indipendente per ogni voce.
+        # Con scatter=0 tutti avanzano dello stesso sync_iot → comportamento identico
+        # a prima. Con scatter>0 e distribution>0 i cursori divergono nel tempo.
+        voice_cursors = [0.0] * max_v
+
+        while any(c < self.duration for c in voice_cursors):
+            # Voice 0 è il riferimento: definisce sync_iot e il valore di scatter
+            t0 = voice_cursors[0]
+            grain_dur_0 = self.grain_duration.get_value(t0)
+            sync_iot = self._density.calculate_inter_onset(t0, grain_dur_0)
+            scatter_val = self._scatter.get_value(t0)
+
+            for voice_index in range(max_v):
+                t = voice_cursors[voice_index]
+
+                if t >= self.duration:
+                    continue
+
+                # Voice 0 condivide già grain_dur_0 (t == t0), evita doppia chiamata
+                grain_dur = grain_dur_0 if voice_index == 0 else self.grain_duration.get_value(t)
+                active = max(1, min(max_v, int(self.num_voices.get_value(t))))
+
+                if voice_index < active:
+                    voice_config = self._voice_manager.get_voice_config(voice_index)
+                    grain = self._create_grain(t, grain_dur, voice_config)
+                    all_voice_grains[voice_index].append(grain)
+
+                # IOT di questa voce: blend tra sync_iot (condiviso) e indep_iot
+                if voice_index == 0 or scatter_val == 0.0:
+                    iot = sync_iot
+                else:
+                    indep_iot = self._density.calculate_inter_onset(t, grain_dur)
+                    iot = (1.0 - scatter_val) * sync_iot + scatter_val * indep_iot
+
+                voice_cursors[voice_index] += iot
+
+        self.voices = all_voice_grains
+        # Flatten e sort per onset (backward compatibility)
+        all_grains = [g for voice in self.voices for g in voice]
+        all_grains.sort(key=lambda g: g.onset)
+        self.grains = all_grains
         self.generated = True
-        
+
         return self.voices
     
-    def _create_grain(self, 
-                      elapsed_time: float, 
-                      grain_dur: float) -> Grain:
+    def _create_grain(self,
+                      elapsed_time: float,
+                      grain_dur: float,
+                      voice_config: Optional['VoiceConfig'] = None) -> Grain:
         """
         Crea un singolo grano con tutti i parametri calcolati.
-        
+
+        Applica gli offset di VoiceConfig sopra i valori base:
+          pitch_ratio  *= 2^(pitch_offset/12)
+          pointer_pos  += pointer_offset
+          pan          += pan_offset
+          onset        += onset_offset
+
         Args:
-            voice_index: indice della voce (0-based)
             elapsed_time: tempo trascorso dall'inizio dello stream
-            grain_dur: durata del grano (già calcolata in generate_grains con eventuale dephase)
-        
+            grain_dur:    durata del grano
+            voice_config: offset per questa voce (None = VoiceConfig(0,0,0,0))
+
         Returns:
             Grain: oggetto grano completo
         """
+        if voice_config is None:
+            voice_config = VoiceConfig(0.0, 0.0, 0.0, 0.0)
+
         grain_reverse = self._calculate_grain_reverse(elapsed_time)
 
-        # === 1. PITCH ===
-        # Base + Voice Offset
+        # === 1. PITCH — base × 2^(semitoni/12) ===
         pitch_ratio = self._pitch.calculate(elapsed_time, grain_reverse=grain_reverse)
-        
-        # === 2. POINTER ===
-        # Base + Voice Offset + Jitter Voce
-        pointer_pos = self._pointer.calculate(elapsed_time,grain_dur,grain_reverse)
+        if voice_config.pitch_offset != 0.0:
+            pitch_ratio *= 2 ** (voice_config.pitch_offset / 12.0)
 
+        # === 2. POINTER — base + voice_offset ===
+        pointer_pos = self._pointer.calculate(elapsed_time, grain_dur, grain_reverse)
+        pointer_pos += voice_config.pointer_offset
+
+        # === 3. VOLUME ===
         volume = self.volume.get_value(elapsed_time)
-        pan = self.pan.get_value(elapsed_time)        
-        # === 6. ONSET ===
-        absolute_onset = self.onset + elapsed_time
 
-        # Nel loop di generazione grani
+        # === 4. PAN — base + voice_offset ===
+        pan = self.pan.get_value(elapsed_time) + voice_config.pan_offset
+
+        # === 5. ONSET — assoluto + voice_onset_offset ===
+        absolute_onset = self.onset + elapsed_time + voice_config.onset_offset
+
+        # === 6. WINDOW ===
         window_name = self._window_controller.select_window()
         window_table_num = self.window_table_map[window_name]
 
@@ -349,8 +493,8 @@ class Stream:
         
     @property
     def num_voices(self):
-        """Espone voice_pitch_offset per ScoreVisualizer."""
-        return 1
+        """Espone num_voices come Parameter (supporta Envelope time-varying)."""
+        return self._num_voices
             
     # =========================================================================
     # REPR

--- a/src/main.py
+++ b/src/main.py
@@ -39,12 +39,24 @@ def _build_renderer(renderer_type: str, generator, **kwargs):
             if ftype == 'sample':
                 sample_reg.load(name)
 
+        cache_manager = None
+        if kwargs.get('use_cache'):
+            import os as _os
+            from rendering.stream_cache_manager import StreamCacheManager
+            yaml_basename = kwargs['yaml_basename']
+            cache_dir = kwargs.get('cache_dir', 'cache')
+            cache_path = _os.path.join(cache_dir, f"{yaml_basename}.json")
+            cache_manager = StreamCacheManager(cache_path=cache_path)
+            print(f"[CACHE] Manifest: {cache_path}")
+
         return RendererFactory.create(
             'numpy',
             sample_registry=sample_reg,
             window_registry=window_reg,
             table_map=table_map,
             output_sr=kwargs.get('output_sr', 48000),
+            cache_manager=cache_manager,
+            stream_data_map=generator.stream_data_map,
         )
 
     if renderer_type == 'csound':

--- a/src/parameters/parameter_definitions.py
+++ b/src/parameters/parameter_definitions.py
@@ -146,7 +146,7 @@ GRANULAR_PARAMETERS: Dict[str, ParameterBounds] = {
     
     'loop_dur': ParameterBounds(
         min_val=0.005,
-        max_val=100.0 
+        max_val=1000.0 
     ),
 
     'loop_start': ParameterBounds(
@@ -156,7 +156,7 @@ GRANULAR_PARAMETERS: Dict[str, ParameterBounds] = {
 
     'loop_end': ParameterBounds(
         min_val=0.0,
-        max_val=100.0 
+        max_val=1000.0 
     ),
 
 
@@ -202,21 +202,49 @@ GRANULAR_PARAMETERS: Dict[str, ParameterBounds] = {
         min_val=0.0,
         max_val=1.0
     ),
+
+    'scatter': ParameterBounds(
+        min_val=0.0,
+        max_val=1.0,
+        variation_mode='additive',
+    ),
 }
 
-def get_parameter_definition(param_name: str) -> ParameterBounds:
+_LOOP_PARAMS = frozenset({'loop_dur', 'loop_start', 'loop_end'})
+
+
+def get_parameter_definition(
+    param_name: str,
+    sample_dur_sec: float | None = None,
+) -> ParameterBounds:
     """
     Recupera la definizione di un parametro dal registro.
-    
+
+    Per loop_dur, loop_start e loop_end, se sample_dur_sec è fornito,
+    restituisce un nuovo ParameterBounds con max_val = sample_dur_sec.
+    Tutti gli altri campi (min_val, min_range, ...) rimangono invariati.
+
     Args:
         param_name: Il nome del parametro (es. 'density')
-        
+        sample_dur_sec: Durata del file audio in secondi (opzionale).
+            Se fornito, sovrascrive max_val per i parametri loop.
+
     Returns:
         ParameterBounds: L'oggetto configurazione.
-        
+
     Raises:
         KeyError: Se il parametro non esiste nel registro.
     """
     if param_name not in GRANULAR_PARAMETERS:
         raise KeyError(f"Parametro '{param_name}' non definito in parameter_definitions.py")
-    return GRANULAR_PARAMETERS[param_name]
+    bounds = GRANULAR_PARAMETERS[param_name]
+    if sample_dur_sec is not None and param_name in _LOOP_PARAMS:
+        return ParameterBounds(
+            min_val=bounds.min_val,
+            max_val=sample_dur_sec,
+            min_range=bounds.min_range,
+            max_range=bounds.max_range,
+            default_jitter=bounds.default_jitter,
+            variation_mode=bounds.variation_mode,
+        )
+    return bounds

--- a/src/parameters/parser.py
+++ b/src/parameters/parser.py
@@ -34,6 +34,7 @@ class GranularParser:
         """
         self.stream_id = config.context.stream_id
         self.duration = config.context.duration
+        self.sample_dur_sec = config.context.sample_dur_sec
         self.time_mode = config.time_mode
         self.distribution_mode = config.distribution_mode
 
@@ -56,9 +57,9 @@ class GranularParser:
         Returns:
             Un'istanza configurata di Parameter.
         """
-        # 1. Recupera la definizione (Bounds & Rules) dal Registry
-        # Se il nome non esiste, get_parameter_definition solleva KeyError (Fail Fast)
-        bounds = get_parameter_definition(name)
+        # 1. Recupera la definizione (Bounds & Rules) dal Registry.
+        # Per loop_dur/loop_start/loop_end il bound massimo è la durata del file audio.
+        bounds = get_parameter_definition(name, sample_dur_sec=self.sample_dur_sec)
 
         # 2. Converte i dati grezzi in formati utilizzabili (float o Envelope)
         # Qui avviene la normalizzazione temporale se necessaria

--- a/src/rendering/numpy_audio_renderer.py
+++ b/src/rendering/numpy_audio_renderer.py
@@ -18,7 +18,7 @@ Template Method interno (comune):
 
 import numpy as np
 import soundfile as sf
-from typing import Dict, Tuple, List
+from typing import Dict, Tuple, List, Optional
 
 from rendering.audio_renderer import AudioRenderer
 from rendering.grain_renderer import GrainRenderer
@@ -39,6 +39,8 @@ class NumpyAudioRenderer(AudioRenderer):
         window_registry: registry delle finestre grano
         table_map: mapping {table_num: ('sample'|'window', name)}
         output_sr: sample rate di output (default: 48000)
+        cache_manager: StreamCacheManager opzionale per skip stream invariati
+        stream_data_map: dict {stream_id: yaml_dict} per fingerprint cache
     """
 
     def __init__(
@@ -47,11 +49,15 @@ class NumpyAudioRenderer(AudioRenderer):
         window_registry: NumpyWindowRegistry,
         table_map: Dict[int, Tuple[str, str]],
         output_sr: int = 48000,
+        cache_manager=None,
+        stream_data_map: Optional[Dict[str, dict]] = None,
     ):
         self.sample_registry = sample_registry
         self.window_registry = window_registry
         self.table_map = table_map
         self.output_sr = output_sr
+        self.cache_manager = cache_manager
+        self.stream_data_map = dict(stream_data_map) if stream_data_map is not None else {}
 
         self._grain_renderer = GrainRenderer(
             sample_registry=sample_registry,
@@ -81,6 +87,16 @@ class NumpyAudioRenderer(AudioRenderer):
         Returns:
             Path del file prodotto
         """
+        # Cache check: skip se stream e' clean
+        if self.cache_manager:
+            stream_dict = self.stream_data_map.get(stream.stream_id)
+            if stream_dict:
+                dirty = self.cache_manager.is_dirty(stream_dict, output_path)
+                status = "DIRTY" if dirty else "clean"
+                print(f"[CACHE] {stream.stream_id}: {status}", flush=True)
+                if not dirty:
+                    return output_path
+
         # 1. Alloca buffer (solo per duration, ignora onset)
         n_total = int(stream.duration * self.output_sr)
         buffer = np.zeros((n_total, 2), dtype=np.float64)
@@ -93,6 +109,12 @@ class NumpyAudioRenderer(AudioRenderer):
         # 3. Clamp + scrivi
         np.clip(buffer, -1.0, 1.0, out=buffer)
         sf.write(output_path, buffer, self.output_sr, format='AIFF')
+
+        # Aggiorna cache dopo build riuscita
+        if self.cache_manager:
+            stream_dict = self.stream_data_map.get(stream.stream_id)
+            if stream_dict:
+                self.cache_manager.update_after_build([stream_dict])
 
         return output_path
 

--- a/src/rendering/renderer_factory.py
+++ b/src/rendering/renderer_factory.py
@@ -63,6 +63,8 @@ class RendererFactory:
                 window_registry=kwargs['window_registry'],
                 table_map=kwargs['table_map'],
                 output_sr=kwargs.get('output_sr', 48000),
+                cache_manager=kwargs.get('cache_manager'),
+                stream_data_map=kwargs.get('stream_data_map'),
             )
 
         if renderer_type == 'csound':

--- a/src/strategies/voice_onset_strategy.py
+++ b/src/strategies/voice_onset_strategy.py
@@ -1,0 +1,184 @@
+# src/strategies/voice_onset_strategy.py
+"""
+voice_onset_strategy.py
+
+Strategy pattern per la distribuzione temporale (onset offset) delle voci
+nella sintesi granulare multi-voice.
+
+Responsabilità:
+- Calcolare l'offset di onset in SECONDI per una voce data.
+- Voce 0 restituisce sempre 0.0 (riferimento immutato).
+- L'offset è additivo rispetto all'onset base dello stream.
+- Gli offset sono sempre >= 0: le voci seguono nel tempo, non precedono.
+
+Design:
+- VoiceOnsetStrategy (ABC): interfaccia comune
+- LinearOnsetStrategy: voce i = i × step
+- GeometricOnsetStrategy: spaziatura esponenziale step * base^(i-1)
+- StochasticOnsetStrategy: offset fisso per voce, seed deterministico, in [0, max_offset]
+- VOICE_ONSET_STRATEGIES: registry globale {nome: classe}
+- register_voice_onset_strategy(): estensibilità dinamica
+- VoiceOnsetStrategyFactory: factory con create() statico
+
+Coerente con: voice_pitch_strategy.py, voice_pan_strategy.py
+"""
+
+import random
+from abc import ABC, abstractmethod
+from typing import Dict, Type
+
+
+# =============================================================================
+# ABSTRACT BASE CLASS
+# =============================================================================
+
+class VoiceOnsetStrategy(ABC):
+    """
+    Strategy astratta per la distribuzione temporale delle voci.
+
+    Il valore restituito è un offset in SECONDI rispetto all'onset base
+    dello stream. Voce 0 restituisce sempre 0.0.
+    """
+
+    @abstractmethod
+    def get_onset_offset(self, voice_index: int, num_voices: int) -> float:
+        """
+        Calcola l'offset di onset per la voce data.
+
+        Args:
+            voice_index: indice della voce (0-based). Voce 0 = riferimento.
+            num_voices: numero totale di voci attive.
+
+        Returns:
+            Offset in secondi (float >= 0.0). Voce 0 → sempre 0.0.
+        """
+        pass
+
+
+# =============================================================================
+# CONCRETE STRATEGIES
+# =============================================================================
+
+class LinearOnsetStrategy(VoiceOnsetStrategy):
+    """
+    Spaziatura lineare uniforme tra voci.
+
+    Voce i → i × step secondi.
+    Esempio: step=0.05, 4 voci → [0.0, 0.05, 0.10, 0.15]
+    Crea un effetto di phasing regolare (Truax-style).
+    """
+
+    def __init__(self, step: float):
+        self.step = step
+
+    def get_onset_offset(self, voice_index: int, num_voices: int) -> float:
+        if voice_index == 0:
+            return 0.0
+        return float(voice_index * self.step)
+
+
+class GeometricOnsetStrategy(VoiceOnsetStrategy):
+    """
+    Spaziatura esponenziale tra voci.
+
+    Voce 1 → step
+    Voce 2 → step × base
+    Voce 3 → step × base²
+    Voce i → step × base^(i-1)
+
+    Con base > 1: le voci più lontane hanno offset sempre più grandi.
+    Con base = 1: equivale a LinearOnsetStrategy con step fisso per tutte le voci.
+    Utile per distribuzioni logaritmiche nello spazio temporale.
+    """
+
+    def __init__(self, step: float, base: float):
+        self.step = step
+        self.base = base
+
+    def get_onset_offset(self, voice_index: int, num_voices: int) -> float:
+        if voice_index == 0:
+            return 0.0
+        return float(self.step * (self.base ** (voice_index - 1)))
+
+
+class StochasticOnsetStrategy(VoiceOnsetStrategy):
+    """
+    Offset fisso per voce, calcolato una volta con seed deterministico.
+
+    Seed = hash(stream_id + str(voice_index)) — riproducibile tra sessioni.
+    L'offset è uniforme in [0, max_offset] (sempre non-negativo).
+    Voce 0 → sempre 0.0.
+    """
+
+    def __init__(self, max_offset: float, stream_id: str):
+        self.max_offset = max_offset
+        self.stream_id = stream_id
+        self._cache: Dict[int, float] = {}
+
+    def get_onset_offset(self, voice_index: int, num_voices: int) -> float:
+        if voice_index == 0 or self.max_offset == 0.0:
+            return 0.0
+        if voice_index not in self._cache:
+            seed = hash(self.stream_id + str(voice_index))
+            rng = random.Random(seed)
+            self._cache[voice_index] = rng.uniform(0.0, self.max_offset)
+        return self._cache[voice_index]
+
+
+# =============================================================================
+# REGISTRY
+# =============================================================================
+
+VOICE_ONSET_STRATEGIES: Dict[str, Type[VoiceOnsetStrategy]] = {
+    'linear':      LinearOnsetStrategy,
+    'geometric':   GeometricOnsetStrategy,
+    'stochastic':  StochasticOnsetStrategy,
+}
+
+
+def register_voice_onset_strategy(name: str, cls: Type[VoiceOnsetStrategy]) -> None:
+    """
+    Registra dinamicamente una nuova VoiceOnsetStrategy.
+
+    Args:
+        name: chiave stringa per il registry
+        cls: classe che implementa VoiceOnsetStrategy
+    """
+    VOICE_ONSET_STRATEGIES[name] = cls
+
+
+# =============================================================================
+# FACTORY
+# =============================================================================
+
+class VoiceOnsetStrategyFactory:
+    """
+    Factory per la creazione di VoiceOnsetStrategy da nome stringa.
+
+    Esempio:
+        s = VoiceOnsetStrategyFactory.create('linear', step=0.05)
+        s = VoiceOnsetStrategyFactory.create('geometric', step=0.05, base=2.0)
+        s = VoiceOnsetStrategyFactory.create('stochastic', max_offset=0.1, stream_id='s1')
+    """
+
+    @staticmethod
+    def create(name: str, **kwargs) -> VoiceOnsetStrategy:
+        """
+        Crea una VoiceOnsetStrategy dal nome registrato.
+
+        Args:
+            name: nome della strategy nel registry
+            **kwargs: parametri passati al costruttore della strategy
+
+        Returns:
+            Istanza di VoiceOnsetStrategy
+
+        Raises:
+            KeyError: se il nome non è nel registry
+        """
+        if name not in VOICE_ONSET_STRATEGIES:
+            raise KeyError(
+                f"VoiceOnsetStrategy '{name}' non trovata. "
+                f"Disponibili: {sorted(VOICE_ONSET_STRATEGIES.keys())}"
+            )
+        return VOICE_ONSET_STRATEGIES[name](**kwargs)

--- a/src/strategies/voice_pitch_strategy.py
+++ b/src/strategies/voice_pitch_strategy.py
@@ -1,0 +1,229 @@
+# src/strategies/voice_pitch_strategy.py
+"""
+voice_pitch_strategy.py
+
+Strategy pattern per la distribuzione di pitch (altezza) delle voci
+nella sintesi granulare multi-voice.
+
+Responsabilità:
+- Calcolare l'offset di pitch in SEMITONI per una voce data.
+- Voce 0 restituisce sempre 0.0 (riferimento immutato).
+- NON gestisce la variazione per-grano (responsabilità di PitchController + mod_range).
+
+Design:
+- VoicePitchStrategy (ABC): interfaccia comune
+- StepPitchStrategy: voce i = i × step
+- RangePitchStrategy: distribuiti linearmente in [0, semitone_range]
+- ChordPitchStrategy: offsets da nome accordo, extend all'ottava se num_voices > chord
+- StochasticPitchStrategy: offset fisso per voce, seed deterministico
+- VOICE_PITCH_STRATEGIES: registry globale {nome: classe}
+- register_voice_pitch_strategy(): estensibilità dinamica
+- VoicePitchStrategyFactory: factory con create() statico
+
+Coerente con: voice_pan_strategy.py, variation_strategy.py
+"""
+
+import random
+from abc import ABC, abstractmethod
+from typing import Dict, List, Type
+
+
+# =============================================================================
+# CHORD DEFINITIONS
+# =============================================================================
+
+CHORD_INTERVALS: Dict[str, List[int]] = {
+    'maj':   [0, 4, 7],
+    'min':   [0, 3, 7],
+    'dom7':  [0, 4, 7, 10],
+    'maj7':  [0, 4, 7, 11],
+    'min7':  [0, 3, 7, 10],
+    'dim':   [0, 3, 6],
+    'aug':   [0, 4, 8],
+    'sus2':  [0, 2, 7],
+    'sus4':  [0, 5, 7],
+    'dim7':  [0, 3, 6, 9],
+    'minmaj7': [0, 3, 7, 11],
+}
+
+
+# =============================================================================
+# ABSTRACT BASE CLASS
+# =============================================================================
+
+class VoicePitchStrategy(ABC):
+    """
+    Strategy astratta per la distribuzione di pitch delle voci.
+
+    Il valore restituito è un offset in SEMITONI rispetto al pitch base
+    dello stream. Voce 0 restituisce sempre 0.0.
+    """
+
+    @abstractmethod
+    def get_pitch_offset(self, voice_index: int, num_voices: int) -> float:
+        """
+        Calcola l'offset di pitch per la voce data.
+
+        Args:
+            voice_index: indice della voce (0-based). Voce 0 = riferimento.
+            num_voices: numero totale di voci attive.
+
+        Returns:
+            Offset in semitoni (float). Voce 0 → sempre 0.0.
+        """
+        pass
+
+
+# =============================================================================
+# CONCRETE STRATEGIES
+# =============================================================================
+
+class StepPitchStrategy(VoicePitchStrategy):
+    """
+    Distribuzione lineare per step fisso.
+
+    Voce i → i × step semitoni.
+    Esempio: step=3, 4 voci → [0, 3, 6, 9]
+    """
+
+    def __init__(self, step: float):
+        self.step = step
+
+    def get_pitch_offset(self, voice_index: int, num_voices: int) -> float:
+        if voice_index == 0:
+            return 0.0
+        return float(voice_index * self.step)
+
+
+class RangePitchStrategy(VoicePitchStrategy):
+    """
+    Distribuzione lineare nel range [0, semitone_range].
+
+    Le voci sono distribuite equidistanti nell'intervallo.
+    Esempio: range=12, 4 voci → [0, 4, 8, 12]
+    Con num_voices=1 → [0].
+    """
+
+    def __init__(self, semitone_range: float):
+        self.semitone_range = semitone_range
+
+    def get_pitch_offset(self, voice_index: int, num_voices: int) -> float:
+        if voice_index == 0 or num_voices <= 1:
+            return 0.0
+        return float(voice_index * self.semitone_range / (num_voices - 1))
+
+
+class ChordPitchStrategy(VoicePitchStrategy):
+    """
+    Offsets da nome accordo nominale.
+
+    Gli intervalli sono presi da CHORD_INTERVALS. Se num_voices > len(chord),
+    le voci eccedenti continuano il pattern all'ottava superiore (extend).
+
+    Extend policy: voce i → intervals[i % n] + (i // n) * 12
+    dove n = len(chord_intervals).
+
+    Esempio: dom7=[0,4,7,10], 6 voci → [0, 4, 7, 10, 12, 16]
+    """
+
+    def __init__(self, chord: str):
+        if chord not in CHORD_INTERVALS:
+            raise ValueError(
+                f"Accordo '{chord}' non riconosciuto. "
+                f"Disponibili: {sorted(CHORD_INTERVALS.keys())}"
+            )
+        self.chord = chord
+        self._intervals = CHORD_INTERVALS[chord]
+
+    def get_pitch_offset(self, voice_index: int, num_voices: int) -> float:
+        if voice_index == 0:
+            return 0.0
+        n = len(self._intervals)
+        octave = voice_index // n
+        interval_idx = voice_index % n
+        return float(self._intervals[interval_idx] + octave * 12)
+
+
+class StochasticPitchStrategy(VoicePitchStrategy):
+    """
+    Offset fisso per voce, calcolato una volta con seed deterministico.
+
+    Seed = hash(stream_id + str(voice_index)) — riproducibile tra sessioni.
+    L'offset è uniforme in [-semitone_range, +semitone_range].
+    Voce 0 → sempre 0.0.
+    """
+
+    def __init__(self, semitone_range: float, stream_id: str):
+        self.semitone_range = semitone_range
+        self.stream_id = stream_id
+        self._cache: Dict[int, float] = {}
+
+    def get_pitch_offset(self, voice_index: int, num_voices: int) -> float:
+        if voice_index == 0 or self.semitone_range == 0.0:
+            return 0.0
+        if voice_index not in self._cache:
+            seed = hash(self.stream_id + str(voice_index))
+            rng = random.Random(seed)
+            self._cache[voice_index] = rng.uniform(
+                -self.semitone_range, self.semitone_range
+            )
+        return self._cache[voice_index]
+
+
+# =============================================================================
+# REGISTRY
+# =============================================================================
+
+VOICE_PITCH_STRATEGIES: Dict[str, Type[VoicePitchStrategy]] = {
+    'step':        StepPitchStrategy,
+    'range':       RangePitchStrategy,
+    'chord':       ChordPitchStrategy,
+    'stochastic':  StochasticPitchStrategy,
+}
+
+
+def register_voice_pitch_strategy(name: str, cls: Type[VoicePitchStrategy]) -> None:
+    """
+    Registra dinamicamente una nuova VoicePitchStrategy.
+
+    Args:
+        name: chiave stringa per il registry
+        cls: classe che implementa VoicePitchStrategy
+    """
+    VOICE_PITCH_STRATEGIES[name] = cls
+
+
+# =============================================================================
+# FACTORY
+# =============================================================================
+
+class VoicePitchStrategyFactory:
+    """
+    Factory per la creazione di VoicePitchStrategy da nome stringa.
+
+    Esempio:
+        s = VoicePitchStrategyFactory.create('chord', chord='dom7')
+        s = VoicePitchStrategyFactory.create('step', step=3.0)
+    """
+
+    @staticmethod
+    def create(name: str, **kwargs) -> VoicePitchStrategy:
+        """
+        Crea una VoicePitchStrategy dal nome registrato.
+
+        Args:
+            name: nome della strategy nel registry
+            **kwargs: parametri passati al costruttore della strategy
+
+        Returns:
+            Istanza di VoicePitchStrategy
+
+        Raises:
+            KeyError: se il nome non è nel registry
+        """
+        if name not in VOICE_PITCH_STRATEGIES:
+            raise KeyError(
+                f"VoicePitchStrategy '{name}' non trovata. "
+                f"Disponibili: {sorted(VOICE_PITCH_STRATEGIES.keys())}"
+            )
+        return VOICE_PITCH_STRATEGIES[name](**kwargs)

--- a/src/strategies/voice_pointer_strategy.py
+++ b/src/strategies/voice_pointer_strategy.py
@@ -1,0 +1,169 @@
+# src/strategies/voice_pointer_strategy.py
+"""
+voice_pointer_strategy.py
+
+Strategy pattern per la distribuzione della posizione di lettura (pointer)
+delle voci nella sintesi granulare multi-voice.
+
+Responsabilità:
+- Calcolare l'offset di pointer (normalizzato 0.0-1.0) per una voce data.
+- Voce 0 restituisce sempre 0.0 (riferimento immutato).
+- Il valore è additivo con il pointer base di PointerController e il grain
+  jitter già esistente (mod_range). Vedere pointer_controller.py.
+
+Layering pointer (da design doc):
+  pointer_final = base_pointer(t)        # PointerController
+               + voice_pointer_offset    # VoicePointerStrategy  ← qui
+               + grain_jitter(t)         # mod_range per-grano
+
+Design:
+- VoicePointerStrategy (ABC): interfaccia comune
+- LinearPointerStrategy: voce i = i × step (offset regolare)
+- StochasticPointerStrategy: offset fisso per voce, seed deterministico
+- VOICE_POINTER_STRATEGIES: registry globale {nome: classe}
+- register_voice_pointer_strategy(): estensibilità dinamica
+- VoicePointerStrategyFactory: factory con create() statico
+
+Coerente con: voice_pitch_strategy.py, voice_onset_strategy.py
+"""
+
+import random
+from abc import ABC, abstractmethod
+from typing import Dict, Type
+
+
+# =============================================================================
+# ABSTRACT BASE CLASS
+# =============================================================================
+
+class VoicePointerStrategy(ABC):
+    """
+    Strategy astratta per la distribuzione del pointer delle voci.
+
+    Il valore restituito è un offset normalizzato (tipicamente in [-1.0, 1.0])
+    rispetto alla posizione di lettura base dello stream.
+    Voce 0 restituisce sempre 0.0.
+    """
+
+    @abstractmethod
+    def get_pointer_offset(self, voice_index: int, num_voices: int) -> float:
+        """
+        Calcola l'offset di pointer per la voce data.
+
+        Args:
+            voice_index: indice della voce (0-based). Voce 0 = riferimento.
+            num_voices: numero totale di voci attive.
+
+        Returns:
+            Offset normalizzato (float). Voce 0 → sempre 0.0.
+        """
+        pass
+
+
+# =============================================================================
+# CONCRETE STRATEGIES
+# =============================================================================
+
+class LinearPointerStrategy(VoicePointerStrategy):
+    """
+    Offset lineare uniforme tra voci.
+
+    Voce i → i × step.
+    Esempio: step=0.1, 4 voci → [0.0, 0.1, 0.2, 0.3]
+    Crea un effetto di lettura da posizioni equidistanti nel sample.
+    Step negativo → le voci leggono indietro rispetto alla voce 0.
+    """
+
+    def __init__(self, step: float):
+        self.step = step
+
+    def get_pointer_offset(self, voice_index: int, num_voices: int) -> float:
+        if voice_index == 0:
+            return 0.0
+        return float(voice_index * self.step)
+
+
+class StochasticPointerStrategy(VoicePointerStrategy):
+    """
+    Offset fisso per voce, calcolato una volta con seed deterministico.
+
+    Seed = hash(stream_id + str(voice_index)) — riproducibile tra sessioni.
+    L'offset è uniforme in [-pointer_range, +pointer_range].
+    Voce 0 → sempre 0.0.
+
+    Utile per "thickening": ogni voce legge da una posizione leggermente
+    diversa nel sample, creando variazione timbrica senza pattern regolari.
+    """
+
+    def __init__(self, pointer_range: float, stream_id: str):
+        self.pointer_range = pointer_range
+        self.stream_id = stream_id
+        self._cache: Dict[int, float] = {}
+
+    def get_pointer_offset(self, voice_index: int, num_voices: int) -> float:
+        if voice_index == 0 or self.pointer_range == 0.0:
+            return 0.0
+        if voice_index not in self._cache:
+            seed = hash(self.stream_id + str(voice_index))
+            rng = random.Random(seed)
+            self._cache[voice_index] = rng.uniform(
+                -self.pointer_range, self.pointer_range
+            )
+        return self._cache[voice_index]
+
+
+# =============================================================================
+# REGISTRY
+# =============================================================================
+
+VOICE_POINTER_STRATEGIES: Dict[str, Type[VoicePointerStrategy]] = {
+    'linear':      LinearPointerStrategy,
+    'stochastic':  StochasticPointerStrategy,
+}
+
+
+def register_voice_pointer_strategy(name: str, cls: Type[VoicePointerStrategy]) -> None:
+    """
+    Registra dinamicamente una nuova VoicePointerStrategy.
+
+    Args:
+        name: chiave stringa per il registry
+        cls: classe che implementa VoicePointerStrategy
+    """
+    VOICE_POINTER_STRATEGIES[name] = cls
+
+
+# =============================================================================
+# FACTORY
+# =============================================================================
+
+class VoicePointerStrategyFactory:
+    """
+    Factory per la creazione di VoicePointerStrategy da nome stringa.
+
+    Esempio:
+        s = VoicePointerStrategyFactory.create('linear', step=0.05)
+        s = VoicePointerStrategyFactory.create('stochastic', pointer_range=0.2, stream_id='s1')
+    """
+
+    @staticmethod
+    def create(name: str, **kwargs) -> VoicePointerStrategy:
+        """
+        Crea una VoicePointerStrategy dal nome registrato.
+
+        Args:
+            name: nome della strategy nel registry
+            **kwargs: parametri passati al costruttore della strategy
+
+        Returns:
+            Istanza di VoicePointerStrategy
+
+        Raises:
+            KeyError: se il nome non è nel registry
+        """
+        if name not in VOICE_POINTER_STRATEGIES:
+            raise KeyError(
+                f"VoicePointerStrategy '{name}' non trovata. "
+                f"Disponibili: {sorted(VOICE_POINTER_STRATEGIES.keys())}"
+            )
+        return VOICE_POINTER_STRATEGIES[name](**kwargs)

--- a/tests/controllers/test_voice_manager.py
+++ b/tests/controllers/test_voice_manager.py
@@ -1,0 +1,373 @@
+# tests/controllers/test_voice_manager.py
+"""
+test_voice_manager.py
+
+Suite TDD per voice_manager.py
+
+Moduli sotto test (da scrivere):
+- VoiceConfig (frozen dataclass)
+- VoiceManager (orchestratore strategy)
+
+VoiceConfig:
+  pitch_offset: float    # semitoni
+  pointer_offset: float  # normalizzato
+  pan_offset: float      # gradi
+  onset_offset: float    # secondi
+
+VoiceManager:
+  - Riceve max_voices + le quattro strategy (pitch, pointer, onset, pan)
+  - Pre-computa VoiceConfig per ogni voice_index 0..max_voices-1
+  - Voce 0 → VoiceConfig(0.0, 0.0, 0.0, 0.0) sempre
+  - get_voice_config(voice_index) → VoiceConfig
+  - pan_strategy usa pan_spread come parametro aggiuntivo
+
+Principi:
+  - VoiceConfig è frozen (immutabile dopo creazione)
+  - Le strategy sono opzionali: se non fornite, offset = 0 per tutte le voci
+  - VoiceManager è agnostico rispetto al tempo (la logica time-varying
+    di num_voices è responsabilità di Stream.generate_grains)
+
+Organizzazione:
+  1.  VoiceConfig dataclass
+  2.  VoiceManager costruzione
+  3.  Voce 0 sempre zeros
+  4.  Delega corretta alle strategy
+  5.  Strategy opzionali (NullStrategy)
+  6.  pan_spread passato correttamente alla pan strategy
+  7.  Pre-computazione voice_configs
+  8.  Edge cases
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+
+# =============================================================================
+# IMPORT LAZY
+# =============================================================================
+
+def _get_module():
+    from controllers.voice_manager import VoiceConfig, VoiceManager
+    return VoiceConfig, VoiceManager
+
+
+def _get_strategies():
+    from strategies.voice_pitch_strategy import StepPitchStrategy
+    from strategies.voice_onset_strategy import LinearOnsetStrategy
+    from strategies.voice_pointer_strategy import LinearPointerStrategy
+    from strategies.voice_pan_strategy import LinearPanStrategy, AdditivePanStrategy
+    return StepPitchStrategy, LinearOnsetStrategy, LinearPointerStrategy, LinearPanStrategy, AdditivePanStrategy
+
+
+# =============================================================================
+# 1. VoiceConfig dataclass
+# =============================================================================
+
+class TestVoiceConfig:
+
+    def test_can_be_instantiated(self):
+        VoiceConfig, _ = _get_module()
+        vc = VoiceConfig(pitch_offset=3.0, pointer_offset=0.1,
+                         pan_offset=30.0, onset_offset=0.05)
+        assert vc.pitch_offset == 3.0
+        assert vc.pointer_offset == 0.1
+        assert vc.pan_offset == 30.0
+        assert vc.onset_offset == 0.05
+
+    def test_is_frozen(self):
+        """VoiceConfig non è mutabile dopo la creazione."""
+        VoiceConfig, _ = _get_module()
+        vc = VoiceConfig(pitch_offset=0.0, pointer_offset=0.0,
+                         pan_offset=0.0, onset_offset=0.0)
+        with pytest.raises((AttributeError, TypeError)):
+            vc.pitch_offset = 5.0
+
+    def test_zero_config(self):
+        VoiceConfig, _ = _get_module()
+        vc = VoiceConfig(0.0, 0.0, 0.0, 0.0)
+        assert vc.pitch_offset == 0.0
+        assert vc.pointer_offset == 0.0
+        assert vc.pan_offset == 0.0
+        assert vc.onset_offset == 0.0
+
+    def test_equality(self):
+        VoiceConfig, _ = _get_module()
+        a = VoiceConfig(1.0, 2.0, 3.0, 4.0)
+        b = VoiceConfig(1.0, 2.0, 3.0, 4.0)
+        assert a == b
+
+    def test_inequality(self):
+        VoiceConfig, _ = _get_module()
+        a = VoiceConfig(1.0, 0.0, 0.0, 0.0)
+        b = VoiceConfig(2.0, 0.0, 0.0, 0.0)
+        assert a != b
+
+
+# =============================================================================
+# 2. VoiceManager costruzione
+# =============================================================================
+
+class TestVoiceManagerConstruction:
+
+    def test_can_be_instantiated_with_max_voices(self):
+        _, VoiceManager = _get_module()
+        vm = VoiceManager(max_voices=4)
+        assert vm is not None
+
+    def test_stores_max_voices(self):
+        _, VoiceManager = _get_module()
+        vm = VoiceManager(max_voices=6)
+        assert vm.max_voices == 6
+
+    def test_accepts_all_strategies(self):
+        _, VoiceManager = _get_module()
+        StepPitchStrategy, LinearOnsetStrategy, LinearPointerStrategy, LinearPanStrategy, _ = _get_strategies()
+        vm = VoiceManager(
+            max_voices=4,
+            pitch_strategy=StepPitchStrategy(step=3.0),
+            onset_strategy=LinearOnsetStrategy(step=0.05),
+            pointer_strategy=LinearPointerStrategy(step=0.1),
+            pan_strategy=LinearPanStrategy(),
+            pan_spread=60.0,
+        )
+        assert vm is not None
+
+    def test_max_voices_1_valid(self):
+        _, VoiceManager = _get_module()
+        vm = VoiceManager(max_voices=1)
+        assert vm.max_voices == 1
+
+
+# =============================================================================
+# 3. Voce 0 sempre zeros
+# =============================================================================
+
+class TestVoiceZeroAlwaysZero:
+
+    def test_voice_0_all_zeros_no_strategies(self):
+        VoiceConfig, VoiceManager = _get_module()
+        vm = VoiceManager(max_voices=4)
+        vc = vm.get_voice_config(0)
+        assert vc == VoiceConfig(0.0, 0.0, 0.0, 0.0)
+
+    def test_voice_0_all_zeros_with_strategies(self):
+        VoiceConfig, VoiceManager = _get_module()
+        StepPitchStrategy, LinearOnsetStrategy, LinearPointerStrategy, LinearPanStrategy, _ = _get_strategies()
+        vm = VoiceManager(
+            max_voices=4,
+            pitch_strategy=StepPitchStrategy(step=7.0),
+            onset_strategy=LinearOnsetStrategy(step=1.0),
+            pointer_strategy=LinearPointerStrategy(step=0.5),
+            pan_strategy=LinearPanStrategy(),
+            pan_spread=90.0,
+        )
+        vc = vm.get_voice_config(0)
+        assert vc == VoiceConfig(0.0, 0.0, 0.0, 0.0)
+
+    def test_voice_0_zero_regardless_of_pitch_strategy(self):
+        VoiceConfig, VoiceManager = _get_module()
+        StepPitchStrategy, *_ = _get_strategies()
+        vm = VoiceManager(max_voices=3, pitch_strategy=StepPitchStrategy(step=12.0))
+        assert vm.get_voice_config(0).pitch_offset == 0.0
+
+    def test_voice_0_zero_regardless_of_onset_strategy(self):
+        VoiceConfig, VoiceManager = _get_module()
+        _, LinearOnsetStrategy, *_ = _get_strategies()
+        vm = VoiceManager(max_voices=3, onset_strategy=LinearOnsetStrategy(step=5.0))
+        assert vm.get_voice_config(0).onset_offset == 0.0
+
+
+# =============================================================================
+# 4. Delega corretta alle strategy
+# =============================================================================
+
+class TestVoiceManagerDelegation:
+
+    def test_pitch_delegated_to_strategy(self):
+        VoiceConfig, VoiceManager = _get_module()
+        StepPitchStrategy, *_ = _get_strategies()
+        vm = VoiceManager(max_voices=4, pitch_strategy=StepPitchStrategy(step=3.0))
+        assert vm.get_voice_config(1).pitch_offset == pytest.approx(3.0)
+        assert vm.get_voice_config(2).pitch_offset == pytest.approx(6.0)
+        assert vm.get_voice_config(3).pitch_offset == pytest.approx(9.0)
+
+    def test_onset_delegated_to_strategy(self):
+        _, VoiceManager = _get_module()
+        _, LinearOnsetStrategy, *_ = _get_strategies()
+        vm = VoiceManager(max_voices=4, onset_strategy=LinearOnsetStrategy(step=0.1))
+        assert vm.get_voice_config(1).onset_offset == pytest.approx(0.1)
+        assert vm.get_voice_config(2).onset_offset == pytest.approx(0.2)
+
+    def test_pointer_delegated_to_strategy(self):
+        _, VoiceManager = _get_module()
+        _, _, LinearPointerStrategy, *_ = _get_strategies()
+        vm = VoiceManager(max_voices=4, pointer_strategy=LinearPointerStrategy(step=0.05))
+        assert vm.get_voice_config(1).pointer_offset == pytest.approx(0.05)
+        assert vm.get_voice_config(2).pointer_offset == pytest.approx(0.10)
+
+    def test_pan_delegated_to_strategy_with_spread(self):
+        """LinearPanStrategy con 4 voci e spread=60: voce 0 → -30, voce 3 → +30."""
+        _, VoiceManager = _get_module()
+        _, _, _, LinearPanStrategy, _ = _get_strategies()
+        vm = VoiceManager(
+            max_voices=4,
+            pan_strategy=LinearPanStrategy(),
+            pan_spread=60.0,
+        )
+        assert vm.get_voice_config(0).pan_offset == pytest.approx(0.0)   # voce 0 sempre 0
+        # voce 1 con LinearPanStrategy: -30 + 1*(60/3) = -30 + 20 = -10
+        assert vm.get_voice_config(1).pan_offset == pytest.approx(-10.0)
+        assert vm.get_voice_config(3).pan_offset == pytest.approx(30.0)
+
+    def test_all_strategies_combined(self):
+        VoiceConfig, VoiceManager = _get_module()
+        StepPitchStrategy, LinearOnsetStrategy, LinearPointerStrategy, _, AdditivePanStrategy = _get_strategies()
+        vm = VoiceManager(
+            max_voices=3,
+            pitch_strategy=StepPitchStrategy(step=4.0),
+            onset_strategy=LinearOnsetStrategy(step=0.1),
+            pointer_strategy=LinearPointerStrategy(step=0.05),
+            pan_strategy=AdditivePanStrategy(),
+            pan_spread=10.0,
+        )
+        vc2 = vm.get_voice_config(2)
+        assert vc2.pitch_offset == pytest.approx(8.0)
+        assert vc2.onset_offset == pytest.approx(0.2)
+        assert vc2.pointer_offset == pytest.approx(0.10)
+
+
+# =============================================================================
+# 5. Strategy opzionali (default → 0 per tutte le voci)
+# =============================================================================
+
+class TestOptionalStrategies:
+
+    def test_no_pitch_strategy_all_zero(self):
+        _, VoiceManager = _get_module()
+        vm = VoiceManager(max_voices=4)
+        for i in range(4):
+            assert vm.get_voice_config(i).pitch_offset == 0.0
+
+    def test_no_onset_strategy_all_zero(self):
+        _, VoiceManager = _get_module()
+        vm = VoiceManager(max_voices=4)
+        for i in range(4):
+            assert vm.get_voice_config(i).onset_offset == 0.0
+
+    def test_no_pointer_strategy_all_zero(self):
+        _, VoiceManager = _get_module()
+        vm = VoiceManager(max_voices=4)
+        for i in range(4):
+            assert vm.get_voice_config(i).pointer_offset == 0.0
+
+    def test_no_pan_strategy_all_zero(self):
+        _, VoiceManager = _get_module()
+        vm = VoiceManager(max_voices=4)
+        for i in range(4):
+            assert vm.get_voice_config(i).pan_offset == 0.0
+
+    def test_partial_strategies(self):
+        """Solo pitch strategy fornita, resto zero."""
+        _, VoiceManager = _get_module()
+        StepPitchStrategy, *_ = _get_strategies()
+        vm = VoiceManager(max_voices=3, pitch_strategy=StepPitchStrategy(step=5.0))
+        vc = vm.get_voice_config(1)
+        assert vc.pitch_offset == pytest.approx(5.0)
+        assert vc.onset_offset == 0.0
+        assert vc.pointer_offset == 0.0
+        assert vc.pan_offset == 0.0
+
+
+# =============================================================================
+# 6. pan_spread passato correttamente
+# =============================================================================
+
+class TestPanSpread:
+
+    def test_pan_spread_zero_all_zero(self):
+        _, VoiceManager = _get_module()
+        _, _, _, LinearPanStrategy, _ = _get_strategies()
+        vm = VoiceManager(max_voices=4, pan_strategy=LinearPanStrategy(), pan_spread=0.0)
+        for i in range(4):
+            assert vm.get_voice_config(i).pan_offset == 0.0
+
+    def test_pan_spread_passed_to_strategy(self):
+        """La pan strategy riceve spread corretto per ogni voce non-zero."""
+        _, VoiceManager = _get_module()
+        mock_pan = MagicMock()
+        mock_pan.get_pan_offset.return_value = 15.0
+        vm = VoiceManager(max_voices=3, pan_strategy=mock_pan, pan_spread=45.0)
+        # Pre-computa all'init: controlla che voice_index=1 sia stato chiamato
+        mock_pan.get_pan_offset.assert_any_call(
+            voice_index=1, num_voices=3, spread=45.0
+        )
+
+    def test_default_pan_spread_is_zero(self):
+        _, VoiceManager = _get_module()
+        _, _, _, LinearPanStrategy, _ = _get_strategies()
+        vm = VoiceManager(max_voices=4, pan_strategy=LinearPanStrategy())
+        for i in range(4):
+            assert vm.get_voice_config(i).pan_offset == 0.0
+
+
+# =============================================================================
+# 7. Pre-computazione voice_configs
+# =============================================================================
+
+class TestPrecomputedConfigs:
+
+    def test_all_configs_precomputed(self):
+        """voice_configs contiene max_voices elementi."""
+        _, VoiceManager = _get_module()
+        vm = VoiceManager(max_voices=5)
+        assert len(vm.voice_configs) == 5
+
+    def test_get_voice_config_consistent_with_precomputed(self):
+        _, VoiceManager = _get_module()
+        StepPitchStrategy, *_ = _get_strategies()
+        vm = VoiceManager(max_voices=4, pitch_strategy=StepPitchStrategy(step=2.0))
+        for i in range(4):
+            assert vm.get_voice_config(i) == vm.voice_configs[i]
+
+    def test_voice_configs_are_voice_config_instances(self):
+        VoiceConfig, VoiceManager = _get_module()
+        vm = VoiceManager(max_voices=3)
+        for vc in vm.voice_configs:
+            assert isinstance(vc, VoiceConfig)
+
+    def test_get_voice_config_out_of_range_raises(self):
+        _, VoiceManager = _get_module()
+        vm = VoiceManager(max_voices=3)
+        with pytest.raises((IndexError, ValueError)):
+            vm.get_voice_config(5)
+
+
+# =============================================================================
+# 8. Edge cases
+# =============================================================================
+
+class TestEdgeCases:
+
+    def test_max_voices_1_only_voice_0(self):
+        VoiceConfig, VoiceManager = _get_module()
+        vm = VoiceManager(max_voices=1)
+        assert vm.get_voice_config(0) == VoiceConfig(0.0, 0.0, 0.0, 0.0)
+
+    def test_chord_strategy_with_voice_manager(self):
+        """Integrazione ChordPitchStrategy con VoiceManager."""
+        _, VoiceManager = _get_module()
+        from strategies.voice_pitch_strategy import ChordPitchStrategy
+        vm = VoiceManager(max_voices=4, pitch_strategy=ChordPitchStrategy(chord="dom7"))
+        assert vm.get_voice_config(0).pitch_offset == 0.0
+        assert vm.get_voice_config(1).pitch_offset == 4.0
+        assert vm.get_voice_config(2).pitch_offset == 7.0
+        assert vm.get_voice_config(3).pitch_offset == 10.0
+
+    def test_stochastic_pitch_with_voice_manager(self):
+        _, VoiceManager = _get_module()
+        from strategies.voice_pitch_strategy import StochasticPitchStrategy
+        s = StochasticPitchStrategy(semitone_range=2.0, stream_id="test")
+        vm = VoiceManager(max_voices=4, pitch_strategy=s)
+        assert vm.get_voice_config(0).pitch_offset == 0.0
+        for i in range(1, 4):
+            assert -2.0 <= vm.get_voice_config(i).pitch_offset <= 2.0

--- a/tests/core/test_stream.py
+++ b/tests/core/test_stream.py
@@ -87,17 +87,13 @@ def _make_mock_density(inter_onset=0.1):
 
 
 def _make_mock_voice_manager(max_voices=1):
-    """Crea un mock VoiceManager."""
+    """Crea un mock VoiceManager compatibile con la nuova interfaccia VoiceConfig."""
+    from controllers.voice_manager import VoiceConfig
     vm = Mock()
     vm.max_voices = max_voices
-    vm.is_voice_active = Mock(return_value=True)
-    vm.get_voice_pitch_multiplier = Mock(return_value=1.0)
-    vm.get_voice_pointer_offset = Mock(return_value=0.0)
-    vm.get_voice_pointer_range = Mock(return_value=0.0)
-    vm.num_voices_value = max_voices
-    vm.voice_pitch_offset_value = 0.0
-    vm.voice_pointer_offset_value = 0.0
-    vm.voice_pointer_range_value = 0.0
+    # get_voice_config(i) → VoiceConfig(0,0,0,0) per tutti (voce 0 = riferimento)
+    vm.get_voice_config = Mock(return_value=VoiceConfig(0.0, 0.0, 0.0, 0.0))
+    vm.voice_configs = [VoiceConfig(0.0, 0.0, 0.0, 0.0)] * max_voices
     return vm
 
 
@@ -186,6 +182,16 @@ def stream_factory():
         s._density = _make_mock_density(inter_onset)
         s._voice_manager = _make_mock_voice_manager(max_voices)
         s._window_controller = _make_mock_window_controller()
+
+        # num_voices: mock Parameter che restituisce max_voices per ogni t
+        _nv = Mock()
+        _nv.get_value = Mock(return_value=float(max_voices))
+        s._num_voices = _nv
+
+        # scatter: mock Parameter che restituisce 0.0 (comportamento cluster)
+        _sc = Mock()
+        _sc.get_value = Mock(return_value=0.0)
+        s._scatter = _sc
 
         # Csound references
         s.sample_table_num = 1
@@ -1184,9 +1190,9 @@ class TestStreamParametrized:
 
     @pytest.mark.parametrize("max_voices", [1, 2, 5, 10])
     def test_voice_count(self, stream_factory, max_voices):
-        """Single voice stream: voices contiene sempre esattamente 1 lista."""
+        """voices contiene esattamente max_voices liste (una per voce)."""
         s = stream_factory(max_voices=max_voices, duration=0.3, inter_onset=0.1)
 
         s.generate_grains()
 
-        assert len(s.voices) == 1
+        assert len(s.voices) == max_voices

--- a/tests/core/test_stream_multivoice.py
+++ b/tests/core/test_stream_multivoice.py
@@ -1,0 +1,669 @@
+# tests/core/test_stream_multivoice.py
+"""
+test_stream_multivoice.py
+
+Suite TDD per il sistema multi-voice di Stream.
+
+Copre le modifiche a:
+- generate_grains(): loop multi-voice con VoiceManager
+- _create_grain(): applicazione VoiceConfig (pitch, pointer, pan, onset)
+
+Principi testati:
+- Voce 0 produce grani identici al comportamento mono-voice
+- N voci → ~N volte i grani (overall density = per_voice_density × N)
+- Ogni voce applica gli offset di VoiceConfig ai parametri del grano
+- self.grains è il flatten ordinato per onset di tutte le voci
+- self.voices ha un entry per ogni voce con grani
+
+Queste suite si appoggiano alla stessa infrastruttura di mock di test_stream.py.
+"""
+
+import math
+import pytest
+from unittest.mock import Mock
+
+from core.stream import Stream
+from controllers.voice_manager import VoiceConfig, VoiceManager
+
+
+# =============================================================================
+# MOCK INFRASTRUCTURE (duplicata da test_stream.py per isolamento)
+# =============================================================================
+
+def _make_mock_parameter(value=0.0, name='mock_param'):
+    p = Mock()
+    p.name = name
+    p._value = value
+    p.value = value
+    p.get_value = Mock(return_value=float(value))
+    p._probability_gate = Mock()
+    p._probability_gate.should_apply = Mock(return_value=False)
+    p._mod_range = None
+    return p
+
+
+def _make_mock_pointer(return_value=0.5):
+    ptr = Mock()
+    ptr.calculate = Mock(return_value=return_value)
+    ptr.get_speed = Mock(return_value=1.0)
+    ptr.speed = Mock()
+    ptr.speed.value = 1.0
+    ptr.loop_start = None
+    ptr.loop_end = None
+    ptr.loop_dur = None
+    return ptr
+
+
+def _make_mock_pitch(return_value=1.0):
+    pitch = Mock()
+    pitch.calculate = Mock(return_value=return_value)
+    pitch.base_ratio = return_value
+    pitch.base_semitones = None
+    pitch.range = 0.0
+    return pitch
+
+
+def _make_mock_density(inter_onset=0.1):
+    dens = Mock()
+    dens.calculate_inter_onset = Mock(return_value=inter_onset)
+    dens.density = 10.0
+    dens.fill_factor = None
+    dens.distribution = Mock()
+    dens.distribution.value = 0.0
+    return dens
+
+
+def _make_mock_window_controller():
+    wc = Mock()
+    wc.select_window = Mock(return_value='hanning')
+    return wc
+
+
+def _make_stream(
+    duration=1.0,
+    onset=0.0,
+    inter_onset=0.1,
+    grain_dur=0.05,
+    pitch_ratio=1.0,
+    pointer_pos=0.5,
+    pan_value=0.0,
+    voice_manager=None,
+    num_voices_fn=None,
+    scatter_fn=None,
+    density_side_effect=None,
+):
+    """Crea uno Stream con tutti i controller mockati e VoiceManager reale/mock.
+
+    num_voices_fn: callable t → float, se None restituisce max_voices per ogni t.
+    """
+    s = object.__new__(Stream)
+    s.stream_id = 'test_stream'
+    s.onset = onset
+    s.duration = duration
+    s.sample = 'test.wav'
+    s.sample_dur_sec = 5.0
+    s.grain_reverse_mode = 'auto'
+
+    s.grain_duration = _make_mock_parameter(grain_dur, 'grain_duration')
+    s.volume = _make_mock_parameter(-6.0, 'volume')
+    s.pan = _make_mock_parameter(pan_value, 'pan')
+    s.reverse = _make_mock_parameter(0, 'reverse')
+    s.grain_envelope = 'hanning'
+
+    s._pointer = _make_mock_pointer(pointer_pos)
+    s._pitch = _make_mock_pitch(pitch_ratio)
+    s._window_controller = _make_mock_window_controller()
+
+    s._voice_manager = voice_manager or VoiceManager(max_voices=1)
+
+    # density: supporta side_effect per simulare distribution > 0
+    if density_side_effect is not None:
+        dens = Mock()
+        dens.calculate_inter_onset = Mock(side_effect=density_side_effect)
+        dens.density = 10.0
+        dens.fill_factor = None
+        dens.distribution = Mock()
+        dens.distribution.value = 0.0
+        s._density = dens
+    else:
+        s._density = _make_mock_density(inter_onset)
+
+    # num_voices: mock Parameter che restituisce max_voices per default
+    max_v = float(s._voice_manager.max_voices)
+    nv = Mock()
+    nv.get_value = Mock(
+        side_effect=num_voices_fn if num_voices_fn is not None
+        else lambda t: max_v
+    )
+    s._num_voices = nv
+
+    # scatter: mock Parameter, default = 0.0 (cluster)
+    sc = Mock()
+    sc.get_value = Mock(
+        side_effect=scatter_fn if scatter_fn is not None
+        else lambda t: 0.0
+    )
+    s._scatter = sc
+
+    s.sample_table_num = 1
+    s.envelope_table_num = 2
+    s.window_table_map = {'hanning': 2}
+
+    s.voices = []
+    s.grains = []
+    s.generated = False
+
+    return s
+
+
+# =============================================================================
+# 1. generate_grains — comportamento mono-voice (backward compat)
+# =============================================================================
+
+class TestGenerateGrainsBackwardCompat:
+    """Con VoiceManager(max_voices=1) il comportamento è identico a prima."""
+
+    def test_single_voice_grain_count(self):
+        """1 voce, duration=1.0, inter_onset=0.1 → ~10 grani (floating point tolerance)."""
+        s = _make_stream(duration=1.0, inter_onset=0.1)
+        s.generate_grains()
+        assert len(s.grains) in (10, 11)
+
+    def test_single_voice_voices_list_has_one_entry(self):
+        s = _make_stream(duration=1.0, inter_onset=0.1)
+        s.generate_grains()
+        assert len(s.voices) == 1
+
+    def test_single_voice_grains_equals_voices_0(self):
+        s = _make_stream(duration=1.0, inter_onset=0.1)
+        s.generate_grains()
+        assert s.grains == s.voices[0]
+
+    def test_single_voice_onset_is_absolute(self):
+        s = _make_stream(duration=0.5, onset=2.0, inter_onset=0.1)
+        s.generate_grains()
+        assert s.grains[0].onset == pytest.approx(2.0)
+
+    def test_generated_flag_set(self):
+        s = _make_stream()
+        s.generate_grains()
+        assert s.generated is True
+
+
+# =============================================================================
+# 2. generate_grains — multi-voice grain count
+# =============================================================================
+
+class TestGenerateGrainsMultiVoiceCount:
+
+    def test_two_voices_double_grain_count(self):
+        """2 voci, stessa density → 2× i grani totali."""
+        vm = VoiceManager(max_voices=2)
+        s1 = _make_stream(duration=1.0, inter_onset=0.1, voice_manager=VoiceManager(max_voices=1))
+        s2 = _make_stream(duration=1.0, inter_onset=0.1, voice_manager=vm)
+        s1.generate_grains()
+        s2.generate_grains()
+        assert len(s2.grains) == len(s1.grains) * 2
+
+    def test_three_voices_triple_grain_count(self):
+        vm = VoiceManager(max_voices=3)
+        s1 = _make_stream(duration=1.0, inter_onset=0.1, voice_manager=VoiceManager(max_voices=1))
+        s3 = _make_stream(duration=1.0, inter_onset=0.1, voice_manager=vm)
+        s1.generate_grains()
+        s3.generate_grains()
+        assert len(s3.grains) == len(s1.grains) * 3
+
+    def test_two_voices_voices_list_has_two_entries(self):
+        vm = VoiceManager(max_voices=2)
+        s = _make_stream(duration=1.0, inter_onset=0.1, voice_manager=vm)
+        s.generate_grains()
+        assert len(s.voices) == 2
+
+    def test_each_voice_has_same_grain_count(self):
+        vm = VoiceManager(max_voices=3)
+        s = _make_stream(duration=1.0, inter_onset=0.1, voice_manager=vm)
+        s.generate_grains()
+        counts = [len(v) for v in s.voices]
+        assert counts[0] == counts[1] == counts[2]
+
+    def test_grains_is_flatten_of_all_voices(self):
+        vm = VoiceManager(max_voices=2)
+        s = _make_stream(duration=1.0, inter_onset=0.1, voice_manager=vm)
+        s.generate_grains()
+        expected = sorted(
+            [g for voice in s.voices for g in voice],
+            key=lambda g: g.onset
+        )
+        assert s.grains == expected
+
+    def test_grains_sorted_by_onset(self):
+        vm = VoiceManager(max_voices=2)
+        s = _make_stream(duration=1.0, inter_onset=0.1, voice_manager=vm)
+        s.generate_grains()
+        onsets = [g.onset for g in s.grains]
+        assert onsets == sorted(onsets)
+
+
+# =============================================================================
+# 3. generate_grains — voice 0 è sempre il riferimento
+# =============================================================================
+
+class TestGenerateGrainsVoiceZeroReference:
+
+    def test_voice_0_pitch_unmodified(self):
+        """Voce 0 non ha pitch offset → pitch_ratio identico al base."""
+        from strategies.voice_pitch_strategy import StepPitchStrategy
+        vm = VoiceManager(max_voices=2, pitch_strategy=StepPitchStrategy(step=12.0))
+        s = _make_stream(duration=0.3, inter_onset=0.1, pitch_ratio=1.0, voice_manager=vm)
+        s.generate_grains()
+        voice_0_pitches = [g.pitch_ratio for g in s.voices[0]]
+        assert all(p == pytest.approx(1.0) for p in voice_0_pitches)
+
+    def test_voice_0_pointer_unmodified(self):
+        from strategies.voice_pointer_strategy import LinearPointerStrategy
+        vm = VoiceManager(max_voices=2, pointer_strategy=LinearPointerStrategy(step=0.3))
+        s = _make_stream(duration=0.3, inter_onset=0.1, pointer_pos=0.5, voice_manager=vm)
+        s.generate_grains()
+        voice_0_pointers = [g.pointer_pos for g in s.voices[0]]
+        assert all(p == pytest.approx(0.5) for p in voice_0_pointers)
+
+    def test_voice_0_onset_unmodified(self):
+        from strategies.voice_onset_strategy import LinearOnsetStrategy
+        vm = VoiceManager(max_voices=2, onset_strategy=LinearOnsetStrategy(step=1.0))
+        s = _make_stream(duration=0.3, onset=5.0, inter_onset=0.1, voice_manager=vm)
+        s.generate_grains()
+        # Voce 0: onset = stream_onset + elapsed (no offset)
+        assert s.voices[0][0].onset == pytest.approx(5.0)
+
+    def test_voice_0_pan_unmodified(self):
+        from strategies.voice_pan_strategy import LinearPanStrategy
+        vm = VoiceManager(max_voices=2, pan_strategy=LinearPanStrategy(), pan_spread=60.0)
+        s = _make_stream(duration=0.3, inter_onset=0.1, pan_value=0.0, voice_manager=vm)
+        s.generate_grains()
+        voice_0_pans = [g.pan for g in s.voices[0]]
+        assert all(p == pytest.approx(0.0) for p in voice_0_pans)
+
+
+# =============================================================================
+# 4. generate_grains — voice 1 riceve gli offset
+# =============================================================================
+
+class TestGenerateGrainsVoiceOneOffsets:
+
+    def test_voice_1_pitch_offset_applied(self):
+        """Voce 1 con StepPitchStrategy(step=12) → pitch_ratio = base * 2^(12/12) = 2.0."""
+        from strategies.voice_pitch_strategy import StepPitchStrategy
+        vm = VoiceManager(max_voices=2, pitch_strategy=StepPitchStrategy(step=12.0))
+        s = _make_stream(duration=0.3, inter_onset=0.1, pitch_ratio=1.0, voice_manager=vm)
+        s.generate_grains()
+        voice_1_pitches = [g.pitch_ratio for g in s.voices[1]]
+        expected = 2 ** (12.0 / 12.0)  # = 2.0
+        assert all(p == pytest.approx(expected) for p in voice_1_pitches)
+
+    def test_voice_1_pitch_offset_7_semitones(self):
+        """Voce 1 con step=7 → pitch_ratio = 2^(7/12) ≈ 1.4983."""
+        from strategies.voice_pitch_strategy import StepPitchStrategy
+        vm = VoiceManager(max_voices=2, pitch_strategy=StepPitchStrategy(step=7.0))
+        s = _make_stream(duration=0.3, inter_onset=0.1, pitch_ratio=1.0, voice_manager=vm)
+        s.generate_grains()
+        expected = 2 ** (7.0 / 12.0)
+        voice_1_pitches = [g.pitch_ratio for g in s.voices[1]]
+        assert all(p == pytest.approx(expected, rel=1e-4) for p in voice_1_pitches)
+
+    def test_voice_1_pointer_offset_applied(self):
+        """Voce 1 con LinearPointerStrategy(step=0.2) → pointer = base + 0.2."""
+        from strategies.voice_pointer_strategy import LinearPointerStrategy
+        vm = VoiceManager(max_voices=2, pointer_strategy=LinearPointerStrategy(step=0.2))
+        s = _make_stream(duration=0.3, inter_onset=0.1, pointer_pos=0.3, voice_manager=vm)
+        s.generate_grains()
+        voice_1_pointers = [g.pointer_pos for g in s.voices[1]]
+        assert all(p == pytest.approx(0.5) for p in voice_1_pointers)
+
+    def test_voice_1_onset_offset_applied(self):
+        """Voce 1 con LinearOnsetStrategy(step=0.5) → primo onset = onset + 0.0 + 0.5."""
+        from strategies.voice_onset_strategy import LinearOnsetStrategy
+        vm = VoiceManager(max_voices=2, onset_strategy=LinearOnsetStrategy(step=0.5))
+        s = _make_stream(duration=0.3, onset=2.0, inter_onset=0.1, voice_manager=vm)
+        s.generate_grains()
+        # Voce 1, primo grano: onset = stream_onset + elapsed(0.0) + onset_offset(0.5) = 2.5
+        assert s.voices[1][0].onset == pytest.approx(2.5)
+
+    def test_voice_1_pan_offset_applied(self):
+        """Voce 1 con LinearPanStrategy spread=60 → pan = base_pan + pan_offset."""
+        from strategies.voice_pan_strategy import LinearPanStrategy
+        # 2 voci, LinearPanStrategy: voce 0 = -30, voce 1 = +30
+        vm = VoiceManager(max_voices=2, pan_strategy=LinearPanStrategy(), pan_spread=60.0)
+        s = _make_stream(duration=0.3, inter_onset=0.1, pan_value=0.0, voice_manager=vm)
+        s.generate_grains()
+        voice_1_pans = [g.pan for g in s.voices[1]]
+        assert all(p == pytest.approx(30.0) for p in voice_1_pans)
+
+
+# =============================================================================
+# 5. _create_grain con VoiceConfig
+# =============================================================================
+
+class TestCreateGrainWithVoiceConfig:
+
+    def test_zero_voice_config_identical_to_default(self):
+        """VoiceConfig(0,0,0,0) produce lo stesso grano di nessun config."""
+        s = _make_stream(pitch_ratio=1.0, pointer_pos=0.5, pan_value=0.0, onset=1.0)
+        vc = VoiceConfig(0.0, 0.0, 0.0, 0.0)
+        g = s._create_grain(elapsed_time=0.0, grain_dur=0.05, voice_config=vc)
+        assert g.onset == pytest.approx(1.0)
+        assert g.pitch_ratio == pytest.approx(1.0)
+        assert g.pointer_pos == pytest.approx(0.5)
+        assert g.pan == pytest.approx(0.0)
+
+    def test_pitch_offset_semitones_to_ratio(self):
+        """pitch_offset=12 → pitch_ratio moltiplicato per 2^(12/12) = 2.0."""
+        s = _make_stream(pitch_ratio=1.0)
+        vc = VoiceConfig(pitch_offset=12.0, pointer_offset=0.0, pan_offset=0.0, onset_offset=0.0)
+        g = s._create_grain(0.0, 0.05, voice_config=vc)
+        assert g.pitch_ratio == pytest.approx(2.0)
+
+    def test_pitch_offset_multiplies_base_ratio(self):
+        """Se base_ratio=2.0 e pitch_offset=12 → 2.0 * 2.0 = 4.0."""
+        s = _make_stream(pitch_ratio=2.0)
+        vc = VoiceConfig(pitch_offset=12.0, pointer_offset=0.0, pan_offset=0.0, onset_offset=0.0)
+        g = s._create_grain(0.0, 0.05, voice_config=vc)
+        assert g.pitch_ratio == pytest.approx(4.0)
+
+    def test_pointer_offset_added(self):
+        """pointer_offset=0.2 viene sommato al pointer base."""
+        s = _make_stream(pointer_pos=0.3)
+        vc = VoiceConfig(pitch_offset=0.0, pointer_offset=0.2, pan_offset=0.0, onset_offset=0.0)
+        g = s._create_grain(0.0, 0.05, voice_config=vc)
+        assert g.pointer_pos == pytest.approx(0.5)
+
+    def test_pan_offset_added(self):
+        """pan_offset=30.0 viene sommato al pan base."""
+        s = _make_stream(pan_value=10.0)
+        vc = VoiceConfig(pitch_offset=0.0, pointer_offset=0.0, pan_offset=30.0, onset_offset=0.0)
+        g = s._create_grain(0.0, 0.05, voice_config=vc)
+        assert g.pan == pytest.approx(40.0)
+
+    def test_onset_offset_added(self):
+        """onset_offset=0.5 viene sommato all'onset assoluto."""
+        s = _make_stream(onset=2.0)
+        vc = VoiceConfig(pitch_offset=0.0, pointer_offset=0.0, pan_offset=0.0, onset_offset=0.5)
+        g = s._create_grain(elapsed_time=0.1, grain_dur=0.05, voice_config=vc)
+        # onset = stream_onset(2.0) + elapsed(0.1) + onset_offset(0.5) = 2.6
+        assert g.onset == pytest.approx(2.6)
+
+    def test_negative_pitch_offset(self):
+        """pitch_offset=-12 → pitch_ratio / 2 (ottava inferiore)."""
+        s = _make_stream(pitch_ratio=1.0)
+        vc = VoiceConfig(pitch_offset=-12.0, pointer_offset=0.0, pan_offset=0.0, onset_offset=0.0)
+        g = s._create_grain(0.0, 0.05, voice_config=vc)
+        assert g.pitch_ratio == pytest.approx(0.5)
+
+    def test_voice_config_none_uses_zeros(self):
+        """voice_config=None → comportamento identico a VoiceConfig(0,0,0,0)."""
+        s = _make_stream(pitch_ratio=1.0, pointer_pos=0.5, pan_value=0.0, onset=1.0)
+        g_none = s._create_grain(0.0, 0.05, voice_config=None)
+        g_zero = s._create_grain(0.0, 0.05, voice_config=VoiceConfig(0.0, 0.0, 0.0, 0.0))
+        assert g_none.pitch_ratio == g_zero.pitch_ratio
+        assert g_none.pointer_pos == g_zero.pointer_pos
+        assert g_none.pan == g_zero.pan
+        assert g_none.onset == g_zero.onset
+
+
+# =============================================================================
+# 6. Reset e stato
+# =============================================================================
+
+class TestGenerateGrainsReset:
+
+    def test_reset_on_regeneration(self):
+        vm = VoiceManager(max_voices=2)
+        s = _make_stream(duration=1.0, inter_onset=0.1, voice_manager=vm)
+        s.generate_grains()
+        first_count = len(s.grains)
+        s.generate_grains()
+        assert len(s.grains) == first_count
+
+    def test_voices_cleared_on_regeneration(self):
+        vm = VoiceManager(max_voices=2)
+        s = _make_stream(duration=1.0, inter_onset=0.1, voice_manager=vm)
+        s.generate_grains()
+        s.generate_grains()
+        assert len(s.voices) == 2
+
+
+# =============================================================================
+# 7. num_voices time-varying — generate_grains usa get_value(t) per tick
+# =============================================================================
+
+class TestNumVoicesTimeVarying:
+    """
+    generate_grains() deve chiedere num_voices.get_value(elapsed_time) ad ogni
+    tick e usare il risultato come numero di voci attive in quel momento.
+    """
+
+    def test_num_voices_get_value_called_per_tick(self):
+        """get_value viene chiamato una volta per voce per tick."""
+        max_v = 3
+        vm = VoiceManager(max_voices=max_v)
+        s = _make_stream(duration=1.0, inter_onset=0.1, voice_manager=vm)
+        s.generate_grains()
+        ticks = len(s.voices[0])  # voice 0 ha un grano per tick
+        assert s.num_voices.get_value.call_count == ticks * max_v
+
+    def test_static_num_voices_all_voices_receive_grains(self):
+        """Quando num_voices è costante == max_voices, tutte le voci ricevono grani."""
+        vm = VoiceManager(max_voices=3)
+        s = _make_stream(duration=1.0, inter_onset=0.1, voice_manager=vm)
+        s.generate_grains()
+        for voice_grains in s.voices:
+            assert len(voice_grains) > 0
+
+    def test_num_voices_1_only_voice_0_gets_grains(self):
+        """Con num_voices=1 fisso (< max_voices), solo la voce 0 riceve grani."""
+        vm = VoiceManager(max_voices=3)
+        s = _make_stream(
+            duration=1.0, inter_onset=0.1,
+            voice_manager=vm,
+            num_voices_fn=lambda t: 1.0,
+        )
+        s.generate_grains()
+        assert len(s.voices[0]) > 0
+        assert len(s.voices[1]) == 0
+        assert len(s.voices[2]) == 0
+
+    def test_num_voices_2_voices_0_and_1_get_grains(self):
+        """Con num_voices=2, le voci 0 e 1 ricevono grani; la 2 no."""
+        vm = VoiceManager(max_voices=3)
+        s = _make_stream(
+            duration=1.0, inter_onset=0.1,
+            voice_manager=vm,
+            num_voices_fn=lambda t: 2.0,
+        )
+        s.generate_grains()
+        assert len(s.voices[0]) > 0
+        assert len(s.voices[1]) > 0
+        assert len(s.voices[2]) == 0
+
+    def test_voices_list_length_always_equals_max_voices(self):
+        """s.voices ha sempre max_voices entry anche quando num_voices < max."""
+        vm = VoiceManager(max_voices=4)
+        s = _make_stream(
+            duration=1.0, inter_onset=0.1,
+            voice_manager=vm,
+            num_voices_fn=lambda t: 1.0,
+        )
+        s.generate_grains()
+        assert len(s.voices) == 4
+
+    def test_growing_voices_voice_0_has_more_grains_than_voice_3(self):
+        """Voci attivate progressivamente: voce 0 accumula più grani di voce 3."""
+        # num_voices cresce da 1 a 4 in 10 secondi
+        vm = VoiceManager(max_voices=4)
+        s = _make_stream(
+            duration=10.0, inter_onset=1.0,
+            voice_manager=vm,
+            num_voices_fn=lambda t: min(4.0, 1.0 + t * 3.0 / 9.0),
+        )
+        s.generate_grains()
+        assert len(s.voices[0]) > len(s.voices[3])
+
+    def test_growing_voices_voice_3_eventually_receives_grains(self):
+        """Quando num_voices raggiunge 4, anche la voce 3 deve ricevere grani."""
+        vm = VoiceManager(max_voices=4)
+        s = _make_stream(
+            duration=10.0, inter_onset=1.0,
+            voice_manager=vm,
+            num_voices_fn=lambda t: min(4.0, 1.0 + t * 3.0 / 9.0),
+        )
+        s.generate_grains()
+        assert len(s.voices[3]) > 0
+
+    def test_voice_0_always_gets_grain_at_every_tick(self):
+        """La voce 0 riceve sempre un grano (num_voices >= 1 per ogni tick)."""
+        vm = VoiceManager(max_voices=4)
+        total_ticks = 10
+        s = _make_stream(
+            duration=float(total_ticks), inter_onset=1.0,
+            voice_manager=vm,
+            num_voices_fn=lambda t: min(4.0, 1.0 + t),
+        )
+        s.generate_grains()
+        assert len(s.voices[0]) == total_ticks
+
+
+# =============================================================================
+# 8. scatter — cursori per voce e blend IOT
+# =============================================================================
+
+import itertools
+
+class TestScatter:
+    """
+    Con scatter=0 (default) il comportamento è identico all'originale.
+    Con scatter>0 e IOT variabile, le voci divergono nel tempo.
+    Con IOT costante (distribution=0 analog), scatter è sempre inerte.
+    """
+
+    # ── BACKWARD COMPAT ────────────────────────────────────────────────────
+
+    def test_scatter_zero_constant_iot_same_grain_count(self):
+        """scatter=0, IOT costante → ogni voce ha lo stesso numero di grani."""
+        vm = VoiceManager(max_voices=2)
+        s = _make_stream(duration=1.0, inter_onset=0.1, voice_manager=vm)
+        s.generate_grains()
+        assert len(s.voices[0]) == len(s.voices[1])
+
+    def test_scatter_zero_varying_iot_voices_synchronized(self):
+        """scatter=0, IOT variabile → voci usano sync_iot condiviso → stesso conteggio."""
+        vm = VoiceManager(max_voices=2)
+        iots = itertools.cycle([0.1, 0.2])
+        s = _make_stream(
+            duration=1.0, voice_manager=vm,
+            density_side_effect=lambda t, gd: next(iots),
+        )
+        s.generate_grains()
+        assert len(s.voices[0]) == len(s.voices[1])
+
+    def test_scatter_zero_voices_list_length(self):
+        """scatter=0 → s.voices ha max_v entry."""
+        vm = VoiceManager(max_voices=3)
+        s = _make_stream(duration=1.0, inter_onset=0.1, voice_manager=vm)
+        s.generate_grains()
+        assert len(s.voices) == 3
+
+    def test_scatter_zero_grains_sorted_by_onset(self):
+        """scatter=0 → s.grains ordinato per onset."""
+        vm = VoiceManager(max_voices=2)
+        s = _make_stream(duration=1.0, inter_onset=0.1, voice_manager=vm)
+        s.generate_grains()
+        onsets = [g.onset for g in s.grains]
+        assert onsets == sorted(onsets)
+
+    # ── SCATTER INERTE (IOT COSTANTE) ──────────────────────────────────────
+
+    def test_scatter_one_constant_iot_voices_still_equal(self):
+        """scatter=1, IOT costante → lerp(c, c, 1) = c → voci sincronizzate."""
+        vm = VoiceManager(max_voices=2)
+        s = _make_stream(
+            duration=1.0, voice_manager=vm,
+            scatter_fn=lambda t: 1.0,
+            inter_onset=0.1,
+        )
+        s.generate_grains()
+        assert len(s.voices[0]) == len(s.voices[1])
+
+    # ── SCATTER ATTIVO (IOT VARIABILE) ─────────────────────────────────────
+
+    def test_scatter_one_varying_iot_voices_diverge(self):
+        """scatter=1, IOT alternato [0.1, 0.2] → v0 ha più grani di v1.
+
+        Sequenza chiamate con 2 voci e scatter=1:
+          iter 1: call→0.1 (sync_iot, v0 usa questo), call→0.2 (indep v1)
+          iter 2: call→0.1 (sync_iot, v0), call→0.2 (indep v1)
+          ...
+          v0 avanza di 0.1 ogni iter → 10 grani in duration=1.0
+          v1 avanza di 0.2 ogni iter → 5 grani in duration=1.0
+        """
+        vm = VoiceManager(max_voices=2)
+        iots = itertools.cycle([0.1, 0.2])
+        s = _make_stream(
+            duration=1.0, voice_manager=vm,
+            scatter_fn=lambda t: 1.0,
+            density_side_effect=lambda t, gd: next(iots),
+        )
+        s.generate_grains()
+        assert len(s.voices[0]) > len(s.voices[1])
+
+    def test_scatter_one_varying_iot_v0_more_grains_than_v1(self):
+        """scatter=1, sync_iot < indep_iot → v0 accumula più grani di v1."""
+        # Il mock ritorna valori alternati [0.1, 0.2].
+        # v0 usa sync_iot (call 1 di ogni iterazione = 0.1 quando entrambe le voci
+        # sono attive), v1 usa indep_iot (call 2 = 0.2). v0 avanza più lentamente
+        # → più grani in duration=1.0.
+        vm = VoiceManager(max_voices=2)
+        iots = itertools.cycle([0.1, 0.2])
+        s = _make_stream(
+            duration=1.0, voice_manager=vm,
+            scatter_fn=lambda t: 1.0,
+            density_side_effect=lambda t, gd: next(iots),
+        )
+        s.generate_grains()
+        assert len(s.voices[0]) > len(s.voices[1])
+        assert len(s.voices[1]) > 0
+
+    def test_scatter_partial_blend_v0_more_than_v1(self):
+        """scatter=0.5, IOT alternato → v1 avanza più veloce di v0 → v0 > v1."""
+        # sync_iot (v0) < blend(sync, indep, 0.5) (v1): v0 ha più grani.
+        vm = VoiceManager(max_voices=2)
+        iots = itertools.cycle([0.1, 0.2])
+        s = _make_stream(
+            duration=1.0, voice_manager=vm,
+            scatter_fn=lambda t: 0.5,
+            density_side_effect=lambda t, gd: next(iots),
+        )
+        s.generate_grains()
+        assert len(s.voices[0]) > len(s.voices[1])
+        assert len(s.voices[1]) > 0
+
+    # ── SCATTER COME ENVELOPE ──────────────────────────────────────────────
+
+    def test_scatter_get_value_called_per_iteration(self):
+        """_scatter.get_value viene chiamato una volta per iterazione del while."""
+        vm = VoiceManager(max_voices=2)
+        s = _make_stream(duration=1.0, inter_onset=0.1, voice_manager=vm)
+        s.generate_grains()
+        ticks = len(s.voices[0])
+        assert s._scatter.get_value.call_count == ticks
+
+    def test_scatter_grains_sorted_by_onset_with_diverging_cursors(self):
+        """Anche con cursori divergenti, s.grains è ordinato per onset."""
+        vm = VoiceManager(max_voices=2)
+        iots = itertools.cycle([0.1, 0.2])
+        s = _make_stream(
+            duration=1.0, voice_manager=vm,
+            scatter_fn=lambda t: 1.0,
+            density_side_effect=lambda t, gd: next(iots),
+        )
+        s.generate_grains()
+        onsets = [g.onset for g in s.grains]
+        assert onsets == sorted(onsets)

--- a/tests/core/test_stream_voices_yaml.py
+++ b/tests/core/test_stream_voices_yaml.py
@@ -1,0 +1,492 @@
+# tests/core/test_stream_voices_yaml.py
+"""
+test_stream_voices_yaml.py
+
+Suite TDD per il parsing del blocco YAML `voices:` in Stream._init_voice_manager.
+
+Verifica che Stream costruisca correttamente VoiceManager dai parametri YAML:
+
+  voices:
+    num_voices: 4
+    pitch:
+      strategy: chord
+      chord: "dom7"
+    onset_offset:
+      strategy: linear
+      step: 0.05
+    pointer:
+      strategy: stochastic
+      pointer_range: 0.1
+    pan:
+      strategy: linear
+      spread: 60
+
+Principi:
+- voices assente → VoiceManager(max_voices=1, nessuna strategy)
+- stream_id auto-iniettato nelle strategy stochastiche
+- spread estratto dal blocco pan e passato a VoiceManager
+- strategy names invalidi → ValueError/KeyError
+
+Organizzazione:
+  1.  Default senza voices
+  2.  num_voices
+  3.  pitch strategy
+  4.  onset_offset strategy
+  5.  pointer strategy
+  6.  pan strategy + spread
+  7.  strategy stochastiche — stream_id auto-iniettato
+  8.  Blocco voices parziale
+  9.  Strategie invalide → errore
+  10. Integrazione end-to-end: VoiceManager usato in generate_grains
+"""
+
+import pytest
+from unittest.mock import patch, Mock
+
+from core.stream import Stream
+from controllers.voice_manager import VoiceManager, VoiceConfig
+from strategies.voice_pitch_strategy import (
+    StepPitchStrategy, RangePitchStrategy,
+    ChordPitchStrategy, StochasticPitchStrategy,
+)
+from strategies.voice_onset_strategy import (
+    LinearOnsetStrategy, GeometricOnsetStrategy, StochasticOnsetStrategy,
+)
+from strategies.voice_pointer_strategy import (
+    LinearPointerStrategy, StochasticPointerStrategy,
+)
+from strategies.voice_pan_strategy import LinearPanStrategy
+
+
+# =============================================================================
+# HELPERS
+# =============================================================================
+
+SAMPLE_DUR = 5.0
+
+def _build_stream(voices_params=None, stream_id='s1'):
+    """Costruisce uno Stream reale con params YAML minimi + voices block."""
+    params = {
+        'stream_id': stream_id,
+        'onset': 0.0,
+        'duration': 10.0,
+        'sample': 'test.wav',
+    }
+    if voices_params is not None:
+        params['voices'] = voices_params
+
+    with patch('core.stream.get_sample_duration', return_value=SAMPLE_DUR):
+        return Stream(params)
+
+
+# =============================================================================
+# 1. Default — voices assente
+# =============================================================================
+
+class TestVoicesDefault:
+
+    def test_no_voices_key_max_voices_1(self):
+        s = _build_stream()
+        assert s._voice_manager.max_voices == 1
+
+    def test_no_voices_key_voice_config_0_is_zero(self):
+        s = _build_stream()
+        vc = s._voice_manager.get_voice_config(0)
+        assert vc == VoiceConfig(0.0, 0.0, 0.0, 0.0)
+
+    def test_empty_voices_dict_max_voices_1(self):
+        s = _build_stream(voices_params={})
+        assert s._voice_manager.max_voices == 1
+
+
+# =============================================================================
+# 2. num_voices
+# =============================================================================
+
+class TestNumVoices:
+
+    def test_num_voices_4(self):
+        s = _build_stream({'num_voices': 4})
+        assert s._voice_manager.max_voices == 4
+
+    def test_num_voices_1_explicit(self):
+        s = _build_stream({'num_voices': 1})
+        assert s._voice_manager.max_voices == 1
+
+    def test_num_voices_default_when_absent(self):
+        s = _build_stream({'pitch': {'strategy': 'step', 'step': 3.0}})
+        assert s._voice_manager.max_voices == 1
+
+
+# =============================================================================
+# 3. Pitch strategy
+# =============================================================================
+
+class TestVoicesPitchStrategy:
+
+    def test_step_pitch_strategy(self):
+        s = _build_stream({
+            'num_voices': 3,
+            'pitch': {'strategy': 'step', 'step': 4.0},
+        })
+        assert s._voice_manager.get_voice_config(1).pitch_offset == pytest.approx(4.0)
+        assert s._voice_manager.get_voice_config(2).pitch_offset == pytest.approx(8.0)
+
+    def test_range_pitch_strategy(self):
+        s = _build_stream({
+            'num_voices': 3,
+            'pitch': {'strategy': 'range', 'semitone_range': 12.0},
+        })
+        assert s._voice_manager.get_voice_config(0).pitch_offset == 0.0
+        assert s._voice_manager.get_voice_config(2).pitch_offset == pytest.approx(12.0)
+
+    def test_chord_pitch_strategy_dom7(self):
+        s = _build_stream({
+            'num_voices': 4,
+            'pitch': {'strategy': 'chord', 'chord': 'dom7'},
+        })
+        assert s._voice_manager.get_voice_config(1).pitch_offset == 4.0
+        assert s._voice_manager.get_voice_config(2).pitch_offset == 7.0
+        assert s._voice_manager.get_voice_config(3).pitch_offset == 10.0
+
+    def test_chord_pitch_strategy_maj(self):
+        s = _build_stream({
+            'num_voices': 3,
+            'pitch': {'strategy': 'chord', 'chord': 'maj'},
+        })
+        assert s._voice_manager.get_voice_config(1).pitch_offset == 4.0
+        assert s._voice_manager.get_voice_config(2).pitch_offset == 7.0
+
+    def test_no_pitch_block_pitch_offset_zero(self):
+        s = _build_stream({'num_voices': 3})
+        for i in range(3):
+            assert s._voice_manager.get_voice_config(i).pitch_offset == 0.0
+
+
+# =============================================================================
+# 4. Onset strategy
+# =============================================================================
+
+class TestVoicesOnsetStrategy:
+
+    def test_linear_onset_strategy(self):
+        s = _build_stream({
+            'num_voices': 3,
+            'onset_offset': {'strategy': 'linear', 'step': 0.1},
+        })
+        assert s._voice_manager.get_voice_config(1).onset_offset == pytest.approx(0.1)
+        assert s._voice_manager.get_voice_config(2).onset_offset == pytest.approx(0.2)
+
+    def test_geometric_onset_strategy(self):
+        s = _build_stream({
+            'num_voices': 3,
+            'onset_offset': {'strategy': 'geometric', 'step': 0.1, 'base': 2.0},
+        })
+        assert s._voice_manager.get_voice_config(1).onset_offset == pytest.approx(0.1)
+        assert s._voice_manager.get_voice_config(2).onset_offset == pytest.approx(0.2)
+
+    def test_no_onset_block_onset_offset_zero(self):
+        s = _build_stream({'num_voices': 3})
+        for i in range(3):
+            assert s._voice_manager.get_voice_config(i).onset_offset == 0.0
+
+
+# =============================================================================
+# 5. Pointer strategy
+# =============================================================================
+
+class TestVoicesPointerStrategy:
+
+    def test_linear_pointer_strategy(self):
+        s = _build_stream({
+            'num_voices': 3,
+            'pointer': {'strategy': 'linear', 'step': 0.1},
+        })
+        assert s._voice_manager.get_voice_config(1).pointer_offset == pytest.approx(0.1)
+        assert s._voice_manager.get_voice_config(2).pointer_offset == pytest.approx(0.2)
+
+    def test_no_pointer_block_pointer_offset_zero(self):
+        s = _build_stream({'num_voices': 3})
+        for i in range(3):
+            assert s._voice_manager.get_voice_config(i).pointer_offset == 0.0
+
+
+# =============================================================================
+# 6. Pan strategy + spread
+# =============================================================================
+
+class TestVoicesPanStrategy:
+
+    def test_linear_pan_strategy_with_spread(self):
+        """LinearPanStrategy con 2 voci e spread=60: voce 1 → +30."""
+        s = _build_stream({
+            'num_voices': 2,
+            'pan': {'strategy': 'linear', 'spread': 60.0},
+        })
+        assert s._voice_manager.get_voice_config(0).pan_offset == 0.0
+        assert s._voice_manager.get_voice_config(1).pan_offset == pytest.approx(30.0)
+
+    def test_spread_zero_all_pan_zero(self):
+        s = _build_stream({
+            'num_voices': 3,
+            'pan': {'strategy': 'linear', 'spread': 0.0},
+        })
+        for i in range(3):
+            assert s._voice_manager.get_voice_config(i).pan_offset == 0.0
+
+    def test_no_pan_block_pan_offset_zero(self):
+        s = _build_stream({'num_voices': 3})
+        for i in range(3):
+            assert s._voice_manager.get_voice_config(i).pan_offset == 0.0
+
+
+# =============================================================================
+# 7. Stochastic strategies — stream_id auto-iniettato
+# =============================================================================
+
+class TestStochasticStreamIdInjection:
+
+    def test_stochastic_pitch_deterministic_by_stream_id(self):
+        """Due stream con id diversi → pitch offsets diversi."""
+        s1 = _build_stream({
+            'num_voices': 3,
+            'pitch': {'strategy': 'stochastic', 'semitone_range': 3.0},
+        }, stream_id='stream_A')
+        s2 = _build_stream({
+            'num_voices': 3,
+            'pitch': {'strategy': 'stochastic', 'semitone_range': 3.0},
+        }, stream_id='stream_B')
+        offsets1 = [s1._voice_manager.get_voice_config(i).pitch_offset for i in range(1, 3)]
+        offsets2 = [s2._voice_manager.get_voice_config(i).pitch_offset for i in range(1, 3)]
+        assert offsets1 != offsets2
+
+    def test_stochastic_pitch_same_stream_id_reproducible(self):
+        """Due stream con stesso id → stessi pitch offsets."""
+        s1 = _build_stream({
+            'num_voices': 3,
+            'pitch': {'strategy': 'stochastic', 'semitone_range': 3.0},
+        }, stream_id='same_stream')
+        s2 = _build_stream({
+            'num_voices': 3,
+            'pitch': {'strategy': 'stochastic', 'semitone_range': 3.0},
+        }, stream_id='same_stream')
+        for i in range(3):
+            assert (s1._voice_manager.get_voice_config(i).pitch_offset ==
+                    s2._voice_manager.get_voice_config(i).pitch_offset)
+
+    def test_stochastic_onset_stream_id_injected(self):
+        """StochasticOnsetStrategy riceve stream_id automaticamente."""
+        s = _build_stream({
+            'num_voices': 3,
+            'onset_offset': {'strategy': 'stochastic', 'max_offset': 0.2},
+        }, stream_id='my_stream')
+        # Se stream_id fosse mancante, solleverebbe TypeError
+        for i in range(3):
+            offset = s._voice_manager.get_voice_config(i).onset_offset
+            assert 0.0 <= offset <= 0.2
+
+    def test_stochastic_pointer_stream_id_injected(self):
+        """StochasticPointerStrategy riceve stream_id automaticamente."""
+        s = _build_stream({
+            'num_voices': 3,
+            'pointer': {'strategy': 'stochastic', 'pointer_range': 0.1},
+        }, stream_id='my_stream')
+        for i in range(3):
+            offset = s._voice_manager.get_voice_config(i).pointer_offset
+            assert -0.1 <= offset <= 0.1
+
+
+# =============================================================================
+# 8. Blocco voices parziale
+# =============================================================================
+
+class TestPartialVoicesBlock:
+
+    def test_only_num_voices_no_strategies(self):
+        s = _build_stream({'num_voices': 4})
+        assert s._voice_manager.max_voices == 4
+        for i in range(4):
+            assert s._voice_manager.get_voice_config(i).pitch_offset == 0.0
+            assert s._voice_manager.get_voice_config(i).onset_offset == 0.0
+
+    def test_pitch_only_onset_zero(self):
+        s = _build_stream({
+            'num_voices': 3,
+            'pitch': {'strategy': 'step', 'step': 3.0},
+        })
+        assert s._voice_manager.get_voice_config(1).onset_offset == 0.0
+
+    def test_onset_only_pitch_zero(self):
+        s = _build_stream({
+            'num_voices': 3,
+            'onset_offset': {'strategy': 'linear', 'step': 0.1},
+        })
+        assert s._voice_manager.get_voice_config(1).pitch_offset == 0.0
+
+
+# =============================================================================
+# 9. Strategy invalide → errore
+# =============================================================================
+
+class TestInvalidStrategies:
+
+    def test_invalid_pitch_strategy_raises(self):
+        with pytest.raises((KeyError, ValueError)):
+            _build_stream({
+                'num_voices': 2,
+                'pitch': {'strategy': 'nonexistent_xyz'},
+            })
+
+    def test_invalid_onset_strategy_raises(self):
+        with pytest.raises((KeyError, ValueError)):
+            _build_stream({
+                'num_voices': 2,
+                'onset_offset': {'strategy': 'nonexistent_xyz'},
+            })
+
+    def test_invalid_pointer_strategy_raises(self):
+        with pytest.raises((KeyError, ValueError)):
+            _build_stream({
+                'num_voices': 2,
+                'pointer': {'strategy': 'nonexistent_xyz'},
+            })
+
+
+# =============================================================================
+# 10. Integrazione: VoiceManager effettivamente usato in generate_grains
+# =============================================================================
+
+class TestVoicesYamlIntegration:
+
+    def _prep_for_generate(self, s):
+        """Prepara uno Stream reale per generate_grains senza Generator."""
+        mock_density = Mock()
+        mock_density.calculate_inter_onset = Mock(return_value=0.1)
+        s._density = mock_density
+        s.sample_table_num = 1
+        s.window_table_map = {'hanning': 2}
+
+    def test_num_voices_2_doubles_grains(self):
+        """Con num_voices=2, generate_grains produce il doppio dei grani."""
+        s1 = _build_stream({'num_voices': 1})
+        s2 = _build_stream({'num_voices': 2})
+        self._prep_for_generate(s1)
+        self._prep_for_generate(s2)
+
+        s1.generate_grains()
+        s2.generate_grains()
+
+        assert len(s2.grains) == len(s1.grains) * 2
+
+    def test_chord_dom7_pitch_ratios_in_grains(self):
+        """Voce 1 con dom7 ha pitch_ratio base × 2^(4/12)."""
+        s = _build_stream({
+            'num_voices': 2,
+            'pitch': {'strategy': 'chord', 'chord': 'dom7'},
+        })
+        self._prep_for_generate(s)
+
+        s.generate_grains()
+
+        voice_1 = s.voices[1]
+        expected = 2 ** (4.0 / 12.0)
+        assert all(g.pitch_ratio == pytest.approx(expected, rel=1e-4) for g in voice_1)
+
+
+# =============================================================================
+# 11. num_voices come Envelope (time-varying)
+# =============================================================================
+
+class TestNumVoicesEnvelope:
+    """
+    num_voices può essere un Envelope YAML → Stream pre-computa max_voices
+    e genera grains con il conteggio giusto per tick.
+    """
+
+    def test_envelope_num_voices_max_voices_precomputed_from_peak(self):
+        """VoiceManager.max_voices == picco dell'envelope."""
+        s = _build_stream({'num_voices': [[0, 1], [5, 4]]})
+        assert s._voice_manager.max_voices == 4
+
+    def test_envelope_num_voices_stored_as_parameter_with_get_value(self):
+        """stream.num_voices espone get_value()."""
+        s = _build_stream({'num_voices': [[0, 1], [5, 4]]})
+        assert hasattr(s.num_voices, 'get_value')
+        assert callable(s.num_voices.get_value)
+
+    def test_envelope_num_voices_evaluates_1_at_start(self):
+        s = _build_stream({'num_voices': [[0, 1], [5, 4]]})
+        assert int(s.num_voices.get_value(0.0)) == 1
+
+    def test_envelope_num_voices_evaluates_4_at_peak(self):
+        s = _build_stream({'num_voices': [[0, 1], [5, 4]]})
+        assert int(s.num_voices.get_value(5.0)) == 4
+
+    def test_static_num_voices_stored_as_parameter(self):
+        """Anche num_voices: 3 statico viene esposto come Parameter."""
+        s = _build_stream({'num_voices': 3})
+        assert hasattr(s.num_voices, 'get_value')
+        assert int(s.num_voices.get_value(0.0)) == 3
+
+    def test_envelope_num_voices_integration_voice_0_gets_all_ticks(self):
+        """Con Envelope 1→4, la voce 0 riceve un grano per ogni tick."""
+        s = _build_stream({'num_voices': [[0, 1], [5, 4]]})
+        prep = lambda st: setattr(
+            st, '_density',
+            type('D', (), {'calculate_inter_onset': staticmethod(lambda t, d: 1.0)})()
+        )
+        prep(s)
+        s.sample_table_num = 1
+        s.window_table_map = {'hanning': 2}
+        s.generate_grains()
+        # voice 0 è sempre attiva → ha un grano per ogni tick
+        assert len(s.voices[0]) == int(s.duration)
+
+    def test_envelope_num_voices_integration_voice_3_activates_late(self):
+        """Con Envelope 1→4, la voce 3 riceve meno grani della voce 0."""
+        s = _build_stream({'num_voices': [[0, 1], [5, 4]]})
+        s._density = type('D', (), {'calculate_inter_onset': staticmethod(lambda t, d: 1.0)})()
+        s.sample_table_num = 1
+        s.window_table_map = {'hanning': 2}
+        s.generate_grains()
+        assert len(s.voices[3]) < len(s.voices[0])
+        assert len(s.voices[3]) > 0  # ma diventa attiva
+
+
+# =============================================================================
+# 12. scatter — parsing YAML
+# =============================================================================
+
+class TestScatterParsing:
+    """
+    scatter nel blocco voices: viene parsato come Parameter.
+    Default = 0.0 (cluster, backward compat).
+    """
+
+    def test_no_scatter_default_is_zero(self):
+        """Senza scatter nel blocco voices, default = 0.0."""
+        s = _build_stream({'num_voices': 2})
+        assert s._scatter.get_value(0.0) == pytest.approx(0.0)
+
+    def test_scatter_static_value(self):
+        """scatter: 0.8 → Parameter che vale 0.8."""
+        s = _build_stream({'num_voices': 2, 'scatter': 0.8})
+        assert s._scatter.get_value(0.0) == pytest.approx(0.8)
+
+    def test_scatter_envelope(self):
+        """scatter come Envelope [[0, 0.0], [10, 1.0]]."""
+        s = _build_stream({'num_voices': 2, 'scatter': [[0, 0.0], [10, 1.0]]})
+        assert s._scatter.get_value(0.0) == pytest.approx(0.0)
+        assert s._scatter.get_value(10.0) == pytest.approx(1.0)
+        assert 0.0 < s._scatter.get_value(5.0) < 1.0
+
+    def test_no_voices_block_scatter_exists_and_is_zero(self):
+        """Senza blocco voices, _scatter esiste con valore 0.0."""
+        s = _build_stream()
+        assert hasattr(s, '_scatter')
+        assert s._scatter.get_value(0.0) == pytest.approx(0.0)
+
+    def test_scatter_has_get_value(self):
+        """_scatter espone get_value (è un Parameter)."""
+        s = _build_stream({'num_voices': 2, 'scatter': 0.5})
+        assert callable(s._scatter.get_value)

--- a/tests/e2e/test_numpy_renderer_e2e.py
+++ b/tests/e2e/test_numpy_renderer_e2e.py
@@ -6,13 +6,9 @@ Invoca `make all RENDERER=numpy` come subprocess e verifica
 che la pipeline YAML → NumPy → .aif produca i file corretti.
 
 Scenari:
-1. TestNumpyStems - STEMS=true: un .aif per stream, naming corretto
-2. TestNumpyMix   - STEMS=false: un .aif unico con tutti gli stream
-
-Differenze rispetto ai test Csound E2E:
-- Nessun cache/manifest (StreamCacheManager non è usato da NumPy)
-- Nessun subprocess csound: tutto in-process Python
-- Ogni build ri-renderizza sempre tutto (no incremental)
+1. TestNumpyStems      - STEMS=true: un .aif per stream, naming corretto
+2. TestNumpyMix        - STEMS=false: un .aif unico con tutti gli stream
+3. TestNumpyStemsCache - STEMS=true CACHE=true: dirty/clean incrementale
 
 Requisiti:
   - sox nel PATH (per audio trimming)
@@ -83,16 +79,29 @@ def _write_yaml(tmp_path, content: str):
     (configs_dir / "e2e_numpy_test.yml").write_text(content)
 
 
-def _make_build_stems(tmp_path):
+def _load_manifest(tmp_path) -> dict:
+    """Carica il manifest JSON dalla cache temporanea."""
+    import json
+    manifest_path = tmp_path / "cache" / "e2e_numpy_test.json"
+    if not manifest_path.exists():
+        return {}
+    return json.loads(manifest_path.read_text())
+
+
+def _make_build_stems(tmp_path, cache=True):
     """
     Invoca `make all STEMS=true RENDERER=numpy` con directory temporanee.
+
+    Args:
+        cache: se True passa CACHE=true (abilita manifest incrementale)
 
     Returns:
         tuple (CompletedProcess, str) — processo e output combinato
     """
-    sfdir  = tmp_path / "output"
-    logdir = tmp_path / "logs"
-    ymldir = tmp_path / "configs"
+    sfdir    = tmp_path / "output"
+    cachedir = tmp_path / "cache"
+    logdir   = tmp_path / "logs"
+    ymldir   = tmp_path / "configs"
 
     for d in (sfdir, logdir, ymldir):
         d.mkdir(exist_ok=True)
@@ -102,12 +111,14 @@ def _make_build_stems(tmp_path):
         'FILE=e2e_numpy_test',
         'STEMS=true',
         'RENDERER=numpy',
+        f'CACHE={"true" if cache else "false"}',
         'AUTOKILL=false',
         'AUTOPEN=false',
         'AUTOVISUAL=false',
         'SHOWSTATIC=false',
         'PRECLEAN=false',
         f'SFDIR={sfdir}',
+        f'CACHEDIR={cachedir}',
         f'LOGDIR={logdir}',
         f'YMLDIR={ymldir}',
     ]
@@ -201,16 +212,16 @@ class TestNumpyStems:
         assert len(aif_files) == 3, \
             f"attesi 3 file .aif, trovati {len(aif_files)}: {aif_files}"
 
-    def test_no_cache_manifest_created(self, tmp_path):
-        """NumPy non usa StreamCacheManager: nessun manifest JSON creato."""
+    def test_no_cache_manifest_without_cache_flag(self, tmp_path):
+        """Senza CACHE=true non viene creato alcun manifest JSON."""
         _write_yaml(tmp_path, _YAML_TWO_STREAMS)
-        result, output = _make_build_stems(tmp_path)
+        result, output = _make_build_stems(tmp_path, cache=False)
 
         assert result.returncode == 0, f"make fallito:\n{output}"
 
         cache_dir = tmp_path / "cache"
         assert not cache_dir.exists() or not list(cache_dir.glob("*.json")), \
-            "manifest JSON creato per errore da renderer NumPy"
+            "manifest JSON creato per errore senza CACHE=true"
 
 
 # =============================================================================
@@ -242,3 +253,72 @@ class TestNumpyMix:
         per_stream_files = list(sfdir.glob("e2e_numpy_test_*.aif"))
         assert len(per_stream_files) == 0, \
             f"file per-stream creati per errore in MIX mode: {per_stream_files}"
+
+
+# =============================================================================
+# 3. STEMS + CACHE (numpy incrementale)
+# =============================================================================
+
+_YAML_S1_MODIFIED = """\
+composition:
+  title: "e2e numpy test"
+
+streams:
+  - stream_id: "s1"
+    onset: 0.0
+    duration: 1.5
+    sample: "pino.wav"
+  - stream_id: "s2"
+    onset: 1.0
+    duration: 1.0
+    sample: "pino.wav"
+"""
+
+
+@pytest.mark.e2e
+class TestNumpyStemsCache:
+    """STEMS=true RENDERER=numpy CACHE=true: build incrementale."""
+
+    def test_first_build_both_dirty(self, tmp_path):
+        """Prima build: entrambi gli stream DIRTY."""
+        _write_yaml(tmp_path, _YAML_TWO_STREAMS)
+        result, output = _make_build_stems(tmp_path, cache=True)
+
+        assert result.returncode == 0, f"make fallito:\n{output}"
+        assert "[CACHE] s1: DIRTY" in output
+        assert "[CACHE] s2: DIRTY" in output
+
+    def test_manifest_created_after_first_build(self, tmp_path):
+        """Prima build: manifest JSON creato con fingerprint per s1 e s2."""
+        _write_yaml(tmp_path, _YAML_TWO_STREAMS)
+        result, output = _make_build_stems(tmp_path, cache=True)
+
+        assert result.returncode == 0, f"make fallito:\n{output}"
+
+        manifest = _load_manifest(tmp_path)
+        assert "s1" in manifest
+        assert "s2" in manifest
+
+    def test_second_build_both_clean(self, tmp_path):
+        """Seconda build invariata: entrambi gli stream clean."""
+        _write_yaml(tmp_path, _YAML_TWO_STREAMS)
+        r1, _ = _make_build_stems(tmp_path, cache=True)
+        assert r1.returncode == 0
+
+        r2, output2 = _make_build_stems(tmp_path, cache=True)
+        assert r2.returncode == 0
+        assert "[CACHE] s1: clean" in output2
+        assert "[CACHE] s2: clean" in output2
+
+    def test_partial_rebuild_only_modified_stream_dirty(self, tmp_path):
+        """Modifica s1: solo s1 DIRTY, s2 clean."""
+        _write_yaml(tmp_path, _YAML_TWO_STREAMS)
+        r1, _ = _make_build_stems(tmp_path, cache=True)
+        assert r1.returncode == 0
+
+        _write_yaml(tmp_path, _YAML_S1_MODIFIED)
+        r2, output2 = _make_build_stems(tmp_path, cache=True)
+        assert r2.returncode == 0
+
+        assert "[CACHE] s1: DIRTY" in output2
+        assert "[CACHE] s2: clean" in output2

--- a/tests/parameters/test_parameter_definitions.py
+++ b/tests/parameters/test_parameter_definitions.py
@@ -54,7 +54,7 @@ EXPECTED_PARAMETERS = {
     'volume', 'pan',
     # Voices
     'num_voices', 'voice_pitch_offset', 'voice_pointer_offset',
-    'voice_pointer_range',
+    'voice_pointer_range', 'scatter',
 }
 
 # Variation modes validi nel sistema
@@ -479,7 +479,7 @@ class TestPointerBounds:
     def test_loop_dur_bounds(self):
         b = GRANULAR_PARAMETERS['loop_dur']
         assert b.min_val == 0.005
-        assert b.max_val == 100.0
+        # max_val statico è un fallback permissivo: il bound reale è sample_dur_sec
 
     def test_loop_dur_min_positive(self):
         assert GRANULAR_PARAMETERS['loop_dur'].min_val > 0
@@ -487,18 +487,18 @@ class TestPointerBounds:
     def test_loop_start_bounds(self):
         b = GRANULAR_PARAMETERS['loop_start']
         assert b.min_val == 0
-        assert b.max_val == 100.0
+        # max_val statico è un fallback permissivo: il bound reale è sample_dur_sec
 
     def test_loop_end_bounds(self):
         b = GRANULAR_PARAMETERS['loop_end']
         assert b.min_val == 0.0
-        assert b.max_val == 100.0
+        # max_val statico è un fallback permissivo: il bound reale è sample_dur_sec
 
     def test_loop_start_end_same_max(self):
-        """loop_start e loop_end hanno lo stesso max_val."""
-        s = GRANULAR_PARAMETERS['loop_start']
-        e = GRANULAR_PARAMETERS['loop_end']
-        assert s.max_val == e.max_val
+        """Con sample_dur_sec, loop_start e loop_end hanno lo stesso max_val dinamico."""
+        s = get_parameter_definition('loop_start', sample_dur_sec=30.0)
+        e = get_parameter_definition('loop_end', sample_dur_sec=30.0)
+        assert s.max_val == e.max_val == 30.0
 
 
 # =============================================================================
@@ -590,6 +590,17 @@ class TestVoicesBounds:
     def test_voice_pointer_range_non_negative(self):
         """voice_pointer_range >= 0 (e' un range, non puo' essere negativo)."""
         assert GRANULAR_PARAMETERS['voice_pointer_range'].min_val >= 0
+
+    def test_scatter_present_in_registry(self):
+        assert 'scatter' in GRANULAR_PARAMETERS
+
+    def test_scatter_bounds(self):
+        b = GRANULAR_PARAMETERS['scatter']
+        assert b.min_val == 0.0
+        assert b.max_val == 1.0
+
+    def test_scatter_variation_mode_additive(self):
+        assert GRANULAR_PARAMETERS['scatter'].variation_mode == 'additive'
 
 
 # =============================================================================
@@ -907,3 +918,72 @@ class TestEdgeCases:
         """Passare un intero solleva errore."""
         with pytest.raises((KeyError, TypeError)):
             get_parameter_definition(42)
+
+
+# =============================================================================
+# 14. BOUNDS DINAMICI PER PARAMETRI LOOP (sample_dur_sec)
+# =============================================================================
+
+LOOP_PARAMS = ['loop_dur', 'loop_start', 'loop_end']
+
+
+class TestGetParameterDefinitionDynamic:
+    """
+    get_parameter_definition(name, sample_dur_sec=X) deve restituire bounds
+    con max_val = sample_dur_sec per i parametri loop_dur, loop_start, loop_end.
+    Per tutti gli altri parametri il comportamento rimane invariato.
+    """
+
+    @pytest.mark.parametrize("name", LOOP_PARAMS)
+    def test_loop_param_uses_sample_dur_as_max(self, name):
+        """sample_dur_sec diventa max_val per i parametri loop."""
+        bounds = get_parameter_definition(name, sample_dur_sec=45.0)
+        assert bounds.max_val == 45.0
+
+    @pytest.mark.parametrize("name", LOOP_PARAMS)
+    def test_min_val_preserved_with_sample_dur(self, name):
+        """min_val del registry statico è preservato anche con sample_dur_sec."""
+        original = GRANULAR_PARAMETERS[name]
+        bounds = get_parameter_definition(name, sample_dur_sec=45.0)
+        assert bounds.min_val == original.min_val
+
+    @pytest.mark.parametrize("name", LOOP_PARAMS)
+    def test_other_fields_preserved_with_sample_dur(self, name):
+        """min_range, max_range, variation_mode sono preservati."""
+        original = GRANULAR_PARAMETERS[name]
+        bounds = get_parameter_definition(name, sample_dur_sec=45.0)
+        assert bounds.min_range == original.min_range
+        assert bounds.max_range == original.max_range
+        assert bounds.variation_mode == original.variation_mode
+
+    @pytest.mark.parametrize("name", LOOP_PARAMS)
+    def test_returns_new_bounds_object_not_mutate_registry(self, name):
+        """Con sample_dur_sec restituisce un NUOVO oggetto, non muta il registry."""
+        original_max = GRANULAR_PARAMETERS[name].max_val
+        bounds = get_parameter_definition(name, sample_dur_sec=99.0)
+        assert bounds is not GRANULAR_PARAMETERS[name]
+        assert GRANULAR_PARAMETERS[name].max_val == original_max  # immutato
+
+    def test_loop_start_end_same_max_with_sample_dur(self):
+        """loop_start e loop_end hanno lo stesso max_val quando sample_dur_sec è dato."""
+        s = get_parameter_definition('loop_start', sample_dur_sec=30.0)
+        e = get_parameter_definition('loop_end', sample_dur_sec=30.0)
+        assert s.max_val == e.max_val == 30.0
+
+    def test_without_sample_dur_returns_static_object(self):
+        """Senza sample_dur_sec, restituisce il bounds statico invariato."""
+        for name in LOOP_PARAMS:
+            result = get_parameter_definition(name)
+            assert result is GRANULAR_PARAMETERS[name]
+
+    def test_non_loop_param_unaffected_by_sample_dur(self):
+        """Parametri non-loop ignorano sample_dur_sec."""
+        bounds_with = get_parameter_definition('density', sample_dur_sec=45.0)
+        bounds_without = get_parameter_definition('density')
+        assert bounds_with is bounds_without
+
+    @pytest.mark.parametrize("dur", [1.0, 10.5, 60.0, 300.0, 3600.0])
+    def test_various_sample_durations(self, dur):
+        """Il bound dinamico funziona per qualsiasi durata positiva."""
+        bounds = get_parameter_definition('loop_end', sample_dur_sec=dur)
+        assert bounds.max_val == dur

--- a/tests/parameters/test_parameter_factory.py
+++ b/tests/parameters/test_parameter_factory.py
@@ -221,7 +221,7 @@ class TestCreateConstantParameter:
 
     def test_restituisce_un_parameter(self):
         factory = ParameterFactory(make_config())
-        result = factory.create_constant_parameter('loop_end', 8.0)
+        result = factory.create_constant_parameter('loop_end', 4.0)
         assert isinstance(result, Parameter)
 
     def test_valore_corretto(self):
@@ -359,7 +359,7 @@ class TestParameterOrchestrator:
 
     def test_create_constant_parameter_restituisce_parameter(self):
         orchestrator = ParameterOrchestrator(make_config())
-        result = orchestrator.create_constant_parameter('loop_end', 8.0)
+        result = orchestrator.create_constant_parameter('loop_end', 4.0)
         assert isinstance(result, Parameter)
 
     def test_create_constant_parameter_delega_alla_factory(self):
@@ -695,11 +695,90 @@ class TestFactoryOrchestratorParametrized:
         schema = [
             ParameterSpec('volume', 'value', -6.0, is_smart=is_smart)
         ]
-        yaml_data = {'value': -12.0}        
+        yaml_data = {'value': -12.0}
 
         params = orchestrator.create_all_parameters(yaml_data, schema)
-        
+
         if is_smart:
             assert isinstance(params['volume'], Parameter)
         else:
             assert params['volume'] == -12.0
+
+
+def make_config_with_sample_dur(sample_dur_sec: float) -> StreamConfig:
+    """Crea StreamConfig con sample_dur_sec specifico per test loop bounds."""
+    context = StreamContext(
+        stream_id='test_stream',
+        onset=0.0,
+        duration=10.0,
+        sample='test.wav',
+        sample_dur_sec=sample_dur_sec,
+    )
+    return StreamConfig(context=context)
+
+
+# =============================================================================
+# TEST INTEGRAZIONE — PARSER LOOP BOUNDS DINAMICI
+# =============================================================================
+
+class TestParserDynamicLoopBounds:
+    """
+    GranularParser deve validare loop_end, loop_start, loop_dur
+    usando sample_dur_sec come max_val effettivo.
+    """
+
+    def test_parser_stores_sample_dur_sec(self):
+        """GranularParser memorizza sample_dur_sec dal config."""
+        config = make_config_with_sample_dur(8.0)
+        parser = GranularParser(config)
+        assert parser.sample_dur_sec == 8.0
+
+    def test_loop_end_within_sample_dur_is_valid(self):
+        """loop_end <= sample_dur_sec deve essere accettato."""
+        config = make_config_with_sample_dur(10.0)
+        parser = GranularParser(config)
+        param = parser.parse_parameter('loop_end', 8.0)
+        assert param.get_value(0) == pytest.approx(8.0)
+
+    def test_loop_end_exceeds_sample_dur_raises(self):
+        """loop_end > sample_dur_sec deve sollevare ValueError in strict mode."""
+        config = make_config_with_sample_dur(10.0)
+        parser = GranularParser(config)
+        with pytest.raises(ValueError):
+            parser.parse_parameter('loop_end', 15.0)
+
+    def test_loop_start_within_sample_dur_is_valid(self):
+        """loop_start <= sample_dur_sec deve essere accettato."""
+        config = make_config_with_sample_dur(10.0)
+        parser = GranularParser(config)
+        param = parser.parse_parameter('loop_start', 3.0)
+        assert param.get_value(0) == pytest.approx(3.0)
+
+    def test_loop_start_exceeds_sample_dur_raises(self):
+        """loop_start > sample_dur_sec deve sollevare ValueError."""
+        config = make_config_with_sample_dur(10.0)
+        parser = GranularParser(config)
+        with pytest.raises(ValueError):
+            parser.parse_parameter('loop_start', 12.0)
+
+    def test_loop_dur_within_sample_dur_is_valid(self):
+        """loop_dur <= sample_dur_sec deve essere accettato."""
+        config = make_config_with_sample_dur(10.0)
+        parser = GranularParser(config)
+        param = parser.parse_parameter('loop_dur', 5.0)
+        assert param.get_value(0) == pytest.approx(5.0)
+
+    def test_loop_dur_exceeds_sample_dur_raises(self):
+        """loop_dur > sample_dur_sec deve sollevare ValueError."""
+        config = make_config_with_sample_dur(10.0)
+        parser = GranularParser(config)
+        with pytest.raises(ValueError):
+            parser.parse_parameter('loop_dur', 20.0)
+
+    def test_loop_bound_uses_actual_sample_duration(self):
+        """Il bound effettivo dipende da sample_dur_sec, non da una costante fissa."""
+        # Con sample di 200 secondi, loop_end=150 deve essere valido
+        config = make_config_with_sample_dur(200.0)
+        parser = GranularParser(config)
+        param = parser.parse_parameter('loop_end', 150.0)
+        assert param.get_value(0) == pytest.approx(150.0)

--- a/tests/rendering/test_numpy_audio_renderer.py
+++ b/tests/rendering/test_numpy_audio_renderer.py
@@ -385,3 +385,126 @@ class TestEdgeCases:
         data, _ = sf.read(output_path)
         assert np.max(np.abs(data)) < 1e-10
 
+
+# =============================================================================
+# 7. TEST CACHE
+# =============================================================================
+
+class TestNumpyAudioRendererCache:
+    """Cache incrementale: stesso comportamento di CsoundRenderer."""
+
+    def _make_renderer_with_cache(self, cache_path, sample_registry, window_registry, table_map, stream_data_map=None):
+        from rendering.stream_cache_manager import StreamCacheManager
+        cm = StreamCacheManager(cache_path=str(cache_path))
+        return NumpyAudioRenderer(
+            sample_registry=sample_registry,
+            window_registry=window_registry,
+            table_map=table_map,
+            output_sr=OUTPUT_SR,
+            cache_manager=cm,
+            stream_data_map=stream_data_map or {'s1': {'stream_id': 's1', 'duration': 1.0}},
+        )
+
+    def test_cache_manager_none_by_default(self, sample_registry, window_registry, table_map):
+        """cache_manager e' None per default: comportamento invariato."""
+        r = NumpyAudioRenderer(
+            sample_registry=sample_registry,
+            window_registry=window_registry,
+            table_map=table_map,
+        )
+        assert r.cache_manager is None
+
+    def test_dirty_stream_is_rendered(self, sample_registry, window_registry, table_map, tmp_path):
+        """Stream dirty (non in manifest): file viene scritto."""
+        cache_path = tmp_path / 'cache.json'
+        r = self._make_renderer_with_cache(cache_path, sample_registry, window_registry, table_map)
+        stream = make_mock_stream(stream_id='s1', duration=0.2)
+        output_path = str(tmp_path / 's1.aif')
+
+        r.render_single_stream(stream, output_path)
+
+        assert os.path.exists(output_path)
+
+    def test_clean_stream_is_skipped(self, sample_registry, window_registry, table_map, tmp_path):
+        """Stream clean (fingerprint invariato, .aif esiste): non viene riscritto."""
+        import soundfile as sf
+        cache_path = tmp_path / 'cache.json'
+        r = self._make_renderer_with_cache(cache_path, sample_registry, window_registry, table_map)
+        stream = make_mock_stream(stream_id='s1', duration=0.2)
+        output_path = str(tmp_path / 's1.aif')
+
+        # Prima build: crea il file
+        r.render_single_stream(stream, output_path)
+        mtime_first = os.path.getmtime(output_path)
+
+        import time
+        time.sleep(0.05)
+
+        # Seconda build: stream clean → file non riscritto
+        r.render_single_stream(stream, output_path)
+        mtime_second = os.path.getmtime(output_path)
+
+        assert mtime_first == mtime_second
+
+    def test_dirty_stream_logs_dirty(self, sample_registry, window_registry, table_map, tmp_path, capsys):
+        """Stream dirty stampa '[CACHE] s1: DIRTY'."""
+        cache_path = tmp_path / 'cache.json'
+        r = self._make_renderer_with_cache(cache_path, sample_registry, window_registry, table_map)
+        stream = make_mock_stream(stream_id='s1', duration=0.2)
+        output_path = str(tmp_path / 's1.aif')
+
+        r.render_single_stream(stream, output_path)
+
+        captured = capsys.readouterr()
+        assert '[CACHE] s1: DIRTY' in captured.out
+
+    def test_clean_stream_logs_clean(self, sample_registry, window_registry, table_map, tmp_path, capsys):
+        """Stream clean stampa '[CACHE] s1: clean'."""
+        cache_path = tmp_path / 'cache.json'
+        r = self._make_renderer_with_cache(cache_path, sample_registry, window_registry, table_map)
+        stream = make_mock_stream(stream_id='s1', duration=0.2)
+        output_path = str(tmp_path / 's1.aif')
+
+        r.render_single_stream(stream, output_path)  # prima build → dirty
+        capsys.readouterr()  # svuota
+
+        r.render_single_stream(stream, output_path)  # seconda build → clean
+        captured = capsys.readouterr()
+        assert '[CACHE] s1: clean' in captured.out
+
+    def test_manifest_updated_after_build(self, sample_registry, window_registry, table_map, tmp_path):
+        """Il manifest viene aggiornato con il fingerprint dopo la build."""
+        import json
+        from rendering.stream_cache_manager import StreamCacheManager
+        cache_path = tmp_path / 'cache.json'
+        stream_dict = {'stream_id': 's1', 'duration': 1.0}
+        r = self._make_renderer_with_cache(
+            cache_path, sample_registry, window_registry, table_map,
+            stream_data_map={'s1': stream_dict},
+        )
+        stream = make_mock_stream(stream_id='s1', duration=0.2)
+        output_path = str(tmp_path / 's1.aif')
+
+        r.render_single_stream(stream, output_path)
+
+        manifest = json.loads(cache_path.read_text())
+        assert 's1' in manifest
+        expected_fp = StreamCacheManager(str(cache_path)).compute_fingerprint(stream_dict)
+        assert manifest['s1'] == expected_fp
+
+    def test_no_cache_manager_no_skip(self, renderer, tmp_path):
+        """Senza cache_manager, ogni chiamata renderizza sempre."""
+        stream = make_mock_stream(stream_id='s1', duration=0.2)
+        output_path = str(tmp_path / 's1.aif')
+
+        renderer.render_single_stream(stream, output_path)
+        mtime_first = os.path.getmtime(output_path)
+
+        import time
+        time.sleep(0.05)
+
+        renderer.render_single_stream(stream, output_path)
+        mtime_second = os.path.getmtime(output_path)
+
+        assert mtime_second > mtime_first
+

--- a/tests/strategies/test_voice_onset_strategy.py
+++ b/tests/strategies/test_voice_onset_strategy.py
@@ -1,0 +1,380 @@
+# tests/strategies/test_voice_onset_strategy.py
+"""
+test_voice_onset_strategy.py
+
+Suite TDD per voice_onset_strategy.py
+
+Moduli sotto test (da scrivere):
+- VoiceOnsetStrategy (ABC)
+- LinearOnsetStrategy    → voce i = i × step (secondi)
+- GeometricOnsetStrategy → spaziatura esponenziale: step * base^i
+- StochasticOnsetStrategy → offset fisso per voce, seed deterministico
+- VOICE_ONSET_STRATEGIES (registry dict)
+- register_voice_onset_strategy()
+- VoiceOnsetStrategyFactory
+
+Principi di design:
+- Voce 0 restituisce SEMPRE 0.0 (riferimento immutato)
+- Il valore restituito è un offset in SECONDI
+- StochasticOnsetStrategy: seed = hash(stream_id + str(voice_index))
+- L'offset è additivo rispetto all'onset base dello stream
+
+Organizzazione:
+  1.  VoiceOnsetStrategy ABC
+  2.  LinearOnsetStrategy
+  3.  GeometricOnsetStrategy
+  4.  StochasticOnsetStrategy
+  5.  Invariante voce 0
+  6.  Edge cases
+  7.  VOICE_ONSET_STRATEGIES registry
+  8.  register_voice_onset_strategy()
+  9.  VoiceOnsetStrategyFactory
+"""
+
+import pytest
+
+
+# =============================================================================
+# IMPORT LAZY
+# =============================================================================
+
+def _get_module():
+    from strategies.voice_onset_strategy import (
+        VoiceOnsetStrategy,
+        LinearOnsetStrategy,
+        GeometricOnsetStrategy,
+        StochasticOnsetStrategy,
+        VOICE_ONSET_STRATEGIES,
+        register_voice_onset_strategy,
+        VoiceOnsetStrategyFactory,
+    )
+    return (
+        VoiceOnsetStrategy,
+        LinearOnsetStrategy,
+        GeometricOnsetStrategy,
+        StochasticOnsetStrategy,
+        VOICE_ONSET_STRATEGIES,
+        register_voice_onset_strategy,
+        VoiceOnsetStrategyFactory,
+    )
+
+
+# =============================================================================
+# FIXTURES
+# =============================================================================
+
+@pytest.fixture(autouse=True)
+def restore_registry():
+    try:
+        _, _, _, _, registry, _, _ = _get_module()
+        original = dict(registry)
+        yield
+        registry.clear()
+        registry.update(original)
+    except ImportError:
+        yield
+
+
+# =============================================================================
+# 1. VoiceOnsetStrategy ABC
+# =============================================================================
+
+class TestVoiceOnsetStrategyABC:
+
+    def test_is_abstract(self):
+        VoiceOnsetStrategy, *_ = _get_module()
+        with pytest.raises(TypeError):
+            VoiceOnsetStrategy()
+
+    def test_get_onset_offset_is_abstract(self):
+        VoiceOnsetStrategy, *_ = _get_module()
+        assert hasattr(VoiceOnsetStrategy, 'get_onset_offset')
+
+    def test_concrete_must_implement_get_onset_offset(self):
+        VoiceOnsetStrategy, *_ = _get_module()
+        class Incomplete(VoiceOnsetStrategy):
+            pass
+        with pytest.raises(TypeError):
+            Incomplete()
+
+    def test_signature(self):
+        VoiceOnsetStrategy, *_ = _get_module()
+        import inspect
+        sig = inspect.signature(VoiceOnsetStrategy.get_onset_offset)
+        params = list(sig.parameters.keys())
+        assert 'voice_index' in params
+        assert 'num_voices' in params
+
+
+# =============================================================================
+# 2. LinearOnsetStrategy
+# =============================================================================
+
+class TestLinearOnsetStrategy:
+
+    def test_voice_0_returns_zero(self):
+        _, LinearOnsetStrategy, *_ = _get_module()
+        s = LinearOnsetStrategy(step=0.05)
+        assert s.get_onset_offset(voice_index=0, num_voices=4) == 0.0
+
+    def test_voice_1_returns_one_step(self):
+        _, LinearOnsetStrategy, *_ = _get_module()
+        s = LinearOnsetStrategy(step=0.05)
+        assert s.get_onset_offset(voice_index=1, num_voices=4) == pytest.approx(0.05)
+
+    def test_voice_2_returns_two_steps(self):
+        _, LinearOnsetStrategy, *_ = _get_module()
+        s = LinearOnsetStrategy(step=0.05)
+        assert s.get_onset_offset(voice_index=2, num_voices=4) == pytest.approx(0.10)
+
+    def test_voice_3_returns_three_steps(self):
+        _, LinearOnsetStrategy, *_ = _get_module()
+        s = LinearOnsetStrategy(step=0.05)
+        assert s.get_onset_offset(voice_index=3, num_voices=4) == pytest.approx(0.15)
+
+    def test_step_zero_all_voices_zero(self):
+        _, LinearOnsetStrategy, *_ = _get_module()
+        s = LinearOnsetStrategy(step=0.0)
+        for i in range(4):
+            assert s.get_onset_offset(voice_index=i, num_voices=4) == 0.0
+
+    def test_large_step(self):
+        _, LinearOnsetStrategy, *_ = _get_module()
+        s = LinearOnsetStrategy(step=1.0)
+        assert s.get_onset_offset(voice_index=5, num_voices=6) == pytest.approx(5.0)
+
+    def test_num_voices_one(self):
+        _, LinearOnsetStrategy, *_ = _get_module()
+        s = LinearOnsetStrategy(step=0.1)
+        assert s.get_onset_offset(voice_index=0, num_voices=1) == 0.0
+
+    def test_offset_is_always_non_negative(self):
+        _, LinearOnsetStrategy, *_ = _get_module()
+        s = LinearOnsetStrategy(step=0.03)
+        for i in range(8):
+            assert s.get_onset_offset(voice_index=i, num_voices=8) >= 0.0
+
+
+# =============================================================================
+# 3. GeometricOnsetStrategy
+# =============================================================================
+
+class TestGeometricOnsetStrategy:
+
+    def test_voice_0_returns_zero(self):
+        _, _, GeometricOnsetStrategy, *_ = _get_module()
+        s = GeometricOnsetStrategy(step=0.05, base=2.0)
+        assert s.get_onset_offset(voice_index=0, num_voices=4) == 0.0
+
+    def test_voice_1_returns_step(self):
+        """Voce 1 → step * base^0 = step."""
+        _, _, GeometricOnsetStrategy, *_ = _get_module()
+        s = GeometricOnsetStrategy(step=0.1, base=2.0)
+        assert s.get_onset_offset(voice_index=1, num_voices=4) == pytest.approx(0.1)
+
+    def test_voice_2_geometric_growth(self):
+        """Voce 2 → step * base^1 = 0.1 * 2 = 0.2."""
+        _, _, GeometricOnsetStrategy, *_ = _get_module()
+        s = GeometricOnsetStrategy(step=0.1, base=2.0)
+        assert s.get_onset_offset(voice_index=2, num_voices=4) == pytest.approx(0.2)
+
+    def test_voice_3_geometric_growth(self):
+        """Voce 3 → step * base^2 = 0.1 * 4 = 0.4."""
+        _, _, GeometricOnsetStrategy, *_ = _get_module()
+        s = GeometricOnsetStrategy(step=0.1, base=2.0)
+        assert s.get_onset_offset(voice_index=3, num_voices=4) == pytest.approx(0.4)
+
+    def test_base_one_equals_linear_step(self):
+        """Base=1 → ogni voce ha lo stesso step (uguale a linear)."""
+        _, _, GeometricOnsetStrategy, *_ = _get_module()
+        s = GeometricOnsetStrategy(step=0.1, base=1.0)
+        assert s.get_onset_offset(voice_index=1, num_voices=4) == pytest.approx(0.1)
+        assert s.get_onset_offset(voice_index=2, num_voices=4) == pytest.approx(0.1)
+        assert s.get_onset_offset(voice_index=3, num_voices=4) == pytest.approx(0.1)
+
+    def test_offsets_increase_with_voice_index(self):
+        """Con base>1 gli offset crescono monotonicamente."""
+        _, _, GeometricOnsetStrategy, *_ = _get_module()
+        s = GeometricOnsetStrategy(step=0.05, base=1.5)
+        offsets = [s.get_onset_offset(i, 5) for i in range(5)]
+        for a, b in zip(offsets, offsets[1:]):
+            assert b >= a
+
+    def test_num_voices_one(self):
+        _, _, GeometricOnsetStrategy, *_ = _get_module()
+        s = GeometricOnsetStrategy(step=0.1, base=2.0)
+        assert s.get_onset_offset(voice_index=0, num_voices=1) == 0.0
+
+
+# =============================================================================
+# 4. StochasticOnsetStrategy
+# =============================================================================
+
+class TestStochasticOnsetStrategy:
+
+    def test_voice_0_always_zero(self):
+        _, _, _, StochasticOnsetStrategy, *_ = _get_module()
+        s = StochasticOnsetStrategy(max_offset=0.1, stream_id="s1")
+        assert s.get_onset_offset(voice_index=0, num_voices=4) == 0.0
+
+    def test_offset_within_range(self):
+        _, _, _, StochasticOnsetStrategy, *_ = _get_module()
+        s = StochasticOnsetStrategy(max_offset=0.2, stream_id="s1")
+        for i in range(1, 8):
+            offset = s.get_onset_offset(voice_index=i, num_voices=8)
+            assert 0.0 <= offset <= 0.2
+
+    def test_deterministic_same_stream(self):
+        _, _, _, StochasticOnsetStrategy, *_ = _get_module()
+        s1 = StochasticOnsetStrategy(max_offset=0.5, stream_id="my_stream")
+        s2 = StochasticOnsetStrategy(max_offset=0.5, stream_id="my_stream")
+        for i in range(1, 5):
+            assert s1.get_onset_offset(i, 5) == s2.get_onset_offset(i, 5)
+
+    def test_different_stream_ids_different_offsets(self):
+        _, _, _, StochasticOnsetStrategy, *_ = _get_module()
+        s1 = StochasticOnsetStrategy(max_offset=0.5, stream_id="stream_A")
+        s2 = StochasticOnsetStrategy(max_offset=0.5, stream_id="stream_B")
+        offsets1 = [s1.get_onset_offset(i, 4) for i in range(1, 4)]
+        offsets2 = [s2.get_onset_offset(i, 4) for i in range(1, 4)]
+        assert offsets1 != offsets2
+
+    def test_max_offset_zero_all_zero(self):
+        _, _, _, StochasticOnsetStrategy, *_ = _get_module()
+        s = StochasticOnsetStrategy(max_offset=0.0, stream_id="s1")
+        for i in range(4):
+            assert s.get_onset_offset(i, 4) == 0.0
+
+    def test_offset_non_negative(self):
+        """L'onset offset è sempre >= 0 (non si può andare prima della voce 0)."""
+        _, _, _, StochasticOnsetStrategy, *_ = _get_module()
+        s = StochasticOnsetStrategy(max_offset=0.3, stream_id="s1")
+        for i in range(1, 6):
+            assert s.get_onset_offset(i, 6) >= 0.0
+
+
+# =============================================================================
+# 5. Invariante voce 0 — tutte le strategy
+# =============================================================================
+
+class TestVoiceZeroInvariant:
+
+    @pytest.mark.parametrize("strategy_fixture", [
+        lambda m: m[1](step=0.05),
+        lambda m: m[2](step=0.05, base=2.0),
+        lambda m: m[3](max_offset=0.1, stream_id="s1"),
+    ])
+    def test_voice_0_is_always_zero(self, strategy_fixture):
+        mod = _get_module()
+        strategy = strategy_fixture(mod)
+        assert strategy.get_onset_offset(voice_index=0, num_voices=4) == 0.0
+
+
+# =============================================================================
+# 6. Edge cases
+# =============================================================================
+
+class TestEdgeCases:
+
+    def test_linear_num_voices_1(self):
+        _, LinearOnsetStrategy, *_ = _get_module()
+        s = LinearOnsetStrategy(step=0.1)
+        assert s.get_onset_offset(0, 1) == 0.0
+
+    def test_geometric_num_voices_1(self):
+        _, _, GeometricOnsetStrategy, *_ = _get_module()
+        s = GeometricOnsetStrategy(step=0.1, base=2.0)
+        assert s.get_onset_offset(0, 1) == 0.0
+
+    def test_stochastic_num_voices_1(self):
+        _, _, _, StochasticOnsetStrategy, *_ = _get_module()
+        s = StochasticOnsetStrategy(max_offset=0.1, stream_id="s1")
+        assert s.get_onset_offset(0, 1) == 0.0
+
+
+# =============================================================================
+# 7. VOICE_ONSET_STRATEGIES registry
+# =============================================================================
+
+class TestVoiceOnsetStrategiesRegistry:
+
+    def test_registry_exists(self):
+        *_, VOICE_ONSET_STRATEGIES, _, _ = _get_module()
+        assert isinstance(VOICE_ONSET_STRATEGIES, dict)
+
+    def test_registry_contains_linear(self):
+        *_, VOICE_ONSET_STRATEGIES, _, _ = _get_module()
+        assert 'linear' in VOICE_ONSET_STRATEGIES
+
+    def test_registry_contains_geometric(self):
+        *_, VOICE_ONSET_STRATEGIES, _, _ = _get_module()
+        assert 'geometric' in VOICE_ONSET_STRATEGIES
+
+    def test_registry_contains_stochastic(self):
+        *_, VOICE_ONSET_STRATEGIES, _, _ = _get_module()
+        assert 'stochastic' in VOICE_ONSET_STRATEGIES
+
+    def test_registry_values_are_classes(self):
+        *_, VOICE_ONSET_STRATEGIES, _, _ = _get_module()
+        for name, cls in VOICE_ONSET_STRATEGIES.items():
+            assert isinstance(cls, type), f"{name} non è una classe"
+
+
+# =============================================================================
+# 8. register_voice_onset_strategy()
+# =============================================================================
+
+class TestRegisterVoiceOnsetStrategy:
+
+    def test_register_new_strategy(self):
+        VoiceOnsetStrategy, _, _, _, VOICE_ONSET_STRATEGIES, register_voice_onset_strategy, _ = _get_module()
+
+        class FixedOnset(VoiceOnsetStrategy):
+            def get_onset_offset(self, voice_index, num_voices):
+                return 0.0 if voice_index == 0 else 1.0
+
+        register_voice_onset_strategy('fixed', FixedOnset)
+        assert 'fixed' in VOICE_ONSET_STRATEGIES
+
+    def test_registered_strategy_usable_via_factory(self):
+        VoiceOnsetStrategy, _, _, _, _, register_voice_onset_strategy, VoiceOnsetStrategyFactory = _get_module()
+
+        class HalfSecond(VoiceOnsetStrategy):
+            def get_onset_offset(self, voice_index, num_voices):
+                return 0.0 if voice_index == 0 else 0.5
+
+        register_voice_onset_strategy('half', HalfSecond)
+        s = VoiceOnsetStrategyFactory.create('half')
+        assert s.get_onset_offset(1, 2) == 0.5
+
+
+# =============================================================================
+# 9. VoiceOnsetStrategyFactory
+# =============================================================================
+
+class TestVoiceOnsetStrategyFactory:
+
+    def test_create_linear(self):
+        _, LinearOnsetStrategy, _, _, _, _, VoiceOnsetStrategyFactory = _get_module()
+        s = VoiceOnsetStrategyFactory.create('linear', step=0.05)
+        assert isinstance(s, LinearOnsetStrategy)
+
+    def test_create_geometric(self):
+        _, _, GeometricOnsetStrategy, _, _, _, VoiceOnsetStrategyFactory = _get_module()
+        s = VoiceOnsetStrategyFactory.create('geometric', step=0.05, base=2.0)
+        assert isinstance(s, GeometricOnsetStrategy)
+
+    def test_create_stochastic(self):
+        _, _, _, StochasticOnsetStrategy, _, _, VoiceOnsetStrategyFactory = _get_module()
+        s = VoiceOnsetStrategyFactory.create('stochastic', max_offset=0.1, stream_id='s1')
+        assert isinstance(s, StochasticOnsetStrategy)
+
+    def test_unknown_strategy_raises(self):
+        *_, VoiceOnsetStrategyFactory = _get_module()
+        with pytest.raises((KeyError, ValueError)):
+            VoiceOnsetStrategyFactory.create('nonexistent_xyz')
+
+    def test_factory_returns_voice_onset_strategy_instance(self):
+        VoiceOnsetStrategy, *_, VoiceOnsetStrategyFactory = _get_module()
+        s = VoiceOnsetStrategyFactory.create('linear', step=0.1)
+        assert isinstance(s, VoiceOnsetStrategy)

--- a/tests/strategies/test_voice_pitch_strategy.py
+++ b/tests/strategies/test_voice_pitch_strategy.py
@@ -1,0 +1,474 @@
+# tests/strategies/test_voice_pitch_strategy.py
+"""
+test_voice_pitch_strategy.py
+
+Suite TDD per voice_pitch_strategy.py
+
+Moduli sotto test (da scrivere):
+- VoicePitchStrategy (ABC)
+- StepPitchStrategy    → voce i = i × step
+- RangePitchStrategy   → distribuiti nell'intervallo [0, range]
+- ChordPitchStrategy   → offsets da nome accordo, extend se num_voices > chord
+- StochasticPitchStrategy → offset fisso per voce, seed deterministico
+- VOICE_PITCH_STRATEGIES (registry dict)
+- register_voice_pitch_strategy()
+- VoicePitchStrategyFactory
+
+Principi di design:
+- Voce 0 restituisce SEMPRE 0.0 (riferimento immutato)
+- Il valore restituito è un offset in SEMITONI
+- StochasticPitchStrategy: seed = hash(stream_id + str(voice_index))
+- ChordPitchStrategy: se num_voices > len(chord) → extend all'ottava superiore
+
+Organizzazione:
+  1.  VoicePitchStrategy ABC — interfaccia e contratto
+  2.  StepPitchStrategy — distribuzione lineare per step
+  3.  RangePitchStrategy — distribuzione nel range
+  4.  ChordPitchStrategy — offsets da accordo nominale
+  5.  ChordPitchStrategy extend — ottava superiore se num_voices > chord
+  6.  StochasticPitchStrategy — offset deterministico per voce
+  7.  Invariante voce 0 — tutte le strategy restituiscono 0.0
+  8.  Edge cases — num_voices=1, step=0, range=0
+  9.  VOICE_PITCH_STRATEGIES registry
+  10. register_voice_pitch_strategy()
+  11. VoicePitchStrategyFactory
+"""
+
+import pytest
+
+
+# =============================================================================
+# IMPORT LAZY
+# =============================================================================
+
+def _get_module():
+    from strategies.voice_pitch_strategy import (
+        VoicePitchStrategy,
+        StepPitchStrategy,
+        RangePitchStrategy,
+        ChordPitchStrategy,
+        StochasticPitchStrategy,
+        VOICE_PITCH_STRATEGIES,
+        register_voice_pitch_strategy,
+        VoicePitchStrategyFactory,
+    )
+    return (
+        VoicePitchStrategy,
+        StepPitchStrategy,
+        RangePitchStrategy,
+        ChordPitchStrategy,
+        StochasticPitchStrategy,
+        VOICE_PITCH_STRATEGIES,
+        register_voice_pitch_strategy,
+        VoicePitchStrategyFactory,
+    )
+
+
+# =============================================================================
+# FIXTURES
+# =============================================================================
+
+@pytest.fixture(autouse=True)
+def restore_registry():
+    try:
+        _, _, _, _, _, registry, _, _ = _get_module()
+        original = dict(registry)
+        yield
+        registry.clear()
+        registry.update(original)
+    except ImportError:
+        yield
+
+
+# =============================================================================
+# 1. VoicePitchStrategy ABC
+# =============================================================================
+
+class TestVoicePitchStrategyABC:
+
+    def test_is_abstract(self):
+        """VoicePitchStrategy non è istanziabile direttamente."""
+        VoicePitchStrategy, *_ = _get_module()
+        with pytest.raises(TypeError):
+            VoicePitchStrategy()
+
+    def test_get_pitch_offset_is_abstract(self):
+        """get_pitch_offset deve essere abstractmethod."""
+        VoicePitchStrategy, *_ = _get_module()
+        assert hasattr(VoicePitchStrategy, 'get_pitch_offset')
+
+    def test_concrete_must_implement_get_pitch_offset(self):
+        """Sottoclasse senza get_pitch_offset non è istanziabile."""
+        VoicePitchStrategy, *_ = _get_module()
+        class Incomplete(VoicePitchStrategy):
+            pass
+        with pytest.raises(TypeError):
+            Incomplete()
+
+    def test_signature(self):
+        """get_pitch_offset(voice_index, num_voices) → float."""
+        VoicePitchStrategy, *_ = _get_module()
+        import inspect
+        sig = inspect.signature(VoicePitchStrategy.get_pitch_offset)
+        params = list(sig.parameters.keys())
+        assert 'voice_index' in params
+        assert 'num_voices' in params
+
+
+# =============================================================================
+# 2. StepPitchStrategy
+# =============================================================================
+
+class TestStepPitchStrategy:
+
+    def test_voice_0_returns_zero(self):
+        _, StepPitchStrategy, *_ = _get_module()
+        s = StepPitchStrategy(step=3.0)
+        assert s.get_pitch_offset(voice_index=0, num_voices=4) == 0.0
+
+    def test_voice_1_returns_one_step(self):
+        _, StepPitchStrategy, *_ = _get_module()
+        s = StepPitchStrategy(step=3.0)
+        assert s.get_pitch_offset(voice_index=1, num_voices=4) == 3.0
+
+    def test_voice_2_returns_two_steps(self):
+        _, StepPitchStrategy, *_ = _get_module()
+        s = StepPitchStrategy(step=3.0)
+        assert s.get_pitch_offset(voice_index=2, num_voices=4) == 6.0
+
+    def test_voice_3_returns_three_steps(self):
+        _, StepPitchStrategy, *_ = _get_module()
+        s = StepPitchStrategy(step=3.0)
+        assert s.get_pitch_offset(voice_index=3, num_voices=4) == 9.0
+
+    def test_negative_step(self):
+        _, StepPitchStrategy, *_ = _get_module()
+        s = StepPitchStrategy(step=-2.0)
+        assert s.get_pitch_offset(voice_index=2, num_voices=4) == -4.0
+
+    def test_step_zero_all_voices_zero(self):
+        _, StepPitchStrategy, *_ = _get_module()
+        s = StepPitchStrategy(step=0.0)
+        for i in range(4):
+            assert s.get_pitch_offset(voice_index=i, num_voices=4) == 0.0
+
+    def test_fractional_step(self):
+        _, StepPitchStrategy, *_ = _get_module()
+        s = StepPitchStrategy(step=0.5)
+        assert s.get_pitch_offset(voice_index=3, num_voices=4) == pytest.approx(1.5)
+
+    def test_num_voices_one(self):
+        _, StepPitchStrategy, *_ = _get_module()
+        s = StepPitchStrategy(step=5.0)
+        assert s.get_pitch_offset(voice_index=0, num_voices=1) == 0.0
+
+
+# =============================================================================
+# 3. RangePitchStrategy
+# =============================================================================
+
+class TestRangePitchStrategy:
+
+    def test_voice_0_returns_zero(self):
+        _, _, RangePitchStrategy, *_ = _get_module()
+        s = RangePitchStrategy(semitone_range=12.0)
+        assert s.get_pitch_offset(voice_index=0, num_voices=4) == 0.0
+
+    def test_last_voice_returns_range(self):
+        """Con 4 voci e range=12: voce 3 → 12.0."""
+        _, _, RangePitchStrategy, *_ = _get_module()
+        s = RangePitchStrategy(semitone_range=12.0)
+        assert s.get_pitch_offset(voice_index=3, num_voices=4) == pytest.approx(12.0)
+
+    def test_middle_voice_interpolated(self):
+        """Con 4 voci e range=12: voce 1 → 4.0, voce 2 → 8.0."""
+        _, _, RangePitchStrategy, *_ = _get_module()
+        s = RangePitchStrategy(semitone_range=12.0)
+        assert s.get_pitch_offset(voice_index=1, num_voices=4) == pytest.approx(4.0)
+        assert s.get_pitch_offset(voice_index=2, num_voices=4) == pytest.approx(8.0)
+
+    def test_two_voices_only_zero_and_range(self):
+        _, _, RangePitchStrategy, *_ = _get_module()
+        s = RangePitchStrategy(semitone_range=7.0)
+        assert s.get_pitch_offset(voice_index=0, num_voices=2) == 0.0
+        assert s.get_pitch_offset(voice_index=1, num_voices=2) == pytest.approx(7.0)
+
+    def test_num_voices_one_returns_zero(self):
+        _, _, RangePitchStrategy, *_ = _get_module()
+        s = RangePitchStrategy(semitone_range=12.0)
+        assert s.get_pitch_offset(voice_index=0, num_voices=1) == 0.0
+
+
+# =============================================================================
+# 4. ChordPitchStrategy — accordi nominali
+# =============================================================================
+
+class TestChordPitchStrategyKnownChords:
+
+    def test_voice_0_always_zero(self):
+        _, _, _, ChordPitchStrategy, *_ = _get_module()
+        s = ChordPitchStrategy(chord="maj")
+        assert s.get_pitch_offset(voice_index=0, num_voices=3) == 0.0
+
+    def test_major_triad(self):
+        """maj → [0, 4, 7]."""
+        _, _, _, ChordPitchStrategy, *_ = _get_module()
+        s = ChordPitchStrategy(chord="maj")
+        assert s.get_pitch_offset(voice_index=0, num_voices=3) == 0
+        assert s.get_pitch_offset(voice_index=1, num_voices=3) == 4
+        assert s.get_pitch_offset(voice_index=2, num_voices=3) == 7
+
+    def test_minor_triad(self):
+        """min → [0, 3, 7]."""
+        _, _, _, ChordPitchStrategy, *_ = _get_module()
+        s = ChordPitchStrategy(chord="min")
+        assert s.get_pitch_offset(voice_index=1, num_voices=3) == 3
+        assert s.get_pitch_offset(voice_index=2, num_voices=3) == 7
+
+    def test_dominant_seventh(self):
+        """dom7 → [0, 4, 7, 10]."""
+        _, _, _, ChordPitchStrategy, *_ = _get_module()
+        s = ChordPitchStrategy(chord="dom7")
+        assert s.get_pitch_offset(voice_index=1, num_voices=4) == 4
+        assert s.get_pitch_offset(voice_index=2, num_voices=4) == 7
+        assert s.get_pitch_offset(voice_index=3, num_voices=4) == 10
+
+    def test_major_seventh(self):
+        """maj7 → [0, 4, 7, 11]."""
+        _, _, _, ChordPitchStrategy, *_ = _get_module()
+        s = ChordPitchStrategy(chord="maj7")
+        assert s.get_pitch_offset(voice_index=3, num_voices=4) == 11
+
+    def test_minor_seventh(self):
+        """min7 → [0, 3, 7, 10]."""
+        _, _, _, ChordPitchStrategy, *_ = _get_module()
+        s = ChordPitchStrategy(chord="min7")
+        assert s.get_pitch_offset(voice_index=1, num_voices=4) == 3
+        assert s.get_pitch_offset(voice_index=3, num_voices=4) == 10
+
+    def test_unknown_chord_raises(self):
+        _, _, _, ChordPitchStrategy, *_ = _get_module()
+        with pytest.raises((ValueError, KeyError)):
+            ChordPitchStrategy(chord="unknown_chord_xyz")
+
+
+# =============================================================================
+# 5. ChordPitchStrategy — extend all'ottava superiore
+# =============================================================================
+
+class TestChordPitchStrategyExtend:
+
+    def test_dom7_5_voices_extends(self):
+        """dom7 = [0,4,7,10]. Voce 4 → 12 (0+ottava)."""
+        _, _, _, ChordPitchStrategy, *_ = _get_module()
+        s = ChordPitchStrategy(chord="dom7")
+        assert s.get_pitch_offset(voice_index=4, num_voices=6) == 12
+
+    def test_dom7_6_voices_extends(self):
+        """dom7. Voce 5 → 16 (4+ottava)."""
+        _, _, _, ChordPitchStrategy, *_ = _get_module()
+        s = ChordPitchStrategy(chord="dom7")
+        assert s.get_pitch_offset(voice_index=5, num_voices=6) == 16
+
+    def test_maj_triad_4_voices(self):
+        """maj=[0,4,7]. Voce 3 → 12 (0+ottava)."""
+        _, _, _, ChordPitchStrategy, *_ = _get_module()
+        s = ChordPitchStrategy(chord="maj")
+        assert s.get_pitch_offset(voice_index=3, num_voices=4) == 12
+
+    def test_maj_triad_7_voices_two_octaves(self):
+        """maj=[0,4,7]. Voci 3-5 = [12,16,19]. Voce 6 = 24 (0+2 ottave)."""
+        _, _, _, ChordPitchStrategy, *_ = _get_module()
+        s = ChordPitchStrategy(chord="maj")
+        assert s.get_pitch_offset(voice_index=5, num_voices=7) == 19
+        assert s.get_pitch_offset(voice_index=6, num_voices=7) == 24
+
+
+# =============================================================================
+# 6. StochasticPitchStrategy
+# =============================================================================
+
+class TestStochasticPitchStrategy:
+
+    def test_voice_0_always_zero(self):
+        _, _, _, _, StochasticPitchStrategy, *_ = _get_module()
+        s = StochasticPitchStrategy(semitone_range=2.0, stream_id="s1")
+        assert s.get_pitch_offset(voice_index=0, num_voices=4) == 0.0
+
+    def test_offset_within_range(self):
+        _, _, _, _, StochasticPitchStrategy, *_ = _get_module()
+        s = StochasticPitchStrategy(semitone_range=3.0, stream_id="s1")
+        for i in range(1, 8):
+            offset = s.get_pitch_offset(voice_index=i, num_voices=8)
+            assert -3.0 <= offset <= 3.0
+
+    def test_deterministic_same_stream(self):
+        """Stesso stream_id e voice_index → stesso offset."""
+        _, _, _, _, StochasticPitchStrategy, *_ = _get_module()
+        s1 = StochasticPitchStrategy(semitone_range=5.0, stream_id="my_stream")
+        s2 = StochasticPitchStrategy(semitone_range=5.0, stream_id="my_stream")
+        for i in range(1, 5):
+            assert s1.get_pitch_offset(i, 5) == s2.get_pitch_offset(i, 5)
+
+    def test_different_stream_ids_different_offsets(self):
+        """stream_id diversi → offsets diversi (con alta probabilità)."""
+        _, _, _, _, StochasticPitchStrategy, *_ = _get_module()
+        s1 = StochasticPitchStrategy(semitone_range=5.0, stream_id="stream_A")
+        s2 = StochasticPitchStrategy(semitone_range=5.0, stream_id="stream_B")
+        offsets1 = [s1.get_pitch_offset(i, 4) for i in range(1, 4)]
+        offsets2 = [s2.get_pitch_offset(i, 4) for i in range(1, 4)]
+        assert offsets1 != offsets2
+
+    def test_different_voices_different_offsets(self):
+        """voice_index diversi → offsets diversi (con alta probabilità)."""
+        _, _, _, _, StochasticPitchStrategy, *_ = _get_module()
+        s = StochasticPitchStrategy(semitone_range=5.0, stream_id="s1")
+        offsets = [s.get_pitch_offset(i, 6) for i in range(1, 6)]
+        assert len(set(offsets)) > 1
+
+    def test_range_zero_all_zero(self):
+        _, _, _, _, StochasticPitchStrategy, *_ = _get_module()
+        s = StochasticPitchStrategy(semitone_range=0.0, stream_id="s1")
+        for i in range(4):
+            assert s.get_pitch_offset(i, 4) == 0.0
+
+
+# =============================================================================
+# 7. Invariante voce 0 — tutte le strategy
+# =============================================================================
+
+class TestVoiceZeroInvariant:
+
+    @pytest.mark.parametrize("strategy_fixture", [
+        lambda m: m[1](step=3.0),                            # StepPitchStrategy
+        lambda m: m[2](semitone_range=12.0),                  # RangePitchStrategy
+        lambda m: m[3](chord="dom7"),                         # ChordPitchStrategy
+        lambda m: m[4](semitone_range=2.0, stream_id="s1"),   # StochasticPitchStrategy
+    ])
+    def test_voice_0_is_always_zero(self, strategy_fixture):
+        mod = _get_module()
+        strategy = strategy_fixture(mod)
+        assert strategy.get_pitch_offset(voice_index=0, num_voices=4) == 0.0
+
+
+# =============================================================================
+# 8. Edge cases
+# =============================================================================
+
+class TestEdgeCases:
+
+    def test_step_num_voices_1(self):
+        _, StepPitchStrategy, *_ = _get_module()
+        s = StepPitchStrategy(step=7.0)
+        assert s.get_pitch_offset(0, 1) == 0.0
+
+    def test_range_num_voices_1(self):
+        _, _, RangePitchStrategy, *_ = _get_module()
+        s = RangePitchStrategy(semitone_range=12.0)
+        assert s.get_pitch_offset(0, 1) == 0.0
+
+    def test_chord_num_voices_1(self):
+        _, _, _, ChordPitchStrategy, *_ = _get_module()
+        s = ChordPitchStrategy(chord="maj")
+        assert s.get_pitch_offset(0, 1) == 0.0
+
+
+# =============================================================================
+# 9. VOICE_PITCH_STRATEGIES registry
+# =============================================================================
+
+class TestVoicePitchStrategiesRegistry:
+
+    def test_registry_exists(self):
+        *_, VOICE_PITCH_STRATEGIES, _, _ = _get_module()
+        assert isinstance(VOICE_PITCH_STRATEGIES, dict)
+
+    def test_registry_contains_step(self):
+        *_, VOICE_PITCH_STRATEGIES, _, _ = _get_module()
+        assert 'step' in VOICE_PITCH_STRATEGIES
+
+    def test_registry_contains_range(self):
+        *_, VOICE_PITCH_STRATEGIES, _, _ = _get_module()
+        assert 'range' in VOICE_PITCH_STRATEGIES
+
+    def test_registry_contains_chord(self):
+        *_, VOICE_PITCH_STRATEGIES, _, _ = _get_module()
+        assert 'chord' in VOICE_PITCH_STRATEGIES
+
+    def test_registry_contains_stochastic(self):
+        *_, VOICE_PITCH_STRATEGIES, _, _ = _get_module()
+        assert 'stochastic' in VOICE_PITCH_STRATEGIES
+
+    def test_registry_values_are_classes(self):
+        *_, VOICE_PITCH_STRATEGIES, _, _ = _get_module()
+        for name, cls in VOICE_PITCH_STRATEGIES.items():
+            assert isinstance(cls, type), f"{name} non è una classe"
+
+
+# =============================================================================
+# 10. register_voice_pitch_strategy()
+# =============================================================================
+
+class TestRegisterVoicePitchStrategy:
+
+    def test_register_new_strategy(self):
+        VoicePitchStrategy, _, _, _, _, VOICE_PITCH_STRATEGIES, register_voice_pitch_strategy, _ = _get_module()
+
+        class MySemitoneStrategy(VoicePitchStrategy):
+            def get_pitch_offset(self, voice_index, num_voices):
+                return float(voice_index * 2)
+
+        register_voice_pitch_strategy('my_semi', MySemitoneStrategy)
+        assert 'my_semi' in VOICE_PITCH_STRATEGIES
+
+    def test_registered_strategy_usable_via_factory(self):
+        VoicePitchStrategy, _, _, _, _, VOICE_PITCH_STRATEGIES, register_voice_pitch_strategy, VoicePitchStrategyFactory = _get_module()
+
+        class FixedStrategy(VoicePitchStrategy):
+            def get_pitch_offset(self, voice_index, num_voices):
+                return 99.0 if voice_index > 0 else 0.0
+
+        register_voice_pitch_strategy('fixed99', FixedStrategy)
+        s = VoicePitchStrategyFactory.create('fixed99')
+        assert s.get_pitch_offset(1, 2) == 99.0
+
+
+# =============================================================================
+# 11. VoicePitchStrategyFactory
+# =============================================================================
+
+class TestVoicePitchStrategyFactory:
+
+    def test_create_step(self):
+        *_, VoicePitchStrategyFactory = _get_module()
+        _, StepPitchStrategy, *_ = _get_module()
+        s = VoicePitchStrategyFactory.create('step', step=4.0)
+        assert isinstance(s, StepPitchStrategy)
+
+    def test_create_range(self):
+        *_, VoicePitchStrategyFactory = _get_module()
+        _, _, RangePitchStrategy, *_ = _get_module()
+        s = VoicePitchStrategyFactory.create('range', semitone_range=12.0)
+        assert isinstance(s, RangePitchStrategy)
+
+    def test_create_chord(self):
+        *_, VoicePitchStrategyFactory = _get_module()
+        _, _, _, ChordPitchStrategy, *_ = _get_module()
+        s = VoicePitchStrategyFactory.create('chord', chord='maj7')
+        assert isinstance(s, ChordPitchStrategy)
+
+    def test_create_stochastic(self):
+        *_, VoicePitchStrategyFactory = _get_module()
+        _, _, _, _, StochasticPitchStrategy, *_ = _get_module()
+        s = VoicePitchStrategyFactory.create('stochastic', semitone_range=2.0, stream_id='s1')
+        assert isinstance(s, StochasticPitchStrategy)
+
+    def test_unknown_strategy_raises(self):
+        *_, VoicePitchStrategyFactory = _get_module()
+        with pytest.raises((KeyError, ValueError)):
+            VoicePitchStrategyFactory.create('nonexistent_xyz')
+
+    def test_factory_returns_voice_pitch_strategy_instance(self):
+        VoicePitchStrategy, *_, VoicePitchStrategyFactory = _get_module()
+        s = VoicePitchStrategyFactory.create('step', step=1.0)
+        assert isinstance(s, VoicePitchStrategy)

--- a/tests/strategies/test_voice_pointer_strategy.py
+++ b/tests/strategies/test_voice_pointer_strategy.py
@@ -1,0 +1,305 @@
+# tests/strategies/test_voice_pointer_strategy.py
+"""
+test_voice_pointer_strategy.py
+
+Suite TDD per voice_pointer_strategy.py
+
+Moduli sotto test (da scrivere):
+- VoicePointerStrategy (ABC)
+- LinearPointerStrategy    → voce i = i × step (normalizzato 0.0-1.0)
+- StochasticPointerStrategy → offset fisso per voce, seed deterministico
+
+Principi di design:
+- Voce 0 restituisce SEMPRE 0.0 (riferimento immutato)
+- Il valore restituito è un offset normalizzato (0.0-1.0) sulla posizione nel sample
+- Additivo con il pointer base di PointerController e il grain jitter (già esistente)
+- StochasticPointerStrategy: seed = hash(stream_id + str(voice_index))
+
+Organizzazione:
+  1.  VoicePointerStrategy ABC
+  2.  LinearPointerStrategy
+  3.  StochasticPointerStrategy
+  4.  Invariante voce 0
+  5.  Edge cases
+  6.  VOICE_POINTER_STRATEGIES registry
+  7.  register_voice_pointer_strategy()
+  8.  VoicePointerStrategyFactory
+"""
+
+import pytest
+
+
+# =============================================================================
+# IMPORT LAZY
+# =============================================================================
+
+def _get_module():
+    from strategies.voice_pointer_strategy import (
+        VoicePointerStrategy,
+        LinearPointerStrategy,
+        StochasticPointerStrategy,
+        VOICE_POINTER_STRATEGIES,
+        register_voice_pointer_strategy,
+        VoicePointerStrategyFactory,
+    )
+    return (
+        VoicePointerStrategy,
+        LinearPointerStrategy,
+        StochasticPointerStrategy,
+        VOICE_POINTER_STRATEGIES,
+        register_voice_pointer_strategy,
+        VoicePointerStrategyFactory,
+    )
+
+
+# =============================================================================
+# FIXTURES
+# =============================================================================
+
+@pytest.fixture(autouse=True)
+def restore_registry():
+    try:
+        _, _, _, registry, _, _ = _get_module()
+        original = dict(registry)
+        yield
+        registry.clear()
+        registry.update(original)
+    except ImportError:
+        yield
+
+
+# =============================================================================
+# 1. VoicePointerStrategy ABC
+# =============================================================================
+
+class TestVoicePointerStrategyABC:
+
+    def test_is_abstract(self):
+        VoicePointerStrategy, *_ = _get_module()
+        with pytest.raises(TypeError):
+            VoicePointerStrategy()
+
+    def test_get_pointer_offset_is_abstract(self):
+        VoicePointerStrategy, *_ = _get_module()
+        assert hasattr(VoicePointerStrategy, 'get_pointer_offset')
+
+    def test_concrete_must_implement_get_pointer_offset(self):
+        VoicePointerStrategy, *_ = _get_module()
+        class Incomplete(VoicePointerStrategy):
+            pass
+        with pytest.raises(TypeError):
+            Incomplete()
+
+    def test_signature(self):
+        VoicePointerStrategy, *_ = _get_module()
+        import inspect
+        sig = inspect.signature(VoicePointerStrategy.get_pointer_offset)
+        params = list(sig.parameters.keys())
+        assert 'voice_index' in params
+        assert 'num_voices' in params
+
+
+# =============================================================================
+# 2. LinearPointerStrategy
+# =============================================================================
+
+class TestLinearPointerStrategy:
+
+    def test_voice_0_returns_zero(self):
+        _, LinearPointerStrategy, *_ = _get_module()
+        s = LinearPointerStrategy(step=0.1)
+        assert s.get_pointer_offset(voice_index=0, num_voices=4) == 0.0
+
+    def test_voice_1_returns_one_step(self):
+        _, LinearPointerStrategy, *_ = _get_module()
+        s = LinearPointerStrategy(step=0.1)
+        assert s.get_pointer_offset(voice_index=1, num_voices=4) == pytest.approx(0.1)
+
+    def test_voice_2_returns_two_steps(self):
+        _, LinearPointerStrategy, *_ = _get_module()
+        s = LinearPointerStrategy(step=0.1)
+        assert s.get_pointer_offset(voice_index=2, num_voices=4) == pytest.approx(0.2)
+
+    def test_voice_3_returns_three_steps(self):
+        _, LinearPointerStrategy, *_ = _get_module()
+        s = LinearPointerStrategy(step=0.1)
+        assert s.get_pointer_offset(voice_index=3, num_voices=4) == pytest.approx(0.3)
+
+    def test_negative_step(self):
+        _, LinearPointerStrategy, *_ = _get_module()
+        s = LinearPointerStrategy(step=-0.05)
+        assert s.get_pointer_offset(voice_index=2, num_voices=4) == pytest.approx(-0.10)
+
+    def test_step_zero_all_voices_zero(self):
+        _, LinearPointerStrategy, *_ = _get_module()
+        s = LinearPointerStrategy(step=0.0)
+        for i in range(4):
+            assert s.get_pointer_offset(voice_index=i, num_voices=4) == 0.0
+
+    def test_num_voices_one(self):
+        _, LinearPointerStrategy, *_ = _get_module()
+        s = LinearPointerStrategy(step=0.1)
+        assert s.get_pointer_offset(voice_index=0, num_voices=1) == 0.0
+
+    def test_small_step_fine_spread(self):
+        _, LinearPointerStrategy, *_ = _get_module()
+        s = LinearPointerStrategy(step=0.01)
+        assert s.get_pointer_offset(voice_index=5, num_voices=8) == pytest.approx(0.05)
+
+
+# =============================================================================
+# 3. StochasticPointerStrategy
+# =============================================================================
+
+class TestStochasticPointerStrategy:
+
+    def test_voice_0_always_zero(self):
+        _, _, StochasticPointerStrategy, *_ = _get_module()
+        s = StochasticPointerStrategy(pointer_range=0.2, stream_id="s1")
+        assert s.get_pointer_offset(voice_index=0, num_voices=4) == 0.0
+
+    def test_offset_within_range(self):
+        _, _, StochasticPointerStrategy, *_ = _get_module()
+        s = StochasticPointerStrategy(pointer_range=0.3, stream_id="s1")
+        for i in range(1, 8):
+            offset = s.get_pointer_offset(voice_index=i, num_voices=8)
+            assert -0.3 <= offset <= 0.3
+
+    def test_deterministic_same_stream(self):
+        _, _, StochasticPointerStrategy, *_ = _get_module()
+        s1 = StochasticPointerStrategy(pointer_range=0.5, stream_id="my_stream")
+        s2 = StochasticPointerStrategy(pointer_range=0.5, stream_id="my_stream")
+        for i in range(1, 5):
+            assert s1.get_pointer_offset(i, 5) == s2.get_pointer_offset(i, 5)
+
+    def test_different_stream_ids_different_offsets(self):
+        _, _, StochasticPointerStrategy, *_ = _get_module()
+        s1 = StochasticPointerStrategy(pointer_range=0.5, stream_id="stream_A")
+        s2 = StochasticPointerStrategy(pointer_range=0.5, stream_id="stream_B")
+        offsets1 = [s1.get_pointer_offset(i, 4) for i in range(1, 4)]
+        offsets2 = [s2.get_pointer_offset(i, 4) for i in range(1, 4)]
+        assert offsets1 != offsets2
+
+    def test_pointer_range_zero_all_zero(self):
+        _, _, StochasticPointerStrategy, *_ = _get_module()
+        s = StochasticPointerStrategy(pointer_range=0.0, stream_id="s1")
+        for i in range(4):
+            assert s.get_pointer_offset(i, 4) == 0.0
+
+    def test_different_voices_different_offsets(self):
+        _, _, StochasticPointerStrategy, *_ = _get_module()
+        s = StochasticPointerStrategy(pointer_range=0.5, stream_id="s1")
+        offsets = [s.get_pointer_offset(i, 6) for i in range(1, 6)]
+        assert len(set(offsets)) > 1
+
+
+# =============================================================================
+# 4. Invariante voce 0
+# =============================================================================
+
+class TestVoiceZeroInvariant:
+
+    @pytest.mark.parametrize("strategy_fixture", [
+        lambda m: m[1](step=0.1),
+        lambda m: m[2](pointer_range=0.2, stream_id="s1"),
+    ])
+    def test_voice_0_is_always_zero(self, strategy_fixture):
+        mod = _get_module()
+        strategy = strategy_fixture(mod)
+        assert strategy.get_pointer_offset(voice_index=0, num_voices=4) == 0.0
+
+
+# =============================================================================
+# 5. Edge cases
+# =============================================================================
+
+class TestEdgeCases:
+
+    def test_linear_num_voices_1(self):
+        _, LinearPointerStrategy, *_ = _get_module()
+        s = LinearPointerStrategy(step=0.1)
+        assert s.get_pointer_offset(0, 1) == 0.0
+
+    def test_stochastic_num_voices_1(self):
+        _, _, StochasticPointerStrategy, *_ = _get_module()
+        s = StochasticPointerStrategy(pointer_range=0.2, stream_id="s1")
+        assert s.get_pointer_offset(0, 1) == 0.0
+
+
+# =============================================================================
+# 6. VOICE_POINTER_STRATEGIES registry
+# =============================================================================
+
+class TestVoicePointerStrategiesRegistry:
+
+    def test_registry_exists(self):
+        _, _, _, VOICE_POINTER_STRATEGIES, _, _ = _get_module()
+        assert isinstance(VOICE_POINTER_STRATEGIES, dict)
+
+    def test_registry_contains_linear(self):
+        _, _, _, VOICE_POINTER_STRATEGIES, _, _ = _get_module()
+        assert 'linear' in VOICE_POINTER_STRATEGIES
+
+    def test_registry_contains_stochastic(self):
+        _, _, _, VOICE_POINTER_STRATEGIES, _, _ = _get_module()
+        assert 'stochastic' in VOICE_POINTER_STRATEGIES
+
+    def test_registry_values_are_classes(self):
+        _, _, _, VOICE_POINTER_STRATEGIES, _, _ = _get_module()
+        for name, cls in VOICE_POINTER_STRATEGIES.items():
+            assert isinstance(cls, type), f"{name} non è una classe"
+
+
+# =============================================================================
+# 7. register_voice_pointer_strategy()
+# =============================================================================
+
+class TestRegisterVoicePointerStrategy:
+
+    def test_register_new_strategy(self):
+        VoicePointerStrategy, _, _, VOICE_POINTER_STRATEGIES, register_voice_pointer_strategy, _ = _get_module()
+
+        class FixedPointer(VoicePointerStrategy):
+            def get_pointer_offset(self, voice_index, num_voices):
+                return 0.0 if voice_index == 0 else 0.5
+
+        register_voice_pointer_strategy('fixed', FixedPointer)
+        assert 'fixed' in VOICE_POINTER_STRATEGIES
+
+    def test_registered_strategy_usable_via_factory(self):
+        VoicePointerStrategy, _, _, _, register_voice_pointer_strategy, VoicePointerStrategyFactory = _get_module()
+
+        class HalfPointer(VoicePointerStrategy):
+            def get_pointer_offset(self, voice_index, num_voices):
+                return 0.0 if voice_index == 0 else 0.25
+
+        register_voice_pointer_strategy('quarter', HalfPointer)
+        s = VoicePointerStrategyFactory.create('quarter')
+        assert s.get_pointer_offset(1, 2) == 0.25
+
+
+# =============================================================================
+# 8. VoicePointerStrategyFactory
+# =============================================================================
+
+class TestVoicePointerStrategyFactory:
+
+    def test_create_linear(self):
+        _, LinearPointerStrategy, _, _, _, VoicePointerStrategyFactory = _get_module()
+        s = VoicePointerStrategyFactory.create('linear', step=0.05)
+        assert isinstance(s, LinearPointerStrategy)
+
+    def test_create_stochastic(self):
+        _, _, StochasticPointerStrategy, _, _, VoicePointerStrategyFactory = _get_module()
+        s = VoicePointerStrategyFactory.create('stochastic', pointer_range=0.2, stream_id='s1')
+        assert isinstance(s, StochasticPointerStrategy)
+
+    def test_unknown_strategy_raises(self):
+        *_, VoicePointerStrategyFactory = _get_module()
+        with pytest.raises((KeyError, ValueError)):
+            VoicePointerStrategyFactory.create('nonexistent_xyz')
+
+    def test_factory_returns_voice_pointer_strategy_instance(self):
+        VoicePointerStrategy, *_, VoicePointerStrategyFactory = _get_module()
+        s = VoicePointerStrategyFactory.create('linear', step=0.1)
+        assert isinstance(s, VoicePointerStrategy)


### PR DESCRIPTION
## Summary

- **Multi-voice system**: ogni stream può generare N voci con offset indipendenti di pitch, pointer, onset e pan. `num_voices` e `spread` supportano valori statici o envelope.
- **VoiceManager + Strategy pattern**: `VoicePitchStrategy` (step/range/chord/stochastic), `VoicePointerStrategy` (linear/stochastic), `VoiceOnsetStrategy` (linear/geometric/stochastic).
- **Fix cache numpy**: `NumpyAudioRenderer` non usava `StreamCacheManager` — il log dirty/clean non veniva mai stampato e ogni build ri-renderizzava tutto.

## Dettaglio modifiche

### feat: multi-voice
- `src/core/stream.py`: generazione grani per N voci, integrazione VoiceManager
- `src/parameters/parameter_definitions.py`: nuovi parametri `num_voices`, `voice_spread`, `voice_pitch_strategy`, `voice_pointer_strategy`, `voice_onset_strategy`
- `src/controllers/voice_manager.py`: orchestratore strategy, pre-computa VoiceConfig
- `src/strategies/voice_*_strategy.py`: 3 nuovi file di strategy

### fix: numpy cache
- `make/build.mk`: aggiunto `--cache --cache-dir` nel branch numpy+stems
- `src/rendering/numpy_audio_renderer.py`: cache check + update in `render_single_stream`
- `src/rendering/renderer_factory.py`: forward `cache_manager`/`stream_data_map`
- `src/main.py`: crea `StreamCacheManager` anche per `renderer_type==numpy`

## Test plan

- [ ] `make tests` — 3787 test verdi
- [ ] `make all FILE=PGE_testVoices` — verifica rendering multi-voice
- [ ] `make all FILE=PGE_scatter_experiments` — verifica log dirty/clean con numpy cache