### PR TITLE
fix(engine): logging strutturato per errori sample mancanti (#33)

### DIFF
--- a/docs/plans/2026-05-09-001-fix-engine-error-logging-plan.md
+++ b/docs/plans/2026-05-09-001-fix-engine-error-logging-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "fix: logging strutturato per errori engine — sample mancanti con messaggio terminale pulito (issue #33)"
 type: fix
-status: draft
+status: done
 date: 2026-05-09
 issue: 33
 ---
@@ -217,7 +217,36 @@ Estensioni future seguiranno lo stesso pattern (`EngineError` + caller wrapping 
 
 ## Done criteria
 
-- [ ] `make tests` verde
-- [ ] Sample mancante produce messaggio terminale pulito + log file con traceback
-- [ ] Nessuna regressione su path felice (sample esistenti)
-- [ ] `pino.wav` test case riproducibile e gestito correttamente
+- [x] `make tests` verde (4088 test passano)
+- [x] Sample mancante produce messaggio terminale pulito + log file con traceback
+- [x] Nessuna regressione su path felice (sample esistenti) — verificato con `configs/PGE_density_experiment.yml`
+- [x] Test case riproducibile (`__nonexistent_sample_123__.wav`) e gestito correttamente
+
+## E2E verifica (step 7)
+
+Comando:
+```
+.venv/bin/python src/main.py /tmp/pge_e2e/broken.yml out.aif --renderer numpy
+```
+
+Output terminale (exit 1):
+```
+Caricamento /tmp/pge_e2e/broken.yml...
+Generazione streams...
+Creazione di 1 stream...
+[ERRORE] Sample non trovato: '__nonexistent_sample_123__.wav'
+  Path cercato: ./refs/__nonexistent_sample_123__.wav
+  Stream:       drone_a
+  Config:       /tmp/pge_e2e/broken.yml
+  Dettagli:     ./logs/broken_engine.log
+```
+
+File `./logs/broken_engine.log`:
+```
+2026-05-09 18:41:43 [ERROR] Sample non trovato: '__nonexistent_sample_123__.wav' in ./refs/
+Traceback (most recent call last):
+  File ".../src/main.py", line 231, in main
+    generator.create_elements()
+  ...
+shared.exceptions.SampleNotFoundError: Sample non trovato: '__nonexistent_sample_123__.wav' in ./refs/
+```

--- a/docs/plans/2026-05-09-001-fix-engine-error-logging-plan.md
+++ b/docs/plans/2026-05-09-001-fix-engine-error-logging-plan.md
@@ -1,0 +1,223 @@
+---
+title: "fix: logging strutturato per errori engine — sample mancanti con messaggio terminale pulito (issue #33)"
+type: fix
+status: draft
+date: 2026-05-09
+issue: 33
+---
+
+# fix: logging strutturato per errori engine
+
+## Overview
+
+Issue #33: quando un sample referenziato dal YAML non esiste in `./refs/`, il pipeline crasha con un traceback Python grezzo da `soundfile.LibsndfileError`. Niente messaggio leggibile, niente file di log per errori engine, niente context (quale stream, quale config).
+
+Questo piano introduce:
+1. Gerarchia `EngineError` con sotto-tipi specifici (a partire da `SampleNotFoundError`)
+2. `engine_logger` separato dal `clip_logger` esistente, scrive su `./logs/<yaml>_engine.log`
+3. Top-level handler in `main.py` che formatta messaggio terminale pulito + persiste traceback nel log
+4. Wrapping del context (stream_id, yaml_file) lato caller — `Stream.__init__` arricchisce l'errore con info che `get_sample_duration` non possiede
+
+**Ambito iniziale:** solo `SampleNotFoundError`. Altri errori (YAML invalidi, render failures) restano traceback finché non emergeranno come issue separate.
+
+---
+
+## Vincolo architetturale
+
+`get_sample_duration` (`src/shared/utils.py`) resta una utility pura: non conosce `stream_id` né `yaml_file`. Il context viene aggiunto dal caller (`Stream.__init__`) tramite wrapping dell'eccezione. Separazione concerns: utility = primitive su filesystem; stream = consapevole del proprio identity.
+
+Il logger engine è separato dal `clip_logger` esistente perché:
+- diverso scope (errori fatali vs warning di clipping envelope)
+- diversa configurazione (sempre file, mai console; vs clip configurabile)
+- diverso ciclo di vita (engine logger sempre attivo da inizio main; clip configurato dopo arg parsing)
+
+---
+
+## Problem Frame
+
+### Comportamento attuale
+
+```
+$ make all FILE=PGE_test
+...
+ Errore: Error opening './refs/pino.wav': System error.
+Traceback (most recent call last):
+  File ".../main.py", line 214, in main
+    generator.create_elements()
+  File ".../generator.py", line 106, in create_elements
+    self._create_streams(filtered_streams)
+  File ".../generator.py", line 240, in _create_streams
+    stream = Stream(stream_data)
+  File ".../stream.py", line 76, in __init__
+    config = StreamConfig.from_yaml(...)
+  File ".../utils.py", line 9, in get_sample_duration
+    info = sf.info(PATHSAMPLES + filepath)
+  ...
+soundfile.LibsndfileError: Error opening './refs/pino.wav': System error.
+```
+
+Problemi:
+- traceback Python invece di messaggio leggibile
+- messaggio "System error" da libsndfile non aiuta utente
+- niente indicazione dello stream colpevole
+- niente file di log persistente per debug futuro
+- l'utente deve leggere stack trace per capire che manca un file
+
+### Comportamento atteso
+
+Terminale:
+```
+[ERRORE] Sample non trovato: 'pino.wav'
+  Path cercato:  ./refs/pino.wav
+  Stream:        <stream_id>
+  Config:        configs/PGE_test.yml
+  Dettagli:      ./logs/PGE_test_engine.log
+```
+
+File `./logs/PGE_test_engine.log`:
+```
+2026-05-09 14:23:01 [ERROR] SampleNotFoundError: 'pino.wav' (path: ./refs/pino.wav, stream: <id>, config: configs/PGE_test.yml)
+Traceback (most recent call last):
+  ...
+```
+
+---
+
+## Design
+
+### Nuovi moduli
+
+**`src/shared/exceptions.py`** (nuovo file)
+```python
+class EngineError(Exception):
+    """Base per errori dell'engine destinati a output user-facing pulito."""
+    def user_message(self) -> str: ...
+
+class SampleNotFoundError(EngineError):
+    def __init__(self, filename: str, search_path: str,
+                 stream_id: str | None = None,
+                 config_file: str | None = None):
+        ...
+```
+
+`user_message()` ritorna stringa formattata multi-line per terminale. `__str__` resta usabile per log.
+
+### Estensioni a moduli esistenti
+
+**`src/shared/logger.py`**
+- aggiungere `configure_engine_logger(yaml_name, log_dir='./logs')`
+- aggiungere `get_engine_logger() -> logging.Logger`
+- file handler su `./logs/<yaml>_engine.log`, livello ERROR
+- nessun console handler (terminal output gestito da main.py)
+
+**`src/shared/utils.py:get_sample_duration`**
+- check `os.path.exists(PATHSAMPLES + filepath)` prima di `sf.info()`
+- se manca: raise `SampleNotFoundError(filename=filepath, search_path=PATHSAMPLES)`
+- nessun riferimento a stream_id (utility pura)
+
+**`src/core/stream.py:Stream.__init__`**
+- wrap `StreamConfig.from_yaml(...)` in try/except `SampleNotFoundError`
+- arricchisce con `stream_id` (presente in `params`) e re-raise
+
+**`src/main.py`**
+- chiamare `configure_engine_logger(yaml_basename)` prima del try
+- nuovo branch nel except: `except EngineError as e:` → `print(e.user_message())` + `engine_logger.error(...)` con traceback
+- `Generator` o `main` arricchisce con `config_file` (path YAML noto solo qui)
+
+### Flusso del context
+
+```
+get_sample_duration  →  raise SampleNotFoundError(filename, search_path)
+                              ↓ propaga
+Stream.__init__      →  catch, aggiungi stream_id, re-raise
+                              ↓ propaga
+Generator.create_elements →  catch, aggiungi config_file, re-raise
+                              ↓ propaga
+main.py              →  catch EngineError, log + print
+```
+
+Ogni layer aggiunge solo ciò che conosce. Mai accesso a info che non gli appartiene.
+
+---
+
+## Implementation Plan (TDD)
+
+Ogni step: test rosso → conferma fallimento → impl → verde → `make tests`.
+
+### Step 1: `EngineError` base + `SampleNotFoundError`
+- `tests/test_engine_exceptions.py`
+  - `test_sample_not_found_has_user_message`
+  - `test_sample_not_found_includes_optional_context`
+  - `test_engine_error_subclass`
+- impl: `src/shared/exceptions.py`
+
+### Step 2: `get_sample_duration` raise pulito
+- `tests/test_utils_sample_duration.py` (estende esistente se c'è)
+  - `test_get_sample_duration_raises_sample_not_found_for_missing_file`
+  - `test_get_sample_duration_message_contains_path`
+- impl: guard `os.path.exists` in `utils.py`
+
+### Step 3: `Stream.__init__` arricchisce con `stream_id`
+- `tests/test_stream_error_context.py`
+  - `test_stream_init_wraps_sample_error_with_id`
+- impl: try/except in `Stream.__init__`
+
+### Step 4: `Generator.create_elements` arricchisce con `config_file`
+- test analogo per generator
+- impl: try/except in `Generator.create_elements`
+
+### Step 5: `engine_logger` configurabile
+- `tests/test_engine_logger.py`
+  - `test_engine_logger_writes_to_file`
+  - `test_engine_logger_separate_from_clip_logger`
+- impl: estensioni a `shared/logger.py`
+
+### Step 6: `main.py` handler
+- test e2e su sample mancante (forse manuale, o smoke test con subprocess)
+- impl: catch `EngineError` in `main.py`, log + print
+
+### Step 7: e2e manuale
+- creare config con sample inesistente
+- eseguire `make all FILE=...`
+- verificare:
+  - exit code 1
+  - terminale: messaggio pulito senza traceback
+  - file `./logs/<yaml>_engine.log` contiene traceback completo
+
+---
+
+## File toccati (riassunto)
+
+**Nuovi:**
+- `src/shared/exceptions.py`
+- `tests/test_engine_exceptions.py`
+- `tests/test_engine_logger.py`
+- `tests/test_stream_error_context.py`
+
+**Modificati:**
+- `src/shared/utils.py` — guard `os.path.exists`
+- `src/shared/logger.py` — `configure_engine_logger`, `get_engine_logger`
+- `src/core/stream.py` — wrap in `__init__`
+- `src/engine/generator.py` — wrap in `create_elements`
+- `src/main.py` — handler `EngineError`
+- test esistenti su utils/stream se presenti
+
+---
+
+## Out of scope
+
+- Logging per errori YAML malformati (parser, schema validation)
+- Logging per errori di rendering (Csound exit fail, NumPy buffer issues)
+- Logging strutturato JSON
+- Rotazione log
+
+Estensioni future seguiranno lo stesso pattern (`EngineError` + caller wrapping + handler in `main.py`).
+
+---
+
+## Done criteria
+
+- [ ] `make tests` verde
+- [ ] Sample mancante produce messaggio terminale pulito + log file con traceback
+- [ ] Nessuna regressione su path felice (sample esistenti)
+- [ ] `pino.wav` test case riproducibile e gestito correttamente

--- a/src/core/stream.py
+++ b/src/core/stream.py
@@ -22,6 +22,7 @@ from controllers.pointer_controller import PointerController
 from controllers.pitch_controller import PitchController
 from controllers.density_controller import DensityController
 from shared.utils import get_sample_duration
+from shared.exceptions import SampleNotFoundError
 from parameters.parameter_schema import STREAM_PARAMETER_SCHEMA
 from parameters.parameter_orchestrator import ParameterOrchestrator
 from core.stream_config import StreamConfig, StreamContext
@@ -74,7 +75,12 @@ class Stream:
                 f"Stream '{stream_id}': campo 'sample' mancante o null — "
                 "specificare il nome del file wav (es. sample: mio_file.wav)"
             )
-        config = StreamConfig.from_yaml(params, StreamContext.from_yaml(params, sample_dur_sec=get_sample_duration(sample)))
+        try:
+            sample_dur = get_sample_duration(sample)
+        except SampleNotFoundError as err:
+            err.stream_id = stream_id
+            raise
+        config = StreamConfig.from_yaml(params, StreamContext.from_yaml(params, sample_dur_sec=sample_dur))
         self._init_stream_context(params)
         # === 4. PARAMETRI SPECIALI ===
         self._init_grain_reverse(params)

--- a/src/engine/generator.py
+++ b/src/engine/generator.py
@@ -19,6 +19,7 @@ from core.cartridge import Cartridge
 from rendering.ftable_manager import FtableManager
 from rendering.score_writer import ScoreWriter
 from controllers.window_controller import WindowController
+from shared.exceptions import SampleNotFoundError
 
 class Generator:
     """
@@ -103,7 +104,11 @@ class Generator:
         filtered_streams = self._filter_solo_mute(stream_data_list)
         
         # Crea stream (QUI viene chiamato _register_stream_windows)
-        self._create_streams(filtered_streams)
+        try:
+            self._create_streams(filtered_streams)
+        except SampleNotFoundError as err:
+            err.config_file = self.yaml_path
+            raise
         
         # Crea cartridges
         cartridge_data_list = self.data.get('cartridges', [])

--- a/src/main.py
+++ b/src/main.py
@@ -2,9 +2,25 @@
 # MAIN
 # =============================================================================
 
-from shared.logger import configure_clip_logger, get_clip_log_path
+import traceback
+
+from shared.logger import (
+    configure_clip_logger, get_clip_log_path,
+    configure_engine_logger, get_engine_logger, get_engine_log_path,
+)
+from shared.exceptions import EngineError
 from engine.generator import Generator
 from rendering.score_visualizer import ScoreVisualizer
+
+
+def _handle_engine_error(err: EngineError) -> None:
+    """Stampa user_message su stdout e persiste traceback nel file engine log."""
+    log_path = get_engine_log_path()
+    print(err.user_message())
+    if log_path:
+        print(f"  Dettagli:     {log_path}")
+    logger = get_engine_logger()
+    logger.error("%s\n%s", err, traceback.format_exc())
 
 
 def _build_renderer(renderer_type: str, generator, **kwargs):
@@ -203,6 +219,7 @@ def main():
         yaml_name=yaml_basename,
         log_transformations=False
     )
+    configure_engine_logger(yaml_name=yaml_basename, log_dir='./logs')
 
     try:
         generator = Generator(yaml_file)
@@ -286,9 +303,11 @@ def main():
     except FileNotFoundError:
         print(f" Errore: file '{yaml_file}' non trovato")
         sys.exit(1)
+    except EngineError as e:
+        _handle_engine_error(e)
+        sys.exit(1)
     except Exception as e:
         print(f" Errore: {e}")
-        import traceback
         traceback.print_exc()
         sys.exit(1)
 

--- a/src/shared/exceptions.py
+++ b/src/shared/exceptions.py
@@ -1,0 +1,35 @@
+# =============================================================================
+# src/shared/exceptions.py
+# =============================================================================
+"""
+Gerarchia EngineError per errori engine destinati a output user-facing pulito
+(issue #33). Ogni eccezione fornisce user_message() per il terminale e
+__str__ per i log.
+"""
+
+
+class EngineError(Exception):
+    """Base per errori dell'engine. Sottoclassi forniscono user_message()."""
+
+    def user_message(self) -> str:
+        return str(self)
+
+
+class SampleNotFoundError(EngineError):
+    def __init__(self, filename: str, search_path: str):
+        self.filename = filename
+        self.search_path = search_path
+        self.stream_id: str | None = None
+        self.config_file: str | None = None
+        super().__init__(f"Sample non trovato: '{filename}' in {search_path}")
+
+    def user_message(self) -> str:
+        lines = [
+            f"[ERRORE] Sample non trovato: '{self.filename}'",
+            f"  Path cercato: {self.search_path}{self.filename}",
+        ]
+        if self.stream_id:
+            lines.append(f"  Stream:       {self.stream_id}")
+        if self.config_file:
+            lines.append(f"  Config:       {self.config_file}")
+        return "\n".join(lines)

--- a/src/shared/logger.py
+++ b/src/shared/logger.py
@@ -135,17 +135,63 @@ def get_clip_logger():
 def get_clip_log_path():
     """
     Ritorna il percorso del file di log corrente (se esiste).
-    
+
     Returns:
         str o None
     """
     if _clip_logger is None:
         return None
-    
+
     for handler in _clip_logger.handlers:
         if isinstance(handler, logging.FileHandler):
             return handler.baseFilename
     return None
+
+
+# =============================================================================
+# ENGINE LOGGER (issue #33) — errori engine fatali, sempre su file
+# =============================================================================
+_engine_logger = None
+_engine_log_path: str | None = None
+
+
+def configure_engine_logger(yaml_name: str | None = None, log_dir: str = './logs'):
+    """Configura logger engine: scrive ERROR + traceback su <log_dir>/<yaml_name>_engine.log."""
+    global _engine_logger, _engine_log_path
+
+    if not os.path.exists(log_dir):
+        os.makedirs(log_dir)
+
+    name = yaml_name if yaml_name else datetime.now().strftime("%Y%m%d_%H%M%S")
+    log_filename = f'{name}_engine.log'
+    log_path = os.path.join(log_dir, log_filename)
+
+    logger = logging.getLogger('engine')
+    logger.setLevel(logging.ERROR)
+    logger.handlers = []
+
+    file_handler = logging.FileHandler(log_path, mode='w', encoding='utf-8')
+    file_handler.setLevel(logging.ERROR)
+    file_handler.setFormatter(logging.Formatter(
+        '%(asctime)s [%(levelname)s] %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S',
+    ))
+    logger.addHandler(file_handler)
+
+    _engine_logger = logger
+    _engine_log_path = log_path
+
+
+def get_engine_logger() -> logging.Logger:
+    """Ottiene engine logger; auto-configura se non ancora chiamato."""
+    if _engine_logger is None:
+        configure_engine_logger()
+    return _engine_logger
+
+
+def get_engine_log_path() -> str | None:
+    """Path del file di log engine corrente."""
+    return _engine_log_path
 
 def log_clip_warning(stream_id, param_name, time, raw_value, clipped_value, 
                      min_val, max_val, is_envelope=False):

--- a/src/shared/utils.py
+++ b/src/shared/utils.py
@@ -1,12 +1,23 @@
+import os
 import random
 import soundfile as sf
 from typing import Any
+
+from shared.exceptions import SampleNotFoundError
+
 # Path per i sample audio
 PATHSAMPLES = './refs/'
 
 def get_sample_duration(filepath: str) -> float:
-    """Ottiene la durata di un file audio in secondi."""
-    info = sf.info(PATHSAMPLES + filepath)
+    """Ottiene la durata di un file audio in secondi.
+
+    Raises:
+        SampleNotFoundError: se il file non esiste in PATHSAMPLES.
+    """
+    full_path = PATHSAMPLES + filepath
+    if not os.path.exists(full_path):
+        raise SampleNotFoundError(filename=filepath, search_path=PATHSAMPLES)
+    info = sf.info(full_path)
     return info.duration
 
 

--- a/tests/core/test_stream_error_context.py
+++ b/tests/core/test_stream_error_context.py
@@ -1,0 +1,41 @@
+# =============================================================================
+# tests/core/test_stream_error_context.py
+# =============================================================================
+"""
+Test per l'arricchimento del context su SampleNotFoundError nel layer Stream
+(issue #33, step 3).
+
+Stream.__init__ deve catturare SampleNotFoundError sollevato da
+get_sample_duration e arricchirlo con stream_id prima del re-raise.
+"""
+import pytest
+
+from core.stream import Stream
+from shared.exceptions import SampleNotFoundError
+
+
+def test_stream_init_enriches_sample_not_found_with_stream_id():
+    """Stream.__init__ aggiunge stream_id all'errore prima di re-raise."""
+    params = {
+        'stream_id': 'drone_a',
+        'sample': '__missing_test_sample_xyz__.wav',
+        # campi minimi: __init__ fallisce su sample prima di toccarli
+    }
+
+    with pytest.raises(SampleNotFoundError) as exc_info:
+        Stream(params)
+
+    assert exc_info.value.stream_id == 'drone_a'
+    assert exc_info.value.filename == '__missing_test_sample_xyz__.wav'
+
+
+def test_stream_init_enriches_with_unknown_id_when_missing():
+    """Stream senza stream_id usa 'unknown' (coerente con altri errori dello Stream)."""
+    params = {
+        'sample': 'missing.wav',
+    }
+
+    with pytest.raises(SampleNotFoundError) as exc_info:
+        Stream(params)
+
+    assert exc_info.value.stream_id == 'unknown'

--- a/tests/engine/test_generator_error_context.py
+++ b/tests/engine/test_generator_error_context.py
@@ -1,0 +1,53 @@
+# =============================================================================
+# tests/engine/test_generator_error_context.py
+# =============================================================================
+"""
+Test per l'arricchimento del context su SampleNotFoundError nel layer Generator
+(issue #33, step 4).
+
+Generator.create_elements deve catturare SampleNotFoundError e arricchirlo
+con config_file (yaml_path) prima del re-raise.
+"""
+import pytest
+
+from engine.generator import Generator
+from shared.exceptions import SampleNotFoundError
+
+
+MINIMAL_YAML_WITH_MISSING_SAMPLE = """\
+composition:
+  title: "test"
+streams:
+  - stream_id: "drone_a"
+    time_mode: normalized
+    onset: 0.0
+    duration: 1.0
+    sample: "__missing_test_sample_xyz__.wav"
+    distribution_mode: 'gaussian'
+    density:
+      type: cubic
+      points: [[0,10],[1,10]]
+    distribution: [[0,1],[1,1]]
+    pointer:
+      speed_ratio: 1.0
+    grain:
+      duration: 0.05
+      duration_range: 0.01
+"""
+
+
+def test_generator_create_elements_enriches_with_config_file(tmp_path):
+    """Generator aggiunge config_file (yaml_path) all'errore."""
+    yaml_file = tmp_path / "broken.yml"
+    yaml_file.write_text(MINIMAL_YAML_WITH_MISSING_SAMPLE)
+
+    gen = Generator(str(yaml_file))
+    gen.load_yaml()
+
+    with pytest.raises(SampleNotFoundError) as exc_info:
+        gen.create_elements()
+
+    err = exc_info.value
+    assert err.config_file == str(yaml_file)
+    assert err.stream_id == 'drone_a'  # propagato da Stream
+    assert err.filename == '__missing_test_sample_xyz__.wav'

--- a/tests/shared/test_engine_exceptions.py
+++ b/tests/shared/test_engine_exceptions.py
@@ -1,0 +1,53 @@
+# =============================================================================
+# tests/shared/test_engine_exceptions.py
+# =============================================================================
+"""
+Test per la gerarchia di EngineError e SampleNotFoundError (issue #33).
+
+Verifica che gli errori engine producano messaggi user-facing puliti
+con il context disponibile a ciascun layer.
+"""
+import pytest
+
+
+def test_sample_not_found_user_message_contains_filename_and_path():
+    """SampleNotFoundError espone un messaggio leggibile con file e path cercato."""
+    from shared.exceptions import SampleNotFoundError
+
+    err = SampleNotFoundError(filename="pino.wav", search_path="./refs/")
+
+    msg = err.user_message()
+    assert "pino.wav" in msg
+    assert "./refs/" in msg
+
+
+def test_sample_not_found_is_engine_error():
+    """SampleNotFoundError è catturabile come EngineError (handler unico in main)."""
+    from shared.exceptions import EngineError, SampleNotFoundError
+
+    err = SampleNotFoundError(filename="x.wav", search_path="./refs/")
+    assert isinstance(err, EngineError)
+    assert isinstance(err, Exception)
+
+
+def test_sample_not_found_user_message_includes_optional_context():
+    """Quando stream_id e config_file sono settati, compaiono nel messaggio."""
+    from shared.exceptions import SampleNotFoundError
+
+    err = SampleNotFoundError(filename="pino.wav", search_path="./refs/")
+    err.stream_id = "drone_a"
+    err.config_file = "configs/PGE_test.yml"
+
+    msg = err.user_message()
+    assert "drone_a" in msg
+    assert "configs/PGE_test.yml" in msg
+
+
+def test_sample_not_found_user_message_omits_missing_context():
+    """Senza context arricchito, il messaggio non mostra righe vuote."""
+    from shared.exceptions import SampleNotFoundError
+
+    err = SampleNotFoundError(filename="x.wav", search_path="./refs/")
+    msg = err.user_message()
+    assert "Stream:" not in msg
+    assert "Config:" not in msg

--- a/tests/shared/test_engine_logger.py
+++ b/tests/shared/test_engine_logger.py
@@ -1,0 +1,55 @@
+# =============================================================================
+# tests/shared/test_engine_logger.py
+# =============================================================================
+"""
+Test per engine_logger (issue #33, step 5).
+
+Logger separato da clip_logger, scrive su file <log_dir>/<yaml_name>_engine.log
+con livello ERROR e traceback completo.
+"""
+import logging
+import os
+import pytest
+
+from shared.logger import (
+    configure_engine_logger,
+    get_engine_logger,
+    get_engine_log_path,
+    get_clip_logger,
+)
+
+
+def test_configure_engine_logger_creates_file_handler(tmp_path):
+    """configure_engine_logger crea file <log_dir>/<yaml_name>_engine.log."""
+    configure_engine_logger(yaml_name='myconfig', log_dir=str(tmp_path))
+
+    log_path = get_engine_log_path()
+    assert log_path is not None
+    assert log_path.endswith('myconfig_engine.log')
+    assert os.path.dirname(log_path) == str(tmp_path)
+
+
+def test_engine_logger_writes_error_to_file(tmp_path):
+    """Messaggi ERROR finiscono nel file di log."""
+    configure_engine_logger(yaml_name='test', log_dir=str(tmp_path))
+
+    logger = get_engine_logger()
+    logger.error("test error message: pino.wav not found")
+
+    for handler in logger.handlers:
+        handler.flush()
+
+    log_path = get_engine_log_path()
+    contents = open(log_path).read()
+    assert "test error message: pino.wav not found" in contents
+
+
+def test_engine_logger_separate_from_clip_logger(tmp_path):
+    """engine_logger e clip_logger sono istanze distinte."""
+    configure_engine_logger(yaml_name='test', log_dir=str(tmp_path))
+
+    engine_logger = get_engine_logger()
+    clip_logger = get_clip_logger()
+
+    assert engine_logger is not clip_logger
+    assert engine_logger.name != (clip_logger.name if clip_logger else 'envelope_clip')

--- a/tests/shared/test_utils.py
+++ b/tests/shared/test_utils.py
@@ -22,7 +22,13 @@ from shared.utils import get_sample_duration, random_percent, get_nested, PATHSA
 
 class TestGetSampleDuration:
     """Test per get_sample_duration() - usa mock di soundfile."""
-    
+
+    @pytest.fixture(autouse=True)
+    def _mock_path_exists(self):
+        """Default: simula sample esistente. Test specifici override via patch locale."""
+        with patch('shared.utils.os.path.exists', return_value=True):
+            yield
+
     @patch('shared.utils.sf.info')
     def test_get_duration_normal_file(self, mock_info):
         """File audio normale restituisce durata corretta."""
@@ -83,19 +89,31 @@ class TestGetSampleDuration:
     
     @patch('shared.utils.sf.info')
     def test_file_not_found_error(self, mock_info):
-        """File non esistente solleva errore."""
+        """File esistente ma sf.info fallisce con FileNotFoundError → propaga."""
         mock_info.side_effect = FileNotFoundError("File not found")
-        
-        with pytest.raises(FileNotFoundError):
-            get_sample_duration('nonexistent.wav')
+        with patch('shared.utils.os.path.exists', return_value=True):
+            with pytest.raises(FileNotFoundError):
+                get_sample_duration('nonexistent.wav')
     
     @patch('shared.utils.sf.info')
     def test_invalid_audio_file(self, mock_info):
         """File non valido solleva errore soundfile."""
         mock_info.side_effect = RuntimeError("Invalid audio file")
-        
-        with pytest.raises(RuntimeError):
-            get_sample_duration('invalid.wav')
+        with patch('shared.utils.os.path.exists', return_value=True):
+            with pytest.raises(RuntimeError):
+                get_sample_duration('invalid.wav')
+
+    def test_missing_sample_raises_sample_not_found_error(self):
+        """File assente in PATHSAMPLES → SampleNotFoundError con filename e path."""
+        from shared.exceptions import SampleNotFoundError
+
+        with patch('shared.utils.os.path.exists', return_value=False):
+            with pytest.raises(SampleNotFoundError) as exc_info:
+                get_sample_duration('pino.wav')
+
+        err = exc_info.value
+        assert err.filename == 'pino.wav'
+        assert err.search_path == './refs/'
 
 
 # =============================================================================
@@ -360,10 +378,11 @@ class TestUtilsIntegration:
     """Test di integrazione tra le funzioni utilities."""
     
     @patch('shared.utils.sf.info')
-    def test_chaining_functions(self, mock_info):
+    @patch('shared.utils.os.path.exists', return_value=True)
+    def test_chaining_functions(self, mock_exists, mock_info):
         """Test concatenazione funzioni utils."""
         mock_info.return_value = Mock(duration=2.5)
-        
+
         # Simula workflow reale
         duration = get_sample_duration('test.wav')
         
@@ -412,10 +431,11 @@ class TestPathSamplesConstant:
         assert PATHSAMPLES == './refs/'
     
     @patch('shared.utils.sf.info')
-    def test_pathsamples_used_in_get_duration(self, mock_info):
+    @patch('shared.utils.os.path.exists', return_value=True)
+    def test_pathsamples_used_in_get_duration(self, mock_exists, mock_info):
         """get_sample_duration usa PATHSAMPLES."""
         mock_info.return_value = Mock(duration=1.0)
-        
+
         get_sample_duration('test.wav')
         
         # Verifica che il path includa PATHSAMPLES

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -48,6 +48,9 @@ def _make_mock_logger_module():
     mod = types.ModuleType('logger')
     mod.configure_clip_logger = MagicMock()
     mod.get_clip_log_path = MagicMock(return_value='/tmp/test.log')
+    mod.configure_engine_logger = MagicMock()
+    mod.get_engine_logger = MagicMock(return_value=MagicMock())
+    mod.get_engine_log_path = MagicMock(return_value='/tmp/engine.log')
     return mod
 
 

--- a/tests/test_main_engine_error.py
+++ b/tests/test_main_engine_error.py
@@ -1,0 +1,48 @@
+# =============================================================================
+# tests/test_main_engine_error.py
+# =============================================================================
+"""
+Test per il handler EngineError in main.py (issue #33, step 6).
+
+Verifica che:
+- terminale riceva user_message() pulito + riga "Dettagli: <log_path>"
+- file di log contenga messaggio + traceback
+"""
+import os
+import sys
+
+import pytest
+
+
+def test_handle_engine_error_prints_user_message_and_logs_traceback(tmp_path, capsys):
+    """Handler stampa user_message su stdout e logga su file."""
+    # Carica handler senza eseguire main()
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+    from main import _handle_engine_error
+    from shared.exceptions import SampleNotFoundError
+    from shared.logger import configure_engine_logger, get_engine_log_path
+
+    configure_engine_logger(yaml_name='broken', log_dir=str(tmp_path))
+
+    err = SampleNotFoundError(filename='pino.wav', search_path='./refs/')
+    err.stream_id = 'drone_a'
+    err.config_file = 'configs/broken.yml'
+
+    try:
+        raise err
+    except SampleNotFoundError as e:
+        _handle_engine_error(e)
+
+    captured = capsys.readouterr()
+    assert "Sample non trovato: 'pino.wav'" in captured.out
+    assert "drone_a" in captured.out
+    assert "configs/broken.yml" in captured.out
+    assert "Dettagli:" in captured.out
+
+    log_path = get_engine_log_path()
+    for h in __import__('logging').getLogger('engine').handlers:
+        h.flush()
+    contents = open(log_path).read()
+    assert "SampleNotFoundError" in contents
+    assert "pino.wav" in contents
+    assert "Traceback" in contents


### PR DESCRIPTION
## Summary

Risolve #33: errori engine (sample non trovato) producono ora un messaggio terminale leggibile invece del traceback Python grezzo da `soundfile.LibsndfileError`. Stack trace completo persistito in `./logs/<yaml>_engine.log`.

- Gerarchia `EngineError` + `SampleNotFoundError` con context layered (filename/path → stream_id → config_file)
- `engine_logger` separato dal `clip_logger` esistente
- Top-level handler in `main.py` cattura `EngineError`, stampa `user_message()` pulito, logga traceback su file

## Output prima/dopo

**Prima:**
```
 Errore: Error opening './refs/pino.wav': System error.
Traceback (most recent call last):
  File ".../main.py", line 214, in main
    ...
soundfile.LibsndfileError: Error opening './refs/pino.wav': System error.
```

**Dopo:**
```
[ERRORE] Sample non trovato: 'pino.wav'
  Path cercato: ./refs/pino.wav
  Stream:       drone_a
  Config:       configs/PGE_test.yml
  Dettagli:     ./logs/PGE_test_engine.log
```

Traceback completo finisce nel log file con timestamp.

## Architettura

Context arricchito a ogni layer (caller-side wrapping):

```
get_sample_duration  →  raise SampleNotFoundError(filename, search_path)
Stream.__init__      →  catch, set err.stream_id, re-raise
Generator.create_elements  →  catch, set err.config_file, re-raise
main.py              →  catch EngineError, log + print clean message
```

`get_sample_duration` resta utility pura (nessun knowledge di stream/yaml).

## Piano

`docs/plans/2026-05-09-001-fix-engine-error-logging-plan.md` — 7 step TDD, ognuno con test rosso → verde.

## Test plan
- [x] `make tests` verde (4088 passati, +8 vs main)
- [x] E2E manuale: sample mancante produce messaggio pulito + log file con traceback
- [x] E2E manuale: path felice (`configs/PGE_density_experiment.yml`) renderizza senza regressioni

Closes #33