### PR TITLE
chore: ignora .vscode/ completamente

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -685,12 +685,7 @@ poetry.toml
 pyrightconfig.json
 
 ### VisualStudioCode ###
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
-!.vscode/*.code-snippets
+.vscode/
 
 # Local History for Visual Studio Code
 .history/


### PR DESCRIPTION
Rimuove le eccezioni che tracciavano settings.json, launch.json ecc. — le configurazioni VSCode sono locali e non devono essere versionate.