### PR TITLE
refactor(window): WindowStrategyFactory con registry + kwargs

### DIFF
--- a/configs/PGE_window_strategy_test.yml
+++ b/configs/PGE_window_strategy_test.yml
@@ -1,0 +1,64 @@
+# PGE_window_strategy_test.yml
+#
+# Config di test empirico per WindowStrategyFactory refactoring.
+# Tre stream che esercitano le tre strategy principali:
+#   S1 — SingleWindowStrategy   (envelope: stringa)
+#   S2 — TransitionWindowStrategy (envelope: {from, to, curve})
+#   S3 — MultiStateWindowStrategy (envelope: {states, curve})
+#
+# Parametri comuni:
+#   density:  0.5  (un grano ogni ~2 secondi)
+#   duration: 1.0s (grano lungo, involucro ben udibile)
+#   durata stream: 60s
+
+streams:
+
+  # ---------------------------------------------------------------------------
+  # S1 — SingleWindowStrategy
+  # Sempre hanning. Riferimento: nessuna variazione di envelope.
+  # ---------------------------------------------------------------------------
+  - stream_id: "s1_single_hanning"
+    onset: 0.0
+    duration: 60.0
+    sample: "sinus.wav"
+    density: 0.5
+    grain:
+      duration: 1.0
+      envelope: hanning
+
+  # ---------------------------------------------------------------------------
+  # S2 — TransitionWindowStrategy
+  # Da hanning (morbido) a expodec (attacco netto) in 60 secondi.
+  # Si sente lo spostamento progressivo del timbro dell'involucro.
+  # ---------------------------------------------------------------------------
+  - stream_id: "s2_transition_hanning_to_expodec"
+    onset: 60.0
+    duration: 60.0
+    sample: "sinus.wav"
+    density: 10
+    grain:
+      duration: .1
+      envelope:
+        from: hanning
+        to: expodec
+        curve: [[0, 0], [60, 1]]
+
+  # ---------------------------------------------------------------------------
+  # S3 — MultiStateWindowStrategy
+  # Quattro stati: hanning → bartlett → gaussian → blackman
+  # La curve percorre tutto l'arco in 60s.
+  # ---------------------------------------------------------------------------
+  - stream_id: "s3_multistate_four_windows"
+    onset: 120.0
+    duration: 60.0
+    sample: "sinus.wav"
+    density: 15
+    grain:
+      duration: 0.01
+      envelope:
+        states:
+          - [0.0, hanning]
+          - [0.33, bartlett]
+          - [0.66, exporise]
+          - [1.0, blackman]
+        curve: [[0, 0], [60, 1]]

--- a/src/controllers/window_controller.py
+++ b/src/controllers/window_controller.py
@@ -1,14 +1,10 @@
-# src/window_controller.py
-from typing import List, Optional, Dict, Any
+# src/controllers/window_controller.py
+from typing import List
 from controllers.window_registry import WindowRegistry
 from controllers.window_selection_strategy import (
     WindowSelectionStrategy,
-    SingleWindowStrategy,
-    RandomWindowStrategy,
-    TransitionWindowStrategy,
-    MultiStateWindowStrategy,
+    WindowStrategyFactory,
 )
-import random
 from core.stream_config import StreamConfig
 from parameters.gate_factory import GateFactory
 from parameters.parameter_definitions import DEFAULT_PROB
@@ -32,13 +28,14 @@ class WindowController:
     """
     Gestisce selezione grain envelope.
 
-    Supporta tre modalità:
-      - Stringa singola: sempre la stessa finestra
-      - Lista:           selezione casuale governata da gate probabilistico
-      - Transition dict: morphing probabilistico from→to via Envelope
+    Supporta quattro modalità (via WindowStrategyFactory):
+      - Stringa singola:  sempre la stessa finestra (SingleWindowStrategy)
+      - Lista:            selezione casuale con gate (RandomWindowStrategy)
+      - Transition dict:  morphing probabilistico from→to (TransitionWindowStrategy)
+      - Multi-state dict: transizione attraverso N stati (MultiStateWindowStrategy)
 
-    Per aggiungere nuove modalità: crea una WindowSelectionStrategy e registrala
-    nel metodo __init__() senza toccare select_window() né le strategie esistenti.
+    Per aggiungere nuove modalità: registra una WindowSelectionStrategy nel
+    WINDOW_STRATEGY_REGISTRY senza modificare questo controller.
     """
 
     # =========================================================================
