### PR TITLE
fix(stream): GrainClipStrategy — controllo dichiarativo grain out-of-bounds (#27)

### DIFF
--- a/docs/plans/2026-05-03-001-fix-grain-clip-strategy-plan.md
+++ b/docs/plans/2026-05-03-001-fix-grain-clip-strategy-plan.md
@@ -1,0 +1,345 @@
+---
+title: "fix: GrainClipStrategy — controllo dichiarativo dei grain out-of-bounds (issue #27)"
+type: fix
+status: active
+date: 2026-05-03
+---
+
+# fix: GrainClipStrategy — controllo dichiarativo dei grain out-of-bounds
+
+## Overview
+
+Quando `onset_offset` di una voce spinge l'onset di un grain oltre `stream.onset + stream.duration`, il comportamento dipende dal renderer. La fix introduce `GrainClipStrategy` — applicata in post-process dentro `generate_grains` — che rende `stream.voices` la **unica fonte di verità** su quali grain esistono. Il renderer non ha più opinioni proprie sui bounds: si limita a renderizzare fedelmente ciò che riceve.
+
+---
+
+## Vincolo architetturale
+
+**Il renderer è un passthrough puro.** Non filtra, non tronca, non ha logica sui bounds. L'unica superficie di controllo per decidere quali grain esistono è `GrainClipStrategy`. Il comportamento del renderer (durata buffer, campioni scritti) emerge da `stream.voices` — non da parametri indipendenti nel renderer.
+
+Conseguenza diretta: la guard `onset_sample < n_total` in `numpy_audio_renderer.py:240` e il troncamento coda (righe 234–237) **devono essere rimossi** — piano 002. Lasciarli sarebbe una seconda superficie di controllo ortogonale alla strategy.
+
+---
+
+## Problem Frame
+
+`stream.voices` contiene attualmente grain non validati — il filtro avviene (parzialmente, solo per onset) a livello renderer NumPy. Questo significa:
+
+- Renderer NumPy e Csound ricevono grain diversi per lo stesso stream → divergenza output
+- Il renderer ha conoscenza dei bounds dello stream — accoppiamento indesiderato
+- Aggiungere una nuova strategy (es. `FadeMarginClipStrategy`) richiederebbe modificare anche il renderer
+
+Radice: responsabilità di filtraggio nel posto sbagliato (renderer invece di modello).
+
+---
+
+## Requirements Trace
+
+- R1. Grain con `onset >= stream.onset + stream.duration` non entrano mai in `stream.voices`.
+- R2. Grain con `onset < stream_end` ma `onset + grain.duration > stream_end + margin` sono esclusi (margin default = 0.0).
+- R3. La strategia di clipping è pluggabile via Strategy pattern — OCP: nuove strategie senza toccare Stream o i renderer.
+- R4. Default: `OverflowMarginClipStrategy(margin=0.0)` — nessuna coda può sforare.
+- R5. `PassthroughClipStrategy` lascia passare tutti i grain — il renderer li riceve e li renderizza integralmente (richiede piano 002 per buffer corretto).
+- R6. NumPy e Csound ricevono le stesse `stream.voices` → parità garantita strutturalmente.
+- R7. Il parametro `margin` è predisposto per futura configurazione YAML per-stream (fuori scope di questo piano).
+- R8. Tutti i test esistenti restano verdi senza modifiche.
+
+---
+
+## Scope Boundaries
+
+- Nessuna modifica a NumPy renderer, Csound renderer, ScoreWriter — quelli sono piano 002.
+- Nessuna nuova sintassi YAML in questo piano — `margin` è hardcoded a `0.0`.
+- `Grain` rimane frozen dataclass, invariato.
+- `_create_grain` rimane invariato — il filtro è post-process, non inline nel loop.
+- Csound: nessun troncamento della durata del grain (il grain è escluso o incluso intero).
+
+---
+
+## Context & Research
+
+### Codice rilevante
+
+- `src/core/stream.py:307–366` — `generate_grains`: loop cursor-based; assegna `self.voices` e `self.grains` dopo il loop. Il post-process si inserisce tra fine loop (riga 359) e assegnazione (righe 359–363).
+- `src/core/grain.py:9–10` — `Grain` ha `onset: float` e `duration: float` come campi frozen dataclass.
+- `src/core/stream.py:410` — `absolute_onset = self.onset + elapsed_time + voice_config.onset_offset` — il grain conosce già l'onset assoluto quando viene creato.
+- `src/strategies/voice_pitch_strategy.py` — pattern ABC + registry + factory da replicare per `GrainClipStrategy`.
+- `src/rendering/numpy_audio_renderer.py:234–241` — guard e troncamento che diventano obsoleti dopo piano 002 (buffer dinamico + passthrough).
+
+### Decisioni architetturali
+
+- **Post-process, non inline**: il loop `generate_grains` gestisce avanzamento cursore temporale — responsabilità singola. Il clipping è responsabilità separata, applicata dopo che tutti i grain sono stati generati. SRP e OCP entrambi rispettati.
+- **Condition: onset + coda**: `grain.onset < stream_end AND grain.onset + grain.duration <= stream_end + margin`. Con `margin=0.0`: il grain deve essere completamente contenuto nello stream.
+- **`PassthroughClipStrategy` è una scelta semantica**: lasciare passare grain che sforano non è un "opt-out di sicurezza" — è una scelta esplicita che il renderer deve onorare renderizzando completamente quei grain. Richiede piano 002.
+- **Stream tiene il riferimento alla strategy**: `self._clip_strategy: GrainClipStrategy` — inizializzata a `OverflowMarginClipStrategy(margin=0.0)` in `__init__`.
+- **`stream_end` = `stream.onset + stream.duration`**: onset assoluto — coerente con `absolute_onset` in `_create_grain`.
+
+---
+
+## High-Level Technical Design
+
+```
+generate_grains()
+  └─ [loop esistente, invariato]
+       └─ all_voice_grains[voice_index].append(grain)
+
+  └─ [POST-PROCESS — nuovo]
+       └─ self._clip_strategy.apply(all_voice_grains, stream=self)
+            └─ OverflowMarginClipStrategy(margin=0.0)  [default]
+                 stream_end = stream.onset + stream.duration
+                 grain valido iff:
+                   grain.onset < stream_end
+                   AND grain.onset + grain.duration <= stream_end + margin
+
+            └─ PassthroughClipStrategy  [opt-in esplicito]
+                 tutti i grain passano → renderer li riceve e li renderizza integralmente
+
+  └─ self.voices = filtered_voice_grains  ← unica fonte di verità
+  └─ self.grains = flatten + sort
+```
+
+Il renderer (piano 002) riceve `stream.voices` e alloca buffer su `max(g.onset + g.duration)` sui grain ricevuti — senza logica di bounds propria.
+
+---
+
+## Implementation Units
+
+---
+
+### U1. `GrainClipStrategy` — ABC + implementazioni + registry + factory
+
+**Goal:** Definire l'interfaccia pluggabile e le due implementazioni concrete iniziali.
+
+**Requirements:** R1, R2, R3, R4, R5
+
+**Dependencies:** None
+
+**Files:**
+- Crea: `src/strategies/grain_clip_strategy.py`
+- Crea: `tests/strategies/test_grain_clip_strategy.py`
+
+**Approach:**
+
+```python
+# src/strategies/grain_clip_strategy.py
+
+class GrainClipStrategy(ABC):
+    @abstractmethod
+    def apply(self, voices: List[List[Grain]], stream) -> List[List[Grain]]:
+        """Filtra grain invalidi da ogni voice. Restituisce nuova struttura."""
+        ...
+
+class OverflowMarginClipStrategy(GrainClipStrategy):
+    """Esclude grain la cui coda sfora stream_end + margin."""
+    def __init__(self, margin: float = 0.0):
+        self.margin = margin
+
+    def apply(self, voices, stream):
+        stream_end = stream.onset + stream.duration
+        limit = stream_end + self.margin
+        return [
+            [g for g in voice if g.onset < stream_end and g.onset + g.duration <= limit]
+            for voice in voices
+        ]
+
+class PassthroughClipStrategy(GrainClipStrategy):
+    """Nessun filtro — tutti i grain passano al renderer che li renderizza integralmente."""
+    def apply(self, voices, stream):
+        return voices
+
+GRAIN_CLIP_STRATEGIES = {
+    'overflow_margin': OverflowMarginClipStrategy,
+    'passthrough': PassthroughClipStrategy,
+}
+
+class GrainClipStrategyFactory:
+    @staticmethod
+    def create(name: str, **kwargs) -> GrainClipStrategy:
+        if name not in GRAIN_CLIP_STRATEGIES:
+            raise ValueError(f"GrainClipStrategy sconosciuta: '{name}'")
+        return GRAIN_CLIP_STRATEGIES[name](**kwargs)
+```
+
+**Test scenarios (`test_grain_clip_strategy.py`):**
+
+`OverflowMarginClipStrategy.apply`:
+- Grain completamente dentro stream → incluso
+- Grain con onset >= stream_end → escluso (R1)
+- Grain con onset < stream_end ma coda sfora con margin=0 → escluso (R2)
+- Grain con onset < stream_end e coda sfora ma dentro margin=0.5 → incluso
+- Grain con onset == stream_end - ε → incluso
+- Grain con onset == stream_end → escluso (strict `<`)
+- Grain con onset + duration == stream_end → incluso (`<=` su limit)
+- Voice vuota → restituita vuota
+- Tutte le voice filtrate correttamente (non solo voice 0)
+- stream.onset != 0: offset assoluto calcolato correttamente
+
+`PassthroughClipStrategy.apply`:
+- Tutti i grain restituiti invariati — inclusi grain con onset >= stream_end e grain con coda che sfora
+- Struttura voices preservata (stessa lista di liste)
+
+`GrainClipStrategyFactory.create`:
+- `'overflow_margin'` → istanza `OverflowMarginClipStrategy`
+- `'passthrough'` → istanza `PassthroughClipStrategy`
+- Nome sconosciuto → `ValueError`
+- `create('overflow_margin', margin=1.0)` → `strategy.margin == 1.0`
+
+**Verification:**
+- `pytest tests/strategies/test_grain_clip_strategy.py` green
+- Nessun import circolare: `grain_clip_strategy.py` importa da `core.grain` — verificare che `core.grain` non importi da `strategies`
+
+---
+
+### U2. Integrazione in `Stream.generate_grains`
+
+**Goal:** Applicare `_clip_strategy` come post-process in `generate_grains`, prima dell'assegnazione a `self.voices`.
+
+**Requirements:** R1, R2, R5, R6, R8
+
+**Dependencies:** U1
+
+**Files:**
+- Modifica: `src/core/stream.py`
+- Modifica: `tests/core/test_stream_multivoice.py` (nuovi test, esistenti invariati)
+
+**Approach:**
+
+In `__init__` (dopo `_init_voice_manager`):
+```python
+from strategies.grain_clip_strategy import GrainClipStrategyFactory
+self._clip_strategy = GrainClipStrategyFactory.create(
+    self._config.clip_strategy,
+    margin=self._config.clip_margin,
+)
+```
+
+In `generate_grains`, sostituire **riga 359** (`self.voices = all_voice_grains`) con:
+```python
+# PRIMA (riga 359)
+self.voices = all_voice_grains
+
+# DOPO
+self.voices = self._clip_strategy.apply(all_voice_grains, self)
+```
+
+Il post-process va inserito **prima** della riga 359 — quella riga è già l'assegnazione, non c'è codice intermedio. Il resto del metodo (flatten + sort per `self.grains`, righe 361–363) rimane invariato — opera su `self.voices` già filtrate.
+
+**Test scenarios (`test_stream_multivoice.py` — nuova sezione):**
+
+- Stream con `onset_offset` fisso che spinge grain oltre duration: grain esclusi da `stream.voices`
+- Stream con 2 voci: voice 0 grain tutti dentro bounds, voice 1 grain alcuni fuori → solo voice 1 filtrata
+- `stream.grains` (flat) non contiene grain fuori bounds
+- `len(stream.voices[i])` riflette solo grain validi
+- Con `PassthroughClipStrategy` iniettata: grain con onset >= stream_end presenti in `stream.voices` (il renderer li riceverà integralmente — validato in test piano 002)
+- Grain con coda che sfora di esattamente 0 (`onset + duration == stream_end`): incluso
+- Grain con coda che sfora di ε oltre `stream_end`: escluso
+
+**Regressione su test esistenti:**
+- Tutti i test esistenti in `test_stream.py`, `test_stream_multivoice.py`, `test_stream_voices_yaml.py` rimangono verdi senza modifiche — i grain di test hanno onset piccoli (< 1.0s) e duration standard (es. 0.05s), ben dentro la durata dei mock stream.
+
+**Verification:**
+- `make tests` green
+- `stream.voices` e `stream.grains` non contengono mai grain con `onset >= stream.onset + stream.duration` (con strategy default)
+- ScoreWriter e NumPy renderer non modificati in questo piano
+
+---
+
+## System-Wide Impact
+
+| Componente | Impatto |
+|------------|---------|
+| `generate_grains` | Aggiunge post-process — loop invariato |
+| `stream.voices` / `stream.grains` | Unica fonte di verità: contengono esattamente i grain decisi dalla strategy |
+| NumPy renderer | Invariato in questo piano — le guard esistenti diventano obsolete con piano 002 |
+| ScoreWriter / Csound renderer | Invariati — ricevono stream già filtrate |
+| VoiceManager / Strategy voice | Invariati |
+| `StreamConfig` | Aggiunge `clip_strategy: str` e `clip_margin: float` — `from_yaml` invariato |
+| YAML parsing | `clip_strategy` e `clip_margin` leggibili come campi piatti nel blocco stream |
+
+---
+
+## Relazione con piano 002
+
+Piano 002 rimuove le guard nel renderer NumPy (`onset_sample < n_total`, `end_sample > n_total`) e dimensiona il buffer sull'extent reale dei grain. Questo è **necessario** per onorare `PassthroughClipStrategy`: se la strategy lascia passare grain che sforano, il renderer deve renderizzarli integralmente.
+
+L'ordine di implementazione raccomandato: **001 → 002**. Piano 001 stabilizza `stream.voices` come fonte di verità; piano 002 rende il renderer fedele a quella fonte.
+
+---
+
+## Configurazione YAML via StreamConfig
+
+`clip_strategy` e `clip_margin` vivono in `StreamConfig` — non in `StreamContext`. Motivazione: sono regole di processo (come `time_mode`, `dephase`), non identità dello stream.
+
+### Modifiche a `StreamConfig`
+
+```python
+# src/core/stream_config.py
+@dataclass(frozen=True)
+class StreamConfig:
+    dephase: ...
+    range_always_active: bool = False
+    distribution_mode: str = 'uniform'
+    time_mode: str = 'absolute'
+    time_scale: float = 1.0
+    clip_strategy: str = 'overflow_margin'  # nuovo
+    clip_margin: float = 0.0               # nuovo
+    context: Optional[StreamContext] = None
+```
+
+`StreamConfig.from_yaml` non richiede modifiche — legge dinamicamente i `field_names` noti.
+
+### Sintassi YAML
+
+```yaml
+# default — omettere equivale a overflow_margin + margin 0.0
+streams:
+  - stream_id: "s1"
+    onset: 0.0
+    duration: 10.0
+    sample: "sample.wav"
+
+# clip con margine
+streams:
+  - stream_id: "s2"
+    clip_strategy: overflow_margin
+    clip_margin: 0.5
+
+# passthrough — tutti i grain raggiungono il renderer
+streams:
+  - stream_id: "s3"
+    clip_strategy: passthrough
+```
+
+`clip_margin` è un float fisso — non un Parameter con envelope. Coerente con `time_scale`.
+
+### File aggiuntivi coinvolti
+
+- Modifica: `src/core/stream_config.py` — aggiunge i due campi
+- Modifica: `tests/core/test_stream_config.py` — verifica default e parsing YAML
+- Modifica: `docs/yaml-reference.md` — documenta `clip_strategy` e `clip_margin` nella sezione "Configurazione Processo"
+
+### Test scenarios aggiuntivi (`test_stream_config.py`)
+
+- Default: `StreamConfig()` → `clip_strategy == 'overflow_margin'`, `clip_margin == 0.0`
+- `from_yaml({'clip_strategy': 'passthrough'})` → `clip_strategy == 'passthrough'`
+- `from_yaml({'clip_margin': 0.5})` → `clip_margin == 0.5`
+- YAML senza `clip_strategy`: default preservato
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Mock stream in test senza `onset`/`duration` espliciti: `stream.onset + stream.duration` fallisce | Verificare in U2 che tutti i mock in `test_stream_multivoice.py` abbiano questi attributi numerici. |
+| Import circolare `grain_clip_strategy` ↔ `core.grain` | `grain_clip_strategy.py` importa `Grain` da `core.grain`. `core.grain` non importa da `strategies` — no ciclo. Verificare con `pytest --import-mode=importlib`. |
+| Behavioral change su stream con grain onset < stream_end ma coda che sfora | Con `margin=0.0`, questi grain ora esclusi — più restrittivo del comportamento precedente NumPy. Scelta intenzionale, documentata in Requirements. |
+| `PassthroughClipStrategy` usata senza piano 002: grain che sforano vengono troncati silenziosamente dal renderer | Questo è il comportamento pre-002 — non peggiora nulla. Il troncamento sparisce quando piano 002 è applicato. |
+
+---
+
+## Documentation / Operational Notes
+
+- Dopo merge: aggiornare `docs/ARCHITECTURE.md` sezione "Implementation Notes" con nota su `GrainClipStrategy` come unica superficie di controllo per i bounds dei grain.
+- Chiudere issue #27 con riferimento a questo plan e al PR.
+- `docs/workflows.md`: aggiungere `grain_clip_strategy.py` alla lista file da toccare quando si aggiunge logica di generazione grain.

--- a/src/core/stream.py
+++ b/src/core/stream.py
@@ -30,6 +30,7 @@ from strategies.voice_pitch_strategy import VoicePitchStrategyFactory
 from strategies.voice_onset_strategy import VoiceOnsetStrategyFactory
 from strategies.voice_pointer_strategy import VoicePointerStrategyFactory
 from strategies.voice_pan_strategy import VoicePanStrategyFactory
+from strategies.grain_clip_strategy import GrainClipStrategyFactory, OverflowMarginClipStrategy
 from dataclasses import fields
 
 
@@ -83,6 +84,11 @@ class Stream:
         self._init_controllers(params, config)
         # === 7. VOICE MANAGER ===
         self._init_voice_manager(params, config)
+        # === 7.5. GRAIN CLIP STRATEGY ===
+        self._clip_strategy = GrainClipStrategyFactory.create(
+            config.clip_strategy,
+            margin=config.clip_margin,
+        )
         # === 8. RIFERIMENTI CSOUND (assegnati da Generator) ===
         self.sample_table_num: Optional[int] = None
         self.envelope_table_num: Optional[int] = None
@@ -356,7 +362,13 @@ class Stream:
 
                 voice_cursors[voice_index] += iot
 
-        self.voices = all_voice_grains
+        # Post-process: applica GrainClipStrategy (Plan 001 U2).
+        # stream.voices diventa l'unica fonte di verita' su quali grain esistono.
+        # Fallback per mock stream creati con object.__new__ senza __init__.
+        clip_strategy = getattr(self, '_clip_strategy', None)
+        if clip_strategy is None:
+            clip_strategy = OverflowMarginClipStrategy(margin=0.0)
+        self.voices = clip_strategy.apply(all_voice_grains, self)
         # Flatten e sort per onset (backward compatibility)
         all_grains = [g for voice in self.voices for g in voice]
         all_grains.sort(key=lambda g: g.onset)

--- a/src/core/stream_config.py
+++ b/src/core/stream_config.py
@@ -48,7 +48,9 @@ class StreamConfig:
     distribution_mode: str = 'uniform'
     time_mode: str = 'absolute'
     time_scale: float = 1.0
-    context: Optional[StreamContext] = None  
+    clip_strategy: str = 'overflow_margin'
+    clip_margin: float = 0.0
+    context: Optional[StreamContext] = None
 
     @classmethod
     def from_yaml(cls, yaml_data: dict, context: StreamContext, allow_none: bool = True) -> 'StreamConfig':

--- a/src/strategies/grain_clip_strategy.py
+++ b/src/strategies/grain_clip_strategy.py
@@ -1,0 +1,73 @@
+# src/strategies/grain_clip_strategy.py
+"""
+GrainClipStrategy — controllo dichiarativo dei grain out-of-bounds.
+
+Plan riferimento: docs/plans/2026-05-03-001-fix-grain-clip-strategy-plan.md (U1)
+
+Responsabilita': filtrare grain non validi da stream.voices in post-process,
+prima dell'assegnazione finale a Stream. Rende stream.voices unica fonte di
+verita' su quali grain esistono. Il renderer non ha piu' opinioni sui bounds.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Dict, List, Type
+
+from core.grain import Grain
+
+
+class GrainClipStrategy(ABC):
+    """Strategy astratta per filtrare grain out-of-bounds da stream.voices."""
+
+    @abstractmethod
+    def apply(self, voices: List[List[Grain]], stream) -> List[List[Grain]]:
+        """Filtra grain invalidi da ogni voce. Restituisce nuova struttura."""
+        ...
+
+
+class OverflowMarginClipStrategy(GrainClipStrategy):
+    """Esclude grain la cui coda sfora stream_end + margin."""
+
+    def __init__(self, margin: float = 0.0):
+        self.margin = margin
+
+    def apply(self, voices, stream):
+        stream_end = stream.onset + stream.duration
+        limit = stream_end + self.margin
+        return [
+            [g for g in voice if g.onset < stream_end and g.onset + g.duration <= limit]
+            for voice in voices
+        ]
+
+
+class PassthroughClipStrategy(GrainClipStrategy):
+    """Nessun filtro: tutti i grain passano al renderer integralmente."""
+
+    def apply(self, voices, stream):
+        return voices
+
+
+# =============================================================================
+# REGISTRY
+# =============================================================================
+
+GRAIN_CLIP_STRATEGIES: Dict[str, Type[GrainClipStrategy]] = {
+    'overflow_margin': OverflowMarginClipStrategy,
+    'passthrough': PassthroughClipStrategy,
+}
+
+
+# =============================================================================
+# FACTORY
+# =============================================================================
+
+class GrainClipStrategyFactory:
+    """Factory per creare GrainClipStrategy da nome registrato."""
+
+    @staticmethod
+    def create(name: str, **kwargs) -> GrainClipStrategy:
+        if name not in GRAIN_CLIP_STRATEGIES:
+            raise ValueError(
+                f"GrainClipStrategy sconosciuta: '{name}'. "
+                f"Disponibili: {sorted(GRAIN_CLIP_STRATEGIES.keys())}"
+            )
+        return GRAIN_CLIP_STRATEGIES[name](**kwargs)

--- a/tests/core/test_stream.py
+++ b/tests/core/test_stream.py
@@ -197,6 +197,11 @@ def stream_factory():
         s.envelope_table_num = 2
         s.window_table_map = {'hanning': 2}
 
+        # Clip strategy: passthrough per test (preserva semantiche pre-U2).
+        # Test specifici per clipping iniettano la strategy esplicitamente.
+        from strategies.grain_clip_strategy import PassthroughClipStrategy
+        s._clip_strategy = PassthroughClipStrategy()
+
         # Stato
         s.voices = []
         s.grains = []
@@ -521,9 +526,11 @@ class TestStreamInit:
                 patch('core.stream.PointerController'), \
                 patch('core.stream.PitchController'), \
                 patch('core.stream.DensityController'), \
-                patch('core.stream.WindowController'):
+                patch('core.stream.WindowController'), \
+                patch('core.stream.GrainClipStrategyFactory') as MockClipFactory:
                 MockSCtx.from_yaml.return_value = Mock()
                 MockSC.from_yaml.return_value = Mock()
+                MockClipFactory.create.return_value = Mock()
 
                 mock_orch_inst = MockOrch.return_value
                 mock_orch_inst.create_all_parameters.return_value = {

--- a/tests/core/test_stream_config.py
+++ b/tests/core/test_stream_config.py
@@ -268,20 +268,38 @@ class TestStreamConfigDefaults:
         assert config.distribution_mode == 'uniform'
         assert config.time_mode == 'absolute'
         assert config.time_scale == 1.0
+        assert config.clip_strategy == 'overflow_margin'
+        assert config.clip_margin == 0.0
         assert config.context is None
 
     def test_field_count(self):
-        """StreamConfig ha esattamente 6 campi."""
-        assert len(fields(StreamConfig)) == 6
+        """StreamConfig ha esattamente 8 campi."""
+        assert len(fields(StreamConfig)) == 8
 
     def test_field_names(self):
         """Nomi campi nell'ordine atteso."""
         names = [f.name for f in fields(StreamConfig)]
         expected = [
             'dephase', 'range_always_active', 'distribution_mode',
-            'time_mode', 'time_scale', 'context'
+            'time_mode', 'time_scale', 'clip_strategy', 'clip_margin', 'context'
         ]
         assert names == expected
+
+    def test_clip_strategy_from_yaml_passthrough(self, stream_context):
+        """from_yaml legge clip_strategy=passthrough."""
+        config = StreamConfig.from_yaml({'clip_strategy': 'passthrough'}, context=stream_context)
+        assert config.clip_strategy == 'passthrough'
+
+    def test_clip_margin_from_yaml(self, stream_context):
+        """from_yaml legge clip_margin float."""
+        config = StreamConfig.from_yaml({'clip_margin': 0.5}, context=stream_context)
+        assert config.clip_margin == 0.5
+
+    def test_clip_strategy_default_when_omitted(self, stream_context):
+        """YAML senza clip_strategy: default preservato."""
+        config = StreamConfig.from_yaml({}, context=stream_context)
+        assert config.clip_strategy == 'overflow_margin'
+        assert config.clip_margin == 0.0
 
 
 # =============================================================================

--- a/tests/core/test_stream_multivoice.py
+++ b/tests/core/test_stream_multivoice.py
@@ -149,6 +149,10 @@ def _make_stream(
     s.envelope_table_num = 2
     s.window_table_map = {'hanning': 2}
 
+    # Clip strategy: passthrough per test (preserva semantiche pre-U2).
+    from strategies.grain_clip_strategy import PassthroughClipStrategy
+    s._clip_strategy = PassthroughClipStrategy()
+
     s.voices = []
     s.grains = []
     s.generated = False
@@ -731,3 +735,124 @@ class TestGenerateGrainsEnvelopePerGrain:
             assert grain.pitch_ratio == pytest.approx(expected_ratio, rel=1e-4), (
                 f"grain {i} at t={t:.1f}: expected ratio {expected_ratio:.4f}, got {grain.pitch_ratio:.4f}"
             )
+
+
+# =============================================================================
+# 7. GrainClipStrategy integration (Plan 001 U2)
+# =============================================================================
+
+class TestGrainClipStrategyIntegration:
+    """generate_grains applica _clip_strategy in post-process.
+
+    Default: OverflowMarginClipStrategy(margin=0.0) — esclude grain con
+    onset >= stream_end o coda che sfora stream_end.
+    """
+
+    def test_default_excludes_grain_with_onset_past_stream_end(self):
+        """Voce 1 con onset_offset enorme: grain spinti oltre stream_end → esclusi."""
+        from strategies.voice_onset_strategy import LinearOnsetStrategy
+        from strategies.grain_clip_strategy import OverflowMarginClipStrategy
+        vm = VoiceManager(max_voices=2, onset_strategy=LinearOnsetStrategy(step=10.0))
+        s = _make_stream(duration=1.0, onset=0.0, inter_onset=0.1,
+                         grain_dur=0.05, voice_manager=vm)
+        s._clip_strategy = OverflowMarginClipStrategy(margin=0.0)
+        s.generate_grains()
+        # voce 0: onsets in [0, 1.0), nessun offset → tutti dentro
+        assert len(s.voices[0]) > 0
+        for g in s.voices[0]:
+            assert g.onset < 1.0
+            assert g.onset + g.duration <= 1.0
+        # voce 1: onset_offset=10.0 → tutti onset >= 10.0 → tutti esclusi
+        assert s.voices[1] == []
+
+    def test_default_filters_per_voice_independently(self):
+        """Voice 0 dentro bounds, voice 1 fuori: solo voice 1 filtrata."""
+        from strategies.voice_onset_strategy import LinearOnsetStrategy
+        from strategies.grain_clip_strategy import OverflowMarginClipStrategy
+        vm = VoiceManager(max_voices=2, onset_strategy=LinearOnsetStrategy(step=10.0))
+        s = _make_stream(duration=1.0, onset=0.0, inter_onset=0.1,
+                         grain_dur=0.05, voice_manager=vm)
+        s._clip_strategy = OverflowMarginClipStrategy(margin=0.0)
+        s.generate_grains()
+        voice_0_count = len(s.voices[0])
+        assert voice_0_count >= 9  # ~10 grani in 1.0s @ 0.1s IOT
+        assert len(s.voices[1]) == 0
+
+    def test_default_grains_flat_excludes_out_of_bounds(self):
+        """stream.grains (flatten) non contiene grain fuori bounds."""
+        from strategies.voice_onset_strategy import LinearOnsetStrategy
+        from strategies.grain_clip_strategy import OverflowMarginClipStrategy
+        vm = VoiceManager(max_voices=2, onset_strategy=LinearOnsetStrategy(step=10.0))
+        s = _make_stream(duration=1.0, onset=0.0, inter_onset=0.1,
+                         grain_dur=0.05, voice_manager=vm)
+        s._clip_strategy = OverflowMarginClipStrategy(margin=0.0)
+        s.generate_grains()
+        stream_end = s.onset + s.duration
+        for g in s.grains:
+            assert g.onset < stream_end
+            assert g.onset + g.duration <= stream_end
+
+    def test_passthrough_strategy_keeps_out_of_bounds_grains(self):
+        """PassthroughClipStrategy iniettata: grain fuori bounds presenti."""
+        from strategies.voice_onset_strategy import LinearOnsetStrategy
+        from strategies.grain_clip_strategy import PassthroughClipStrategy
+        vm = VoiceManager(max_voices=2, onset_strategy=LinearOnsetStrategy(step=10.0))
+        s = _make_stream(duration=1.0, onset=0.0, inter_onset=0.1,
+                         grain_dur=0.05, voice_manager=vm)
+        s._clip_strategy = PassthroughClipStrategy()
+        s.generate_grains()
+        # voce 1 ora ha grain con onset >= 10.0
+        assert len(s.voices[1]) > 0
+        assert all(g.onset >= 10.0 for g in s.voices[1])
+
+    def test_grain_with_tail_exactly_at_stream_end_included(self):
+        """grain.onset + grain.duration == stream_end → incluso (limit `<=`)."""
+        from strategies.grain_clip_strategy import OverflowMarginClipStrategy
+        # inter_onset=0.25, grain_dur=0.25 FP-safe: onsets 0, 0.25, 0.5, 0.75
+        # ultimo grain: onset=0.75, coda=1.0 == stream_end → incluso
+        s = _make_stream(duration=1.0, onset=0.0, inter_onset=0.25, grain_dur=0.25)
+        s._clip_strategy = OverflowMarginClipStrategy(margin=0.0)
+        s.generate_grains()
+        onsets = [g.onset for g in s.grains]
+        assert any(o == pytest.approx(0.75) for o in onsets)
+        for g in s.grains:
+            assert g.onset + g.duration <= 1.0 + 1e-9
+
+    def test_grain_with_tail_overflow_excluded(self):
+        """grain con coda che sfora stream_end → escluso (margin=0.0)."""
+        from strategies.grain_clip_strategy import OverflowMarginClipStrategy
+        # duration=1.0, grain_dur=0.2: grain con onset=0.9 → coda=1.1 > 1.0 → escluso
+        s = _make_stream(duration=1.0, onset=0.0, inter_onset=0.1, grain_dur=0.2)
+        s._clip_strategy = OverflowMarginClipStrategy(margin=0.0)
+        s.generate_grains()
+        for g in s.grains:
+            assert g.onset + g.duration <= 1.0
+
+    def test_margin_allows_tail_overflow(self):
+        """margin=0.5 ammette coda oltre stream_end → piu' grain di margin=0.0."""
+        from strategies.grain_clip_strategy import OverflowMarginClipStrategy
+        s_strict = _make_stream(duration=1.0, onset=0.0, inter_onset=0.1, grain_dur=0.2)
+        s_strict._clip_strategy = OverflowMarginClipStrategy(margin=0.0)
+        s_strict.generate_grains()
+        s_loose = _make_stream(duration=1.0, onset=0.0, inter_onset=0.1, grain_dur=0.2)
+        s_loose._clip_strategy = OverflowMarginClipStrategy(margin=0.5)
+        s_loose.generate_grains()
+        # con margin=0.0 grain con coda > 1.0 esclusi, con margin=0.5 inclusi
+        assert len(s_loose.grains) > len(s_strict.grains)
+        # coda max con margin=0.0
+        for g in s_strict.grains:
+            assert g.onset + g.duration <= 1.0 + 1e-9
+        # coda max con margin=0.5
+        for g in s_loose.grains:
+            assert g.onset + g.duration <= 1.5 + 1e-9
+
+    def test_stream_with_nonzero_onset(self):
+        """stream.onset != 0: stream_end = onset + duration calcolato corretto."""
+        from strategies.grain_clip_strategy import OverflowMarginClipStrategy
+        s = _make_stream(duration=1.0, onset=5.0, inter_onset=0.1, grain_dur=0.05)
+        s._clip_strategy = OverflowMarginClipStrategy(margin=0.0)
+        s.generate_grains()
+        for g in s.grains:
+            assert g.onset >= 5.0
+            assert g.onset < 6.0 + 1e-9
+            assert g.onset + g.duration <= 6.0 + 1e-9

--- a/tests/strategies/test_grain_clip_strategy.py
+++ b/tests/strategies/test_grain_clip_strategy.py
@@ -1,0 +1,207 @@
+# tests/strategies/test_grain_clip_strategy.py
+"""
+Suite TDD per grain_clip_strategy.py
+
+Plan riferimento: docs/plans/2026-05-03-001-fix-grain-clip-strategy-plan.md (U1)
+
+Moduli sotto test:
+- GrainClipStrategy (ABC)
+- OverflowMarginClipStrategy(margin=0.0)  default
+- PassthroughClipStrategy
+- GRAIN_CLIP_STRATEGIES (registry)
+- GrainClipStrategyFactory.create
+
+Contratto:
+- strategy.apply(voices, stream) -> List[List[Grain]]
+- voices: List[List[Grain]] (struttura per-voce)
+- stream: oggetto con `.onset` e `.duration` (float, secondi)
+"""
+
+import pytest
+from types import SimpleNamespace
+
+from core.grain import Grain
+
+
+def make_grain(onset: float, duration: float = 0.05) -> Grain:
+    """Helper per costruire grain minimi con valori validi."""
+    return Grain(
+        onset=onset,
+        duration=duration,
+        pointer_pos=0.0,
+        pitch_ratio=1.0,
+        volume=1.0,
+        pan=0.5,
+        sample_table=1,
+        envelope_table=2,
+    )
+
+
+def make_stream(onset: float = 0.0, duration: float = 1.0):
+    return SimpleNamespace(onset=onset, duration=duration)
+
+
+# =============================================================================
+# 1. OverflowMarginClipStrategy — comportamento base
+# =============================================================================
+
+class TestOverflowMarginClipStrategy:
+
+    def test_grain_completely_inside_stream_is_kept(self):
+        from strategies.grain_clip_strategy import OverflowMarginClipStrategy
+        strategy = OverflowMarginClipStrategy(margin=0.0)
+        stream = make_stream(onset=0.0, duration=1.0)
+        grain = make_grain(onset=0.5, duration=0.05)
+
+        result = strategy.apply([[grain]], stream)
+
+        assert result == [[grain]]
+
+    def test_grain_with_onset_at_or_past_stream_end_is_excluded(self):
+        """R1: grain.onset >= stream_end -> escluso (strict <)."""
+        from strategies.grain_clip_strategy import OverflowMarginClipStrategy
+        strategy = OverflowMarginClipStrategy(margin=0.0)
+        stream = make_stream(onset=0.0, duration=1.0)
+        g_at = make_grain(onset=1.0, duration=0.05)
+        g_past = make_grain(onset=1.5, duration=0.05)
+
+        result = strategy.apply([[g_at, g_past]], stream)
+
+        assert result == [[]]
+
+    def test_grain_tail_overflows_with_zero_margin_is_excluded(self):
+        """R2: onset < stream_end ma onset+duration > stream_end+margin (margin=0) -> escluso."""
+        from strategies.grain_clip_strategy import OverflowMarginClipStrategy
+        strategy = OverflowMarginClipStrategy(margin=0.0)
+        stream = make_stream(onset=0.0, duration=1.0)
+        grain = make_grain(onset=0.99, duration=0.05)  # tail = 1.04 > 1.0
+
+        result = strategy.apply([[grain]], stream)
+
+        assert result == [[]]
+
+    def test_grain_tail_within_margin_is_kept(self):
+        """Grain coda dentro margin -> incluso."""
+        from strategies.grain_clip_strategy import OverflowMarginClipStrategy
+        strategy = OverflowMarginClipStrategy(margin=0.5)
+        stream = make_stream(onset=0.0, duration=1.0)
+        grain = make_grain(onset=0.99, duration=0.05)  # tail 1.04 <= 1.5
+
+        result = strategy.apply([[grain]], stream)
+
+        assert result == [[grain]]
+
+    def test_grain_tail_exactly_equals_stream_end_is_kept(self):
+        """Boundary: onset + duration == stream_end -> incluso (<= su limit)."""
+        from strategies.grain_clip_strategy import OverflowMarginClipStrategy
+        strategy = OverflowMarginClipStrategy(margin=0.0)
+        stream = make_stream(onset=0.0, duration=1.0)
+        grain = make_grain(onset=0.95, duration=0.05)  # tail = 1.0 esatto
+
+        result = strategy.apply([[grain]], stream)
+
+        assert result == [[grain]]
+
+    def test_empty_voice_returns_empty(self):
+        from strategies.grain_clip_strategy import OverflowMarginClipStrategy
+        strategy = OverflowMarginClipStrategy(margin=0.0)
+        stream = make_stream(onset=0.0, duration=1.0)
+
+        result = strategy.apply([[]], stream)
+
+        assert result == [[]]
+
+    def test_filters_each_voice_independently(self):
+        """Multi-voice: solo voice non valide filtrate, struttura preservata."""
+        from strategies.grain_clip_strategy import OverflowMarginClipStrategy
+        strategy = OverflowMarginClipStrategy(margin=0.0)
+        stream = make_stream(onset=0.0, duration=1.0)
+        v0_keep = make_grain(onset=0.1, duration=0.05)
+        v1_keep = make_grain(onset=0.2, duration=0.05)
+        v1_drop = make_grain(onset=2.0, duration=0.05)
+
+        result = strategy.apply([[v0_keep], [v1_keep, v1_drop]], stream)
+
+        assert result == [[v0_keep], [v1_keep]]
+
+    def test_stream_with_nonzero_onset(self):
+        """stream.onset != 0: bounds calcolati su offset assoluto."""
+        from strategies.grain_clip_strategy import OverflowMarginClipStrategy
+        strategy = OverflowMarginClipStrategy(margin=0.0)
+        stream = make_stream(onset=10.0, duration=1.0)  # stream_end=11.0
+        g_in = make_grain(onset=10.5, duration=0.05)
+        g_out = make_grain(onset=11.5, duration=0.05)
+
+        result = strategy.apply([[g_in, g_out]], stream)
+
+        assert result == [[g_in]]
+
+
+# =============================================================================
+# 2. PassthroughClipStrategy
+# =============================================================================
+
+class TestPassthroughClipStrategy:
+
+    def test_passes_all_grains_unchanged(self):
+        """R5: tutti i grain restituiti, inclusi quelli che sforano."""
+        from strategies.grain_clip_strategy import PassthroughClipStrategy
+        strategy = PassthroughClipStrategy()
+        stream = make_stream(onset=0.0, duration=1.0)
+        g_in = make_grain(onset=0.1)
+        g_tail = make_grain(onset=0.99, duration=0.5)
+        g_out = make_grain(onset=5.0)
+
+        result = strategy.apply([[g_in, g_tail, g_out]], stream)
+
+        assert result == [[g_in, g_tail, g_out]]
+
+    def test_preserves_voice_structure(self):
+        from strategies.grain_clip_strategy import PassthroughClipStrategy
+        strategy = PassthroughClipStrategy()
+        stream = make_stream()
+        voices = [[make_grain(0.1)], [], [make_grain(0.2), make_grain(5.0)]]
+
+        result = strategy.apply(voices, stream)
+
+        assert len(result) == 3
+        assert result[0] == voices[0]
+        assert result[1] == []
+        assert result[2] == voices[2]
+
+
+# =============================================================================
+# 3. Registry + Factory
+# =============================================================================
+
+class TestGrainClipStrategyFactory:
+
+    def test_creates_overflow_margin_default(self):
+        from strategies.grain_clip_strategy import (
+            GrainClipStrategyFactory, OverflowMarginClipStrategy,
+        )
+        s = GrainClipStrategyFactory.create('overflow_margin')
+        assert isinstance(s, OverflowMarginClipStrategy)
+        assert s.margin == 0.0
+
+    def test_creates_overflow_margin_with_margin(self):
+        from strategies.grain_clip_strategy import GrainClipStrategyFactory
+        s = GrainClipStrategyFactory.create('overflow_margin', margin=1.0)
+        assert s.margin == 1.0
+
+    def test_creates_passthrough(self):
+        from strategies.grain_clip_strategy import (
+            GrainClipStrategyFactory, PassthroughClipStrategy,
+        )
+        s = GrainClipStrategyFactory.create('passthrough')
+        assert isinstance(s, PassthroughClipStrategy)
+
+    def test_unknown_name_raises(self):
+        from strategies.grain_clip_strategy import GrainClipStrategyFactory
+        with pytest.raises(ValueError, match="sconosciuta"):
+            GrainClipStrategyFactory.create('bogus')
+
+    def test_registry_contains_both_strategies(self):
+        from strategies.grain_clip_strategy import GRAIN_CLIP_STRATEGIES
+        assert 'overflow_margin' in GRAIN_CLIP_STRATEGIES
+        assert 'passthrough' in GRAIN_CLIP_STRATEGIES


### PR DESCRIPTION
## Summary

Piano 001 di [docs/plans/2026-05-03-001-fix-grain-clip-strategy-plan.md](docs/plans/2026-05-03-001-fix-grain-clip-strategy-plan.md).

Introduce `GrainClipStrategy` come post-process in `Stream.generate_grains`: `stream.voices` diventa l'unica fonte di verità su quali grain esistono. Il renderer non filtra più — riceve grain già validati.

- `GrainClipStrategy` ABC + `OverflowMarginClipStrategy(margin=0.0)` (default) + `PassthroughClipStrategy`
- Registry + `GrainClipStrategyFactory` (stesso shape delle voice strategy)
- `StreamConfig`: nuovi campi `clip_strategy: str` e `clip_margin: float`
- Integrazione in `Stream.__init__` + post-process in `generate_grains`

## Scope

- Nessuna modifica a renderer NumPy/Csound — quelli sono Plan 002 (passthrough buffer).
- Nessuna sintassi YAML nuova oltre i due campi piatti — coerenti con `time_mode`/`time_scale`.
- Csound: nessun troncamento del grain (incluso intero o escluso).

## Test plan

- [x] `make tests` → 4067 passed, 0 failed
- [x] Default `OverflowMarginClipStrategy(margin=0.0)`: grain con coda che sfora `stream_end` esclusi
- [x] `PassthroughClipStrategy`: tutti i grain passano (in attesa di Plan 002 per buffer fedele)
- [x] `GrainClipStrategyFactory.create('passthrough'|'overflow_margin', margin=...)` validato
- [x] Regressione voice strategy invariata
- [x] `StreamConfig.from_yaml` legge `clip_strategy`/`clip_margin` come campi piatti

## Refs

Issue #27. Prossimo step: Plan 002 (`fix-numpy-renderer-passthrough`) — rimuove guard renderer e dimensiona buffer su extent reale.