### PR TITLE
feat(pitch): SpectralPitchStrategy — voci sui parziali della serie armonica

### DIFF
--- a/configs/PGE_spectral_test.yml
+++ b/configs/PGE_spectral_test.yml
@@ -1,0 +1,109 @@
+composition:
+  title: "SpectralPitchStrategy — test serie armonica"
+
+streams:
+
+  # ==========================================================================
+  # SEZIONE 1 — SPECTRAL BASE
+  # Serie armonica: [0, 12, 19, 24, 28, 31, 34, 36] semitoni (8 voci)
+  # ==========================================================================
+
+  - stream_id: "spectral_8voci"
+    onset: 0.0
+    duration: 8.0
+    sample: "pino2.wav"
+    grain:
+      duration: 0.1
+    voices:
+      num_voices: 8
+      pitch:
+        strategy: spectral
+    pitch:
+      semitones: -24
+  # ==========================================================================
+  # SEZIONE 2 — CONFRONTO CON ALTRE STRATEGY
+  # Stesso contesto acustico, strategy diverse — utile per ascolto comparativo
+  # ==========================================================================
+
+  # chord dom7 — armonia temperata
+  - stream_id: "confronto_chord"
+    onset: 10.0
+    duration: 8.0
+    sample: "pino2.wav"
+    density: 10
+    grain:
+      duration: 0.1
+    voices:
+      num_voices: 4
+      pitch:
+        strategy: chord
+        chord: "dom7"
+
+  # step fisso — distribuzione lineare
+  - stream_id: "confronto_step"
+    onset: 20.0
+    duration: 8.0
+    sample: "pino2.wav"
+    density: 10
+    grain:
+      duration: 0.1
+    voices:
+      num_voices: 4
+      pitch:
+        strategy: step
+        step: 7.0
+
+  # ==========================================================================
+  # SEZIONE 3 — SPECTRAL CON POCHE VOCI
+  # Parziali bassi: [0, 12, 19] — fondamentale + ottava + quinta
+  # ==========================================================================
+
+  - stream_id: "spectral_3voci"
+    onset: 30.0
+    duration: 8.0
+    sample: "pino2.wav"
+    density: 10
+    grain:
+      duration: 0.12
+    voices:
+      num_voices: 3
+      pitch:
+        strategy: spectral
+
+  # ==========================================================================
+  # SEZIONE 4 — SPECTRAL + PAN STEREO
+  # La distribuzione spettrale incontra la distribuzione spaziale
+  # ==========================================================================
+
+  - stream_id: "spectral_pan"
+    onset: 40.0
+    duration: 8.0
+    sample: "pino2.wav"
+    density: 10
+    grain:
+      duration: 0.1
+    voices:
+      num_voices: 6
+      pitch:
+        strategy: spectral
+      pan:
+        strategy: linear
+        spread: 80.0
+
+  # ==========================================================================
+  # SEZIONE 5 — SPECTRAL + max_partial CUSTOM
+  # Pre-calcola solo i primi 4 parziali; le voci 5-8 vengono estese dinamicamente
+  # ==========================================================================
+
+  - stream_id: "spectral_max_partial"
+    onset: 50.0
+    duration: 8.0
+    sample: "pino2.wav"
+    density: 10
+    grain:
+      duration: 0.1
+    voices:
+      num_voices: 8
+      pitch:
+        strategy: spectral
+        max_partial: 4