@@ -118,93 +115,37 @@ class WindowController:
             config: StreamConfig con regole di processo (dephase, durata, ecc.)
         """
         envelope_spec = params.get('envelope', 'hanning')
+        self._windows = self.parse_window_list(params, config.context.stream_id)
 
-        # --- Modalità MULTI-STATE ---
-        if _is_multistate_spec(envelope_spec):
-            self._windows = self.parse_window_list(params, config.context.stream_id)
-            self._gate = GateFactory.create_gate(
-                dephase=False,
-                param_key='pc_rand_envelope',
-                default_prob=DEFAULT_PROB,
-                has_explicit_range=False,
-                range_always_active=config.range_always_active,
-                duration=config.context.duration,
-                time_mode=config.time_mode,
-            )
-            from envelopes.envelope import Envelope
-            raw_states = envelope_spec['states']
-            curve_data = envelope_spec.get('curve', [[0, 0], [1, 1]])
-            self._strategy: WindowSelectionStrategy = MultiStateWindowStrategy(
-                states=[(float(v), w) for v, w in raw_states],
-                curve=Envelope(curve_data),
-                duration=config.context.duration,
-                time_mode=config.time_mode,
-                stream_id=config.context.stream_id,
-            )
+        uses_gate = not (_is_transition_spec(envelope_spec) or _is_multistate_spec(envelope_spec))
+        gate = GateFactory.create_gate(
+            dephase=config.dephase if uses_gate else False,
+            param_key='pc_rand_envelope',
+            default_prob=DEFAULT_PROB,
+            has_explicit_range=uses_gate and len(self._windows) > 1,
+            range_always_active=config.range_always_active,
+            duration=config.context.duration,
+            time_mode=config.time_mode,
+        )
+        self._strategy: WindowSelectionStrategy = WindowStrategyFactory.from_spec(
+            envelope_spec, config, self._windows, gate
+        )
 
-        # --- Modalità TRANSITION ---
-        elif _is_transition_spec(envelope_spec):
-            self._windows = self.parse_window_list(params, config.context.stream_id)
-            # _gate è placeholder (non usato da TransitionWindowStrategy)
-            self._gate = GateFactory.create_gate(
-                dephase=False,
-                param_key='pc_rand_envelope',
-                default_prob=DEFAULT_PROB,
-                has_explicit_range=False,
-                range_always_active=config.range_always_active,
-                duration=config.context.duration,
-                time_mode=config.time_mode,
-            )
-            from envelopes.envelope import Envelope
-            curve_data = envelope_spec.get('curve', [[0, 0], [1, 1]])
-            self._strategy: WindowSelectionStrategy = TransitionWindowStrategy(
-                from_window=self._windows[0],
-                to_window=self._windows[1],
-                curve=Envelope(curve_data),
-                duration=config.context.duration,
-                time_mode=config.time_mode,
-                stream_id=config.context.stream_id,
-            )
+    @property
+    def _gate(self):
+        """Proxy verso strategy._gate per compatibilità con i test esistenti."""
+        return getattr(self._strategy, '_gate', None)
 
-        # --- Modalità RANDOM / SINGLE ---
-        else:
-            self._windows = self.parse_window_list(params, config.context.stream_id)
-            has_explicit_range = len(self._windows) > 1
-            self._gate = GateFactory.create_gate(
-                dephase=config.dephase,
-                param_key='pc_rand_envelope',
-                default_prob=DEFAULT_PROB,
-                has_explicit_range=has_explicit_range,
-                range_always_active=config.range_always_active,
-                duration=config.context.duration,
-                time_mode=config.time_mode,
-            )
-            if len(self._windows) == 1:
-                self._strategy = SingleWindowStrategy(self._windows[0])
-            else:
-                self._strategy = RandomWindowStrategy(self._windows, self._gate)
+    @_gate.setter
+    def _gate(self, value):
+        if hasattr(self._strategy, '_gate'):
+            self._strategy._gate = value
 
     def select_window(self, elapsed_time: float = 0.0) -> str:
         """
-        Seleziona finestra per grano corrente.
-
-        Per la modalità random la selezione rispetta ctrl._gate anche se sostituito
-        dopo l'inizializzazione (i test esistenti impostano ctrl._gate direttamente).
+        Seleziona la finestra per il grano corrente delegando alla strategy.
 
         Args:
