### PR TITLE
feat(strategies): EngineError per strategy errors (issue #38, PR3)

### DIFF
--- a/src/rendering/naming_strategy.py
+++ b/src/rendering/naming_strategy.py
@@ -15,6 +15,8 @@ import os
 from abc import ABC, abstractmethod
 from typing import List, Tuple, Any
 
+from shared.exceptions import InvalidStrategyConfigError
+
 
 class NamingStrategy(ABC):
     """
@@ -97,7 +99,9 @@ class DefaultNamingStrategy(NamingStrategy):
             return [(streams, base_path)]
 
         else:
-            raise ValueError(
-                f"Mode '{mode}' not supported by DefaultNamingStrategy. "
-                f"Supported: 'stems', 'mix'"
+            raise InvalidStrategyConfigError(
+                strategy_kind="naming",
+                field="mode",
+                value=mode,
+                hint="modalita supportate: 'stems', 'mix'",
             )

--- a/src/shared/distribution_strategy.py
+++ b/src/shared/distribution_strategy.py
@@ -9,6 +9,11 @@ import random
 from abc import ABC, abstractmethod
 from typing import Tuple
 
+from shared.exceptions import (
+    InvalidStrategyConfigError,
+    StrategyNotFoundError,
+)
+
 
 class DistributionStrategy(ABC):
     """
@@ -155,10 +160,10 @@ class DistributionFactory:
             ValueError: Se mode non è riconosciuto
         """
         if mode not in cls._registry:
-            valid_modes = list(cls._registry.keys())
-            raise ValueError(
-                f"Distribuzione '{mode}' non riconosciuta. "
-                f"Modalità valide: {valid_modes}"
+            raise StrategyNotFoundError(
+                strategy_kind="distribution",
+                name=mode,
+                available=list(cls._registry.keys()),
             )
         
         strategy_class = cls._registry[mode]
@@ -172,8 +177,11 @@ class DistributionFactory:
         Esempio:
             DistributionFactory.register('triangular', TriangularDistribution)
         """
-        if not issubclass(strategy_class, DistributionStrategy):
-            raise TypeError(
-                f"{strategy_class} deve essere subclass di DistributionStrategy"
+        if not (isinstance(strategy_class, type) and issubclass(strategy_class, DistributionStrategy)):
+            raise InvalidStrategyConfigError(
+                strategy_kind="distribution",
+                field="strategy_class",
+                value=strategy_class,
+                hint="deve essere subclass di DistributionStrategy",
             )
         cls._registry[name] = strategy_class

--- a/src/shared/exceptions.py
+++ b/src/shared/exceptions.py
@@ -125,6 +125,58 @@ class InvalidParameterError(ConfigError):
         return "\n".join(lines)
 
 
+class StrategyNotFoundError(ConfigError):
+    """Strategia non registrata nel registry corrispondente (issue #38, PR3)."""
+
+    def __init__(self, strategy_kind: str, name: str, available: list[str]):
+        self.strategy_kind = strategy_kind
+        self.name = name
+        self.available = list(available)
+        super().__init__(
+            f"Strategia {strategy_kind} non trovata: '{name}'. "
+            f"Disponibili: {sorted(self.available)}"
+        )
+
+    def user_message(self) -> str:
+        lines = [
+            f"[ERRORE] Strategia {self.strategy_kind} non trovata: '{self.name}'",
+            f"  Disponibili:  {', '.join(sorted(self.available))}",
+        ]
+        lines.extend(self._context_lines())
+        return "\n".join(lines)
+
+
+class InvalidStrategyConfigError(ConfigError):
+    """Strategia trovata ma configurazione invalida (issue #38, PR3)."""
+
+    def __init__(
+        self,
+        strategy_kind: str,
+        field: str,
+        value,
+        hint: str | None = None,
+    ):
+        self.strategy_kind = strategy_kind
+        self.field = field
+        self.value = value
+        self.hint = hint
+        super().__init__(
+            f"Config invalida per strategia {strategy_kind} "
+            f"(campo '{field}'): {value!r}"
+        )
+
+    def user_message(self) -> str:
+        lines = [
+            f"[ERRORE] Config invalida per strategia {self.strategy_kind}",
+            f"  Campo:        {self.field}",
+            f"  Trovato:      {self.value!r}",
+        ]
+        if self.hint:
+            lines.append(f"  Hint:         {self.hint}")
+        lines.extend(self._context_lines())
+        return "\n".join(lines)
+
+
 class ParameterBoundError(ConfigError):
     """Parametro YAML fuori dai bounds (strict validation mode, issue #38, PR2)."""
 

--- a/src/strategies/grain_clip_strategy.py
+++ b/src/strategies/grain_clip_strategy.py
@@ -13,6 +13,7 @@ from abc import ABC, abstractmethod
 from typing import Dict, List, Type
 
 from core.grain import Grain
+from shared.exceptions import StrategyNotFoundError
 
 
 class GrainClipStrategy(ABC):
@@ -66,8 +67,9 @@ class GrainClipStrategyFactory:
     @staticmethod
     def create(name: str, **kwargs) -> GrainClipStrategy:
         if name not in GRAIN_CLIP_STRATEGIES:
-            raise ValueError(
-                f"GrainClipStrategy sconosciuta: '{name}'. "
-                f"Disponibili: {sorted(GRAIN_CLIP_STRATEGIES.keys())}"
+            raise StrategyNotFoundError(
+                strategy_kind="grain_clip",
+                name=name,
+                available=list(GRAIN_CLIP_STRATEGIES.keys()),
             )
         return GRAIN_CLIP_STRATEGIES[name](**kwargs)

--- a/src/strategies/strategy_registry.py
+++ b/src/strategies/strategy_registry.py
@@ -6,6 +6,10 @@ Permette di aggiungere nuove strategie SENZA modificare controller esistenti.
 
 from typing import Dict, Type
 from strategies.strategie import *
+from shared.exceptions import (
+    InvalidStrategyConfigError,
+    StrategyNotFoundError,
+)
 
 # =============================================================================
 # REGISTRI
@@ -51,8 +55,12 @@ class StrategyFactory:
                              all_params: dict) -> PitchStrategy:
         """Crea una strategia di pitch."""
         if selected_param_name not in PITCH_STRATEGIES:
-            raise ValueError(f"Strategia pitch non trovata per: {selected_param_name}")
-        
+            raise StrategyNotFoundError(
+                strategy_kind="pitch",
+                name=selected_param_name,
+                available=list(PITCH_STRATEGIES.keys()),
+            )
+
         strategy_class = PITCH_STRATEGIES[selected_param_name]
         return strategy_class(param_obj)
     
@@ -62,11 +70,20 @@ class StrategyFactory:
                                all_params: dict) -> DensityStrategy:
         """Crea una strategia di density."""
         if selected_param_name not in DENSITY_STRATEGIES:
-            raise ValueError(f"Strategia density non trovata per: {selected_param_name}")
-        
+            raise StrategyNotFoundError(
+                strategy_kind="density",
+                name=selected_param_name,
+                available=list(DENSITY_STRATEGIES.keys()),
+            )
+
         # La strategia density ha bisogno anche del parametro distribution
         distribution_param = all_params.get('distribution')
         if distribution_param is None or not isinstance(distribution_param, Parameter):
-            raise ValueError("Density strategy richiede parametro 'distribution' valido")        
+            raise InvalidStrategyConfigError(
+                strategy_kind="density",
+                field="distribution",
+                value=distribution_param,
+                hint="density strategy richiede parametro 'distribution' valido",
+            )
         strategy_class = DENSITY_STRATEGIES[selected_param_name]
         return strategy_class(param_obj, distribution_param)

--- a/src/strategies/variation_registry.py
+++ b/src/strategies/variation_registry.py
@@ -12,6 +12,7 @@ from strategies.variation_strategy import (
     InvertVariation,
     ChoiceVariation
 )
+from shared.exceptions import StrategyNotFoundError
 
 # =============================================================================
 # REGISTRY
@@ -64,10 +65,10 @@ class VariationFactory:
             ValueError: se variation_mode non è registrato
         """
         if variation_mode not in VARIATION_STRATEGIES:
-            available = ', '.join(VARIATION_STRATEGIES.keys())
-            raise ValueError(
-                f"Strategia variation non trovata: '{variation_mode}'. "
-                f"Strategie disponibili: {available}"
+            raise StrategyNotFoundError(
+                strategy_kind="variation",
+                name=variation_mode,
+                available=list(VARIATION_STRATEGIES.keys()),
             )
         
         strategy_class = VARIATION_STRATEGIES[variation_mode]

--- a/src/strategies/variation_strategy.py
+++ b/src/strategies/variation_strategy.py
@@ -1,8 +1,9 @@
 # variation_strategy.py
 from abc import ABC, abstractmethod
 from shared.distribution_strategy import DistributionStrategy
-from typing import Any 
-import random 
+from shared.exceptions import InvalidParameterError
+from typing import Any
+import random
 
 class VariationStrategy(ABC):
     """Strategia di applicazione randomness a un valore base."""
@@ -65,7 +66,11 @@ class ChoiceVariation(VariationStrategy):
         
         # Caso 3: Lista esplicita
         if not isinstance(value, list):
-            raise TypeError(f"ChoiceVariation richiede stringa, lista, o True. Ricevuto {type(value)}")
+            raise InvalidParameterError(
+                param_name="ChoiceVariation",
+                value=value,
+                hint="richiede stringa, lista, o True",
+            )
         
         # Se mod_range == 0, non variare (usa primo elemento come default)
         if mod_range == 0:

--- a/src/strategies/voice_onset_strategy.py
+++ b/src/strategies/voice_onset_strategy.py
@@ -28,6 +28,7 @@ from abc import ABC, abstractmethod
 from typing import Dict, Type
 
 from parameters.parameter import resolve_param, StrategyParam
+from shared.exceptions import StrategyNotFoundError
 
 
 # =============================================================================
@@ -182,8 +183,9 @@ class VoiceOnsetStrategyFactory:
             KeyError: se il nome non è nel registry
         """
         if name not in VOICE_ONSET_STRATEGIES:
-            raise KeyError(
-                f"VoiceOnsetStrategy '{name}' non trovata. "
-                f"Disponibili: {sorted(VOICE_ONSET_STRATEGIES.keys())}"
+            raise StrategyNotFoundError(
+                strategy_kind="voice_onset",
+                name=name,
+                available=list(VOICE_ONSET_STRATEGIES.keys()),
             )
         return VOICE_ONSET_STRATEGIES[name](**kwargs)

--- a/src/strategies/voice_pan_strategy.py
+++ b/src/strategies/voice_pan_strategy.py
@@ -28,6 +28,11 @@ import random
 from abc import ABC, abstractmethod
 from typing import Dict, Type
 
+from shared.exceptions import (
+    InvalidStrategyConfigError,
+    StrategyNotFoundError,
+)
+
 
 # =============================================================================
 # ABSTRACT BASE CLASS
@@ -145,8 +150,11 @@ class RandomPanStrategy(VoicePanStrategy):
             return 0.0
 
         if spread < 0.0:
-            raise ValueError(
-                f"spread deve essere >= 0, ricevuto: {spread}"
+            raise InvalidStrategyConfigError(
+                strategy_kind="voice_pan",
+                field="spread",
+                value=spread,
+                hint="spread deve essere >= 0",
             )
 
         if voice_index == 0:
@@ -274,10 +282,10 @@ class VoicePanStrategyFactory:
                         con messaggio che elenca le strategy disponibili
         """
         if strategy_name not in VOICE_PAN_STRATEGIES:
-            available = ', '.join(sorted(VOICE_PAN_STRATEGIES.keys()))
-            raise ValueError(
-                f"Strategy pan voce non trovata: '{strategy_name}'. "
-                f"Strategy disponibili: {available}"
+            raise StrategyNotFoundError(
+                strategy_kind="voice_pan",
+                name=strategy_name,
+                available=list(VOICE_PAN_STRATEGIES.keys()),
             )
 
         strategy_class = VOICE_PAN_STRATEGIES[strategy_name]

--- a/src/strategies/voice_pitch_strategy.py
+++ b/src/strategies/voice_pitch_strategy.py
@@ -28,6 +28,11 @@ import random
 from abc import ABC, abstractmethod
 from typing import Dict, List, Type
 
+from shared.exceptions import (
+    InvalidStrategyConfigError,
+    StrategyNotFoundError,
+)
+
 from parameters.parameter import resolve_param, StrategyParam
 
 
@@ -157,16 +162,23 @@ class ChordPitchStrategy(VoicePitchStrategy):
 
     def __init__(self, chord: str, inversion: int = 0):
         if chord not in CHORD_INTERVALS:
-            raise ValueError(
-                f"Accordo '{chord}' non riconosciuto. "
-                f"Disponibili: {sorted(CHORD_INTERVALS.keys())}"
+            raise InvalidStrategyConfigError(
+                strategy_kind="voice_pitch",
+                field="chord",
+                value=chord,
+                hint=f"accordi disponibili: {sorted(CHORD_INTERVALS.keys())}",
             )
         base_intervals = CHORD_INTERVALS[chord]
         n = len(base_intervals)
         if not (0 <= inversion < n):
-            raise ValueError(
-                f"Accordo '{chord}' ha {n} note: inversion deve essere in "
-                f"[0, {n - 1}], ricevuto: {inversion}"
+            raise InvalidStrategyConfigError(
+                strategy_kind="voice_pitch",
+                field="inversion",
+                value=inversion,
+                hint=(
+                    f"accordo '{chord}' ha {n} note: inversion deve essere "
+                    f"in [0, {n - 1}]"
+                ),
             )
         self.chord = chord
         self.inversion = inversion
@@ -298,8 +310,9 @@ class VoicePitchStrategyFactory:
             KeyError: se il nome non è nel registry
         """
         if name not in VOICE_PITCH_STRATEGIES:
-            raise KeyError(
-                f"VoicePitchStrategy '{name}' non trovata. "
-                f"Disponibili: {sorted(VOICE_PITCH_STRATEGIES.keys())}"
+            raise StrategyNotFoundError(
+                strategy_kind="voice_pitch",
+                name=name,
+                available=list(VOICE_PITCH_STRATEGIES.keys()),
             )
         return VOICE_PITCH_STRATEGIES[name](**kwargs)

--- a/src/strategies/voice_pointer_strategy.py
+++ b/src/strategies/voice_pointer_strategy.py
@@ -32,6 +32,7 @@ from abc import ABC, abstractmethod
 from typing import Dict, Type
 
 from parameters.parameter import resolve_param, StrategyParam
+from shared.exceptions import StrategyNotFoundError
 
 
 # =============================================================================
@@ -166,8 +167,9 @@ class VoicePointerStrategyFactory:
             KeyError: se il nome non è nel registry
         """
         if name not in VOICE_POINTER_STRATEGIES:
-            raise KeyError(
-                f"VoicePointerStrategy '{name}' non trovata. "
-                f"Disponibili: {sorted(VOICE_POINTER_STRATEGIES.keys())}"
+            raise StrategyNotFoundError(
+                strategy_kind="voice_pointer",
+                name=name,
+                available=list(VOICE_POINTER_STRATEGIES.keys()),
             )
         return VOICE_POINTER_STRATEGIES[name](**kwargs)

--- a/tests/e2e/test_engine_errors_e2e.py
+++ b/tests/e2e/test_engine_errors_e2e.py
@@ -133,6 +133,24 @@ streams:
       duration_range: 0.01
 """
 
+YAML_INVALID_DISTRIBUTION = f"""\
+composition:
+  title: "test invalid distribution mode"
+streams:
+  - stream_id: "stream_bad_dist"
+    onset: 0.0
+    duration: 5
+    sample: "{REAL_SAMPLE}"
+    distribution_mode: 'bogus_distribution'
+    density: 5
+    distribution: [[0,1],[1,1]]
+    pointer:
+      speed_ratio: 1.0
+    grain:
+      duration: 0.05
+      duration_range: 0.01
+"""
+
 YAML_SAMPLE_NOT_FOUND = """\
 composition:
   title: "test sample not found"
@@ -278,6 +296,19 @@ def test_e2e_invalid_dephase(tmp_path, cleanup_log):
     assert "Formato non valido" in result.stdout
     assert "dephase" in result.stdout
     _assert_log_contains(yaml_abs, "InvalidParameterError", ["dephase"])
+
+
+@pytest.mark.e2e
+def test_e2e_invalid_distribution_strategy(tmp_path, cleanup_log):
+    yaml_abs = _write_yaml(tmp_path, '08_invalid_distribution.yml', YAML_INVALID_DISTRIBUTION)
+    cleanup_log.append(_log_path_for(yaml_abs))
+    result = _run(yaml_abs)
+    assert result.returncode != 0, f"Atteso exit != 0 (stdout={result.stdout})"
+    assert "[ERRORE]" in result.stdout
+    assert "Traceback" not in result.stdout
+    assert "Strategia distribution non trovata" in result.stdout
+    assert "bogus_distribution" in result.stdout
+    _assert_log_contains(yaml_abs, "StrategyNotFoundError", ["bogus_distribution"])
 
 
 @pytest.mark.e2e

--- a/tests/rendering/test_rendering_strategies.py
+++ b/tests/rendering/test_rendering_strategies.py
@@ -110,7 +110,7 @@ class TestDefaultNamingStrategy:
         naming = DefaultNamingStrategy()
         streams = [make_mock_stream()]
 
-        with pytest.raises(ValueError, match="Mode 'invalid' not supported"):
+        with pytest.raises(ValueError, match="naming"):
             naming.generate_paths('/out/base.aif', streams, mode='invalid')
 
 

--- a/tests/shared/test_distribution_strategy.py
+++ b/tests/shared/test_distribution_strategy.py
@@ -360,7 +360,7 @@ class TestDistributionFactory:
         with pytest.raises(ValueError) as exc_info:
             DistributionFactory.create('invalid')
         
-        assert "non riconosciuta" in str(exc_info.value)
+        assert "distribution" in str(exc_info.value)
         assert "invalid" in str(exc_info.value)
     
     def test_create_error_includes_valid_modes(self):
@@ -410,14 +410,17 @@ class TestDistributionFactory:
         assert bounds == (5.0, 15.0)
     
     def test_register_invalid_class_raises_error(self):
-        """Registrazione classe non-DistributionStrategy solleva TypeError."""
+        """Registrazione classe non-DistributionStrategy solleva InvalidStrategyConfigError."""
+        from shared.exceptions import InvalidStrategyConfigError
+
         class NotADistribution:
             pass
-        
-        with pytest.raises(TypeError) as exc_info:
+
+        with pytest.raises(InvalidStrategyConfigError) as exc_info:
             DistributionFactory.register('invalid', NotADistribution)
-        
-        assert "subclass" in str(exc_info.value)
+
+        assert "strategy_class" in str(exc_info.value)
+        assert "NotADistribution" in str(exc_info.value)
 
 
 # =============================================================================

--- a/tests/shared/test_engine_exceptions.py
+++ b/tests/shared/test_engine_exceptions.py
@@ -267,3 +267,101 @@ def test_parameter_bound_error_supports_envelope_violations():
     msg = err.user_message()
     assert "999" in msg
     assert "-5" in msg
+
+
+# =============================================================================
+# Issue #38 — PR3: StrategyNotFoundError, InvalidStrategyConfigError
+# =============================================================================
+
+
+def test_strategy_not_found_error_inherits_config_error():
+    from shared.exceptions import (
+        ConfigError,
+        EngineError,
+        StrategyNotFoundError,
+    )
+
+    err = StrategyNotFoundError(
+        strategy_kind="pitch",
+        name="bogus",
+        available=["step", "range"],
+    )
+    assert isinstance(err, ConfigError)
+    assert isinstance(err, EngineError)
+    assert isinstance(err, ValueError)
+
+
+def test_strategy_not_found_user_message_lists_available():
+    from shared.exceptions import StrategyNotFoundError
+
+    err = StrategyNotFoundError(
+        strategy_kind="variation",
+        name="bogus",
+        available=["additive", "quantized"],
+    )
+    msg = err.user_message()
+    assert "[ERRORE]" in msg
+    assert "variation" in msg
+    assert "bogus" in msg
+    assert "additive" in msg
+    assert "quantized" in msg
+
+
+def test_strategy_not_found_includes_optional_context():
+    from shared.exceptions import StrategyNotFoundError
+
+    err = StrategyNotFoundError(
+        strategy_kind="pitch", name="x", available=["a"],
+    )
+    err.stream_id = "s1"
+    err.config_file = "c.yml"
+    msg = err.user_message()
+    assert "s1" in msg
+    assert "c.yml" in msg
+
+
+def test_invalid_strategy_config_error_inherits_config_error():
+    from shared.exceptions import (
+        ConfigError,
+        EngineError,
+        InvalidStrategyConfigError,
+    )
+
+    err = InvalidStrategyConfigError(
+        strategy_kind="pitch",
+        field="chord",
+        value="bogus",
+    )
+    assert isinstance(err, ConfigError)
+    assert isinstance(err, EngineError)
+    assert isinstance(err, ValueError)
+
+
+def test_invalid_strategy_config_user_message_contains_field_and_value():
+    from shared.exceptions import InvalidStrategyConfigError
+
+    err = InvalidStrategyConfigError(
+        strategy_kind="pitch",
+        field="chord",
+        value="bogus",
+        hint="usa uno tra dom7, maj7",
+    )
+    msg = err.user_message()
+    assert "[ERRORE]" in msg
+    assert "pitch" in msg
+    assert "chord" in msg
+    assert "bogus" in msg
+    assert "dom7" in msg
+
+
+def test_invalid_strategy_config_includes_optional_context():
+    from shared.exceptions import InvalidStrategyConfigError
+
+    err = InvalidStrategyConfigError(
+        strategy_kind="pan", field="spread", value=-1.0,
+    )
+    err.stream_id = "s1"
+    err.config_file = "c.yml"
+    msg = err.user_message()
+    assert "s1" in msg
+    assert "c.yml" in msg

--- a/tests/strategies/test_grain_clip_strategy.py
+++ b/tests/strategies/test_grain_clip_strategy.py
@@ -198,7 +198,7 @@ class TestGrainClipStrategyFactory:
 
     def test_unknown_name_raises(self):
         from strategies.grain_clip_strategy import GrainClipStrategyFactory
-        with pytest.raises(ValueError, match="sconosciuta"):
+        with pytest.raises(ValueError, match="grain_clip"):
             GrainClipStrategyFactory.create('bogus')
 
     def test_registry_contains_both_strategies(self):

--- a/tests/strategies/test_misc_strategy_errors.py
+++ b/tests/strategies/test_misc_strategy_errors.py
@@ -1,0 +1,78 @@
+# =============================================================================
+# tests/strategies/test_misc_strategy_errors.py
+# =============================================================================
+"""
+Issue #38, PR3 — grain_clip / distribution / naming / variation
+sollevano sotto-classi di ConfigError per config user-facing invalida.
+"""
+import pytest
+
+from shared.exceptions import (
+    ConfigError,
+    InvalidParameterError,
+    InvalidStrategyConfigError,
+    StrategyNotFoundError,
+)
+
+
+def test_grain_clip_factory_unknown_raises_strategy_not_found():
+    from strategies.grain_clip_strategy import GrainClipStrategyFactory
+
+    with pytest.raises(StrategyNotFoundError) as exc_info:
+        GrainClipStrategyFactory.create("bogus")
+
+    err = exc_info.value
+    assert isinstance(err, ConfigError)
+    assert err.strategy_kind == "grain_clip"
+
+
+def test_distribution_factory_unknown_raises_strategy_not_found():
+    from shared.distribution_strategy import DistributionFactory
+
+    with pytest.raises(StrategyNotFoundError) as exc_info:
+        DistributionFactory.create("bogus_dist")
+
+    err = exc_info.value
+    assert err.strategy_kind == "distribution"
+    assert err.name == "bogus_dist"
+
+
+def test_distribution_register_invalid_subclass_raises_invalid_strategy_config():
+    from shared.distribution_strategy import DistributionFactory
+
+    class NotAStrategy:
+        pass
+
+    with pytest.raises(InvalidStrategyConfigError) as exc_info:
+        DistributionFactory.register("foo", NotAStrategy)
+
+    err = exc_info.value
+    assert err.strategy_kind == "distribution"
+    assert err.field == "strategy_class"
+
+
+def test_naming_strategy_unknown_mode_raises_invalid_strategy_config():
+    from rendering.naming_strategy import DefaultNamingStrategy
+
+    with pytest.raises(InvalidStrategyConfigError) as exc_info:
+        DefaultNamingStrategy().generate_paths(
+            streams=[], base_path="out.aif", mode="bogus_mode",
+        )
+
+    err = exc_info.value
+    assert err.strategy_kind == "naming"
+    assert err.field == "mode"
+
+
+def test_choice_variation_invalid_type_raises_invalid_parameter_error():
+    from strategies.variation_strategy import ChoiceVariation
+    from shared.distribution_strategy import UniformDistribution
+
+    with pytest.raises(InvalidParameterError) as exc_info:
+        ChoiceVariation().apply(
+            value=12345, mod_range=1, distribution=UniformDistribution()
+        )
+
+    err = exc_info.value
+    assert isinstance(err, ConfigError)
+    assert err.param_name == "ChoiceVariation"

--- a/tests/strategies/test_registry_errors.py
+++ b/tests/strategies/test_registry_errors.py
@@ -1,0 +1,48 @@
+# =============================================================================
+# tests/strategies/test_registry_errors.py
+# =============================================================================
+"""
+Issue #38, PR3 — registry strategy sollevano StrategyNotFoundError
+(sotto-classe ConfigError) per nomi non registrati.
+"""
+import pytest
+
+from shared.exceptions import (
+    ConfigError,
+    StrategyNotFoundError,
+)
+
+
+def test_strategy_factory_pitch_not_found_raises_strategy_not_found_error():
+    from strategies.strategy_registry import StrategyFactory
+
+    with pytest.raises(StrategyNotFoundError) as exc_info:
+        StrategyFactory.create_pitch_strategy("bogus", None, {})
+
+    err = exc_info.value
+    assert isinstance(err, ConfigError)
+    assert err.strategy_kind == "pitch"
+    assert err.name == "bogus"
+
+
+def test_strategy_factory_density_not_found_raises_strategy_not_found_error():
+    from strategies.strategy_registry import StrategyFactory
+
+    with pytest.raises(StrategyNotFoundError) as exc_info:
+        StrategyFactory.create_density_strategy("bogus", None, {})
+
+    err = exc_info.value
+    assert err.strategy_kind == "density"
+    assert err.name == "bogus"
+
+
+def test_variation_factory_unknown_mode_raises_strategy_not_found_error():
+    from strategies.variation_registry import VariationFactory
+
+    with pytest.raises(StrategyNotFoundError) as exc_info:
+        VariationFactory.create("bogus_mode")
+
+    err = exc_info.value
+    assert isinstance(err, ConfigError)
+    assert err.strategy_kind == "variation"
+    assert "bogus_mode" in err.name

--- a/tests/strategies/test_variation_registry.py
+++ b/tests/strategies/test_variation_registry.py
@@ -398,8 +398,9 @@ class TestVariationFactoryErrors:
             VariationFactory.create('xyz')
 
         msg = str(exc_info.value)
-        assert "Strategia variation non trovata: 'xyz'" in msg
-        assert "Strategie disponibili:" in msg
+        assert "variation" in msg
+        assert "'xyz'" in msg
+        assert "Disponibili" in msg
         # Verifica che elenca tutte le strategie
         for mode in EXPECTED_MODE_NAMES:
             assert mode in msg

--- a/tests/strategies/test_variation_strategy.py
+++ b/tests/strategies/test_variation_strategy.py
@@ -568,32 +568,33 @@ class TestChoiceVariationInvalidType:
 
     def test_integer_raises_type_error(self, choice, mock_distribution):
         """value=int -> TypeError."""
-        with pytest.raises(TypeError, match="ChoiceVariation richiede"):
+        with pytest.raises(__import__('shared.exceptions', fromlist=['InvalidParameterError']).InvalidParameterError, match="ChoiceVariation"):
             choice.apply(42, 1.0, mock_distribution)
 
     def test_float_raises_type_error(self, choice, mock_distribution):
         """value=float -> TypeError."""
-        with pytest.raises(TypeError, match="ChoiceVariation richiede"):
+        with pytest.raises(__import__('shared.exceptions', fromlist=['InvalidParameterError']).InvalidParameterError, match="ChoiceVariation"):
             choice.apply(3.14, 1.0, mock_distribution)
 
     def test_none_raises_type_error(self, choice, mock_distribution):
         """value=None -> TypeError."""
-        with pytest.raises(TypeError, match="ChoiceVariation richiede"):
+        with pytest.raises(__import__('shared.exceptions', fromlist=['InvalidParameterError']).InvalidParameterError, match="ChoiceVariation"):
             choice.apply(None, 1.0, mock_distribution)
 
     def test_dict_raises_type_error(self, choice, mock_distribution):
         """value=dict -> TypeError."""
-        with pytest.raises(TypeError, match="ChoiceVariation richiede"):
+        with pytest.raises(__import__('shared.exceptions', fromlist=['InvalidParameterError']).InvalidParameterError, match="ChoiceVariation"):
             choice.apply({'key': 'val'}, 1.0, mock_distribution)
 
     def test_tuple_raises_type_error(self, choice, mock_distribution):
         """value=tuple -> TypeError (non e' lista)."""
-        with pytest.raises(TypeError, match="ChoiceVariation richiede"):
+        with pytest.raises(__import__('shared.exceptions', fromlist=['InvalidParameterError']).InvalidParameterError, match="ChoiceVariation"):
             choice.apply(('a', 'b'), 1.0, mock_distribution)
 
-    def test_error_message_contains_type(self, choice, mock_distribution):
-        """Il messaggio di errore contiene il tipo ricevuto."""
-        with pytest.raises(TypeError, match="<class 'int'>"):
+    def test_error_message_contains_value(self, choice, mock_distribution):
+        """Il messaggio di errore contiene il valore ricevuto."""
+        from shared.exceptions import InvalidParameterError
+        with pytest.raises(InvalidParameterError, match="42"):
             choice.apply(42, 1.0, mock_distribution)
 
 

--- a/tests/strategies/test_voice_strategy_errors.py
+++ b/tests/strategies/test_voice_strategy_errors.py
@@ -1,0 +1,90 @@
+# =============================================================================
+# tests/strategies/test_voice_strategy_errors.py
+# =============================================================================
+"""
+Issue #38, PR3 — Voice strategy factories e validazioni sollevano
+StrategyNotFoundError / InvalidStrategyConfigError (sotto-classi ConfigError).
+"""
+import pytest
+
+from shared.exceptions import (
+    ConfigError,
+    InvalidStrategyConfigError,
+    StrategyNotFoundError,
+)
+
+
+def test_voice_pitch_factory_unknown_raises_strategy_not_found():
+    from strategies.voice_pitch_strategy import VoicePitchStrategyFactory
+
+    with pytest.raises(StrategyNotFoundError) as exc_info:
+        VoicePitchStrategyFactory.create("bogus")
+
+    err = exc_info.value
+    assert isinstance(err, ConfigError)
+    assert err.strategy_kind == "voice_pitch"
+    assert err.name == "bogus"
+
+
+def test_voice_onset_factory_unknown_raises_strategy_not_found():
+    from strategies.voice_onset_strategy import VoiceOnsetStrategyFactory
+
+    with pytest.raises(StrategyNotFoundError) as exc_info:
+        VoiceOnsetStrategyFactory.create("bogus")
+
+    err = exc_info.value
+    assert err.strategy_kind == "voice_onset"
+
+
+def test_voice_pointer_factory_unknown_raises_strategy_not_found():
+    from strategies.voice_pointer_strategy import VoicePointerStrategyFactory
+
+    with pytest.raises(StrategyNotFoundError) as exc_info:
+        VoicePointerStrategyFactory.create("bogus")
+
+    err = exc_info.value
+    assert err.strategy_kind == "voice_pointer"
+
+
+def test_voice_pan_factory_unknown_raises_strategy_not_found():
+    from strategies.voice_pan_strategy import VoicePanStrategyFactory
+
+    with pytest.raises(StrategyNotFoundError) as exc_info:
+        VoicePanStrategyFactory.create("bogus")
+
+    err = exc_info.value
+    assert err.strategy_kind == "voice_pan"
+
+
+def test_chord_pitch_strategy_unknown_chord_raises_invalid_strategy_config():
+    from strategies.voice_pitch_strategy import ChordPitchStrategy
+
+    with pytest.raises(InvalidStrategyConfigError) as exc_info:
+        ChordPitchStrategy(chord="bogus_chord")
+
+    err = exc_info.value
+    assert isinstance(err, ConfigError)
+    assert err.strategy_kind == "voice_pitch"
+    assert err.field == "chord"
+
+
+def test_chord_pitch_strategy_invalid_inversion_raises_invalid_strategy_config():
+    from strategies.voice_pitch_strategy import ChordPitchStrategy
+
+    with pytest.raises(InvalidStrategyConfigError) as exc_info:
+        ChordPitchStrategy(chord="dom7", inversion=99)
+
+    err = exc_info.value
+    assert err.field == "inversion"
+
+
+def test_random_pan_strategy_negative_spread_raises_invalid_strategy_config():
+    from strategies.voice_pan_strategy import RandomPanStrategy
+
+    strategy = RandomPanStrategy(stream_id="s1")
+    with pytest.raises(InvalidStrategyConfigError) as exc_info:
+        strategy.get_pan_offset(voice_index=1, num_voices=2, spread=-0.5, time=0.0)
+
+    err = exc_info.value
+    assert err.field == "spread"
+    assert err.value == -0.5

--- a/tests/test_main_engine_error.py
+++ b/tests/test_main_engine_error.py
@@ -163,3 +163,70 @@ def test_handle_engine_error_works_for_parameter_bound_error(tmp_path, capsys):
     contents = open(log_path).read()
     assert "ParameterBoundError" in contents
     assert "Traceback" in contents
+
+
+def test_handle_engine_error_works_for_strategy_not_found_error(tmp_path, capsys):
+    """Handler EngineError gestisce StrategyNotFoundError (issue #38, PR3)."""
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+    from main import _handle_engine_error
+    from shared.exceptions import StrategyNotFoundError
+    from shared.logger import configure_engine_logger, get_engine_log_path
+
+    configure_engine_logger(yaml_name='broken_strategy', log_dir=str(tmp_path))
+
+    err = StrategyNotFoundError(
+        strategy_kind="voice_pitch", name="bogus", available=["step", "range"],
+    )
+    err.stream_id = 'drone_a'
+    err.config_file = 'configs/broken.yml'
+
+    try:
+        raise err
+    except StrategyNotFoundError as e:
+        _handle_engine_error(e)
+
+    captured = capsys.readouterr()
+    assert "voice_pitch" in captured.out
+    assert "bogus" in captured.out
+    assert "Dettagli:" in captured.out
+
+    log_path = get_engine_log_path()
+    for h in __import__('logging').getLogger('engine').handlers:
+        h.flush()
+    contents = open(log_path).read()
+    assert "StrategyNotFoundError" in contents
+    assert "Traceback" in contents
+
+
+def test_handle_engine_error_works_for_invalid_strategy_config_error(tmp_path, capsys):
+    """Handler EngineError gestisce InvalidStrategyConfigError (issue #38, PR3)."""
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+    from main import _handle_engine_error
+    from shared.exceptions import InvalidStrategyConfigError
+    from shared.logger import configure_engine_logger, get_engine_log_path
+
+    configure_engine_logger(yaml_name='broken_strategy_cfg', log_dir=str(tmp_path))
+
+    err = InvalidStrategyConfigError(
+        strategy_kind="voice_pitch", field="chord", value="bogus_chord",
+        hint="usa dom7, maj7",
+    )
+    err.stream_id = 'drone_a'
+
+    try:
+        raise err
+    except InvalidStrategyConfigError as e:
+        _handle_engine_error(e)
+
+    captured = capsys.readouterr()
+    assert "voice_pitch" in captured.out
+    assert "chord" in captured.out
+    assert "bogus_chord" in captured.out
+    assert "Dettagli:" in captured.out
+
+    log_path = get_engine_log_path()
+    for h in __import__('logging').getLogger('engine').handlers:
+        h.flush()
+    contents = open(log_path).read()
+    assert "InvalidStrategyConfigError" in contents
+    assert "Traceback" in contents


### PR DESCRIPTION
## Summary

Terza PR del refactor `EngineError` (issue #38). Estende il logging strutturato a tutti gli errori user-facing dei layer **strategies**, **distribution**, **naming**.

- Nuove sotto-classi `ConfigError`: `StrategyNotFoundError`, `InvalidStrategyConfigError`
- Refactor di **12 raise** in:
  - `strategy_registry.py` (3) — pitch/density factory
  - `variation_registry.py` (1)
  - `voice_pitch_strategy.py` (3) — chord/inversion + factory
  - `voice_onset_strategy.py` (1)
  - `voice_pointer_strategy.py` (1)
  - `voice_pan_strategy.py` (2) — spread + factory
  - `grain_clip_strategy.py` (1)
  - `variation_strategy.py` (1) — ChoiceVariation tipo invalido → `InvalidParameterError`
  - `shared/distribution_strategy.py` (2) — create + register
  - `rendering/naming_strategy.py` (1)
- Backward-compat preservata via ereditarieta `ValueError`
- Test esistenti adattati ai nuovi messaggi user-facing
- Handler `main.py` polimorfico via `except EngineError` — zero modifiche per nuove sotto-classi

## Test plan

- [x] `make tests` verde (4140 passed)
- [x] Test unit: 6 nuovi in `tests/shared/test_engine_exceptions.py`
- [x] Test integration: `tests/strategies/test_registry_errors.py`, `test_voice_strategy_errors.py`, `test_misc_strategy_errors.py`
- [x] Test handler: 2 nuovi in `tests/test_main_engine_error.py`
- [x] Test e2e: `test_e2e_invalid_distribution_strategy` con YAML inline
- [ ] Verifica manuale post-merge: triggerare YAML con `distribution_mode` invalido

## Out of scope

- PR4: Rendering errors (renderer_factory, ftable, csound, window) — issue #38
- PR5: docs/error-handling.md