### PR TITLE
fix(stream): errore leggibile per sample mancante o null

### DIFF
--- a/src/core/stream.py
+++ b/src/core/stream.py
@@ -53,7 +53,14 @@ class Stream:
             params: dizionario parametri dallo YAML
         """
         # === 3. CONFIGURATION ===
-        config = StreamConfig.from_yaml(params,StreamContext.from_yaml(params, sample_dur_sec=get_sample_duration(params['sample'])))
+        sample = params.get('sample')
+        stream_id = params.get('stream_id', 'unknown')
+        if not sample:
+            raise ValueError(
+                f"Stream '{stream_id}': campo 'sample' mancante o null — "
+                "specificare il nome del file wav (es. sample: mio_file.wav)"
+            )
+        config = StreamConfig.from_yaml(params, StreamContext.from_yaml(params, sample_dur_sec=get_sample_duration(sample)))
         self._init_stream_context(params)
         # === 4. PARAMETRI SPECIALI ===
         self._init_grain_reverse(params)

--- a/tests/core/test_stream.py
+++ b/tests/core/test_stream.py
@@ -544,6 +544,29 @@ class TestStreamInit:
             assert s.generated is False
             assert s.sample_table_num is None
             assert s.envelope_table_num is None
+
+    def test_missing_sample_raises_value_error(self):
+        """Stream senza 'sample' -> ValueError leggibile."""
+        params = _minimal_yaml_params()
+        del params['sample']
+        with pytest.raises(ValueError, match="sample"):
+            Stream(params)
+
+    def test_null_sample_raises_value_error(self):
+        """Stream con sample: null -> ValueError leggibile."""
+        params = _minimal_yaml_params()
+        params['sample'] = None
+        with pytest.raises(ValueError, match="sample"):
+            Stream(params)
+
+    def test_error_message_contains_stream_id(self):
+        """Il messaggio di errore include lo stream_id per facilitare il debug."""
+        params = _minimal_yaml_params()
+        params['stream_id'] = 'stream_problematico'
+        params['sample'] = None
+        with pytest.raises(ValueError, match="stream_problematico"):
+            Stream(params)
+
 # =============================================================================
 # 6. TEST generate_grains - LOOP PRINCIPALE (1 VOCE)
 # =============================================================================


### PR DESCRIPTION
Fixes #11

## Problema

`make all` crashava con `TypeError: can only concatenate str (not "NoneType") to str` quando il campo `sample` era assente o `null` nel YAML. L'errore non indicava quale stream fosse il problema né come risolverlo.

## Fix

Aggiunta validazione esplicita in `Stream.__init__` prima di chiamare `get_sample_duration`:

```
ValueError: Stream 'stream1': campo 'sample' mancante o null — specificare il nome del file wav (es. sample: mio_file.wav)
```

## Test

Aggiunti 3 test in `TestStreamInit`:
- `sample` assente → `ValueError`
- `sample: null` → `ValueError`  
- Il messaggio include lo `stream_id` per facilitare il debug