-            elapsed_time: tempo corrente nello stream, necessario per
-                          gate con probabilità variabile nel tempo (EnvelopeGate)
-                          e per TransitionWindowStrategy.
+            elapsed_time: tempo corrente nello stream (secondi).
         """
-        # Transition / MultiState: delega completamente alla strategy
-        if isinstance(self._strategy, (TransitionWindowStrategy, MultiStateWindowStrategy)):
-            return self._strategy.select(elapsed_time)
-
-        # Single window: guard clause (non consulta il gate)
-        if len(self._windows) == 1:
-            return self._windows[0]
-
-        # Random: consulta self._gate (permettendo sostituzioni post-init nei test)
-        if not self._gate.should_apply(elapsed_time):
-            return self._windows[0]
-        return random.choice(self._windows)
+        return self._strategy.select(elapsed_time)

--- a/src/controllers/window_selection_strategy.py
+++ b/src/controllers/window_selection_strategy.py
@@ -79,10 +79,14 @@ class SingleWindowStrategy(WindowSelectionStrategy):
 
     Ritorna sempre la stessa finestra, senza consultare alcun gate.
     Corrisponde a: envelope: 'hanning'
+
+    Il gate viene memorizzato per compatibilità con il proxy _gate di
+    WindowController, ma non viene mai consultato in select().
     """
 
-    def __init__(self, window: str):
+    def __init__(self, window: str, gate):
         self._window = window
+        self._gate = gate
 
     def select(self, elapsed_time: float) -> str:
         return self._window
@@ -237,3 +241,116 @@ class MultiStateWindowStrategy(WindowSelectionStrategy):
 
         # Fallback (non raggiungibile se states è ordinato e v è clamped)
         return self._states[-1][1]
+
+
+# =============================================================================
+# REGISTRY E FACTORY
+# =============================================================================
+
+from typing import Dict, Type  # noqa: E402  (import locale, dopo le classi)
+
+WINDOW_STRATEGY_REGISTRY: Dict[str, Type[WindowSelectionStrategy]] = {
+    'single':     SingleWindowStrategy,
+    'random':     RandomWindowStrategy,
+    'transition': TransitionWindowStrategy,
+    'multistate': MultiStateWindowStrategy,
+}
+
+
+def register_window_strategy(name: str, cls: Type[WindowSelectionStrategy]) -> None:
+    """
+    Registra dinamicamente una nuova WindowSelectionStrategy.
+
+    Args:
+        name: chiave stringa per il registry
+        cls:  classe che implementa WindowSelectionStrategy
+    """
+    WINDOW_STRATEGY_REGISTRY[name] = cls
+
+
+class WindowStrategyFactory:
+    """
+    Factory per la creazione di WindowSelectionStrategy da nome o spec YAML.
+
+    Esempio:
+        s = WindowStrategyFactory.create('single', window='hanning', gate=gate)
+        s = WindowStrategyFactory.create('random', windows=['hanning', 'expodec'], gate=gate)
+        s = WindowStrategyFactory.from_spec(envelope_spec, config, windows, gate)
+    """
+
+    @staticmethod
+    def create(name: str, **kwargs) -> WindowSelectionStrategy:
+        """
+        Crea una WindowSelectionStrategy dal nome registrato.
+
+        Args:
+            name:    nome della strategy nel registry
+            **kwargs: parametri passati al costruttore
+
+        Raises:
+            KeyError: se il nome non è nel registry
+        """
+        if name not in WINDOW_STRATEGY_REGISTRY:
+            raise KeyError(
+                f"WindowSelectionStrategy '{name}' non trovata. "
+                f"Disponibili: {sorted(WINDOW_STRATEGY_REGISTRY.keys())}"
+            )
+        return WINDOW_STRATEGY_REGISTRY[name](**kwargs)
+
+    @staticmethod
+    def from_spec(
+        envelope_spec,
+        config,
+        windows: List[str],
+        gate,
+    ) -> WindowSelectionStrategy:
+        """
+        Crea la strategy corretta a partire dalla spec YAML envelope.
+
+        Args:
+            envelope_spec: valore del campo 'envelope' dal YAML
+            config:        StreamConfig con duration, time_mode, stream_id
+            windows:       lista di finestre già parsata da parse_window_list()
+            gate:          ProbabilityGate creato da WindowController
+
+        Returns:
+            Istanza di WindowSelectionStrategy appropriata
+        """
+        from envelopes.envelope import Envelope
+
+        duration  = config.context.duration
+        time_mode = config.time_mode
+        stream_id = config.context.stream_id
+
+        # --- Multi-state ---
+        if isinstance(envelope_spec, dict) and 'states' in envelope_spec:
+            raw_states = envelope_spec['states']
+            curve_data = envelope_spec.get('curve', [[0, 0], [1, 1]])
+            return WindowStrategyFactory.create(
+                'multistate',
+                states=[(float(v), w) for v, w in raw_states],
+                curve=Envelope(curve_data),
+                duration=duration,
+                time_mode=time_mode,
+                stream_id=stream_id,
+            )
+
+        # --- Transition ---
+        if isinstance(envelope_spec, dict) and 'from' in envelope_spec and 'to' in envelope_spec:
+            curve_data = envelope_spec.get('curve', [[0, 0], [1, 1]])
+            return WindowStrategyFactory.create(
+                'transition',
+                from_window=windows[0],
+                to_window=windows[1],
+                curve=Envelope(curve_data),
+                duration=duration,
+                time_mode=time_mode,
+                stream_id=stream_id,
+            )
+
+        # --- Random (lista con più finestre) ---
+        if len(windows) > 1:
+            return WindowStrategyFactory.create('random', windows=windows, gate=gate)
+
+        # --- Single ---
+        return WindowStrategyFactory.create('single', window=windows[0], gate=gate)

