### PR TITLE
feat(pointer): start defaults to loop_start + loop bounds relative al file audio

### DIFF
--- a/configs/PGE_scatter_experiments.yml
+++ b/configs/PGE_scatter_experiments.yml
@@ -4,7 +4,7 @@ composition:
 # =============================================================================
 # FILE DI PROVA: scatter × distribution × density
 # Ogni stream è isolato (onset sequenziale) per confronto diretto.
-# Campione di riferimento: pino.wav (corto, buono per loop granulare)
+# Campione di riferimento: pino2.wav (corto, buono per loop granulare)
 #
 # MATRICE DEGLI ESPERIMENTI:
 #   S1-S4   — scatter fisso × distribution fisso (4 angoli della matrice)
@@ -28,7 +28,7 @@ streams:
   - stream_id: "s01_cluster_equidistant"
     onset: 0.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     density: 12
     distribution: 0.0
     grain:
@@ -48,7 +48,7 @@ streams:
   - stream_id: "s01_cluster_equidistant1"
     onset: 0.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     density: 12
     distribution: 0.0
     grain:
@@ -72,18 +72,17 @@ streams:
   - stream_id: "s02_cluster_truax"
     onset: 32.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "001-0_0-3_0.wav"
     density: 12
     distribution: 1.0
     distribution_mode: "gaussian"
     grain:
       duration: 0.08
+    pointer:
+      speed_ratio: .04
     voices:
-      num_voices: 4
-      scatter: 0.0
-      pitch:
-        strategy: step
-        step: 3.0
+      num_voices: 10
+      scatter: [[0,0],[.5,1]]
       pan:
         strategy: linear
         spread: 60.0
@@ -94,49 +93,59 @@ streams:
   - stream_id: "s03_scatter_inert"
     onset: 64.0
     duration: 30.0
-    sample: "pino.wav"
-    density: 12
-    distribution: 0.0
+    sample: "pino2.wav"
+    density: 15
+    distribution: 0.5
+    pointer:
+      offset_range: 0.03
+      speed_ratio: .012
+      loop_start: 0.35
+    pitch:
+      semitones: -24
     grain:
-      duration: 0.08
+      duration: 
+        - [[[0, 0.2], [50,0.02],[100, 0.2]], 30.0, 2]
+      duration_range: 
+        - [[[0, .03], [50, 0.01], [100, .03]], 30.0, 2]
     voices:
-      num_voices: 4
+      num_voices: 13
       scatter: 1.0
       pitch:
-        strategy: step
-        step: 3.0
+        strategy: chord
+        chord: maj7
       pan:
         strategy: linear
         spread: 60.0
-
+    
   # S4: scatter totale + Truax — distribution=1, scatter=1
   # Ogni voce ha il proprio iot calcolato indipendentemente con distribuzione Truax.
   # Suono: nuvola granulare — voci completamente desincronizzate.
-  - stream_id: "s04_fully_independent"
-    onset: 96.0
-    duration: 30.0
-    sample: "pino.wav"
-    density: 12
-    distribution: 1.0
-    distribution_mode: "gaussian"
-    grain:
-      duration: 0.08
-    voices:
-      num_voices: 4
-      scatter: 1.0
-      pitch:
-        strategy: step
-        step: 3.0
-      pan:
-        strategy: linear
-        spread: 60.0
+#  - stream_id: "s04_fully_independent"
+#    onset: 96.0
+#    duration: 30.0
+#    sample: "pino2.wav"
+#    density: 12
+#    distribution: 1.0
+#    distribution_mode: "gaussian"
+#    grain:
+#      duration: 0.08
+#    voices:
+#      num_voices: 4
+#      scatter: 1.0
+#      pitch:
+#        strategy: step
+#        step: 3.0
+#      pan:
+#        strategy: linear
+#        spread: 60.0
 
   - stream_id: "s04_fully_independent1"
     onset: 96.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     time_mode: "normalized"
     density: [[0,3],[.5,3],[1,40]]
+    pan:  [[0.0, -3600.0], [1.0, 3600.0]]
     distribution: [[0,0],[.5,1],[0,0]]
     distribution_mode: "gaussian"
     grain:
@@ -165,22 +174,27 @@ streams:
       pan:
         strategy: linear
         spread: 60.0
