### PR TITLE
Issue #38 PR4: Rendering errors → EngineError

### DIFF
--- a/src/controllers/window_controller.py
+++ b/src/controllers/window_controller.py
@@ -1,6 +1,7 @@
 # src/controllers/window_controller.py
 from typing import List
 from controllers.window_registry import WindowRegistry
+from shared.exceptions import InvalidWindowError
 from controllers.window_selection_strategy import (
     WindowSelectionStrategy,
     WindowStrategyFactory,
@@ -67,9 +68,11 @@ class WindowController:
         if _is_multistate_spec(envelope_spec):
             raw_states = envelope_spec['states']
             if len(raw_states) < 2:
-                raise ValueError(
-                    f"Stream '{stream_id}': 'states' richiede almeno 2 elementi"
+                err = InvalidWindowError(
+                    reason="'states' richiede almeno 2 elementi"
                 )
+                err.stream_id = stream_id
+                raise err
             windows = [w for _, w in raw_states]
 
         # Transition dict: {'from': 'hanning', 'to': 'bartlett', 'curve': ...}
@@ -81,24 +84,25 @@ class WindowController:
         # Lista esplicita
         elif isinstance(envelope_spec, list):
             if not envelope_spec:
-                raise ValueError(
-                    f"Stream '{stream_id}': Lista envelope vuota"
-                )
+                err = InvalidWindowError(reason="Lista envelope vuota")
+                err.stream_id = stream_id
+                raise err
             windows = envelope_spec
         else:
-            raise ValueError(
-                f"Stream '{stream_id}': Formato envelope non valido: {envelope_spec}"
+            err = InvalidWindowError(
+                param="envelope",
+                value=envelope_spec,
             )
+            err.stream_id = stream_id
+            raise err
 
         # Validazione nomi
         available = WindowRegistry.all_names()
         for window in windows:
             if window not in available:
-                raise ValueError(
-                    f"Stream '{stream_id}': "
-                    f"Finestra '{window}' non trovata. "
-                    f"Disponibili: {available}"
-                )
+                err = InvalidWindowError(name=window, available=list(available))
+                err.stream_id = stream_id
+                raise err
 
         return windows
 

--- a/src/main.py
+++ b/src/main.py
@@ -107,8 +107,10 @@ def _build_renderer(renderer_type: str, generator, **kwargs):
             sco_dir=kwargs.get('sco_dir'),
         )
 
-    raise ValueError(
-        f"Renderer '{renderer_type}' non supportato. Tipi validi: csound, numpy"
+    from shared.exceptions import InvalidRendererError
+    raise InvalidRendererError(
+        renderer_type=renderer_type,
+        available=["csound", "numpy"],
     )
 
 

--- a/src/rendering/csound_renderer.py
+++ b/src/rendering/csound_renderer.py
@@ -205,8 +205,9 @@ class CsoundRenderer(AudioRenderer):
         result = subprocess.run(cmd, capture_output=True, text=True)
 
         if result.returncode != 0:
-            raise RuntimeError(
-                f"Csound ha fallito con codice {result.returncode}.\n"
-                f"Comando: {' '.join(cmd)}\n"
-                f"Stderr: {result.stderr}"
+            from shared.exceptions import CsoundRenderError
+            raise CsoundRenderError(
+                returncode=result.returncode,
+                command=cmd,
+                stderr=result.stderr or "",
             )

--- a/src/rendering/ftable_manager.py
+++ b/src/rendering/ftable_manager.py
@@ -48,9 +48,10 @@ class FtableManager:
         
         # Valida che la window esista nel registro
         if WindowRegistry.get(window_name) is None:
-            raise ValueError(
-                f"Window '{window_name}' non valida. "
-                f"Validi: {', '.join(WindowRegistry.all_names())}"
+            from shared.exceptions import InvalidWindowError
+            raise InvalidWindowError(
+                name=window_name,
+                available=list(WindowRegistry.all_names()),
             )
         
         num = self.next_num
@@ -118,10 +119,14 @@ class FtableManager:
                 
                 # ERROR HANDLING AGGIUNTO
                 if spec is None:
-                    raise ValueError(
-                        f"Window '{key}' non trovata nel WindowRegistry. "
-                        f"Questo non dovrebbe accadere se register_window() "
-                        f"ha validato correttamente."
+                    from shared.exceptions import FtableError
+                    raise FtableError(
+                        key=key,
+                        reason=(
+                            f"Window '{key}' non trovata nel WindowRegistry. "
+                            f"Stato incoerente: register_window() avrebbe dovuto "
+                            f"validarla."
+                        ),
                     )
                 
                 f.write(f'; Window: {key} - {spec.description}\n')

--- a/src/rendering/numpy_window_registry.py
+++ b/src/rendering/numpy_window_registry.py
@@ -78,9 +78,8 @@ class NumpyWindowRegistry:
             ValueError: se il nome non e' valido o n <= 0
         """
         if n <= 0:
-            raise ValueError(
-                f"Lunghezza finestra deve essere > 0, ricevuto: {n}"
-            )
+            from shared.exceptions import InvalidWindowError
+            raise InvalidWindowError(param="n", value=n)
 
         key = (name, n)
         if key in self._cache:
@@ -134,10 +133,8 @@ class NumpyWindowRegistry:
             return self._half_sine(n)
 
         # Nome non valido
-        raise ValueError(
-            f"Finestra '{name}' non trovata. "
-            f"Disponibili: {self.available_windows()}"
-        )
+        from shared.exceptions import InvalidWindowError
+        raise InvalidWindowError(name=name, available=self.available_windows())
 
     @staticmethod
     def _gen16(n: int, start: float, curve: float, end: float) -> np.ndarray:

--- a/src/rendering/renderer_factory.py
+++ b/src/rendering/renderer_factory.py
@@ -13,6 +13,7 @@ Usato da main.py per iniettare il renderer in Generator.
 from typing import Dict, Any
 
 from rendering.audio_renderer import AudioRenderer
+from shared.exceptions import InvalidRendererError
 
 
 class RendererFactory:
@@ -51,9 +52,9 @@ class RendererFactory:
             ValueError: se renderer_type non e' supportato
         """
         if renderer_type not in RendererFactory._VALID_TYPES:
-            raise ValueError(
-                f"Renderer '{renderer_type}' non supportato. "
-                f"Tipi validi: {', '.join(sorted(RendererFactory._VALID_TYPES))}"
+            raise InvalidRendererError(
+                renderer_type=renderer_type,
+                available=sorted(RendererFactory._VALID_TYPES),
             )
 
         if renderer_type == 'numpy':

--- a/src/shared/exceptions.py
+++ b/src/shared/exceptions.py
@@ -177,6 +177,128 @@ class InvalidStrategyConfigError(ConfigError):
         return "\n".join(lines)
 
 
+class InvalidRendererError(ConfigError):
+    """Renderer kind sconosciuto (issue #38, PR4)."""
+
+    def __init__(self, renderer_type: str, available: list[str]):
+        self.renderer_type = renderer_type
+        self.available = list(available)
+        super().__init__(
+            f"Renderer '{renderer_type}' non supportato. "
+            f"Tipi validi: {', '.join(sorted(self.available))}"
+        )
+
+    def user_message(self) -> str:
+        lines = [
+            f"[ERRORE] Renderer non supportato: '{self.renderer_type}'",
+            f"  Disponibili:  {', '.join(sorted(self.available))}",
+        ]
+        lines.extend(self._context_lines())
+        return "\n".join(lines)
+
+
+class InvalidWindowError(ConfigError):
+    """Window function invalida (nome sconosciuto o parametri fuori dominio) (issue #38, PR4)."""
+
+    def __init__(
+        self,
+        name: str | None = None,
+        available: list[str] | None = None,
+        reason: str | None = None,
+        param: str | None = None,
+        value=None,
+    ):
+        self.name = name
+        self.available = list(available or [])
+        self.reason = reason
+        self.param = param
+        self.value = value
+        if name and available is not None:
+            base = (
+                f"Finestra '{name}' non trovata. "
+                f"Disponibili: {sorted(self.available)}"
+            )
+        elif param is not None:
+            base = f"Parametro finestra invalido '{param}': {value!r}"
+        else:
+            base = reason or f"Finestra invalida: {name!r}"
+        super().__init__(base)
+
+    def user_message(self) -> str:
+        if self.name and self.available:
+            head = f"[ERRORE] Window non trovata: '{self.name}'"
+            lines = [head, f"  Disponibili:  {', '.join(sorted(self.available))}"]
+        elif self.param is not None:
+            head = f"[ERRORE] Parametro window invalido: '{self.param}'"
+            lines = [head, f"  Trovato:      {self.value!r}"]
+        else:
+            lines = [f"[ERRORE] Window invalida: {self.reason or self.name}"]
+        lines.extend(self._context_lines())
+        return "\n".join(lines)
+
+
+class EngineRuntimeError(EngineError):
+    """Errori a runtime engine (non config) — issue #38, PR4."""
+
+    def __init__(self, message: str):
+        self.stream_id: str | None = None
+        self.config_file: str | None = None
+        super().__init__(message)
+
+    def _context_lines(self) -> list[str]:
+        lines = []
+        if self.stream_id:
+            lines.append(f"  Stream:       {self.stream_id}")
+        if self.config_file:
+            lines.append(f"  Config:       {self.config_file}")
+        return lines
+
+
+class CsoundRenderError(EngineRuntimeError, RuntimeError):
+    """Subprocess csound fallito (issue #38, PR4).
+
+    Eredita RuntimeError per backward-compat.
+    """
+
+    def __init__(self, returncode: int, command: list[str], stderr: str):
+        self.returncode = returncode
+        self.command = list(command)
+        self.stderr = stderr
+        super().__init__(
+            f"Csound ha fallito con codice {returncode}.\n"
+            f"Comando: {' '.join(command)}\n"
+            f"Stderr: {stderr}"
+        )
+
+    def user_message(self) -> str:
+        lines = [
+            f"[ERRORE] Csound rendering fallito (exit code {self.returncode})",
+            f"  Comando:      {' '.join(self.command)}",
+        ]
+        if self.stderr.strip():
+            stderr_first = self.stderr.strip().splitlines()[0]
+            lines.append(f"  Stderr:       {stderr_first}")
+        lines.extend(self._context_lines())
+        return "\n".join(lines)
+
+
+class FtableError(ConfigError):
+    """Errore di stato/coerenza FtableManager (issue #38, PR4)."""
+
+    def __init__(self, key: str, reason: str):
+        self.key = key
+        self.reason = reason
+        super().__init__(f"FtableManager: {reason} (chiave: {key!r})")
+
+    def user_message(self) -> str:
+        lines = [
+            f"[ERRORE] Errore ftable: {self.reason}",
+            f"  Chiave:       {self.key}",
+        ]
+        lines.extend(self._context_lines())
+        return "\n".join(lines)
+
+
 class ParameterBoundError(ConfigError):
     """Parametro YAML fuori dai bounds (strict validation mode, issue #38, PR2)."""
 

--- a/tests/controllers/test_window_controller.py
+++ b/tests/controllers/test_window_controller.py
@@ -118,8 +118,10 @@ class TestParseWindowListDefaults:
         assert result == ['hanning']
 
     def test_default_stream_id_in_error_is_unknown(self):
-        with pytest.raises(ValueError, match="unknown"):
+        from shared.exceptions import InvalidWindowError
+        with pytest.raises(InvalidWindowError) as exc_info:
             WindowController.parse_window_list({'envelope': 'NONEXISTENT'})
+        assert exc_info.value.stream_id == "unknown"
 
 
 # =============================================================================
@@ -188,8 +190,10 @@ class TestParseWindowListExplicit:
             WindowController.parse_window_list({'envelope': []})
 
     def test_empty_list_error_contains_stream_id(self):
-        with pytest.raises(ValueError, match="stream_B"):
+        from shared.exceptions import InvalidWindowError
+        with pytest.raises(InvalidWindowError) as exc_info:
             WindowController.parse_window_list({'envelope': []}, stream_id="stream_B")
+        assert exc_info.value.stream_id == "stream_B"
 
     def test_list_with_one_invalid_raises(self):
         with pytest.raises(ValueError, match="FAKE"):
@@ -231,13 +235,13 @@ class TestParseWindowListAll:
 class TestParseWindowListTypeErrors:
 
     @pytest.mark.parametrize("bad_spec,error_match", [
-        (42, "Formato envelope non valido"),
-        (3.14, "Formato envelope non valido"),
-        (None, "Formato envelope non valido"),
-        (False, "Formato envelope non valido"),
-        ({'type': 'hanning'}, "Formato envelope non valido"),
-        (('hanning', 'hamming'), "Formato envelope non valido"),
-        ([], "Lista envelope vuota"),
+        (42, "envelope"),
+        (3.14, "envelope"),
+        (None, "envelope"),
+        (False, "envelope"),
+        ({'type': 'hanning'}, "envelope"),
+        (('hanning', 'hamming'), "envelope"),
+        ([], "vuota"),
         ('INVALID', "non trovata"),
         (['INVALID'], "non trovata"),
         (['hanning', 'INVALID'], "non trovata"),
@@ -247,8 +251,10 @@ class TestParseWindowListTypeErrors:
             WindowController.parse_window_list({'envelope': bad_spec})
 
     def test_error_includes_stream_id(self):
-        with pytest.raises(ValueError, match="stream_X"):
+        from shared.exceptions import InvalidWindowError
+        with pytest.raises(InvalidWindowError) as exc_info:
             WindowController.parse_window_list({'envelope': 123}, stream_id="stream_X")
+        assert exc_info.value.stream_id == "stream_X"
 
     def test_is_static_method(self):
         assert callable(WindowController.parse_window_list)
@@ -278,8 +284,10 @@ class TestWindowControllerInit:
         assert len(ctrl._windows) == len(WindowRegistry.WINDOWS)
 
     def test_init_uses_stream_id_from_context(self, config_with_stream_id):
-        with pytest.raises(ValueError, match="my_stream_42"):
+        from shared.exceptions import InvalidWindowError
+        with pytest.raises(InvalidWindowError) as exc_info:
             WindowController({'envelope': 'NONEXISTENT'}, config=config_with_stream_id)
+        assert exc_info.value.stream_id == "my_stream_42"
 
     def test_gate_exists_after_init(self, default_config):
         ctrl = WindowController({'envelope': 'hanning'}, config=default_config)
@@ -702,7 +710,7 @@ class TestParseWindowListTransitionDict:
     def test_dict_without_from_to_still_raises_format_error(self):
         """Un dict arbitrario senza from/to → errore formato."""
         spec = {'envelope': {'type': 'hanning'}}
-        with pytest.raises(ValueError, match="Formato envelope non valido"):
+        with pytest.raises(ValueError, match="envelope"):
             WindowController.parse_window_list(spec)
 
     def test_transition_with_alias_in_from(self):

--- a/tests/e2e/test_engine_errors_e2e.py
+++ b/tests/e2e/test_engine_errors_e2e.py
@@ -321,3 +321,74 @@ def test_e2e_sample_not_found(tmp_path, cleanup_log):
     assert "pinuzzo_inesistente.wav" in result.stdout
     assert "stream_missing_file" in result.stdout
     _assert_log_contains(yaml_abs, "SampleNotFoundError", ["pinuzzo_inesistente.wav"])
+
+
+# =============================================================================
+# PR4: Rendering errors
+# =============================================================================
+
+YAML_VALID_RENDERER = f"""\
+composition:
+  title: "test valid base"
+streams:
+  - stream_id: "s1"
+    onset: 0.0
+    duration: 1
+    sample: "{REAL_SAMPLE}"
+    distribution_mode: 'gaussian'
+    density: 5
+    distribution: [[0,1],[1,1]]
+    pointer:
+      speed_ratio: 1.0
+    grain:
+      duration: 0.05
+      duration_range: 0.01
+"""
+
+YAML_INVALID_WINDOW = f"""\
+composition:
+  title: "test invalid window"
+streams:
+  - stream_id: "stream_bad_window"
+    onset: 0.0
+    duration: 5
+    sample: "{REAL_SAMPLE}"
+    distribution_mode: 'gaussian'
+    density: 5
+    distribution: [[0,1],[1,1]]
+    pointer:
+      speed_ratio: 1.0
+    grain:
+      duration: 0.05
+      duration_range: 0.01
+      envelope: "bogus_window_name_xyz"
+"""
+
+
+@pytest.mark.e2e
+def test_e2e_invalid_renderer(tmp_path, cleanup_log):
+    """--renderer bogus produce InvalidRendererError user-facing pulito."""
+    yaml_abs = _write_yaml(tmp_path, '09_invalid_renderer.yml', YAML_VALID_RENDERER)
+    cleanup_log.append(_log_path_for(yaml_abs))
+    result = subprocess.run(
+        ['python', 'src/main.py', yaml_abs, '--renderer', 'bogus'],
+        cwd=PROJECT_ROOT, capture_output=True, text=True, timeout=60,
+    )
+    assert result.returncode != 0
+    assert "[ERRORE]" in result.stdout
+    assert "Traceback" not in result.stdout
+    assert "Renderer non supportato" in result.stdout
+    assert "bogus" in result.stdout
+
+
+@pytest.mark.e2e
+def test_e2e_invalid_window(tmp_path, cleanup_log):
+    """envelope name sconosciuto produce InvalidWindowError user-facing pulito."""
+    yaml_abs = _write_yaml(tmp_path, '10_invalid_window.yml', YAML_INVALID_WINDOW)
+    cleanup_log.append(_log_path_for(yaml_abs))
+    result = _run(yaml_abs)
+    assert result.returncode != 0
+    assert "[ERRORE]" in result.stdout
+    assert "Traceback" not in result.stdout
+    assert "bogus_window_name_xyz" in result.stdout
+    _assert_log_contains(yaml_abs, "InvalidWindowError", ["bogus_window_name_xyz"])

--- a/tests/rendering/test_ftable_errors.py
+++ b/tests/rendering/test_ftable_errors.py
@@ -1,0 +1,46 @@
+# =============================================================================
+# tests/rendering/test_ftable_errors.py
+# =============================================================================
+"""
+Issue #38, PR4 — FtableManager errors.
+
+- register_window con nome sconosciuto → InvalidWindowError
+- write_to_file invariant violation → FtableError
+"""
+import io
+import pytest
+
+
+def test_register_window_unknown_raises_invalid_window_error():
+    from rendering.ftable_manager import FtableManager
+    from shared.exceptions import ConfigError, InvalidWindowError
+
+    mgr = FtableManager()
+    with pytest.raises(InvalidWindowError) as exc_info:
+        mgr.register_window("bogus_window")
+
+    err = exc_info.value
+    assert isinstance(err, ConfigError)
+    assert err.name == "bogus_window"
+    msg = err.user_message()
+    assert "[ERRORE]" in msg
+    assert "bogus_window" in msg
+
+
+def test_write_to_file_corrupt_window_raises_ftable_error():
+    from rendering.ftable_manager import FtableManager
+    from shared.exceptions import ConfigError, FtableError
+
+    mgr = FtableManager()
+    # Inject inconsistent state: table references a window not in WindowRegistry
+    mgr.tables[1] = ('window', 'nonexistent_window_xyz')
+
+    buf = io.StringIO()
+    with pytest.raises(FtableError) as exc_info:
+        mgr.write_to_file(buf)
+
+    err = exc_info.value
+    assert isinstance(err, ConfigError)
+    msg = err.user_message()
+    assert "[ERRORE]" in msg
+    assert "nonexistent_window_xyz" in msg

--- a/tests/rendering/test_ftable_manager.py
+++ b/tests/rendering/test_ftable_manager.py
@@ -259,13 +259,13 @@ class TestRegisterWindow:
         assert num3 == 3
 
     def test_register_invalid_window_raises_valueerror(self, fm):
-        """Window non esistente solleva ValueError."""
-        with pytest.raises(ValueError, match="non valida"):
+        """Window non esistente solleva ValueError (InvalidWindowError eredita ValueError)."""
+        with pytest.raises(ValueError, match="non trovata"):
             fm.register_window("nonexistent_window")
 
     def test_register_invalid_window_error_message_contains_valid_names(self, fm):
         """Messaggio di errore elenca i nomi validi."""
-        with pytest.raises(ValueError, match="Validi:"):
+        with pytest.raises(ValueError, match="Disponibili"):
             fm.register_window("invalid")
 
     def test_register_invalid_window_no_side_effects(self, fm):

--- a/tests/rendering/test_renderer_errors.py
+++ b/tests/rendering/test_renderer_errors.py
@@ -1,0 +1,55 @@
+# =============================================================================
+# tests/rendering/test_renderer_errors.py
+# =============================================================================
+"""
+Issue #38, PR4 — Rendering errors: RendererFactory.create('bogus') solleva
+InvalidRendererError (sotto-classe ConfigError).
+"""
+import pytest
+
+
+def test_csound_render_error_user_message_and_inheritance():
+    from shared.exceptions import (
+        CsoundRenderError,
+        EngineError,
+        EngineRuntimeError,
+    )
+
+    err = CsoundRenderError(
+        returncode=2,
+        command=["csound", "-o", "out.aif", "score.csd"],
+        stderr="error: bad orchestra\n",
+    )
+    assert isinstance(err, EngineRuntimeError)
+    assert isinstance(err, EngineError)
+    assert isinstance(err, RuntimeError)
+    assert err.returncode == 2
+    msg = err.user_message()
+    assert "[ERRORE]" in msg
+    assert "exit code 2" in msg
+    assert "csound" in msg
+
+
+def test_unknown_renderer_raises_invalid_renderer_error():
+    from rendering.renderer_factory import RendererFactory
+    from shared.exceptions import (
+        ConfigError,
+        EngineError,
+        InvalidRendererError,
+    )
+
+    with pytest.raises(InvalidRendererError) as exc_info:
+        RendererFactory.create("bogus")
+
+    err = exc_info.value
+    assert isinstance(err, ConfigError)
+    assert isinstance(err, EngineError)
+    assert isinstance(err, ValueError)
+    assert err.renderer_type == "bogus"
+    assert "numpy" in err.available
+    assert "csound" in err.available
+    msg = err.user_message()
+    assert "[ERRORE]" in msg
+    assert "bogus" in msg
+    assert "numpy" in msg
+    assert "csound" in msg

--- a/tests/rendering/test_window_errors.py
+++ b/tests/rendering/test_window_errors.py
@@ -1,0 +1,95 @@
+# =============================================================================
+# tests/rendering/test_window_errors.py
+# =============================================================================
+"""
+Issue #38, PR4 — Window errors: NumpyWindowRegistry.get solleva
+InvalidWindowError (ConfigError) per nome sconosciuto e lunghezza non valida.
+"""
+import pytest
+
+
+def test_unknown_window_name_raises_invalid_window_error():
+    from rendering.numpy_window_registry import NumpyWindowRegistry
+    from shared.exceptions import (
+        ConfigError,
+        EngineError,
+        InvalidWindowError,
+    )
+
+    reg = NumpyWindowRegistry()
+    with pytest.raises(InvalidWindowError) as exc_info:
+        reg.get("bogus", 100)
+
+    err = exc_info.value
+    assert isinstance(err, ConfigError)
+    assert isinstance(err, EngineError)
+    assert isinstance(err, ValueError)
+    assert err.name == "bogus"
+    assert "hanning" in err.available
+    msg = err.user_message()
+    assert "[ERRORE]" in msg
+    assert "bogus" in msg
+
+
+def test_window_controller_unknown_window_raises_invalid_window_error():
+    from controllers.window_controller import WindowController
+    from shared.exceptions import ConfigError, InvalidWindowError
+
+    with pytest.raises(InvalidWindowError) as exc_info:
+        WindowController.parse_window_list(
+            {"envelope": "totally_bogus"}, stream_id="s1"
+        )
+
+    err = exc_info.value
+    assert isinstance(err, ConfigError)
+    assert err.name == "totally_bogus"
+    msg = err.user_message()
+    assert "[ERRORE]" in msg
+    assert "totally_bogus" in msg
+
+
+def test_window_controller_invalid_envelope_format_raises_invalid_window_error():
+    from controllers.window_controller import WindowController
+    from shared.exceptions import InvalidWindowError
+
+    with pytest.raises(InvalidWindowError) as exc_info:
+        WindowController.parse_window_list({"envelope": 42}, stream_id="s1")
+
+    err = exc_info.value
+    msg = err.user_message()
+    assert "[ERRORE]" in msg
+
+
+def test_window_controller_empty_list_raises_invalid_window_error():
+    from controllers.window_controller import WindowController
+    from shared.exceptions import InvalidWindowError
+
+    with pytest.raises(InvalidWindowError):
+        WindowController.parse_window_list({"envelope": []}, stream_id="s1")
+
+
+def test_window_controller_short_states_raises_invalid_window_error():
+    from controllers.window_controller import WindowController
+    from shared.exceptions import InvalidWindowError
+
+    with pytest.raises(InvalidWindowError):
+        WindowController.parse_window_list(
+            {"envelope": {"states": [[0.0, "hanning"]], "curve": 0}},
+            stream_id="s1",
+        )
+
+
+def test_invalid_length_raises_invalid_window_error():
+    from rendering.numpy_window_registry import NumpyWindowRegistry
+    from shared.exceptions import InvalidWindowError
+
+    reg = NumpyWindowRegistry()
+    with pytest.raises(InvalidWindowError) as exc_info:
+        reg.get("hanning", 0)
+
+    err = exc_info.value
+    assert err.param == "n"
+    assert err.value == 0
+    msg = err.user_message()
+    assert "[ERRORE]" in msg
+    assert "n" in msg

--- a/tests/shared/test_engine_exceptions.py
+++ b/tests/shared/test_engine_exceptions.py
@@ -365,3 +365,90 @@ def test_invalid_strategy_config_includes_optional_context():
     msg = err.user_message()
     assert "s1" in msg
     assert "c.yml" in msg
+
+
+# =============================================================================
+# PR4: Rendering errors
+# =============================================================================
+
+def test_invalid_renderer_error_is_config_error():
+    from shared.exceptions import (
+        ConfigError, EngineError, InvalidRendererError,
+    )
+    err = InvalidRendererError(renderer_type="bogus", available=["numpy", "csound"])
+    assert isinstance(err, ConfigError)
+    assert isinstance(err, EngineError)
+    assert isinstance(err, ValueError)
+
+
+def test_invalid_renderer_user_message_lists_available():
+    from shared.exceptions import InvalidRendererError
+    err = InvalidRendererError(renderer_type="bogus", available=["numpy", "csound"])
+    msg = err.user_message()
+    assert "[ERRORE]" in msg
+    assert "bogus" in msg
+    assert "numpy" in msg
+    assert "csound" in msg
+
+
+def test_invalid_window_error_name_form():
+    from shared.exceptions import ConfigError, InvalidWindowError
+    err = InvalidWindowError(name="bogus", available=["hanning", "hamming"])
+    assert isinstance(err, ConfigError)
+    msg = err.user_message()
+    assert "bogus" in msg
+    assert "hanning" in msg
+
+
+def test_invalid_window_error_param_form():
+    from shared.exceptions import InvalidWindowError
+    err = InvalidWindowError(param="n", value=0)
+    msg = err.user_message()
+    assert "[ERRORE]" in msg
+    assert "n" in msg
+    assert "0" in msg
+
+
+def test_ftable_error_is_config_error():
+    from shared.exceptions import ConfigError, FtableError
+    err = FtableError(key="hanning", reason="Window non trovata nel registry")
+    assert isinstance(err, ConfigError)
+    msg = err.user_message()
+    assert "hanning" in msg
+    assert "non trovata" in msg
+
+
+def test_engine_runtime_error_is_engine_error():
+    from shared.exceptions import EngineError, EngineRuntimeError
+    err = EngineRuntimeError("boom")
+    assert isinstance(err, EngineError)
+    assert err.stream_id is None
+    assert err.config_file is None
+
+
+def test_csound_render_error_inheritance_and_message():
+    from shared.exceptions import (
+        CsoundRenderError, EngineError, EngineRuntimeError,
+    )
+    err = CsoundRenderError(
+        returncode=1,
+        command=["csound", "score.csd"],
+        stderr="orch error\n",
+    )
+    assert isinstance(err, EngineRuntimeError)
+    assert isinstance(err, EngineError)
+    assert isinstance(err, RuntimeError)
+    msg = err.user_message()
+    assert "[ERRORE]" in msg
+    assert "exit code 1" in msg
+    assert "orch error" in msg
+
+
+def test_csound_render_error_context_lines():
+    from shared.exceptions import CsoundRenderError
+    err = CsoundRenderError(returncode=2, command=["csound"], stderr="x")
+    err.stream_id = "drone_a"
+    err.config_file = "configs/x.yml"
+    msg = err.user_message()
+    assert "drone_a" in msg
+    assert "configs/x.yml" in msg

--- a/tests/test_main_engine_error.py
+++ b/tests/test_main_engine_error.py
@@ -230,3 +230,88 @@ def test_handle_engine_error_works_for_invalid_strategy_config_error(tmp_path, c
     contents = open(log_path).read()
     assert "InvalidStrategyConfigError" in contents
     assert "Traceback" in contents
+
+
+def test_handle_engine_error_works_for_invalid_renderer_error(tmp_path, capsys):
+    """Handler EngineError gestisce InvalidRendererError (issue #38, PR4)."""
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+    from main import _handle_engine_error
+    from shared.exceptions import InvalidRendererError
+    from shared.logger import configure_engine_logger, get_engine_log_path
+
+    configure_engine_logger(yaml_name='broken_renderer', log_dir=str(tmp_path))
+
+    err = InvalidRendererError(renderer_type="bogus", available=["numpy", "csound"])
+    err.config_file = 'configs/broken.yml'
+
+    try:
+        raise err
+    except InvalidRendererError as e:
+        _handle_engine_error(e)
+
+    captured = capsys.readouterr()
+    assert "bogus" in captured.out
+    assert "numpy" in captured.out
+    assert "Dettagli:" in captured.out
+
+    log_path = get_engine_log_path()
+    for h in __import__('logging').getLogger('engine').handlers:
+        h.flush()
+    contents = open(log_path).read()
+    assert "InvalidRendererError" in contents
+    assert "Traceback" in contents
+
+
+def test_handle_engine_error_works_for_csound_render_error(tmp_path, capsys):
+    """Handler EngineError gestisce CsoundRenderError (issue #38, PR4)."""
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+    from main import _handle_engine_error
+    from shared.exceptions import CsoundRenderError
+    from shared.logger import configure_engine_logger, get_engine_log_path
+
+    configure_engine_logger(yaml_name='broken_csound', log_dir=str(tmp_path))
+
+    err = CsoundRenderError(
+        returncode=1,
+        command=["csound", "score.csd"],
+        stderr="orchestra error",
+    )
+    err.stream_id = 'drone_a'
+
+    try:
+        raise err
+    except CsoundRenderError as e:
+        _handle_engine_error(e)
+
+    captured = capsys.readouterr()
+    assert "exit code 1" in captured.out
+    assert "Dettagli:" in captured.out
+
+    log_path = get_engine_log_path()
+    for h in __import__('logging').getLogger('engine').handlers:
+        h.flush()
+    contents = open(log_path).read()
+    assert "CsoundRenderError" in contents
+    assert "Traceback" in contents
+
+
+def test_handle_engine_error_works_for_invalid_window_error(tmp_path, capsys):
+    """Handler EngineError gestisce InvalidWindowError (issue #38, PR4)."""
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+    from main import _handle_engine_error
+    from shared.exceptions import InvalidWindowError
+    from shared.logger import configure_engine_logger, get_engine_log_path
+
+    configure_engine_logger(yaml_name='broken_window', log_dir=str(tmp_path))
+
+    err = InvalidWindowError(name="bogus", available=["hanning"])
+    err.stream_id = 'sx'
+
+    try:
+        raise err
+    except InvalidWindowError as e:
+        _handle_engine_error(e)
+
+    captured = capsys.readouterr()
+    assert "bogus" in captured.out
+    assert "Dettagli:" in captured.out


### PR DESCRIPTION
## Summary

Issue #38 PR4 — estende EngineError logging strutturato a errori rendering/window/ftable/csound.

Nuove sotto-classi `src/shared/exceptions.py`:
- `EngineRuntimeError(EngineError)` — intermedio per errori a runtime (non config)
- `InvalidRendererError(ConfigError)` — renderer name sconosciuto
- `InvalidWindowError(ConfigError)` — window function: nome sconosciuto, parametro fuori dominio (`n<=0`), envelope spec malformato
- `FtableError(ConfigError)` — stato/coerenza FtableManager
- `CsoundRenderError(EngineRuntimeError, RuntimeError)` — subprocess csound fallito

## Refactor 11 raise

- `rendering/renderer_factory.py:54` → `InvalidRendererError`
- `main.py:_build_renderer` → `InvalidRendererError`
- `rendering/numpy_window_registry.py:81,137` → `InvalidWindowError`
- `rendering/ftable_manager.py:51` → `InvalidWindowError`, `:121` → `FtableError`
- `controllers/window_controller.py:70,84,89,97` → `InvalidWindowError` (con `stream_id` arricchito)
- `rendering/csound_renderer.py:208` → `CsoundRenderError`

## Backward-compat

`ConfigError → ValueError` preservata. `CsoundRenderError → RuntimeError` preservata.

## Test

- 8 unit `tests/shared/test_engine_exceptions.py` (isinstance + user_message + context)
- 3 nuovi file `tests/rendering/test_renderer_errors.py`, `test_window_errors.py`, `test_ftable_errors.py`
- 3 handler `tests/test_main_engine_error.py` (InvalidRenderer, CsoundRender, InvalidWindow)
- 2 e2e `tests/e2e/test_engine_errors_e2e.py` (renderer invalido, window invalida)
- Adattati 9 test brittle (`test_window_controller.py`, `test_ftable_manager.py`)

Suite: 4161 passed, 49 e2e passed.

## Test plan

- [x] `make tests` (4161 passed)
- [x] `make e2e-tests` (49 passed)