--- a/src/rendering/numpy_window_registry.py
+++ b/src/rendering/numpy_window_registry.py
@@ -94,6 +94,7 @@ class NumpyWindowRegistry:
         """Lista dei nomi di finestra disponibili."""
         names = list(self._NUMPY_WINDOWS.keys())
         names.append('kaiser')
+        names.append('gaussian')
         names.extend(self._GEN16_WINDOWS.keys())
         names.append('half_sine')
         return names
@@ -124,7 +125,11 @@ class NumpyWindowRegistry:
             start, curve, end = self._GEN16_WINDOWS[name]
             return self._gen16(n, start, curve, end)
 
-        # 4. Half-sine (GEN09 equivalente)
+        # 4. Gaussian (campana centrata, sigma=0.4)
+        if name == 'gaussian':
+            return self._gaussian(n)
+
+        # 5. Half-sine (GEN09 equivalente)
         if name == 'half_sine':
             return self._half_sine(n)
 
@@ -159,6 +164,21 @@ class NumpyWindowRegistry:
 
         normalized = (1.0 - np.exp(curve * x)) / (1.0 - np.exp(curve))
         return start + (end - start) * normalized
+
+    @staticmethod
+    def _gaussian(n: int, sigma: float = 0.4) -> np.ndarray:
+        """
+        Genera una finestra gaussiana centrata.
+
+        Equivalente a GEN20 di Csound con p5=gaussian.
+        sigma controlla la larghezza: 0.4 = leggermente più stretta di hanning.
+
+        Args:
+            n:     lunghezza in campioni
+            sigma: deviazione standard normalizzata rispetto a metà finestra
+        """
+        x = np.linspace(-1.0, 1.0, n)
+        return np.exp(-0.5 * (x / sigma) ** 2)
 
     @staticmethod
     def _half_sine(n: int) -> np.ndarray:

--- a/tests/controllers/test_window_controller.py
+++ b/tests/controllers/test_window_controller.py
@@ -1184,3 +1184,358 @@ class TestCurveRangeValidation:
         with patch('controllers.window_selection_strategy.log_window_curve_warning') as mock_warn:
             self._make_transition([[0, 0], [10, 1]], duration=10.0)
             mock_warn.assert_not_called()