-    pointer:
+    pointer: 
       speed_ratio: 
         - [0.0, 1.0]
         - [1.0, 0.0]
       loop_unit: absolute
-      offset_range: 
+      loop_dur:  3
+      loop_end: 
         type: cubic
         points:
           - [0.0, 0.0]
           - [0.5, 1.0]
           - [1.0, 0.0]
       loop_start: 
+        time_unit: absolute
         type: cubic
         points:
-          - [0.0, 0.0]
+          - [0.0, .6]
           - [.5, 1.644]
+    solo:
+    pitch:
+      ratio: 
   # ===========================================================================
   # SEZIONE 2 — SCATTER FISSO, DISTRIBUTION COME ENVELOPE
   # ===========================================================================
@@ -190,7 +204,7 @@ streams:
   - stream_id: "s05_scatter0_dist_breath"
     onset: 128.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     density: 15
     distribution: [[0, 0.0], [15, 1.0], [30, 0.0]]
     distribution_mode: "gaussian"
@@ -213,7 +227,7 @@ streams:
   - stream_id: "s06_scatter_half_dist_grow"
     onset: 160.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     density: 9
     distribution: [[0, 0.0], [30, 1.0]]
     distribution_mode: "gaussian"
@@ -236,7 +250,7 @@ streams:
   - stream_id: "s07_scatter1_dist_grow"
     onset: 192.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     density: 12
     distribution: [[0, 0.0], [10, 0.0], [30, 1.0]]
     distribution_mode: "gaussian"
@@ -259,7 +273,7 @@ streams:
   - stream_id: "s08_scatter1_dist_cycle"
     onset: 224.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     density: 10
     distribution:
       type: cubic
@@ -288,7 +302,7 @@ streams:
   - stream_id: "s09_scatter_grow_dist_fixed"
     onset: 256.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     density: 12
     distribution: 0.7
     distribution_mode: "gaussian"
@@ -313,7 +327,7 @@ streams:
   - stream_id: "s10_scatter_arc_dist1"
     onset: 288.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     density: 15
     distribution: 1.0
     distribution_mode: "gaussian"
@@ -333,7 +347,7 @@ streams:
   - stream_id: "s11_scatter_steps_dist_half"
     onset: 320.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     density: 10
     distribution: 0.5
     distribution_mode: "gaussian"
@@ -359,7 +373,7 @@ streams:
   - stream_id: "s12_scatter_osc_dist08"
     onset: 352.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     density: 9
     distribution: 0.8
     distribution_mode: "gaussian"
@@ -387,7 +401,7 @@ streams:
   - stream_id: "s13_both_grow"
     onset: 384.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     density: 12
     distribution: [[0, 0.0], [30, 1.0]]
     distribution_mode: "gaussian"
@@ -411,7 +425,7 @@ streams:
   - stream_id: "s14_both_shrink"
     onset: 416.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     density: 12
     distribution: [[0, 1.0], [30, 0.0]]
     distribution_mode: "gaussian"
@@ -433,7 +447,7 @@ streams:
   - stream_id: "s15_cross_scatter_grow_dist_shrink"
     onset: 448.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     density: 10
     distribution: [[0, 1.0], [30, 0.0]]
     distribution_mode: "gaussian"
@@ -457,7 +471,7 @@ streams:
   - stream_id: "s16_antiphase_scatter_dist"
     onset: 480.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     density: 12
     distribution:
       type: cubic
@@ -485,7 +499,7 @@ streams:
   - stream_id: "s17_low_density_cluster"
     onset: 512.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     density: 6
     distribution: 0.3
     distribution_mode: "gaussian"
@@ -506,7 +520,7 @@ streams:
   - stream_id: "s18_low_density_scatter"
     onset: 544.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     density: 9
     distribution: 0.9
     distribution_mode: "gaussian"
@@ -530,7 +544,7 @@ streams:
   - stream_id: "s19_density_grow_scatter_half"
     onset: 576.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     density: [[0, 6], [30, 15]]
     distribution: 0.6
     distribution_mode: "gaussian"