--- a/docs/plans/2026-04-25-001-feat-spectral-pitch-strategy-plan.md
+++ b/docs/plans/2026-04-25-001-feat-spectral-pitch-strategy-plan.md
@@ -1,0 +1,236 @@
+---
+title: "feat: Add SpectralPitchStrategy — distribuzione voci sulla serie armonica"
+type: feat
+status: active
+date: 2026-04-25
+origin: https://github.com/DMGiulioRomano/PythonGranularEngine/issues/21
+---
+
+# feat: Add SpectralPitchStrategy — distribuzione voci sulla serie armonica
+
+## Overview
+
+Aggiunge `SpectralPitchStrategy`, una nuova voice pitch strategy che distribuisce le
+voci sui parziali della serie armonica naturale. La voce `i` riceve l'offset
+`round(12 * log2(i + 1))` semitoni, producendo texture risonanti coerenti con
+la fisica acustica. La strategy è accessibile via YAML con `strategy: spectral`.
+
+---
+
+## Problem Frame
+
+Le strategy di pitch esistenti (`step`, `range`, `chord`, `stochastic`) operano in
+logica armonica temperata o stocastica. Nessuna rispecchia la struttura fisica dello
+spettro armonico. `SpectralPitchStrategy` colma questo gap: distribuisce le voci
+secondo i rapporti di frequenza interi (1f, 2f, 3f, …), che convertiti in semitoni
+producono la serie [0, 12, 19, 24, 28, 31, 34, 36, …].
+
+---
+
+## Requirements Trace
+
+- R1. Voce `i` restituisce `round(12 * log2(i + 1))` semitoni (i 1-based per il parziale).
+- R2. Voce 0 restituisce sempre `0.0` (invariante condiviso da tutte le strategy).
+- R3. `max_partial` (default 16) pre-calcola i parziali; se `num_voices > max_partial`, i
+  parziali sono estesi dinamicamente con la stessa formula.
+- R4. La strategy è registrata in `VOICE_PITCH_STRATEGIES` con chiave `'spectral'`.
+- R5. `VoicePitchStrategyFactory.create('spectral')` restituisce un'istanza valida.
+- R6. `strategy: spectral` in un config YAML con `num_voices: 8` produce output coerente.
+
+---
+
+## Scope Boundaries
+
+- Non si modifica la formula matematica della serie armonica — è fisica, non una scelta.
+- Non si aggiunge supporto per `fundamental_hz` o trasposizione assoluta: la strategy
+  restituisce offset in semitoni rispetto al pitch base dello stream, come tutte le altre.
+- Non si tocca `stream.py`, `voice_manager.py`, né alcun renderer: il parser YAML e la
+  factory esistenti gestiscono già `strategy: spectral` senza modifiche.
+- Nessun file di documentazione aggiuntivo richiesto: l'issue è autoesplicativa e
+  `docs/yaml-reference.md` non è nel perimetro di questa PR.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/strategies/voice_pitch_strategy.py` — modulo da estendere; struttura consolidata:
+  costanti → ABC → classi concrete → registry dict → `register_*` → factory.
+- `tests/strategies/test_voice_pitch_strategy.py` — suite da estendere; pattern `_get_module()`
+  con import lazy e unpacking posizionale; fixture `restore_registry` autouse.
+- `TestVoiceZeroInvariant` (riga 342) — usa `pytest.mark.parametrize` con lambda indicizzate
+  sul tuple restituito da `_get_module()`; va aggiunta una lambda per `SpectralPitchStrategy`.
+- `ChordPitchStrategy` — il pattern più vicino per la logica "lista di offsets pre-calcolata
+  al `__init__` + extend dinamico se `voice_index` supera la lista" è il riferimento da seguire.
+
+### Institutional Learnings
+
+- Nessun learning archiviato in `docs/solutions/` (directory assente).
+
+### External References
+
+- Issue #21: tabella parziali 1–16 e formula `round(12 * log2(n))`.
+
+---
+
+## Key Technical Decisions
+
+- **Pre-calcolo al `__init__`**: gli offset sono calcolati una volta sola e memorizzati in
+  `self._offsets: list[float]` fino a `max_partial`. Questo allinea la struttura a
+  `ChordPitchStrategy` (lista `_intervals`) e rende `get_pitch_offset` O(1).
+- **Extend dinamico**: se `voice_index >= max_partial`, l'offset viene calcolato on-demand
+  con la formula e aggiunto alla lista. Nessun limite rigido, nessuna eccezione.
+- **`math.log2`**: si usa il modulo stdlib `math`, non `numpy`, coerentemente con il resto
+  del modulo che non importa numpy.
+- **Arrotondamento a `int` poi cast a `float`**: `round(12 * log2(i+1))` restituisce `int`
+  in Python; il cast a `float` è necessario perché il contratto ABC dichiara `-> float`.
+- **Posizione nel file**: la classe va inserita dopo `StochasticPitchStrategy` e prima del
+  blocco `# REGISTRY`, coerentemente con l'ordine dichiarato nel docstring del modulo.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **`max_partial` è un parametro del costruttore o una costante?** — Parametro del
+  costruttore con default 16, come da issue. Consente flessibilità senza modificare la classe.
+- **La formula usa `round()` o `int()`?** — `round()`, come da issue. I parziali come 7 e 11
+  hanno offset irrazionali (es. 34.02, 41.96); arrotondare è la scelta acusticamente corretta.
+- **`stream.py` va aggiornato?** — No. Il parser estrae `strategy` e fa `pop` dei kwargs
+  rimanenti, passandoli a `VoicePitchStrategyFactory.create(name, **kw)`. Il flusso supporta
+  già `max_partial` come kwarg opzionale senza modifiche.
+
+### Deferred to Implementation
+
+- Nessuno.
+
+---
+
+## Implementation Units
+
+- [x] U1. **Aggiungere `SpectralPitchStrategy` e registrarla nel registry**
+
+**Goal:** Implementare la classe e renderla disponibile via `VOICE_PITCH_STRATEGIES['spectral']`.
+
+**Requirements:** R1, R2, R3, R4, R5
+
+**Dependencies:** Nessuna (l'implementazione viene dopo i test — TDD)
+
+**Files:**
+- Modify: `src/strategies/voice_pitch_strategy.py`
+
+**Approach:**
+- Aggiungere `import math` in cima al file (se non già presente).
+- Definire `SpectralPitchStrategy(VoicePitchStrategy)` dopo `StochasticPitchStrategy`.
+- Nel `__init__(self, max_partial: int = 16)`: pre-calcolare `_offsets` come lista
+  `[float(round(12 * math.log2(i + 1))) for i in range(max_partial)]` con il primo
+  elemento fissato a `0.0` (parziale 1 = fondamentale, `log2(1) = 0`).
+- In `get_pitch_offset`: se `voice_index == 0` restituire `0.0`; se `voice_index <
+  len(self._offsets)` restituire `self._offsets[voice_index]`; altrimenti calcolare
+  on-demand `float(round(12 * math.log2(voice_index + 1)))`, aggiungere alla lista,
+  e restituirlo.
+- Aggiungere `'spectral': SpectralPitchStrategy` in `VOICE_PITCH_STRATEGIES`.
+
+**Execution note:** Implementazione test-first — scrivere U2 prima di questo unit.
+
+**Patterns to follow:**
+- `ChordPitchStrategy.__init__` per la pre-computazione della lista al costruttore.
+- `StochasticPitchStrategy.get_pitch_offset` per il pattern `if voice_index == 0: return 0.0`.
+
+**Test scenarios:**
+- Happy path: `get_pitch_offset(0, 8)` → `0.0` (fondamentale)
+- Happy path: `get_pitch_offset(1, 8)` → `12.0` (parziale 2, ottava)
+- Happy path: `get_pitch_offset(2, 8)` → `19.0` (parziale 3, quinta)
+- Happy path: sequenza voci 0–7 → `[0, 12, 19, 24, 28, 31, 34, 36]`
+- Edge case: offset della serie sono monotonicamente crescenti
+- Edge case: `voice_index == max_partial` (primo oltre la lista) → calcolato dinamicamente
+- Edge case: `voice_index > max_partial` → calcolato correttamente con la formula
+
+**Verification:**
+- `SpectralPitchStrategy` è importabile da `strategies.voice_pitch_strategy`.
+- `'spectral' in VOICE_PITCH_STRATEGIES` è `True`.
+- `get_pitch_offset(0, n)` restituisce `0.0` per qualsiasi `n`.
+
+---
+
+- [x] U2. **Scrivere `TestSpectralPitchStrategy` e aggiornare la suite esistente**
+
+**Goal:** Coprire il contratto di `SpectralPitchStrategy` con test esaustivi; aggiornare
+`_get_module()` e `TestVoiceZeroInvariant` per includere la nuova classe.
+
+**Requirements:** R1, R2, R3, R4, R5
+
+**Dependencies:** Nessuna (i test vanno scritti prima dell'implementazione — TDD)
+
+**Files:**
+- Modify: `tests/strategies/test_voice_pitch_strategy.py`
+
+**Approach:**
+- Estendere l'import in `_get_module()`: aggiungere `SpectralPitchStrategy` all'import e
+  al tuple di ritorno come nono elemento (dopo `VoicePitchStrategyFactory`).
+- Aggiornare `TestVoicePitchStrategiesRegistry` aggiungendo `test_registry_contains_spectral`.
+- Aggiungere una lambda in `TestVoiceZeroInvariant` per `SpectralPitchStrategy`:
+  `lambda m: m[8](max_partial=4)` dove `m[8]` è il nono elemento del tuple.
+- Aggiungere `class TestSpectralPitchStrategy` con i test elencati.
+
+**Execution note:** Scrivi i test prima dell'implementazione. Eseguire `make tests` e
+verificare che tutti i nuovi test falliscano (red) prima di passare a U1.
+
+**Patterns to follow:**
+- Pattern di unpacking `m[8]` per il nono elemento aggiunto a `_get_module()`.
+- `TestStepPitchStrategy` come modello di struttura per la nuova classe di test.
+- `TestVoiceZeroInvariant` per il pattern lambda parametrizzato.
+
+**Test scenarios:**
+- Happy path: `test_voice_0_returns_zero` — `SpectralPitchStrategy().get_pitch_offset(0, 8) == 0.0`
+- Happy path: `test_voice_1_returns_12` — parziale 2 = ottava
+- Happy path: `test_voice_2_returns_19` — parziale 3 = quinta
+- Happy path: `test_first_8_partials` — sequenza `[0, 12, 19, 24, 28, 31, 34, 36]`
+- Edge case: `test_offsets_are_monotonically_increasing` — ogni elemento maggiore del precedente
+- Edge case: `test_beyond_default_max_partial` — voce 16 calcolata dinamicamente con formula corretta
+- Edge case: `test_default_max_partial_is_16` — `SpectralPitchStrategy().max_partial == 16`
+- Edge case: `test_custom_max_partial` — `SpectralPitchStrategy(max_partial=8).max_partial == 8`
+- Integration: `test_in_registry` — `'spectral' in VOICE_PITCH_STRATEGIES`
+- Integration: `test_factory_creates_spectral` — `VoicePitchStrategyFactory.create('spectral')` è istanza di `SpectralPitchStrategy`
+- Integration: `test_factory_creates_spectral_with_max_partial` — `VoicePitchStrategyFactory.create('spectral', max_partial=8)` funziona
+
+**Verification:**
+- `make tests` passa completamente (verde) dopo U1 + U2.
+- Tutti i nuovi test sono rossi prima di U1, verdi dopo.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Nessuna callback o middleware coinvolto. `stream.py` passa `**kw`
+  alla factory senza conoscerne il contenuto — nessuna modifica richiesta.
+- **Error propagation:** `VoicePitchStrategyFactory.create('spectral', max_partial='x')`
+  solleverà `TypeError` dal costruttore Python, comportamento coerente con le altre strategy.
+- **State lifecycle risks:** `_offsets` cresce on-demand ma è bounded da `num_voices` che
+  non varia durante il ciclo di vita di uno stream. Nessun rischio di leak.
+- **API surface parity:** `register_voice_pitch_strategy` resta invariata; il registry
+  esteso non rompe nessun consumer esistente.
+- **Integration coverage:** Un config YAML `strategy: spectral, num_voices: 8` deve
+  produrre 8 voci con pitch offset `[0, 12, 19, 24, 28, 31, 34, 36]` — verificabile
+  manualmente con `make FILE=<config> all`.
+- **Unchanged invariants:** Tutte le strategy esistenti e i loro test rimangono invariati.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| L'unpacking posizionale di `_get_module()` rompe i test esistenti se il nuovo elemento viene inserito in posizione errata | Aggiungere `SpectralPitchStrategy` come **ultimo** elemento del tuple, dopo `VoicePitchStrategyFactory`, e usare `m[8]` nella lambda di `TestVoiceZeroInvariant` |
+| `math.log2(1) == 0.0` ma `round(0.0) == 0` — il parziale 1 deve dare esattamente `0.0` | Pre-calcolo nel `__init__` con `i` che parte da 0: `log2(0+1) = log2(1) = 0.0`, confermato |
+| `voice_index` passato come argomento può differire dall'indice nel dict di parziali se `num_voices` cambia tra chiamate | `get_pitch_offset` usa `voice_index` direttamente come indice del parziale (non `num_voices`) — comportamento deterministico e indipendente da `num_voices` |
+
+---
+
+## Sources & References
+
+- **Origin document (issue):** https://github.com/DMGiulioRomano/PythonGranularEngine/issues/21
+- Related code: `src/strategies/voice_pitch_strategy.py`
+- Related tests: `tests/strategies/test_voice_pitch_strategy.py`

--- a/src/strategies/voice_pitch_strategy.py
+++ b/src/strategies/voice_pitch_strategy.py
@@ -23,6 +23,7 @@ Design:
 Coerente con: voice_pan_strategy.py, variation_strategy.py
 """
 
+import math
 import random
 from abc import ABC, abstractmethod
 from typing import Dict, List, Type
@@ -208,6 +209,35 @@ class StochasticPitchStrategy(VoicePitchStrategy):
         return self._cache[voice_index]
 
 
+class SpectralPitchStrategy(VoicePitchStrategy):
+    """
+    Distribuzione voci sui parziali della serie armonica naturale.
+
+    Voce i → parziale (i+1) → round(12 * log2(i+1)) semitoni.
+    Voce 0 → fondamentale → 0 semitoni (invariante ABC).
+
+    Serie [0, 12, 19, 24, 28, 31, 34, 36, ...] per le prime 8 voci.
+
+    Args:
+        max_partial: numero di parziali pre-calcolati al __init__ (default 16).
+                     Voci oltre max_partial sono calcolate on-demand.
+    """
+
+    def __init__(self, max_partial: int = 16):
+        self.max_partial = max_partial
+        self._offsets: List[float] = [
+            float(round(12 * math.log2(i + 1))) for i in range(max_partial)
+        ]
+
+    def get_pitch_offset(self, voice_index: int, num_voices: int) -> float:
+        if voice_index == 0:
+            return 0.0
+        while voice_index >= len(self._offsets):
+            i = len(self._offsets)
+            self._offsets.append(float(round(12 * math.log2(i + 1))))
+        return self._offsets[voice_index]
+
+
 # =============================================================================
 # REGISTRY
 # =============================================================================
@@ -217,6 +247,7 @@ VOICE_PITCH_STRATEGIES: Dict[str, Type[VoicePitchStrategy]] = {
     'range':       RangePitchStrategy,
     'chord':       ChordPitchStrategy,
     'stochastic':  StochasticPitchStrategy,
+    'spectral':    SpectralPitchStrategy,
 }
 
 

--- a/tests/strategies/test_voice_pitch_strategy.py
+++ b/tests/strategies/test_voice_pitch_strategy.py
@@ -51,16 +51,18 @@ def _get_module():
         VOICE_PITCH_STRATEGIES,
         register_voice_pitch_strategy,
         VoicePitchStrategyFactory,
+        SpectralPitchStrategy,
     )
     return (
-        VoicePitchStrategy,
-        StepPitchStrategy,
-        RangePitchStrategy,
-        ChordPitchStrategy,
-        StochasticPitchStrategy,
-        VOICE_PITCH_STRATEGIES,
-        register_voice_pitch_strategy,
-        VoicePitchStrategyFactory,
+        VoicePitchStrategy,       # m[0]
+        StepPitchStrategy,        # m[1]
+        RangePitchStrategy,       # m[2]
+        ChordPitchStrategy,       # m[3]
+        StochasticPitchStrategy,  # m[4]
+        VOICE_PITCH_STRATEGIES,   # m[5]
+        register_voice_pitch_strategy,  # m[6]
+        VoicePitchStrategyFactory,      # m[7]
+        SpectralPitchStrategy,          # m[8]
     )
 
 
@@ -71,7 +73,7 @@ def _get_module():
 @pytest.fixture(autouse=True)
 def restore_registry():
     try:
-        _, _, _, _, _, registry, _, _ = _get_module()
+        _, _, _, _, _, registry, _, _, _ = _get_module()
         original = dict(registry)
         yield
         registry.clear()
@@ -344,6 +346,7 @@ class TestVoiceZeroInvariant:
         lambda m: m[2](semitone_range=12.0),                  # RangePitchStrategy
         lambda m: m[3](chord="dom7"),                         # ChordPitchStrategy
         lambda m: m[4](semitone_range=2.0, stream_id="s1"),   # StochasticPitchStrategy
+        lambda m: m[8](max_partial=4),                        # SpectralPitchStrategy
     ])
     def test_voice_0_is_always_zero(self, strategy_fixture):
         mod = _get_module()
@@ -380,27 +383,31 @@ class TestEdgeCases:
 class TestVoicePitchStrategiesRegistry:
 
     def test_registry_exists(self):
-        *_, VOICE_PITCH_STRATEGIES, _, _ = _get_module()
+        *_, VOICE_PITCH_STRATEGIES, _, _, _ = _get_module()
         assert isinstance(VOICE_PITCH_STRATEGIES, dict)
 
     def test_registry_contains_step(self):
-        *_, VOICE_PITCH_STRATEGIES, _, _ = _get_module()
+        *_, VOICE_PITCH_STRATEGIES, _, _, _ = _get_module()
         assert 'step' in VOICE_PITCH_STRATEGIES
 
     def test_registry_contains_range(self):
-        *_, VOICE_PITCH_STRATEGIES, _, _ = _get_module()
+        *_, VOICE_PITCH_STRATEGIES, _, _, _ = _get_module()
         assert 'range' in VOICE_PITCH_STRATEGIES
 
     def test_registry_contains_chord(self):
-        *_, VOICE_PITCH_STRATEGIES, _, _ = _get_module()
+        *_, VOICE_PITCH_STRATEGIES, _, _, _ = _get_module()
         assert 'chord' in VOICE_PITCH_STRATEGIES
 
     def test_registry_contains_stochastic(self):
-        *_, VOICE_PITCH_STRATEGIES, _, _ = _get_module()
+        *_, VOICE_PITCH_STRATEGIES, _, _, _ = _get_module()
         assert 'stochastic' in VOICE_PITCH_STRATEGIES
 
+    def test_registry_contains_spectral(self):
+        *_, VOICE_PITCH_STRATEGIES, _, _, _ = _get_module()
+        assert 'spectral' in VOICE_PITCH_STRATEGIES
+
     def test_registry_values_are_classes(self):
-        *_, VOICE_PITCH_STRATEGIES, _, _ = _get_module()
+        *_, VOICE_PITCH_STRATEGIES, _, _, _ = _get_module()
         for name, cls in VOICE_PITCH_STRATEGIES.items():
             assert isinstance(cls, type), f"{name} non è una classe"
 
@@ -412,7 +419,7 @@ class TestVoicePitchStrategiesRegistry:
 class TestRegisterVoicePitchStrategy:
 
     def test_register_new_strategy(self):
-        VoicePitchStrategy, _, _, _, _, VOICE_PITCH_STRATEGIES, register_voice_pitch_strategy, _ = _get_module()
+        VoicePitchStrategy, _, _, _, _, VOICE_PITCH_STRATEGIES, register_voice_pitch_strategy, _, _ = _get_module()
 
         class MySemitoneStrategy(VoicePitchStrategy):
             def get_pitch_offset(self, voice_index, num_voices):
@@ -422,7 +429,7 @@ class TestRegisterVoicePitchStrategy:
         assert 'my_semi' in VOICE_PITCH_STRATEGIES
 
     def test_registered_strategy_usable_via_factory(self):
-        VoicePitchStrategy, _, _, _, _, VOICE_PITCH_STRATEGIES, register_voice_pitch_strategy, VoicePitchStrategyFactory = _get_module()
+        VoicePitchStrategy, _, _, _, _, VOICE_PITCH_STRATEGIES, register_voice_pitch_strategy, VoicePitchStrategyFactory, _ = _get_module()
 
         class FixedStrategy(VoicePitchStrategy):
             def get_pitch_offset(self, voice_index, num_voices):
@@ -440,36 +447,36 @@ class TestRegisterVoicePitchStrategy:
 class TestVoicePitchStrategyFactory:
 
     def test_create_step(self):
-        *_, VoicePitchStrategyFactory = _get_module()
+        _, _, _, _, _, _, _, VoicePitchStrategyFactory, _ = _get_module()
         _, StepPitchStrategy, *_ = _get_module()
         s = VoicePitchStrategyFactory.create('step', step=4.0)
         assert isinstance(s, StepPitchStrategy)
 
     def test_create_range(self):
-        *_, VoicePitchStrategyFactory = _get_module()
+        _, _, _, _, _, _, _, VoicePitchStrategyFactory, _ = _get_module()
         _, _, RangePitchStrategy, *_ = _get_module()
         s = VoicePitchStrategyFactory.create('range', semitone_range=12.0)
         assert isinstance(s, RangePitchStrategy)
 
     def test_create_chord(self):
-        *_, VoicePitchStrategyFactory = _get_module()
+        _, _, _, _, _, _, _, VoicePitchStrategyFactory, _ = _get_module()
         _, _, _, ChordPitchStrategy, *_ = _get_module()
         s = VoicePitchStrategyFactory.create('chord', chord='maj7')
         assert isinstance(s, ChordPitchStrategy)
 
     def test_create_stochastic(self):
-        *_, VoicePitchStrategyFactory = _get_module()
+        _, _, _, _, _, _, _, VoicePitchStrategyFactory, _ = _get_module()
         _, _, _, _, StochasticPitchStrategy, *_ = _get_module()
         s = VoicePitchStrategyFactory.create('stochastic', semitone_range=2.0, stream_id='s1')
         assert isinstance(s, StochasticPitchStrategy)
 
     def test_unknown_strategy_raises(self):
-        *_, VoicePitchStrategyFactory = _get_module()
+        _, _, _, _, _, _, _, VoicePitchStrategyFactory, _ = _get_module()
         with pytest.raises((KeyError, ValueError)):
             VoicePitchStrategyFactory.create('nonexistent_xyz')
 
     def test_factory_returns_voice_pitch_strategy_instance(self):
-        VoicePitchStrategy, *_, VoicePitchStrategyFactory = _get_module()
+        VoicePitchStrategy, _, _, _, _, _, _, VoicePitchStrategyFactory, _ = _get_module()
         s = VoicePitchStrategyFactory.create('step', step=1.0)
         assert isinstance(s, VoicePitchStrategy)
 
@@ -688,3 +695,72 @@ class TestChordInversion:
         for inv in range(max_inv + 1):
             s = self._make(chord_name, inversion=inv)
             assert s.get_pitch_offset(0, 8) == 0.0
+
+
+# =============================================================================
+# 12. SpectralPitchStrategy
+# =============================================================================
+
+class TestSpectralPitchStrategy:
+
+    def _make(self, **kwargs):
+        _, _, _, _, _, _, _, _, SpectralPitchStrategy = _get_module()
+        return SpectralPitchStrategy(**kwargs)
+
+    # --- Happy path ---
+
+    def test_voice_0_returns_zero(self):
+        s = self._make()
+        assert s.get_pitch_offset(0, 8) == 0.0
+
+    def test_voice_1_returns_12(self):
+        s = self._make()
+        assert s.get_pitch_offset(1, 8) == 12.0
+
+    def test_voice_2_returns_19(self):
+        s = self._make()
+        assert s.get_pitch_offset(2, 8) == 19.0
+
+    def test_first_8_partials(self):
+        s = self._make()
+        result = [s.get_pitch_offset(i, 8) for i in range(8)]
+        assert result == [0, 12, 19, 24, 28, 31, 34, 36]
+
+    # --- Edge cases ---
+
+    def test_offsets_are_monotonically_increasing(self):
+        s = self._make()
+        offsets = [s.get_pitch_offset(i, 16) for i in range(16)]
+        for a, b in zip(offsets, offsets[1:]):
+            assert b > a
+
+    def test_beyond_default_max_partial(self):
+        s = self._make()
+        import math
+        expected = float(round(12 * math.log2(17)))
+        assert s.get_pitch_offset(16, 20) == expected
+
+    def test_default_max_partial_is_16(self):
+        s = self._make()
+        assert s.max_partial == 16
+
+    def test_custom_max_partial(self):
+        s = self._make(max_partial=8)
+        assert s.max_partial == 8
+
+    # --- Integration ---
+
+    def test_in_registry(self):
+        *_, VOICE_PITCH_STRATEGIES, _, _, _ = _get_module()
+        assert 'spectral' in VOICE_PITCH_STRATEGIES
+
+    def test_factory_creates_spectral(self):
+        _, _, _, _, _, _, _, VoicePitchStrategyFactory, SpectralPitchStrategy = _get_module()
+        s = VoicePitchStrategyFactory.create('spectral')
+        assert isinstance(s, SpectralPitchStrategy)
+
+    def test_factory_creates_spectral_with_max_partial(self):
+        _, _, _, _, _, _, _, VoicePitchStrategyFactory, SpectralPitchStrategy = _get_module()
+        s = VoicePitchStrategyFactory.create('spectral', max_partial=8)
+        assert isinstance(s, SpectralPitchStrategy)
+        assert s.max_partial == 8


### PR DESCRIPTION
## Sommario

- Aggiunge `SpectralPitchStrategy`: distribuisce le voci sui parziali della serie armonica naturale con la formula `round(12 * log2(i+1))` semitoni
- Registrata in `VOICE_PITCH_STRATEGIES` con chiave `'spectral'`; accessibile da YAML con `strategy: spectral` e parametro opzionale `max_partial` (default 16)
- 11 nuovi test in `TestSpectralPitchStrategy`; suite completa verde a 3987 test

Chiude #21

## Piano

`docs/plans/2026-04-25-001-feat-spectral-pitch-strategy-plan.md`

## Test plan

- [ ] `make tests` verde (3987 passed)
- [ ] `make FILE=PGE_spectral_test all` — verifica ascolto con 5 stream di confronto