### PR TITLE
fix(issue #38, PR2): parser errors -> ConfigError hierarchy

### DIFF
--- a/src/parameters/gate_factory.py
+++ b/src/parameters/gate_factory.py
@@ -7,6 +7,7 @@ from typing import Optional, Any, Union
 from shared.probability_gate import *
 from enum import Enum
 from envelopes.envelope import Envelope, create_scaled_envelope
+from shared.exceptions import InvalidParameterError
 
 class DephaseMode(Enum):
     """Stati semantici di dephase."""
@@ -44,7 +45,11 @@ class GateFactory:
         elif isinstance(dephase, dict):
             return DephaseMode.SPECIFIC
         else:
-            raise ValueError(f"dephase tipo invalido: {type(dephase)}")
+            raise InvalidParameterError(
+                param_name="dephase",
+                value=dephase,
+                hint="atteso bool, numero (0-100), envelope, o dict per chiave",
+            )
 
     @staticmethod
     def create_gate(
@@ -131,7 +136,8 @@ class GateFactory:
                 return AlwaysGate()
         
         # Tipo completamente sbagliato
-        raise ValueError(
-            f"Valore invalido per dephase: {raw_value} (tipo: {type(raw_value).__name__}). "
-            f"Atteso numero (0-100), lista di punti [[t,v],...], o dict envelope."
+        raise InvalidParameterError(
+            param_name="dephase",
+            value=raw_value,
+            hint="atteso numero (0-100), lista [[t,v],...], o dict envelope",
         )

--- a/src/parameters/parser.py
+++ b/src/parameters/parser.py
@@ -15,6 +15,7 @@ from typing import Union, Optional, List, Any
 from parameters.parameter import Parameter, ParamInput
 from envelopes.envelope import Envelope, create_scaled_envelope
 from parameters.parameter_definitions import get_parameter_definition
+from shared.exceptions import InvalidParameterError, ParameterBoundError
 
 class GranularParser:
     """
@@ -125,10 +126,13 @@ class GranularParser:
         if isinstance(raw_data, (list, dict)):
             return create_scaled_envelope(raw_data, self.duration, self.time_mode)
         # Caso Errore: Tipo non supportato
-        raise ValueError(
-            f"Formato non valido per '{context_info}': {raw_data}. "
-            f"Atteso numero, lista di punti, o dict envelope."
+        err = InvalidParameterError(
+            param_name=context_info,
+            value=raw_data,
+            hint="atteso numero, lista di punti, o dict envelope",
         )
+        err.stream_id = self.stream_id
+        raise err
 
     def _validate_and_clip(
         self,
@@ -182,8 +186,15 @@ class GranularParser:
                 )
                 
                 if validation_mode == 'strict':
-                    # FAIL FAST: solleva eccezione
-                    raise ValueError(error_msg)
+                    err = ParameterBoundError(
+                        param_name=param_name,
+                        value_type=value_type,
+                        value=clean,
+                        min_bound=min_bound,
+                        max_bound=max_bound,
+                    )
+                    err.stream_id = self.stream_id
+                    raise err
                 else:
                     # PERMISSIVE: logga e continua
                     log_config_warning(
@@ -195,7 +206,7 @@ class GranularParser:
                         max_val=max_bound,
                         value_type=value_type
                     )
-            
+
             return clipped
         
         # Caso 2: Envelope
@@ -228,7 +239,20 @@ class GranularParser:
                 )
                 
                 if validation_mode == 'strict':
-                    raise ValueError(error_msg)
+                    violations_list = []
+                    for t, y in param.breakpoints:
+                        clipped_y = max(min_bound, y) if max_bound is None else max(min_bound, min(max_bound, y))
+                        if clipped_y != y:
+                            violations_list.append((t, y))
+                    err = ParameterBoundError(
+                        param_name=param_name,
+                        value_type=value_type,
+                        violations=violations_list,
+                        min_bound=min_bound,
+                        max_bound=max_bound,
+                    )
+                    err.stream_id = self.stream_id
+                    raise err
                 else:
                     # Log ogni violazione
                     for t, y in param.breakpoints:

--- a/src/shared/exceptions.py
+++ b/src/shared/exceptions.py
@@ -103,3 +103,67 @@ class InvalidFieldValueError(ConfigError):
             lines.append(f"  Hint:         {self.hint}")
         lines.extend(self._context_lines())
         return "\n".join(lines)
+
+
+class InvalidParameterError(ConfigError):
+    """Parametro YAML con formato/tipo non supportato (issue #38, PR2)."""
+
+    def __init__(self, param_name: str, value, hint: str | None = None):
+        self.param_name = param_name
+        self.value = value
+        self.hint = hint
+        super().__init__(f"Formato non valido per '{param_name}': {value!r}")
+
+    def user_message(self) -> str:
+        lines = [
+            f"[ERRORE] Formato non valido per '{self.param_name}'",
+            f"  Trovato:      {self.value!r}",
+        ]
+        if self.hint:
+            lines.append(f"  Hint:         {self.hint}")
+        lines.extend(self._context_lines())
+        return "\n".join(lines)
+
+
+class ParameterBoundError(ConfigError):
+    """Parametro YAML fuori dai bounds (strict validation mode, issue #38, PR2)."""
+
+    def __init__(
+        self,
+        param_name: str,
+        value_type: str,
+        min_bound: float,
+        max_bound: float | None,
+        value: float | None = None,
+        violations: list[tuple[float, float]] | None = None,
+    ):
+        if value is None and not violations:
+            raise TypeError("ParameterBoundError richiede 'value' o 'violations'")
+        self.param_name = param_name
+        self.value_type = value_type
+        self.value = value
+        self.violations = list(violations or [])
+        self.min_bound = min_bound
+        self.max_bound = max_bound
+        if violations:
+            base = f"Envelope '{param_name}' fuori bounds: {len(violations)} violazione(i)"
+        else:
+            base = f"Parametro '{param_name}' fuori bounds: {value}"
+        super().__init__(base)
+
+    def user_message(self) -> str:
+        bounds = f"[{self.min_bound}, {self.max_bound}]"
+        if self.violations:
+            head = f"[ERRORE] Envelope '{self.param_name}' fuori bounds"
+            lines = [head, f"  Bounds:       {bounds}"]
+            for t, y in self.violations:
+                lines.append(f"  t={t}: {self.value_type}={y}")
+        else:
+            head = f"[ERRORE] Parametro '{self.param_name}' fuori bounds"
+            lines = [
+                head,
+                f"  {self.value_type}:        {self.value}",
+                f"  Bounds:       {bounds}",
+            ]
+        lines.extend(self._context_lines())
+        return "\n".join(lines)

--- a/tests/e2e/test_engine_errors_e2e.py
+++ b/tests/e2e/test_engine_errors_e2e.py
@@ -75,6 +75,64 @@ streams:
       reverse: true
 """
 
+REAL_SAMPLE = "001-0_0-3_0.wav"
+
+
+YAML_INVALID_PARAM_FORMAT = f"""\
+composition:
+  title: "test invalid param format"
+streams:
+  - stream_id: "stream_bad_density"
+    onset: 0.0
+    duration: 5
+    sample: "{REAL_SAMPLE}"
+    distribution_mode: 'gaussian'
+    density: "not_a_number"
+    distribution: [[0,1],[1,1]]
+    pointer:
+      speed_ratio: 1.0
+    grain:
+      duration: 0.05
+      duration_range: 0.01
+"""
+
+YAML_PARAM_OUT_OF_BOUNDS = f"""\
+composition:
+  title: "test param bound violation"
+streams:
+  - stream_id: "stream_bad_bound"
+    onset: 0.0
+    duration: 5
+    sample: "{REAL_SAMPLE}"
+    distribution_mode: 'gaussian'
+    density: 999999
+    distribution: [[0,1],[1,1]]
+    pointer:
+      speed_ratio: 1.0
+    grain:
+      duration: 0.05
+      duration_range: 0.01
+"""
+
+YAML_INVALID_DEPHASE = f"""\
+composition:
+  title: "test invalid dephase"
+streams:
+  - stream_id: "stream_bad_dephase"
+    onset: 0.0
+    duration: 5
+    sample: "{REAL_SAMPLE}"
+    distribution_mode: 'gaussian'
+    density: 5
+    distribution: [[0,1],[1,1]]
+    dephase: "not_a_valid_dephase"
+    pointer:
+      speed_ratio: 1.0
+    grain:
+      duration: 0.05
+      duration_range: 0.01
+"""
+
 YAML_SAMPLE_NOT_FOUND = """\
 composition:
   title: "test sample not found"
@@ -185,6 +243,41 @@ def test_e2e_invalid_grain_reverse(tmp_path, cleanup_log):
     assert "True" in result.stdout
     assert "stream_bad_reverse" in result.stdout
     _assert_log_contains(yaml_abs, "InvalidFieldValueError", ["grain.reverse"])
+
+
+@pytest.mark.e2e
+def test_e2e_invalid_parameter_format(tmp_path, cleanup_log):
+    yaml_abs = _write_yaml(tmp_path, '05_invalid_param.yml', YAML_INVALID_PARAM_FORMAT)
+    cleanup_log.append(_log_path_for(yaml_abs))
+    result = _run(yaml_abs)
+    _assert_clean_user_output(result)
+    assert "Formato non valido" in result.stdout
+    assert "density" in result.stdout
+    assert "stream_bad_density" in result.stdout
+    _assert_log_contains(yaml_abs, "InvalidParameterError", ["density"])
+
+
+@pytest.mark.e2e
+def test_e2e_parameter_out_of_bounds(tmp_path, cleanup_log):
+    yaml_abs = _write_yaml(tmp_path, '06_param_bound.yml', YAML_PARAM_OUT_OF_BOUNDS)
+    cleanup_log.append(_log_path_for(yaml_abs))
+    result = _run(yaml_abs)
+    _assert_clean_user_output(result)
+    assert "fuori bounds" in result.stdout
+    assert "density" in result.stdout
+    assert "stream_bad_bound" in result.stdout
+    _assert_log_contains(yaml_abs, "ParameterBoundError", ["density"])
+
+
+@pytest.mark.e2e
+def test_e2e_invalid_dephase(tmp_path, cleanup_log):
+    yaml_abs = _write_yaml(tmp_path, '07_invalid_dephase.yml', YAML_INVALID_DEPHASE)
+    cleanup_log.append(_log_path_for(yaml_abs))
+    result = _run(yaml_abs)
+    _assert_clean_user_output(result)
+    assert "Formato non valido" in result.stdout
+    assert "dephase" in result.stdout
+    _assert_log_contains(yaml_abs, "InvalidParameterError", ["dephase"])
 
 
 @pytest.mark.e2e

--- a/tests/parameters/test_gate_factory.py
+++ b/tests/parameters/test_gate_factory.py
@@ -155,7 +155,7 @@ class TestClassifyDephase:
 
     def test_invalid_type_raises_valueerror(self):
         """Tipo non riconosciuto solleva ValueError."""
-        with pytest.raises(ValueError, match="dephase tipo invalido"):
+        with pytest.raises(ValueError, match="dephase"):
             GateFactory._classify_dephase("invalid_string")
 
     def test_invalid_type_tuple_raises(self):
@@ -173,7 +173,7 @@ class TestClassifyDephase:
         """Lista non-envelope: _is_envelope_like viene chiamato prima del check dict."""
         # Una lista non-envelope dovrebbe sollevare errore
         # perché non è dict e _is_envelope_like ritorna False
-        with pytest.raises(ValueError, match="dephase tipo invalido"):
+        with pytest.raises(ValueError, match="dephase"):
             GateFactory._classify_dephase([1, 2, 3])
 
     def test_bool_true_is_not_int(self):
@@ -706,12 +706,12 @@ class TestParseRawValue:
 
     def test_string_raises_valueerror(self):
         """Stringa → ValueError."""
-        with pytest.raises(ValueError, match="Valore invalido per dephase"):
+        with pytest.raises(ValueError, match="dephase"):
             GateFactory._parse_raw_value("invalid", duration=1.0, time_mode='absolute')
 
     def test_none_raises_valueerror(self):
         """None → ValueError (None viene gestito a monte in create_gate)."""
-        with pytest.raises(ValueError, match="Valore invalido per dephase"):
+        with pytest.raises(ValueError, match="dephase"):
             GateFactory._parse_raw_value(None, duration=1.0, time_mode='absolute')
 
     def test_bool_treated_as_number(self):
@@ -732,7 +732,7 @@ class TestParseRawValue:
         
         error_msg = str(exc_info.value)
         assert "bad" in error_msg
-        assert "str" in error_msg
+        assert "dephase" in error_msg
 
 
 # =============================================================================

--- a/tests/parameters/test_gate_factory_errors.py
+++ b/tests/parameters/test_gate_factory_errors.py
@@ -1,0 +1,31 @@
+# =============================================================================
+# tests/parameters/test_gate_factory_errors.py
+# =============================================================================
+"""
+Issue #38, PR2 — GateFactory solleva InvalidParameterError per dephase
+malformato (tipo non supportato o valore non parsabile).
+"""
+import pytest
+
+from parameters.gate_factory import GateFactory
+from shared.exceptions import ConfigError, InvalidParameterError
+
+
+def test_classify_dephase_invalid_type_raises_invalid_parameter_error():
+    """dephase di tipo non supportato → InvalidParameterError."""
+    with pytest.raises(InvalidParameterError) as exc_info:
+        GateFactory._classify_dephase(object())
+
+    err = exc_info.value
+    assert isinstance(err, ConfigError)
+    assert "dephase" in err.param_name
+
+
+def test_parse_raw_value_invalid_type_raises_invalid_parameter_error():
+    """Valore dephase per chiave specifica con tipo invalido → InvalidParameterError."""
+    with pytest.raises(InvalidParameterError) as exc_info:
+        GateFactory._parse_raw_value(object(), duration=1.0, time_mode='absolute')
+
+    err = exc_info.value
+    assert isinstance(err, ConfigError)
+    assert "dephase" in err.param_name

--- a/tests/parameters/test_parser_errors.py
+++ b/tests/parameters/test_parser_errors.py
@@ -1,0 +1,72 @@
+# =============================================================================
+# tests/parameters/test_parser_errors.py
+# =============================================================================
+"""
+Issue #38, PR2 — GranularParser solleva sotto-classi di ConfigError
+con context arricchito (stream_id) per errori user-facing.
+"""
+import pytest
+
+from parameters.parser import GranularParser
+from core.stream_config import StreamConfig, StreamContext
+from shared.exceptions import (
+    ConfigError,
+    InvalidParameterError,
+    ParameterBoundError,
+)
+
+
+def _make_parser(stream_id: str = "drone_a", duration: float = 5.0):
+    ctx = StreamContext(
+        stream_id=stream_id,
+        onset=0.0,
+        duration=duration,
+        sample="x.wav",
+        sample_dur_sec=10.0,
+    )
+    cfg = StreamConfig(
+        distribution_mode="uniform",
+        time_mode="absolute",
+        context=ctx,
+    )
+    return GranularParser(cfg)
+
+
+def test_parser_invalid_input_format_raises_invalid_parameter_error():
+    """Tipo non supportato come value_raw → InvalidParameterError con stream_id."""
+    parser = _make_parser(stream_id="drone_a")
+
+    with pytest.raises(InvalidParameterError) as exc_info:
+        parser.parse_parameter(name="density", value_raw="not_a_number")
+
+    err = exc_info.value
+    assert isinstance(err, ConfigError)
+    assert err.stream_id == "drone_a"
+    assert "density" in err.param_name
+
+
+def test_parser_scalar_out_of_bounds_raises_parameter_bound_error():
+    """Scalare fuori bounds in strict mode → ParameterBoundError."""
+    parser = _make_parser(stream_id="drone_b")
+
+    with pytest.raises(ParameterBoundError) as exc_info:
+        parser.parse_parameter(name="density", value_raw=999999.0)
+
+    err = exc_info.value
+    assert isinstance(err, ConfigError)
+    assert err.stream_id == "drone_b"
+    assert err.param_name == "density"
+    assert err.value == 999999.0
+
+
+def test_parser_envelope_out_of_bounds_raises_parameter_bound_error():
+    """Envelope con breakpoint fuori bounds → ParameterBoundError con violations."""
+    parser = _make_parser(stream_id="drone_c", duration=2.0)
+
+    with pytest.raises(ParameterBoundError) as exc_info:
+        parser.parse_parameter(name="density", value_raw=[[0, 999999.0], [1, 5]])
+
+    err = exc_info.value
+    assert err.stream_id == "drone_c"
+    assert err.param_name == "density"
+    assert len(err.violations) >= 1

--- a/tests/shared/test_engine_exceptions.py
+++ b/tests/shared/test_engine_exceptions.py
@@ -150,3 +150,120 @@ def test_invalid_field_value_error_includes_optional_context():
     msg = err.user_message()
     assert "s1" in msg
     assert "c.yml" in msg
+
+
+# =============================================================================
+# Issue #38 — PR2: InvalidParameterError, ParameterBoundError
+# =============================================================================
+
+
+def test_invalid_parameter_error_inherits_config_error():
+    """InvalidParameterError catturabile come ConfigError/EngineError/ValueError."""
+    from shared.exceptions import (
+        ConfigError,
+        EngineError,
+        InvalidParameterError,
+    )
+
+    err = InvalidParameterError(param_name="density.value", value="bad")
+    assert isinstance(err, ConfigError)
+    assert isinstance(err, EngineError)
+    assert isinstance(err, ValueError)
+
+
+def test_invalid_parameter_error_user_message_contains_param_and_value():
+    """user_message mostra param_name e value, formato pulito."""
+    from shared.exceptions import InvalidParameterError
+
+    err = InvalidParameterError(
+        param_name="density.value",
+        value={"x": 1},
+        hint="atteso numero o lista breakpoints",
+    )
+    msg = err.user_message()
+    assert "[ERRORE]" in msg
+    assert "density.value" in msg
+    assert "atteso numero" in msg
+
+
+def test_invalid_parameter_error_includes_optional_context():
+    """stream_id e config_file compaiono quando settati."""
+    from shared.exceptions import InvalidParameterError
+
+    err = InvalidParameterError(param_name="dephase", value=object())
+    err.stream_id = "s1"
+    err.config_file = "c.yml"
+    msg = err.user_message()
+    assert "s1" in msg
+    assert "c.yml" in msg
+
+
+def test_parameter_bound_error_inherits_config_error():
+    """ParameterBoundError catturabile come ConfigError/EngineError/ValueError."""
+    from shared.exceptions import (
+        ConfigError,
+        EngineError,
+        ParameterBoundError,
+    )
+
+    err = ParameterBoundError(
+        param_name="density",
+        value_type="value",
+        value=999.0,
+        min_bound=0.0,
+        max_bound=100.0,
+    )
+    assert isinstance(err, ConfigError)
+    assert isinstance(err, EngineError)
+    assert isinstance(err, ValueError)
+
+
+def test_parameter_bound_error_user_message_shows_violation():
+    """user_message mostra param, valore trovato, bounds."""
+    from shared.exceptions import ParameterBoundError
+
+    err = ParameterBoundError(
+        param_name="density",
+        value_type="value",
+        value=999.0,
+        min_bound=0.0,
+        max_bound=100.0,
+    )
+    msg = err.user_message()
+    assert "[ERRORE]" in msg
+    assert "density" in msg
+    assert "999" in msg
+    assert "100" in msg
+
+
+def test_parameter_bound_error_includes_optional_context():
+    from shared.exceptions import ParameterBoundError
+
+    err = ParameterBoundError(
+        param_name="density",
+        value_type="value",
+        value=-1.0,
+        min_bound=0.0,
+        max_bound=100.0,
+    )
+    err.stream_id = "s1"
+    err.config_file = "c.yml"
+    msg = err.user_message()
+    assert "s1" in msg
+    assert "c.yml" in msg
+
+
+def test_parameter_bound_error_supports_envelope_violations():
+    """ParameterBoundError accetta lista violazioni per envelope."""
+    from shared.exceptions import ParameterBoundError
+
+    err = ParameterBoundError(
+        param_name="density",
+        value_type="value",
+        violations=[(0.0, 999.0), (1.0, -5.0)],
+        min_bound=0.0,
+        max_bound=100.0,
+    )
+    msg = err.user_message()
+    assert "999" in msg
+    assert "-5" in msg

--- a/tests/test_main_engine_error.py
+++ b/tests/test_main_engine_error.py
@@ -101,3 +101,65 @@ def test_handle_engine_error_works_for_invalid_field_value_error(tmp_path, capsy
     assert "grain.reverse" in captured.out
     assert "True" in captured.out
     assert "Dettagli:" in captured.out
+
+
+def test_handle_engine_error_works_for_invalid_parameter_error(tmp_path, capsys):
+    """Handler EngineError gestisce InvalidParameterError (issue #38, PR2)."""
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+    from main import _handle_engine_error
+    from shared.exceptions import InvalidParameterError
+    from shared.logger import configure_engine_logger, get_engine_log_path
+
+    configure_engine_logger(yaml_name='broken_param', log_dir=str(tmp_path))
+
+    err = InvalidParameterError(param_name='density.value', value='abc', hint="atteso numero")
+    err.stream_id = 'drone_a'
+
+    try:
+        raise err
+    except InvalidParameterError as e:
+        _handle_engine_error(e)
+
+    captured = capsys.readouterr()
+    assert "density.value" in captured.out
+    assert "Dettagli:" in captured.out
+
+    log_path = get_engine_log_path()
+    for h in __import__('logging').getLogger('engine').handlers:
+        h.flush()
+    contents = open(log_path).read()
+    assert "InvalidParameterError" in contents
+    assert "Traceback" in contents
+
+
+def test_handle_engine_error_works_for_parameter_bound_error(tmp_path, capsys):
+    """Handler EngineError gestisce ParameterBoundError (issue #38, PR2)."""
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+    from main import _handle_engine_error
+    from shared.exceptions import ParameterBoundError
+    from shared.logger import configure_engine_logger, get_engine_log_path
+
+    configure_engine_logger(yaml_name='broken_bound', log_dir=str(tmp_path))
+
+    err = ParameterBoundError(
+        param_name='density', value_type='value',
+        value=999.0, min_bound=0.0, max_bound=100.0,
+    )
+    err.stream_id = 'drone_b'
+
+    try:
+        raise err
+    except ParameterBoundError as e:
+        _handle_engine_error(e)
+
+    captured = capsys.readouterr()
+    assert "density" in captured.out
+    assert "999" in captured.out
+    assert "Dettagli:" in captured.out
+
+    log_path = get_engine_log_path()
+    for h in __import__('logging').getLogger('engine').handlers:
+        h.flush()
+    contents = open(log_path).read()
+    assert "ParameterBoundError" in contents
+    assert "Traceback" in contents


### PR DESCRIPTION
## Scope

PR2 di issue #38: estende gerarchia EngineError ai 5 raise in `src/parameters/parser.py` e `src/parameters/gate_factory.py`.

## Modifiche

### Nuove eccezioni (`src/shared/exceptions.py`)
- `InvalidParameterError(ConfigError)` — formato/tipo parametro non supportato
- `ParameterBoundError(ConfigError)` — bound violation strict mode (scalare o envelope con `violations`)

### Refactor raise
**parser.py**
- `_parse_input` formato non supportato -> `InvalidParameterError`
- `_validate_and_clip` scalare fuori bounds -> `ParameterBoundError`
- `_validate_and_clip` envelope fuori bounds -> `ParameterBoundError`

**gate_factory.py**
- `_classify_dephase` tipo non supportato -> `InvalidParameterError`
- `_parse_raw_value` valore non parsabile -> `InvalidParameterError`

### Context arricchimento
- `stream_id` settato al raise nel parser (`self.stream_id`)
- `config_file` settato in `Generator.create_elements` (catch `ConfigError` gia esteso in PR1)
- Handler in `main.py` polimorfico via `except EngineError` (zero modifiche)

## Backward compat
`ConfigError` eredita da `ValueError`: catch espliciti pre-esistenti continuano a funzionare. Adattati 5 test in `test_gate_factory.py` (regex su 'dephase' invece di messaggi esatti).

## Test
- Unit: `tests/shared/test_engine_exceptions.py` (+7 test isinstance/user_message)
- Integration: `tests/parameters/test_parser_errors.py`, `test_gate_factory_errors.py`
- Handler: `tests/test_main_engine_error.py` (+2 test)
- E2E: `tests/e2e/test_engine_errors_e2e.py` (+3 YAML inline)

## Test plan
- [x] `make tests` -> 4117 passed
- [x] `make e2e-tests` -> 46 passed (incluso 7 engine error e2e)