@@ -550,7 +564,7 @@ streams:
   - stream_id: "s20_low_density_scatter_grow"
     onset: 608.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     density: 15
     distribution: [[0, 0.0], [15, 1.0], [30, 0.5]]
     distribution_mode: "gaussian"
@@ -578,7 +592,7 @@ streams:
   - stream_id: "s21_high_density_cluster"
     onset: 640.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     density: 100
     distribution: 0.0
     grain:
@@ -597,7 +611,7 @@ streams:
   - stream_id: "s22_high_density_scatter"
     onset: 672.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     density: 200
     distribution: 1.0
     distribution_mode: "gaussian"
@@ -618,7 +632,7 @@ streams:
   - stream_id: "s23_density_explode_scatter_grow"
     onset: 704.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     density: [[0, 50], [30, 300]]
     distribution: [[0, 0.0], [30, 1.0]]
     distribution_mode: "gaussian"
@@ -638,7 +652,7 @@ streams:
   - stream_id: "s24_density_collapse_scatter_shrink"
     onset: 736.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     density: [[0, 300], [30, 6]]
     distribution: [[0, 1.0], [30, 0.0]]
     distribution_mode: "gaussian"
@@ -663,7 +677,7 @@ streams:
   - stream_id: "s25_voices_grow_cluster"
     onset: 768.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     density: 12
     distribution: 0.4
     distribution_mode: "gaussian"
@@ -684,7 +698,7 @@ streams:
   - stream_id: "s26_voices_grow_scatter_grow"
     onset: 800.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     density: 10
     distribution: 0.7
     distribution_mode: "gaussian"
@@ -707,7 +721,7 @@ streams:
   - stream_id: "s27_voices_shrink_scatter_shrink"
     onset: 832.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     density: 12
     distribution: [[0, 1.0], [30, 0.0]]
     distribution_mode: "gaussian"
@@ -727,7 +741,7 @@ streams:
   - stream_id: "s28_voices_arc_scatter_pulse"
     onset: 864.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     density: 9
     distribution: 0.8
     distribution_mode: "gaussian"
@@ -757,7 +771,7 @@ streams:
   - stream_id: "s29_full_combo_texture"
     onset: 896.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     density:
       type: cubic
       points: [[0, 8], [10, 80], [20, 150], [30, 30]]
@@ -783,7 +797,7 @@ streams:
   - stream_id: "s30_full_combo_dense"
     onset: 928.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     density: [[0, 100], [15, 300], [30, 50]]
     distribution: [[0, 0.5], [15, 1.0], [30, 0.3]]
     distribution_mode: "gaussian"
@@ -809,7 +823,7 @@ streams:
   - stream_id: "s31_breath_chord_scatter"
     onset: 960.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     density: [[0, 6], [10, 12], [20, 9], [30, 6]]
     distribution: [[0, 0.0], [10, 0.5], [20, 0.8], [30, 0.2]]
     distribution_mode: "gaussian"
@@ -837,7 +851,7 @@ streams:
   - stream_id: "s32_micro_scatter_perception"
     onset: 992.0
     duration: 30.0
-    sample: "pino.wav"
+    sample: "pino2.wav"
     density: 20
     distribution: [[0, 0.0], [15, 0.2], [30, 0.0]]
     distribution_mode: "gaussian"

