### PR TITLE
fix(numpy_renderer): passthrough puro — buffer dinamico (#27)

### DIFF
--- a/docs/plans/2026-05-03-002-fix-numpy-renderer-passthrough-plan.md
+++ b/docs/plans/2026-05-03-002-fix-numpy-renderer-passthrough-plan.md
@@ -1,0 +1,258 @@
+---
+title: "fix: NumPy renderer passthrough — buffer dinamico, rimozione guard ortogonali (issue #27)"
+type: fix
+status: active
+date: 2026-05-03
+---
+
+# fix: NumPy renderer passthrough — buffer dinamico, rimozione guard ortogonali
+
+## Overview
+
+NumPy renderer contiene guard e troncamenti in `_add_grain_at_position` che costituiscono una **seconda superficie di controllo ortogonale** rispetto a `GrainClipStrategy` (piano 001). Questo piano le rimuove, rendendo il renderer un passthrough puro: dimensiona il buffer sull'extent reale dei grain ricevuti da `stream.voices` e li renderizza integralmente, senza giudizi propri sui bounds.
+
+Questo piano **dipende concettualmente da piano 001**: la rimozione delle guard ha senso solo se `stream.voices` è già la fonte di verità controllata da una strategy. Le guard non vengono rimosse perché "non si attivano mai" — vengono rimosse perché **non devono esistere nel renderer**.
+
+---
+
+## Vincolo architetturale
+
+**Il renderer non ha opinioni sui bounds dei grain.** Riceve `stream.voices`, alloca un buffer che contiene tutti i grain che trova, li renderizza. Il comportamento del buffer (durata, extent) è una conseguenza della strategy scelta in piano 001, non un parametro indipendente del renderer.
+
+Mantenere le guard sarebbe accoppiare il renderer alla semantica dei bounds dello stream — responsabilità che appartiene a `GrainClipStrategy`.
+
+---
+
+## Problem Frame
+
+In `_add_grain_at_position` esistono tre comportamenti di clamp:
+
+| Linea | Condizione | Comportamento | Decisione |
+|-------|-----------|---------------|-----------|
+| 227 | `onset_sample < 0` | Taglia inizio grain (grain inizia prima del buffer) | **Preservare** — difesa legittima, indipendente dai bounds dello stream |
+| 234–237 | `end_sample > n_total` | Tronca coda del grain — artefatto silenzioso | **Rimuovere** — responsabilità della strategy, non del renderer |
+| 240 | `onset_sample >= n_total` | Scarta grain intero — divergenza con Csound | **Rimuovere** — responsabilità della strategy, non del renderer |
+
+Il buffer è fisso a `stream.duration * sr`. Con grain che sforano (consentiti da `PassthroughClipStrategy`), questo produce:
+
+- **Caso A** (onset fuori bounds): grain scartato silenziosamente. Il renderer ignora una scelta semantica esplicita della strategy.
+- **Caso B** (coda fuori bounds): grain troncato. Il renderer modifica un grain che la strategy ha deliberatamente lasciato passare.
+
+Entrambi i casi violano il vincolo architetturale: il renderer non deve sovrascrivere la decisione della strategy.
+
+---
+
+## Requirements Trace
+
+- R1. `render_single_stream` dimensiona il buffer sull'extent reale: `max(g.onset + g.duration - stream.onset)` per tutti i grain in `stream.voices`.
+- R2. `render_merged_streams` dimensiona il buffer sull'extent reale: `max(g.onset + g.duration)` per tutti i grain di tutti gli stream.
+- R3. I clamp `end_sample > n_total` (riga 234) e `onset_sample >= n_total` (riga 240) sono rimossi.
+- R4. Il clamp negativo (riga 227, `onset_sample < 0`) rimane — non riguarda i bounds dello stream.
+- R5. Stream senza grain: fallback a `stream.duration` (comportamento invariato).
+- R6. Con `OverflowMarginClipStrategy` (default): grain filtrati da piano 001 → `max(g.onset + g.duration)` ≤ `stream_end` → buffer == `stream.duration` emerge naturalmente, senza hardcode.
+- R7. Con `PassthroughClipStrategy`: grain che sforano presenti in `stream.voices` → buffer esteso → grain renderizzati integralmente.
+- R8. Tutti i test esistenti restano verdi o aggiornati al nuovo comportamento.
+
+---
+
+## Scope Boundaries
+
+- Solo `numpy_audio_renderer.py` — nessuna modifica a Stream, ScoreWriter, Csound renderer.
+- Nessuna nuova strategia, nessun nuovo parametro YAML.
+- `Grain`, `Stream`, `stream.voices` invariati in questo piano.
+- Il renderer non importa né conosce `GrainClipStrategy` — si adatta implicitamente al contenuto di `stream.voices`.
+
+---
+
+## Context & Research
+
+### I tre clamp in `_add_grain_at_position` (righe 227–241)
+
+```python
+# CLAMP 1 — onset negativo (legittimo, preservare)
+if onset_sample < 0:
+    grain_buffer = grain_buffer[-onset_sample:]
+    onset_sample = 0
+
+end_sample = onset_sample + grain_len
+
+# CLAMP 2 — coda oltre fine buffer (RIMUOVERE)
+if end_sample > n_total:
+    grain_buffer = grain_buffer[:n_total - onset_sample]
+    end_sample = n_total
+
+# CLAMP 3 — onset oltre fine buffer (RIMUOVERE)
+if onset_sample < n_total and grain_buffer.shape[0] > 0:
+    buffer[onset_sample:end_sample] += grain_buffer
+```
+
+### Buffer dinamico elimina entrambe le guard
+
+Con `n_total = max(g.onset + g.duration - stream.onset) * sr` per tutti i grain in `stream.voices`:
+- `end_sample <= n_total` per tutti i grain — CLAMP 2 non si attiva mai
+- `onset_sample < n_total` per tutti i grain — CLAMP 3 sempre vero
+
+Le guard non vanno rimosse perché "non si attivano" — vanno rimosse perché la loro esistenza presuppone che il renderer abbia responsabilità sui bounds. Con il buffer dinamico, questa presupposizione scompare strutturalmente.
+
+### Adattamento implicito alla strategy
+
+Il renderer non conosce quale strategy è stata usata. Vede solo i grain in `stream.voices`:
+
+| Strategy (piano 001) | grain in `stream.voices` | buffer size (piano 002) |
+|---------------------|--------------------------|------------------------|
+| `OverflowMarginClipStrategy(margin=0.0)` | tutti entro `stream_end` | == `stream.duration` (naturale) |
+| `OverflowMarginClipStrategy(margin=0.5)` | coda fino a `stream_end + 0.5` | esteso fino a `stream_end + 0.5` |
+| `PassthroughClipStrategy` | tutti, inclusi quelli che sforano | esteso all'extent reale |
+
+Il renderer si adatta senza conoscere la strategy — il risultato emerge dal contenuto di `stream.voices`.
+
+---
+
+## High-Level Technical Design
+
+### `render_single_stream` (STEMS) — buffer sizing
+
+```python
+# PRIMA
+n_total = int(stream.duration * self.output_sr)
+
+# DOPO
+all_grains = [g for voice in stream.voices for g in voice]
+if all_grains:
+    max_end_rel = max(g.onset + g.duration for g in all_grains) - stream.onset
+else:
+    max_end_rel = stream.duration
+n_total = max(1, int(max_end_rel * self.output_sr))
+```
+
+### `render_merged_streams` (MIX) — buffer sizing
+
+```python
+# PRIMA
+max_end_time = max(s.onset + s.duration for s in streams)
+
+# DOPO
+all_grains = [g for s in streams for v in s.voices for g in v]
+if all_grains:
+    max_end_time = max(g.onset + g.duration for g in all_grains)
+else:
+    max_end_time = max(s.onset + s.duration for s in streams)
+n_total = max(1, int(max_end_time * self.output_sr))
+```
+
+### `_add_grain_at_position` — rimozione CLAMP 2 e 3
+
+```python
+# PRIMA
+end_sample = onset_sample + grain_len
+if end_sample > n_total:
+    grain_buffer = grain_buffer[:n_total - onset_sample]
+    end_sample = n_total
+if onset_sample < n_total and grain_buffer.shape[0] > 0:
+    buffer[onset_sample:end_sample] += grain_buffer
+
+# DOPO
+end_sample = onset_sample + grain_len
+if grain_buffer.shape[0] > 0:
+    buffer[onset_sample:end_sample] += grain_buffer
+```
+
+`n_total` viene rimosso dalla firma di `_add_grain_at_position` in U2 (nessun chiamante esterno — entrambi i caller sono metodi privati della stessa classe). Rimandarlo a un piano successivo lascerebbe un parametro inutilizzato nel corpo, che è peggio della rimozione immediata.
+
+---
+
+## Implementation Units
+
+---
+
+### U1. Buffer sizing dinamico in `render_single_stream` e `render_merged_streams`
+
+**Goal:** Calcolare `n_total` sull'extent reale dei grain invece di `stream.duration`.
+
+**Requirements:** R1, R2, R5, R6, R7
+
+**Dependencies:** Piano 001 U2 (stream.voices come fonte di verità)
+
+**Files:**
+- Modifica: `src/rendering/numpy_audio_renderer.py` (righe ~101 e ~140)
+- Modifica: `tests/rendering/test_numpy_audio_renderer.py`
+
+**Test scenarios:**
+
+`render_single_stream`:
+- Grain tutti dentro `stream.duration` → buffer == `stream.duration * sr` (R6 — emerge naturalmente)
+- Grain con onset ok, coda che sfora (`PassthroughClipStrategy` iniettata in stream) → buffer esteso, grain non troncato (R7)
+- Grain con onset fuori bounds (`PassthroughClipStrategy`) → buffer esteso, grain renderizzato correttamente (R7)
+- Stream senza grain → buffer == `stream.duration * sr` (fallback R5)
+- `stream.onset != 0`: extent calcolato con offset assoluto corretto
+
+`render_merged_streams`:
+- Grain tutti dentro bounds → buffer == `max(s.onset + s.duration) * sr` (invariato)
+- Grain con coda che sfora in uno stream (`PassthroughClipStrategy`) → buffer esteso
+- Tutti gli stream senza grain → fallback corretto
+
+**Verification:**
+- `pytest tests/rendering/test_numpy_audio_renderer.py` green
+
+---
+
+### U2. Rimozione CLAMP 2 e 3 in `_add_grain_at_position`
+
+**Goal:** Rimuovere le guard che presuppongono responsabilità del renderer sui bounds.
+
+**Requirements:** R3, R4
+
+**Dependencies:** U1
+
+**Files:**
+- Modifica: `src/rendering/numpy_audio_renderer.py` (righe 233–241)
+- Modifica: `tests/rendering/test_numpy_audio_renderer.py`
+
+**Firma aggiornata** (rimuove `n_total` da tutti e tre i metodi privati):
+```python
+# _add_grain_at_position — rimuove n_total
+def _add_grain_at_position(self, buffer, grain, onset_sample):
+    ...
+
+# _add_grain_relative — aggiorna call
+self._add_grain_at_position(buffer, grain, onset_sample)
+
+# _add_grain_absolute — aggiorna call
+self._add_grain_at_position(buffer, grain, onset_sample)
+```
+
+**Test scenarios:**
+- Grain con coda che sfora il vecchio `stream.duration` → overlap-add completo, nessun troncamento
+- Grain con onset al boundary → renderizzato correttamente
+- Grain con `grain_buffer` vuoto → nessun overlap-add (guard `shape[0] > 0` preservata)
+- CLAMP 1 (onset < 0) ancora attivo: grain che inizia prima del buffer → taglia inizio correttamente
+
+**Verification:**
+- `pytest tests/rendering/test_numpy_audio_renderer.py` green
+- `_add_grain_at_position` senza parametro `n_total`, senza rami `end_sample > n_total` e senza `onset_sample < n_total`
+
+---
+
+## System-Wide Impact
+
+| Componente | Impatto |
+|------------|---------|
+| `numpy_audio_renderer.py` | Buffer sizing dinamico; CLAMP 2 e 3 rimossi |
+| `stream.voices` / `stream.grains` | Invariati — fonte di verità gestita da piano 001 |
+| ScoreWriter / Csound renderer | Invariati |
+| Output STEMS con `OverflowMarginClipStrategy` | Invariato — buffer == `stream.duration` emerge naturalmente |
+| Output STEMS con `PassthroughClipStrategy` | Può essere > `stream.duration` se grain sfondano — comportamento semanticamente corretto |
+| Output MIX | Analogo |
+| Cache (`StreamCacheManager`) | Fingerprint YAML invariato — nessun impatto |
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Test `test_output_duration_matches_stream` verifica `len(data)/sr ≈ stream.duration` | I grain di test hanno onset=0.0, duration=0.1, stream.duration=0.5 — tutti in-bounds → buffer == stream.duration naturale → test passa senza modifiche |
+| Applicare piano 002 senza piano 001: grain out-of-bounds raggiungono il renderer | Comportamento definito: il renderer li renderizza integralmente. È la scelta corretta se si vuole il passthrough puro. Il rischio semantico (output più lungo del previsto) è responsabilità di chi non ha applicato piano 001. |
+| Buffer overflow NumPy se `max_end_rel` negativo | Guard `max(1, int(...))` in U1; CLAMP 1 (onset < 0) in U2 gestisce onset negativi |
+| Performance: iterazione grain per `max()` in hot path | O(N_grains) una tantum prima dell'allocazione — trascurabile |
+| Troncamento float→int: `int(onset * sr) + int(duration * sr)` può essere < `int((onset + duration) * sr)` | `floor(a) + floor(b) <= floor(a+b)` → `end_sample <= n_total` sempre, nessun overflow. Assunzione: grain renderer produce esattamente `int(grain.duration * sr)` sample. Se il renderer usa resampling o arrotondamento diverso, `grain_len` può sforare di 1 sample → aggiungere test esplicito che `grain_len == int(grain.duration * sr)` nel grain renderer. |

--- a/docs/plans/done/2026-05-03-001-fix-grain-clip-strategy-plan.md
+++ b/docs/plans/done/2026-05-03-001-fix-grain-clip-strategy-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "fix: GrainClipStrategy — controllo dichiarativo dei grain out-of-bounds (issue #27)"
 type: fix
-status: active
+status: done
 date: 2026-05-03
 ---
 

--- a/docs/plans/done/2026-05-03-002-fix-numpy-renderer-passthrough-plan.md
+++ b/docs/plans/done/2026-05-03-002-fix-numpy-renderer-passthrough-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "fix: NumPy renderer passthrough — buffer dinamico, rimozione guard ortogonali (issue #27)"
 type: fix
-status: active
+status: done
 date: 2026-05-03
 ---
 

--- a/docs/yaml-reference.md
+++ b/docs/yaml-reference.md
@@ -66,7 +66,54 @@ range_always_active: false  # true: i _range sono sempre attivi anche senza deph
 distribution_mode: uniform  # (riservato, non usato correntemente)
 
 time_scale: 1.0         # fattore di scala temporale globale (default 1.0)
+
+clip_strategy: overflow_margin  # "overflow_margin" (default) | "passthrough"
+                                # Decide quali grain entrano in stream.voices
+clip_margin: 0.0        # tolleranza in secondi per la coda dei grain (default 0.0)
 ```
+
+### clip_strategy — Controllo grain out-of-bounds
+
+`GrainClipStrategy` filtra i grain in post-process dentro `Stream.generate_grains`. È l'**unica fonte di verità** su quali grain esistono — Csound e NumPy ricevono esattamente la stessa `stream.voices`.
+
+| Valore | Comportamento |
+|--------|---------------|
+| `overflow_margin` (default) | Grain valido iff `grain.onset < stream_end AND grain.onset + grain.duration <= stream_end + clip_margin`. Con `clip_margin=0.0` il grain deve stare interamente dentro lo stream. |
+| `passthrough` | Nessun filtro — tutti i grain passano al renderer, che li renderizza integralmente (il buffer si estende sull'extent reale). |
+
+`stream_end = stream.onset + stream.duration`.
+
+```yaml
+# Default — grain interi dentro lo stream
+streams:
+  - stream_id: "s1"
+    onset: 0.0
+    duration: 10.0
+    sample: "sample.wav"
+
+# Tollera 0.5s di coda oltre stream_end
+streams:
+  - stream_id: "s2"
+    onset: 0.0
+    duration: 10.0
+    sample: "sample.wav"
+    clip_strategy: overflow_margin
+    clip_margin: 0.5
+
+# Passthrough — grain con onset/coda oltre stream_end vengono renderizzati;
+# la durata del file di output puo' essere > stream.duration
+streams:
+  - stream_id: "s3"
+    onset: 0.0
+    duration: 10.0
+    sample: "sample.wav"
+    clip_strategy: passthrough
+```
+
+Note:
+- Con `passthrough` il renderer NumPy alloca un buffer esteso sull'extent reale dei grain (`max(g.onset + g.duration)`), quindi il file `.aif` può superare `stream.duration`.
+- Csound: stesso filtraggio a monte → SCO contiene solo i grain validi. Il grain non viene mai troncato (incluso intero o escluso).
+- `clip_margin` è un float fisso, non un Parameter con envelope (coerente con `time_scale`).
 
 ---
 

--- a/src/rendering/numpy_audio_renderer.py
+++ b/src/rendering/numpy_audio_renderer.py
@@ -97,14 +97,22 @@ class NumpyAudioRenderer(AudioRenderer):
                 if not dirty:
                     return output_path
 
-        # 1. Alloca buffer (solo per duration, ignora onset)
-        n_total = int(stream.duration * self.output_sr)
+        # 1. Alloca buffer su extent reale dei grain (Plan 002 U1).
+        # stream.voices e' la fonte di verita' (Plan 001): il renderer si adatta
+        # al contenuto, senza opinioni proprie sui bounds.
+        all_grains = [g for voice in stream.voices for g in voice]
+        if all_grains:
+            max_end_rel = max(g.onset + g.duration for g in all_grains) - stream.onset
+            max_end_rel = max(max_end_rel, stream.duration)
+        else:
+            max_end_rel = stream.duration
+        n_total = max(1, int(max_end_rel * self.output_sr))
         buffer = np.zeros((n_total, 2), dtype=np.float64)
 
         # 2. Overlap-add con onset RELATIVI
         for voice_grains in stream.voices:
             for grain in voice_grains:
-                self._add_grain_relative(buffer, grain, stream.onset, n_total)
+                self._add_grain_relative(buffer, grain, stream.onset)
 
         # 3. Clamp + scrivi
         np.clip(buffer, -1.0, 1.0, out=buffer)
@@ -136,16 +144,22 @@ class NumpyAudioRenderer(AudioRenderer):
         Returns:
             Path del file prodotto
         """
-        # 1. Calcola durata totale buffer
-        max_end_time = max(s.onset + s.duration for s in streams)
-        n_total = int(max_end_time * self.output_sr)
+        # 1. Calcola durata totale buffer su extent reale (Plan 002 U1).
+        all_grains = [g for s in streams for v in s.voices for g in v]
+        stream_end_max = max(s.onset + s.duration for s in streams)
+        if all_grains:
+            grain_end_max = max(g.onset + g.duration for g in all_grains)
+            max_end_time = max(grain_end_max, stream_end_max)
+        else:
+            max_end_time = stream_end_max
+        n_total = max(1, int(max_end_time * self.output_sr))
         buffer = np.zeros((n_total, 2), dtype=np.float64)
 
         # 2. Overlap-add con onset ASSOLUTI
         for stream in streams:
             for voice_grains in stream.voices:
                 for grain in voice_grains:
-                    self._add_grain_absolute(buffer, grain, n_total)
+                    self._add_grain_absolute(buffer, grain)
 
         # 3. Clamp + scrivi
         np.clip(buffer, -1.0, 1.0, out=buffer)
@@ -162,7 +176,6 @@ class NumpyAudioRenderer(AudioRenderer):
         buffer: np.ndarray,
         grain,
         stream_onset: float,
-        n_total: int,
     ):
         """
         Aggiunge grano al buffer con onset RELATIVO.
@@ -172,72 +185,56 @@ class NumpyAudioRenderer(AudioRenderer):
         Onset calculation: onset_sample = (grain.onset - stream_onset) * sr
         → grano posizionato relativamente allo stream (parte da 0)
         """
-        # Calcola onset RELATIVO (sottrae stream.onset)
         onset_sample = int((grain.onset - stream_onset) * self.output_sr)
-        self._add_grain_at_position(buffer, grain, onset_sample, n_total)
+        self._add_grain_at_position(buffer, grain, onset_sample)
 
     def _add_grain_absolute(
         self,
         buffer: np.ndarray,
         grain,
-        n_total: int,
     ):
         """
         Aggiunge grano al buffer con onset ASSOLUTO.
 
         Usato da: render_merged_streams() (MIX mode)
-
-        Onset calculation: onset_sample = grain.onset * sr
-        → grano posizionato assolutamente (rispetta stream.onset)
         """
-        # Calcola onset ASSOLUTO (usa grain.onset direttamente)
         onset_sample = int(grain.onset * self.output_sr)
-        self._add_grain_at_position(buffer, grain, onset_sample, n_total)
+        self._add_grain_at_position(buffer, grain, onset_sample)
 
     def _add_grain_at_position(
         self,
         buffer: np.ndarray,
         grain,
         onset_sample: int,
-        n_total: int,
     ):
         """
-        Template method: renderizza grano e somma nel buffer (overlap-add).
+        Renderizza grano e somma nel buffer (overlap-add).
 
-        Gestisce:
-        - Rendering grano (sample + window)
-        - Clamping ai bordi buffer
-        - Overlap-add
+        Plan 002: il renderer non ha opinioni sui bounds del buffer.
+        L'unico clamp legittimo e' onset_sample < 0 (grano inizia prima del
+        buffer); CLAMP 2/3 (coda/onset oltre fine buffer) sono stati rimossi
+        — la responsabilita' appartiene a GrainClipStrategy (Plan 001).
 
         Args:
             buffer: buffer stereo output (n_total, 2)
             grain: oggetto Grain
             onset_sample: posizione nel buffer (in samples)
-            n_total: lunghezza buffer
         """
-        # Risolvi sample + window
         sample_name = self._resolve_sample_name(grain.sample_table)
         window_name = self._resolve_window_name(grain.envelope_table)
 
-        # Renderizza grano
         grain_buffer = self._grain_renderer.render(grain, sample_name, window_name)
         grain_len = grain_buffer.shape[0]
 
-        # Clamp ai bordi buffer
+        # CLAMP 1 — onset negativo: taglia inizio del grano (legittimo, indipendente
+        # dai bounds dello stream).
         if onset_sample < 0:
-            # Grano inizia prima del buffer: taglia inizio
             grain_buffer = grain_buffer[-onset_sample:]
             grain_len = grain_buffer.shape[0]
             onset_sample = 0
 
         end_sample = onset_sample + grain_len
-        if end_sample > n_total:
-            # Grano sfora fine buffer: taglia fine
-            grain_buffer = grain_buffer[:n_total - onset_sample]
-            end_sample = n_total
-
-        # Overlap-add
-        if onset_sample < n_total and grain_buffer.shape[0] > 0:
+        if grain_buffer.shape[0] > 0:
             buffer[onset_sample:end_sample] += grain_buffer
 
     # =========================================================================

--- a/tests/rendering/test_numpy_audio_renderer.py
+++ b/tests/rendering/test_numpy_audio_renderer.py
@@ -508,3 +508,149 @@ class TestNumpyAudioRendererCache:
 
         assert mtime_second > mtime_first
 
+
+# =============================================================================
+# 8. TEST PASSTHROUGH BUFFER (Plan 002)
+# =============================================================================
+
+
+class TestPassthroughBufferSizing:
+    """
+    Plan 002: il renderer dimensiona il buffer sull'extent reale dei grain,
+    non su stream.duration. CLAMP 2/3 rimossi: i grain che sforano vengono
+    renderizzati integralmente (passthrough puro).
+    """
+
+    def test_buffer_extends_when_grain_tail_overflows(self, renderer, tmp_path):
+        """Grain con coda oltre stream.duration: buffer esteso, niente truncation."""
+        import soundfile as sf
+        # stream.duration = 0.5, grain finisce a 0.7 (sfora di 0.2s)
+        grains = [make_grain(onset=0.4, duration=0.3, pointer_pos=0.5)]
+        stream = make_mock_stream(duration=0.5, grains=grains)
+        output_path = str(tmp_path / 'overflow_tail.aif')
+
+        renderer.render_single_stream(stream, output_path)
+        data, sr = sf.read(output_path)
+
+        actual_duration = len(data) / sr
+        assert actual_duration >= 0.7 - 1e-3, (
+            f"Buffer should extend to grain end (0.7s), got {actual_duration}"
+        )
+        # Energy oltre stream.duration: il grain non e' stato troncato
+        tail = data[int(0.5 * sr):]
+        assert np.sum(tail ** 2) > 1e-4
+
+    def test_buffer_extends_when_grain_onset_past_stream_end(self, renderer, tmp_path):
+        """Grain con onset >= stream.duration: buffer esteso, grain renderizzato."""
+        import soundfile as sf
+        # stream.duration = 0.3, grain con onset 0.5 (oltre stream_end)
+        grains = [make_grain(onset=0.5, duration=0.1, pointer_pos=0.5)]
+        stream = make_mock_stream(duration=0.3, grains=grains)
+        output_path = str(tmp_path / 'onset_past.aif')
+
+        renderer.render_single_stream(stream, output_path)
+        data, sr = sf.read(output_path)
+
+        actual_duration = len(data) / sr
+        assert actual_duration >= 0.6 - 1e-3, (
+            f"Buffer should extend to grain end (0.6s), got {actual_duration}"
+        )
+        # Energy nella zona del grain: non e' stato scartato
+        grain_zone = data[int(0.5 * sr):int(0.6 * sr)]
+        assert np.sum(grain_zone ** 2) > 1e-4
+
+    def test_buffer_matches_stream_duration_when_grains_in_bounds(self, renderer, tmp_path):
+        """Default OverflowMarginClipStrategy: grain in-bounds → buffer == stream.duration."""
+        import soundfile as sf
+        grains = [
+            make_grain(onset=0.0, duration=0.05),
+            make_grain(onset=0.1, duration=0.05),
+        ]
+        stream = make_mock_stream(duration=0.5, grains=grains)
+        output_path = str(tmp_path / 'in_bounds.aif')
+
+        renderer.render_single_stream(stream, output_path)
+        data, sr = sf.read(output_path)
+
+        actual_duration = len(data) / sr
+        assert abs(actual_duration - 0.5) < 1e-3
+
+    def test_no_grains_falls_back_to_stream_duration(self, renderer, tmp_path):
+        """Stream senza grain: buffer == stream.duration (fallback R5)."""
+        import soundfile as sf
+        stream = make_mock_stream(duration=0.4, grains=[])
+        output_path = str(tmp_path / 'empty.aif')
+
+        renderer.render_single_stream(stream, output_path)
+        data, sr = sf.read(output_path)
+
+        actual_duration = len(data) / sr
+        assert abs(actual_duration - 0.4) < 1e-3
+
+    def test_render_single_stream_with_stream_onset(self, renderer, tmp_path):
+        """stream.onset != 0: extent calcolato relativamente a stream.onset."""
+        import soundfile as sf
+        # stream.onset=2.0, duration=0.5; grain absolute onset 2.0+0.4=2.4, dur 0.3 → end=2.7
+        grains = [make_grain(onset=2.4, duration=0.3, pointer_pos=0.5)]
+        stream = make_mock_stream(onset=2.0, duration=0.5, grains=grains)
+        output_path = str(tmp_path / 'onset_stream.aif')
+
+        renderer.render_single_stream(stream, output_path)
+        data, sr = sf.read(output_path)
+
+        actual_duration = len(data) / sr
+        # Buffer relativo: 2.7 - 2.0 = 0.7
+        assert actual_duration >= 0.7 - 1e-3
+
+    def test_render_merged_streams_extends_for_overflow(self, renderer, tmp_path):
+        """render_merged_streams: buffer esteso se un grain sfora stream_end."""
+        import soundfile as sf
+        # stream onset=0, duration=0.3; grain a onset 0.5, duration 0.1 → 0.6 absolute
+        grains = [make_grain(onset=0.5, duration=0.1, pointer_pos=0.5)]
+        stream = make_mock_stream(onset=0.0, duration=0.3, grains=grains)
+        output_path = str(tmp_path / 'merged_overflow.aif')
+
+        renderer.render_merged_streams([stream], output_path)
+        data, sr = sf.read(output_path)
+
+        actual_duration = len(data) / sr
+        assert actual_duration >= 0.6 - 1e-3
+
+    def test_render_merged_streams_no_grains_falls_back(self, renderer, tmp_path):
+        """render_merged_streams senza grain: max(s.onset+s.duration)."""
+        import soundfile as sf
+        stream = make_mock_stream(onset=0.0, duration=0.4, grains=[])
+        output_path = str(tmp_path / 'merged_empty.aif')
+
+        renderer.render_merged_streams([stream], output_path)
+        data, sr = sf.read(output_path)
+
+        actual_duration = len(data) / sr
+        assert abs(actual_duration - 0.4) < 1e-3
+
+
+class TestAddGrainAtPositionSignature:
+    """U2: _add_grain_at_position non accetta piu' n_total."""
+
+    def test_add_grain_at_position_no_n_total_param(self, renderer):
+        """La firma ha 3 parametri: buffer, grain, onset_sample (no n_total)."""
+        import inspect
+        sig = inspect.signature(renderer._add_grain_at_position)
+        params = list(sig.parameters.keys())
+        assert 'n_total' not in params, (
+            f"_add_grain_at_position must not accept n_total, got params: {params}"
+        )
+
+    def test_negative_onset_clamp_preserved(self, renderer, tmp_path):
+        """CLAMP 1 (onset < 0) preservato: grain che inizia prima del buffer → tagliato all'inizio."""
+        import soundfile as sf
+        # Grain con onset assoluto 0.0 ma stream.onset=0.05 → onset relativo negativo (-0.05s)
+        grains = [make_grain(onset=0.0, duration=0.2, pointer_pos=0.5)]
+        stream = make_mock_stream(onset=0.05, duration=0.5, grains=grains)
+        output_path = str(tmp_path / 'neg_onset.aif')
+
+        renderer.render_single_stream(stream, output_path)
+        data, sr = sf.read(output_path)
+        # File deve essere creato senza errori; energia non zero (parte del grain renderizzata)
+        assert np.max(np.abs(data)) > 1e-5
+


### PR DESCRIPTION
## Summary

Piano 002 di [docs/plans/2026-05-03-002-fix-numpy-renderer-passthrough-plan.md](docs/plans/2026-05-03-002-fix-numpy-renderer-passthrough-plan.md). Segue PR #34 (Plan 001).

Il renderer NumPy diventa passthrough puro: dimensiona il buffer sull'extent reale dei grain in `stream.voices` e li renderizza integralmente, senza guard sui bounds dello stream. La responsabilità di decidere quali grain esistono appartiene a `GrainClipStrategy` (Plan 001).

- `render_single_stream`: `n_total = max(grain_extent_rel, stream.duration)`
- `render_merged_streams`: `n_total = max(grain_extent_abs, stream_end_max)`
- `_add_grain_at_position`: rimossi CLAMP 2 (`end_sample > n_total`) e CLAMP 3 (`onset_sample >= n_total`)
- CLAMP 1 (`onset_sample < 0`) preservato — difesa legittima indipendente dai bounds
- Firme aggiornate: `n_total` rimosso da `_add_grain_at_position`, `_add_grain_relative`, `_add_grain_absolute`

## Scope

- Solo `numpy_audio_renderer.py` — Stream/ScoreWriter/Csound invariati
- Nessun nuovo parametro YAML, nessuna strategy nuova
- Backward compatible: con `OverflowMarginClipStrategy(margin=0.0)` (default), `max(grain_extent) <= stream_end` → `n_total == stream.duration * sr` come prima

## Test plan

- [x] `make tests` → 4076 passed (4067 + 9 nuovi)
- [x] Grain con coda oltre `stream.duration` (PassthroughClipStrategy): buffer esteso, niente truncation
- [x] Grain con onset >= `stream.duration` (PassthroughClipStrategy): buffer esteso, grain renderizzato
- [x] Default OverflowMarginClipStrategy: buffer == `stream.duration` (R6 — emerge naturalmente)
- [x] Stream senza grain: fallback a `stream.duration`
- [x] `stream.onset != 0`: extent calcolato relativamente
- [x] `render_merged_streams` con overflow: buffer esteso
- [x] Firma `_add_grain_at_position` senza `n_total` (verifica via inspect)
- [x] CLAMP 1 (onset negativo) preservato