+
+
+# =============================================================================
+# 23. TEST SingleWindowStrategy — _gate attribute
+# =============================================================================
+
+class TestSingleWindowStrategyGate:
+    """
+    SingleWindowStrategy deve accettare un gate nel costruttore e memorizzarlo,
+    ma non consultarlo mai durante select().
+    """
+
+    def _make(self, gate=None):
+        from controllers.window_selection_strategy import SingleWindowStrategy
+        from shared.probability_gate import NeverGate
+        return SingleWindowStrategy(window='hanning', gate=gate or NeverGate())
+
+    def test_single_strategy_has_gate_attribute(self):
+        s = self._make()
+        assert hasattr(s, '_gate')
+
+    def test_single_strategy_gate_is_the_one_passed_in(self):
+        from shared.probability_gate import AlwaysGate
+        g = AlwaysGate()
+        s = self._make(gate=g)
+        assert s._gate is g
+
+    def test_single_strategy_select_never_calls_gate(self):
+        mock_gate = Mock(spec=ProbabilityGate)
+        from controllers.window_selection_strategy import SingleWindowStrategy
+        s = SingleWindowStrategy(window='hanning', gate=mock_gate)
+        s.select(0.0)
+        s.select(5.0)
+        mock_gate.should_apply.assert_not_called()
+
+    def test_single_strategy_select_returns_window_regardless_of_gate(self):
+        from controllers.window_selection_strategy import SingleWindowStrategy
+        from shared.probability_gate import NeverGate, AlwaysGate
+        for gate in [NeverGate(), AlwaysGate()]:
+            s = SingleWindowStrategy(window='bartlett', gate=gate)
+            assert s.select(0.0) == 'bartlett'
+
+
+# =============================================================================
+# 24. TEST WindowStrategyRegistry
+# =============================================================================
+
+class TestWindowStrategyRegistry:
+    """
+    WINDOW_STRATEGY_REGISTRY deve esistere con le quattro strategy di default.
+    register_window_strategy() deve permettere l'aggiunta di nuove entry.
+    """
+
+    def test_registry_exists(self):
+        from controllers.window_selection_strategy import WINDOW_STRATEGY_REGISTRY
+        assert isinstance(WINDOW_STRATEGY_REGISTRY, dict)
+
+    def test_registry_contains_single(self):
+        from controllers.window_selection_strategy import WINDOW_STRATEGY_REGISTRY, SingleWindowStrategy
+        assert 'single' in WINDOW_STRATEGY_REGISTRY
+        assert WINDOW_STRATEGY_REGISTRY['single'] is SingleWindowStrategy
+
+    def test_registry_contains_random(self):
+        from controllers.window_selection_strategy import WINDOW_STRATEGY_REGISTRY, RandomWindowStrategy
+        assert 'random' in WINDOW_STRATEGY_REGISTRY
+        assert WINDOW_STRATEGY_REGISTRY['random'] is RandomWindowStrategy
+
+    def test_registry_contains_transition(self):
+        from controllers.window_selection_strategy import WINDOW_STRATEGY_REGISTRY, TransitionWindowStrategy
+        assert 'transition' in WINDOW_STRATEGY_REGISTRY
+        assert WINDOW_STRATEGY_REGISTRY['transition'] is TransitionWindowStrategy
+
+    def test_registry_contains_multistate(self):
+        from controllers.window_selection_strategy import WINDOW_STRATEGY_REGISTRY, MultiStateWindowStrategy
+        assert 'multistate' in WINDOW_STRATEGY_REGISTRY
+        assert WINDOW_STRATEGY_REGISTRY['multistate'] is MultiStateWindowStrategy
+
+    def test_register_window_strategy_adds_entry(self):
+        from controllers.window_selection_strategy import (
+            WINDOW_STRATEGY_REGISTRY, register_window_strategy, WindowSelectionStrategy,
+        )
+
+        class DummyStrategy(WindowSelectionStrategy):
+            def select(self, elapsed_time):
+                return 'hanning'
+
+        register_window_strategy('dummy_test', DummyStrategy)
+        assert 'dummy_test' in WINDOW_STRATEGY_REGISTRY
+        assert WINDOW_STRATEGY_REGISTRY['dummy_test'] is DummyStrategy
+        # cleanup
+        del WINDOW_STRATEGY_REGISTRY['dummy_test']
+
+    def test_register_window_strategy_overwrites_existing(self):
+        from controllers.window_selection_strategy import (
+            WINDOW_STRATEGY_REGISTRY, register_window_strategy, WindowSelectionStrategy,
+            SingleWindowStrategy,
+        )
+
+        class AltSingle(WindowSelectionStrategy):
+            def select(self, elapsed_time):
+                return 'gaussian'
+
+        original = WINDOW_STRATEGY_REGISTRY['single']
+        register_window_strategy('single', AltSingle)
+        assert WINDOW_STRATEGY_REGISTRY['single'] is AltSingle
+        # restore
+        register_window_strategy('single', original)
+
+
+# =============================================================================
+# 25. TEST WindowStrategyFactory.create()
+# =============================================================================
+
+class TestWindowStrategyFactoryCreate:
+    """
+    WindowStrategyFactory.create(name, **kwargs) deve istanziare la strategy
+    corretta dal registry passando i kwargs al costruttore.
+    """
+
+    def test_create_single_returns_single_strategy(self):
+        from controllers.window_selection_strategy import WindowStrategyFactory, SingleWindowStrategy
+        from shared.probability_gate import NeverGate
+        s = WindowStrategyFactory.create('single', window='hanning', gate=NeverGate())
+        assert isinstance(s, SingleWindowStrategy)
+
+    def test_create_single_window_is_correct(self):
+        from controllers.window_selection_strategy import WindowStrategyFactory
+        from shared.probability_gate import NeverGate
+        s = WindowStrategyFactory.create('single', window='bartlett', gate=NeverGate())
+        assert s.select(0.0) == 'bartlett'
+
+    def test_create_random_returns_random_strategy(self):
+        from controllers.window_selection_strategy import WindowStrategyFactory, RandomWindowStrategy
+        from shared.probability_gate import AlwaysGate
+        s = WindowStrategyFactory.create('random', windows=['hanning', 'expodec'], gate=AlwaysGate())
+        assert isinstance(s, RandomWindowStrategy)
+
+    def test_create_transition_returns_transition_strategy(self):
+        from controllers.window_selection_strategy import WindowStrategyFactory, TransitionWindowStrategy
+        from envelopes.envelope import Envelope
+        s = WindowStrategyFactory.create(
+            'transition',
+            from_window='hanning', to_window='bartlett',
+            curve=Envelope([[0, 0], [10, 1]]),
+            duration=10.0,
+        )
+        assert isinstance(s, TransitionWindowStrategy)
+
+    def test_create_multistate_returns_multistate_strategy(self):
+        from controllers.window_selection_strategy import WindowStrategyFactory, MultiStateWindowStrategy
+        from envelopes.envelope import Envelope
+        s = WindowStrategyFactory.create(
+            'multistate',
+            states=[(0.0, 'hanning'), (1.0, 'bartlett')],
+            curve=Envelope([[0, 0], [10, 1]]),
+            duration=10.0,
+        )
+        assert isinstance(s, MultiStateWindowStrategy)
+
+    def test_create_unknown_name_raises_key_error(self):
+        from controllers.window_selection_strategy import WindowStrategyFactory
+        with pytest.raises(KeyError, match="non trovata"):
+            WindowStrategyFactory.create('nonexistent_strategy')
+
+
+# =============================================================================
+# 26. TEST WindowStrategyFactory.from_spec()
+# =============================================================================
+
+class TestWindowStrategyFactoryFromSpec:
+    """
+    WindowStrategyFactory.from_spec(envelope_spec, config, windows, gate) deve
+    costruire la strategy corretta per ogni formato di spec YAML.
+    """
+
+    def _make_gate(self):
+        from shared.probability_gate import NeverGate
+        return NeverGate()
+
+    def test_from_spec_single_string_returns_single_strategy(self, default_config):
+        from controllers.window_selection_strategy import WindowStrategyFactory, SingleWindowStrategy
+        s = WindowStrategyFactory.from_spec('hanning', default_config, ['hanning'], self._make_gate())
+        assert isinstance(s, SingleWindowStrategy)
+
+    def test_from_spec_list_returns_random_strategy(self, default_config):
+        from controllers.window_selection_strategy import WindowStrategyFactory, RandomWindowStrategy
+        from shared.probability_gate import AlwaysGate
+        s = WindowStrategyFactory.from_spec(
+            ['hanning', 'expodec'], default_config, ['hanning', 'expodec'], AlwaysGate()
+        )
+        assert isinstance(s, RandomWindowStrategy)
+
+    def test_from_spec_transition_dict_returns_transition_strategy(self, default_config):
+        from controllers.window_selection_strategy import WindowStrategyFactory, TransitionWindowStrategy
+        spec = {'from': 'hanning', 'to': 'bartlett', 'curve': [[0, 0], [10, 1]]}
+        s = WindowStrategyFactory.from_spec(spec, default_config, ['hanning', 'bartlett'], self._make_gate())
+        assert isinstance(s, TransitionWindowStrategy)
+
+    def test_from_spec_multistate_dict_returns_multistate_strategy(self, default_config):
+        from controllers.window_selection_strategy import WindowStrategyFactory, MultiStateWindowStrategy
+        spec = {
+            'states': [[0.0, 'hanning'], [0.5, 'expodec'], [1.0, 'bartlett']],
+            'curve': [[0, 0], [10, 1]],
+        }
+        s = WindowStrategyFactory.from_spec(
+            spec, default_config, ['hanning', 'expodec', 'bartlett'], self._make_gate()
+        )
+        assert isinstance(s, MultiStateWindowStrategy)
+
+    def test_from_spec_single_gate_passed_to_strategy(self, default_config):
+        from controllers.window_selection_strategy import WindowStrategyFactory
+        from shared.probability_gate import AlwaysGate
+        gate = AlwaysGate()
+        s = WindowStrategyFactory.from_spec('hanning', default_config, ['hanning'], gate)
+        assert s._gate is gate
+
+    def test_from_spec_random_gate_passed_to_strategy(self, default_config):
+        from controllers.window_selection_strategy import WindowStrategyFactory
+        from shared.probability_gate import AlwaysGate
+        gate = AlwaysGate()
+        s = WindowStrategyFactory.from_spec(
+            ['hanning', 'expodec'], default_config, ['hanning', 'expodec'], gate
+        )
+        assert s._gate is gate
+
+    def test_from_spec_transition_default_curve_used_when_absent(self, default_config):
+        from controllers.window_selection_strategy import WindowStrategyFactory, TransitionWindowStrategy
+        spec = {'from': 'hanning', 'to': 'bartlett'}  # no 'curve' key
+        s = WindowStrategyFactory.from_spec(spec, default_config, ['hanning', 'bartlett'], self._make_gate())
+        assert isinstance(s, TransitionWindowStrategy)
+
+    def test_from_spec_multistate_default_curve_used_when_absent(self, default_config):
+        from controllers.window_selection_strategy import WindowStrategyFactory, MultiStateWindowStrategy
+        spec = {'states': [[0.0, 'hanning'], [1.0, 'bartlett']]}  # no 'curve' key
+        s = WindowStrategyFactory.from_spec(
+            spec, default_config, ['hanning', 'bartlett'], self._make_gate()
+        )
+        assert isinstance(s, MultiStateWindowStrategy)
+
+
+# =============================================================================
+# 27. TEST WindowController — _gate come property proxy
+# =============================================================================
+
+class TestWindowControllerGateProxy:
+    """
+    ctrl._gate deve essere una property che legge/scrive su strategy._gate.
+    Per strategy senza _gate (Transition, MultiState) ritorna None e
+    l'assegnazione è un no-op.
+    """
+
+    def test_gate_proxy_reads_from_single_strategy(self, default_config):
+        from shared.probability_gate import NeverGate
+        ctrl = WindowController({'envelope': 'hanning'}, config=default_config)
+        assert ctrl._gate is ctrl._strategy._gate
+
+    def test_gate_proxy_reads_from_random_strategy(self, default_config):
+        from shared.probability_gate import AlwaysGate
+        ctrl = WindowController({'envelope': ['hanning', 'expodec']}, config=default_config)
+        assert ctrl._gate is ctrl._strategy._gate
+
+    def test_gate_proxy_write_updates_strategy_gate(self, default_config):
+        from shared.probability_gate import AlwaysGate, NeverGate
+        ctrl = WindowController({'envelope': ['hanning', 'expodec']}, config=default_config)
+        new_gate = NeverGate()
+        ctrl._gate = new_gate
+        assert ctrl._strategy._gate is new_gate
+
+    def test_gate_proxy_write_read_roundtrip(self, default_config):
+        from shared.probability_gate import AlwaysGate
+        ctrl = WindowController({'envelope': ['hanning', 'expodec']}, config=default_config)
+        g = AlwaysGate()
+        ctrl._gate = g
+        assert ctrl._gate is g
+
+    def test_gate_proxy_transition_returns_none(self, default_config):
+        spec = {'envelope': {'from': 'hanning', 'to': 'bartlett', 'curve': [[0, 0], [10, 1]]}}
+        ctrl = WindowController(spec, config=default_config)
+        assert ctrl._gate is None
+
+    def test_gate_proxy_multistate_returns_none(self, default_config):
+        spec = {'envelope': {
+            'states': [[0.0, 'hanning'], [1.0, 'bartlett']],
+            'curve': [[0, 0], [10, 1]],
+        }}
+        ctrl = WindowController(spec, config=default_config)
+        assert ctrl._gate is None
+
+    def test_gate_proxy_transition_write_is_noop(self, default_config):
+        """Assegnare _gate su una transition strategy non deve sollevare eccezioni."""
+        from shared.probability_gate import AlwaysGate
+        spec = {'envelope': {'from': 'hanning', 'to': 'bartlett', 'curve': [[0, 0], [10, 1]]}}
+        ctrl = WindowController(spec, config=default_config)
+        ctrl._gate = AlwaysGate()  # no exception
+
+
+# =============================================================================
+# 28. TEST WindowController — select_window() pura delega
+# =============================================================================
+
+class TestSelectWindowPureDelegation:
+    """
+    select_window() deve delegare interamente a self._strategy.select(elapsed_time)
+    senza contenere logica propria (nessun isinstance, nessun if/else).
+    """
+
+    def test_select_window_calls_strategy_select(self, default_config):
+        ctrl = WindowController({'envelope': 'hanning'}, config=default_config)
+        ctrl._strategy = Mock()
+        ctrl._strategy.select.return_value = 'gaussian'
+        result = ctrl.select_window(3.0)
+        ctrl._strategy.select.assert_called_once_with(3.0)
+        assert result == 'gaussian'
+
+    def test_select_window_passes_elapsed_time_to_strategy(self, default_config):
+        ctrl = WindowController({'envelope': ['hanning', 'expodec']}, config=default_config)
+        ctrl._strategy = Mock()
+        ctrl._strategy.select.return_value = 'hanning'
+        ctrl.select_window(elapsed_time=7.5)
+        ctrl._strategy.select.assert_called_once_with(7.5)
+
+    def test_select_window_default_elapsed_time_zero(self, default_config):
+        ctrl = WindowController({'envelope': 'hanning'}, config=default_config)
+        ctrl._strategy = Mock()
+        ctrl._strategy.select.return_value = 'hanning'
+        ctrl.select_window()
+        ctrl._strategy.select.assert_called_once_with(0.0)
+
+    def test_select_window_delegates_for_transition(self, default_config):
+        spec = {'envelope': {'from': 'hanning', 'to': 'bartlett', 'curve': [[0, 0], [10, 1]]}}
+        ctrl = WindowController(spec, config=default_config)
+        ctrl._strategy = Mock()
+        ctrl._strategy.select.return_value = 'bartlett'
+        result = ctrl.select_window(5.0)
+        ctrl._strategy.select.assert_called_once_with(5.0)
+        assert result == 'bartlett'
+
+    def test_select_window_delegates_for_multistate(self, default_config):
+        spec = {'envelope': {
+            'states': [[0.0, 'hanning'], [1.0, 'expodec']],
+            'curve': [[0, 0], [10, 1]],
+        }}
+        ctrl = WindowController(spec, config=default_config)
+        ctrl._strategy = Mock()
+        ctrl._strategy.select.return_value = 'expodec'
+        result = ctrl.select_window(8.0)
+        ctrl._strategy.select.assert_called_once_with(8.0)
+        assert result == 'expodec'
+
+    def test_select_window_return_value_comes_from_strategy(self, default_config):
+        ctrl = WindowController({'envelope': 'hanning'}, config=default_config)
+        for expected in ['hanning', 'gaussian', 'expodec', 'bartlett']:
+            ctrl._strategy = Mock()
+            ctrl._strategy.select.return_value = expected
+            assert ctrl.select_window(0.0) == expected