--- a/make/utils.mk
+++ b/make/utils.mk
@@ -9,7 +9,7 @@ open:
 	$(OPEN_CMD) $(SFDIR)/*.aif
 
 pdf:
-	$(OPEN_CMD) $(GENDIR)/*.pdf
+	$(OPEN_CMD) $(SFDIR)/*.pdf
 
 sync:
 	git add .

--- a/src/controllers/pointer_controller.py
+++ b/src/controllers/pointer_controller.py
@@ -74,6 +74,10 @@ class PointerController:
 
         # 4. has_loop dipende solo dalla presenza di loop_start
         self.has_loop = 'loop_start' in params
+        # Se loop_start è presente ma start non è esplicito nello YAML,
+        # il pointer parte direttamente da loop_start(t=0) invece di 0.
+        if self.has_loop and 'start' not in params:
+            self.start = self.loop_start.get_value(0.0)
         if self.has_loop and self.loop_end is None and self.loop_dur is None:
             self.loop_end = self._orchestrator.create_constant_parameter(
     'loop_end', self._sample_dur_sec

--- a/src/parameters/parameter.py
+++ b/src/parameters/parameter.py
@@ -142,7 +142,8 @@ class Parameter:
 
     def _clamp(self, value: float, time: float) -> float:
         """Applica i limiti di sicurezza (Min/Max) e logga se taglia."""
-        clamped = max(self._bounds.min_val, min(self._bounds.max_val, value))
+        max_val = self._bounds.max_val
+        clamped = max(self._bounds.min_val, value) if max_val is None else max(self._bounds.min_val, min(max_val, value))
         
         if clamped != value:
             # Logga il warning usando il logger configurato

--- a/src/parameters/parameter_definitions.py
+++ b/src/parameters/parameter_definitions.py
@@ -34,7 +34,7 @@ class ParameterBounds:
                           Es. Reverse (non usa range additivo, usa probabilità).
     """
     min_val: float
-    max_val: float
+    max_val: float | None
     min_range: float = 0.0
     max_range: float = 0.0
     default_jitter: float = 0.0
@@ -146,17 +146,17 @@ GRANULAR_PARAMETERS: Dict[str, ParameterBounds] = {
     
     'loop_dur': ParameterBounds(
         min_val=0.005,
-        max_val=1000.0 
+        max_val=None  # bound reale = sample_dur_sec, passato dinamicamente
     ),
 
     'loop_start': ParameterBounds(
         min_val=0,
-        max_val=100.0 
+        max_val=None  # bound reale = sample_dur_sec, passato dinamicamente
     ),
 
     'loop_end': ParameterBounds(
         min_val=0.0,
-        max_val=1000.0 
+        max_val=None  # bound reale = sample_dur_sec, passato dinamicamente
     ),
 
 

--- a/src/parameters/parser.py
+++ b/src/parameters/parser.py
@@ -134,7 +134,7 @@ class GranularParser:
         self,
         param: Optional[ParamInput],
         min_bound: float,
-        max_bound: float,
+        max_bound: Optional[float],
         param_name: str,
         value_type: str
     ) -> Optional[ParamInput]:
@@ -164,8 +164,8 @@ class GranularParser:
         # Caso 1: Numero scalare
         if isinstance(param, (int, float)):
             clean = float(param)
-            clipped = max(min_bound, min(max_bound, clean))
-            
+            clipped = max(min_bound, clean) if max_bound is None else max(min_bound, min(max_bound, clean))
+
             if clipped != clean:
                 # Calcola messaggio di errore
                 bound_type = "MIN" if clean < min_bound else "MAX"
@@ -205,8 +205,8 @@ class GranularParser:
             fixed_points = []
             
             for t, y in param.breakpoints:
-                clipped_y = max(min_bound, min(max_bound, y))
-                
+                clipped_y = max(min_bound, y) if max_bound is None else max(min_bound, min(max_bound, y))
+
                 if clipped_y != y:
                     needs_fixing = True
                     bound_type = "MIN" if y < min_bound else "MAX"
@@ -232,7 +232,7 @@ class GranularParser:
                 else:
                     # Log ogni violazione
                     for t, y in param.breakpoints:
-                        clipped_y = max(min_bound, min(max_bound, y))
+                        clipped_y = max(min_bound, y) if max_bound is None else max(min_bound, min(max_bound, y))
                         if clipped_y != y:
                             log_config_warning(
                                 stream_id=self.stream_id,

--- a/tests/controllers/test_pointer_controller.py
+++ b/tests/controllers/test_pointer_controller.py
@@ -2385,3 +2385,63 @@ class TestPointerControllerMissingLines:
             assert pointer._drift_log_interval == pytest.approx(5.0)
             assert pointer._drift_last_logged == pytest.approx(-999.0)
             assert pointer._drift_first_warning_emitted is False
+
+
+# =============================================================================
+# GRUPPO 10: START IMPLICITO DA LOOP_START
+# =============================================================================
+
+class TestStartImplicitFromLoopStart:
+    """
+    Se 'start' non è presente nello YAML ma 'loop_start' sì,
+    self.start deve essere sovrascritto con loop_start.get_value(0.0).
+    Se 'start' è esplicito, rimane invariato.
+    """
+
+    def test_start_defaults_to_loop_start_when_absent(self, pointer_factory):
+        """Senza 'start' nello YAML, start = loop_start(t=0)."""
+        pointer = pointer_factory({'loop_start': 3.0, 'loop_end': 6.0})
+        assert pointer.start == pytest.approx(3.0)
+
+    def test_start_explicit_is_not_overridden(self, pointer_factory):
+        """Con 'start' esplicito, rimane invariato anche se loop_start è diverso."""
+        pointer = pointer_factory({'start': 1.0, 'loop_start': 3.0, 'loop_end': 6.0})
+        assert pointer.start == pytest.approx(1.0)
+
+    def test_start_explicit_zero_is_not_overridden(self, pointer_factory):
+        """'start: 0.0' esplicito non deve essere sovrascritto (non è un default)."""
+        pointer = pointer_factory({'start': 0.0, 'loop_start': 3.0, 'loop_end': 6.0})
+        assert pointer.start == pytest.approx(0.0)
+
+    def test_start_defaults_to_loop_start_envelope_initial_value(self, mock_config):
+        """Con loop_start Envelope, start = loop_start.get_value(0.0)."""
+        from envelopes.envelope import Envelope
+
+        env = Envelope([[0.0, 2.5], [1.0, 5.0]])
+
+        with patch('controllers.pointer_controller.ParameterOrchestrator') as MockOrch:
+            mock_orch = MockOrch.return_value
+            mock_config.context.sample_dur_sec = 10.0
+
+            loop_start_param = Mock()
+            loop_start_param._value = env
+            loop_start_param.get_value = Mock(return_value=env.evaluate(0.0))
+
+            mock_orch.create_all_parameters.return_value = {
+                'pointer_start': 0.0,
+                'pointer_speed_ratio': Mock(value=1.0, get_value=Mock(return_value=1.0)),
+                'pointer_deviation': Mock(value=0.0, get_value=Mock(return_value=0.0)),
+                'loop_start': loop_start_param,
+                'loop_end': Mock(value=8.0, get_value=Mock(return_value=8.0)),
+                'loop_dur': None,
+            }
+
+            params = {'loop_start': [[0.0, 2.5], [1.0, 5.0]], 'loop_end': 8.0}
+            pointer = PointerController(params, mock_config)
+
+            assert pointer.start == pytest.approx(env.evaluate(0.0))
+
+    def test_no_loop_start_start_remains_zero(self, pointer_factory):
+        """Senza loop, start rimane al default 0.0."""
+        pointer = pointer_factory({'speed_ratio': 1.0})
+        assert pointer.start == pytest.approx(0.0)

--- a/tests/parameters/test_parameter_definitions.py
+++ b/tests/parameters/test_parameter_definitions.py
@@ -668,8 +668,10 @@ class TestCrossRegistryInvariants:
 
     @pytest.mark.parametrize("param_name", sorted(EXPECTED_PARAMETERS))
     def test_min_val_less_than_or_equal_max_val(self, param_name):
-        """min_val <= max_val per ogni parametro."""
+        """min_val <= max_val per ogni parametro (None = nessun upper bound)."""
         b = GRANULAR_PARAMETERS[param_name]
+        if b.max_val is None:
+            return  # nessun upper bound statico: invariante non applicabile
         assert b.min_val <= b.max_val, (
             f"'{param_name}': min_val={b.min_val} > max_val={b.max_val}"
         )
@@ -875,8 +877,8 @@ class TestEdgeCases:
             assert isinstance(bounds.min_val, (int, float)), (
                 f"'{name}' min_val non numerico: {type(bounds.min_val)}"
             )
-            assert isinstance(bounds.max_val, (int, float)), (
-                f"'{name}' max_val non numerico: {type(bounds.max_val)}"
+            assert bounds.max_val is None or isinstance(bounds.max_val, (int, float)), (
+                f"'{name}' max_val deve essere numero o None: {type(bounds.max_val)}"
             )
             assert isinstance(bounds.min_range, (int, float)), (
                 f"'{name}' min_range non numerico"
@@ -896,12 +898,14 @@ class TestEdgeCases:
             )
 
     def test_no_nan_or_inf_in_bounds(self):
-        """Nessun NaN o Inf nei bounds."""
+        """Nessun NaN o Inf nei bounds (None = nessun bound, non è NaN/Inf)."""
         import math
         for name, bounds in GRANULAR_PARAMETERS.items():
             for field_name in ('min_val', 'max_val', 'min_range',
                                'max_range', 'default_jitter'):
                 val = getattr(bounds, field_name)
+                if val is None:
+                    continue  # None è upper bound assente, non un valore non valido
                 assert not math.isnan(val), (
                     f"'{name}'.{field_name} e' NaN"
                 )
@@ -987,3 +991,35 @@ class TestGetParameterDefinitionDynamic:
         """Il bound dinamico funziona per qualsiasi durata positiva."""
         bounds = get_parameter_definition('loop_end', sample_dur_sec=dur)
         assert bounds.max_val == dur
+
+
+# =============================================================================
+# 15. PARAMETERBOUNDS CON max_val=None (PARAMETRI LOOP SENZA CAMPIONE NOTO)
+# =============================================================================
+
+class TestLoopParamsNoneMaxVal:
+    """
+    loop_dur, loop_start, loop_end non devono avere un upper bound statico
+    arbitrario nel registry. Il bound reale è sempre sample_dur_sec, passato
+    dinamicamente. Senza di esso, max_val deve essere None (nessun limite).
+    """
+
+    @pytest.mark.parametrize("name", LOOP_PARAMS)
+    def test_loop_params_static_max_val_is_none(self, name):
+        """Nel registry statico, i parametri loop hanno max_val=None."""
+        assert GRANULAR_PARAMETERS[name].max_val is None, (
+            f"'{name}' dovrebbe avere max_val=None nel registry, "
+            f"trovato: {GRANULAR_PARAMETERS[name].max_val}"
+        )
+
+    @pytest.mark.parametrize("name", LOOP_PARAMS)
+    def test_get_parameter_definition_without_sample_dur_returns_none_max(self, name):
+        """Senza sample_dur_sec, get_parameter_definition ritorna max_val=None."""
+        bounds = get_parameter_definition(name)
+        assert bounds.max_val is None
+
+    def test_parameter_bounds_accepts_none_max_val(self):
+        """ParameterBounds con max_val=None è costruibile senza errori."""
+        bounds = ParameterBounds(min_val=0.0, max_val=None)
+        assert bounds.max_val is None
+        assert bounds.min_val == 0.0

--- a/tests/parameters/test_parameter_factory.py
+++ b/tests/parameters/test_parameter_factory.py
@@ -782,3 +782,11 @@ class TestParserDynamicLoopBounds:
         parser = GranularParser(config)
         param = parser.parse_parameter('loop_end', 150.0)
         assert param.get_value(0) == pytest.approx(150.0)
+
+    @pytest.mark.parametrize("name", ['loop_end', 'loop_start', 'loop_dur'])
+    def test_loop_param_without_sample_dur_accepts_large_value(self, name):
+        """Senza sample_dur_sec (max_val=None), qualsiasi valore >= min è valido."""
+        config = make_config_with_sample_dur(None)
+        parser = GranularParser(config)
+        param = parser.parse_parameter(name, 9999.0)
+        assert param.get_value(0) == pytest.approx(9999.0)


### PR DESCRIPTION
## Summary

- **`PointerController`**: quando `start` non è specificato nello YAML ma `loop_start` sì, il pointer parte da `loop_start(t=0)` invece che da `0`. Il valore esplicito `start` non viene mai sovrascritto.
- **`ParameterBounds`**: `loop_dur`, `loop_start`, `loop_end` hanno ora `max_val=None` nel registry statico. Il bound reale è sempre `sample_dur_sec`, passato dinamicamente. `_validate_and_clip` e `_clamp` saltano il clipping superiore quando `max_bound` è `None`.

## Test plan

- [ ] `make tests` passa (3802 test, 0 falliti)
- [ ] Nuovi test in `TestStartImplicitFromLoopStart` coprono tutti i casi del default implicito
- [ ] Nuovi test in `TestLoopParamsNoneMaxVal` e `TestParserDynamicLoopBounds` coprono il comportamento con `max_val=None`
- [ ] Invarianti cross-registry aggiornati per gestire `max_val=None`