--- a/tests/controllers/test_window_selection_strategy.py
+++ b/tests/controllers/test_window_selection_strategy.py
@@ -30,18 +30,22 @@ from envelopes.envelope import Envelope
 
 class TestSingleWindowStrategy:
 
+    def _make(self, window='hanning'):
+        from shared.probability_gate import NeverGate
+        return SingleWindowStrategy(window, gate=NeverGate())
+
     def test_always_returns_configured_window(self):
-        s = SingleWindowStrategy('hanning')
+        s = self._make('hanning')
         for _ in range(50):
             assert s.select(0.0) == 'hanning'
 
     def test_returns_correct_window_for_different_names(self):
         for name in ('hanning', 'bartlett', 'expodec', 'gaussian'):
-            s = SingleWindowStrategy(name)
+            s = self._make(name)
             assert s.select(0.0) == name
 
     def test_elapsed_time_has_no_effect(self):
-        s = SingleWindowStrategy('hanning')
+        s = self._make('hanning')
         for t in [0.0, 1.0, 5.0, 100.0]:
             assert s.select(t) == 'hanning'
 


### PR DESCRIPTION
## Summary

Dipende da #18 — mergeare dopo.

- Aggiunge `WINDOW_STRATEGY_REGISTRY` e `register_window_strategy()` in `window_selection_strategy.py`, allineato al pattern `voice_pitch_strategy.py`
- Aggiunge `WindowStrategyFactory` con `create(**kwargs)` e `from_spec()`: tutta la logica di spec-detection estratta da `WindowController.__init__()`
- `SingleWindowStrategy` accetta `gate` nel costruttore (necessario per proxy compat)
- `WindowController._gate` diventa property proxy su `strategy._gate`: backward compat totale con i test esistenti
- `select_window()` ridotta a una riga — delega pura alla strategy, nessun `isinstance`
- Aggiunge `gaussian` window in `NumpyWindowRegistry`
- +35 test per registry, factory, proxy gate e delegazione pura

## Architettura dopo il refactoring

```
# aggiungere una nuova strategy = una riga nel registry
WINDOW_STRATEGY_REGISTRY = {
    'single':     SingleWindowStrategy,
    'random':     RandomWindowStrategy,
    'transition': TransitionWindowStrategy,
    'multistate': MultiStateWindowStrategy,
    'nuova':      NuovaStrategy,   # zero modifiche al controller
}
```

## Test plan

- [ ] `make tests` verde (3919 passed)
- [ ] `ctrl._gate = AlwaysGate()` funziona ancora nei test esistenti (proxy)
- [ ] Build empirico con `PGE_window_strategy_test.yml` completato senza errori