### PR TITLE
fix(engine): controllers raises -> EngineError (issue #46, PR1)

### DIFF
--- a/src/controllers/density_controller.py
+++ b/src/controllers/density_controller.py
@@ -71,9 +71,14 @@ class DensityController:
         """
         candidates = [name for name in self._loaded_params if name in DENSITY_STRATEGIES and self._loaded_params[name] is not None]
         if len(candidates) != 1:
-            raise ValueError(
-                f"Atteso esattamente 1 parametro density dal gruppo esclusivo, "
-                f"trovati: {candidates}"
+            from shared.exceptions import InvalidFieldValueError
+            raise InvalidFieldValueError(
+                field="density (gruppo esclusivo)",
+                value=candidates,
+                hint=(
+                    f"atteso esattamente 1 parametro density dal gruppo esclusivo "
+                    f"({sorted(DENSITY_STRATEGIES.keys())}), trovati: {candidates}"
+                ),
             )
         return candidates[0]
  

--- a/src/controllers/pitch_controller.py
+++ b/src/controllers/pitch_controller.py
@@ -67,9 +67,14 @@ class PitchController:
         """
         candidates = [name for name in self._loaded_params if name in PITCH_STRATEGIES and self._loaded_params[name] is not None]
         if len(candidates) != 1:
-            raise ValueError(
-                f"Atteso esattamente 1 parametro pitch dal gruppo esclusivo, "
-                f"trovati: {candidates}"
+            from shared.exceptions import InvalidFieldValueError
+            raise InvalidFieldValueError(
+                field="pitch (gruppo esclusivo)",
+                value=candidates,
+                hint=(
+                    f"atteso esattamente 1 parametro pitch dal gruppo esclusivo "
+                    f"({sorted(PITCH_STRATEGIES.keys())}), trovati: {candidates}"
+                ),
             )
         return candidates[0]
     

--- a/src/controllers/window_registry.py
+++ b/src/controllers/window_registry.py
@@ -187,7 +187,11 @@ class WindowRegistry:
         """
         spec = cls.get(name)
         if not spec:
-            raise ValueError(f"WINDOW '{name}' non trovato nel registro")
+            from shared.exceptions import InvalidWindowError
+            raise InvalidWindowError(
+                name=name,
+                available=cls.all_names(),
+            )
         
         params_str = ' '.join(str(p) for p in spec.gen_params)
         return f"f {table_num} 0 {size} {spec.gen_routine} {params_str}"

--- a/src/controllers/window_selection_strategy.py
+++ b/src/controllers/window_selection_strategy.py
@@ -18,6 +18,10 @@ from typing import List, Optional, Tuple
 
 from shared.probability_gate import ProbabilityGate
 from shared.logger import log_window_curve_warning
+from shared.exceptions import (
+    InvalidStrategyConfigError,
+    StrategyNotFoundError,
+)
 
 
 def _validate_curve_range(curve, duration: float, time_mode: Optional[str],
@@ -39,12 +43,18 @@ def _validate_curve_range(curve, duration: float, time_mode: Optional[str],
 
     if curve_max_t > valid_max_t + eps:
         mode_label = time_mode or 'absolute'
-        raise ValueError(
-            f"Stream '{stream_id}': curve window transition ha breakpoint a "
-            f"t={curve_max_t} che supera il range valido t={valid_max_t} "
-            f"per time_mode='{mode_label}' (duration={duration}s). "
-            f"Converti i breakpoint o cambia time_mode."
+        err = InvalidStrategyConfigError(
+            strategy_kind="window",
+            field="curve",
+            value=curve_max_t,
+            hint=(
+                f"breakpoint a t={curve_max_t} supera range valido t={valid_max_t} "
+                f"per time_mode='{mode_label}' (duration={duration}s). "
+                f"Converti i breakpoint o cambia time_mode."
+            ),
         )
+        err.stream_id = stream_id
+        raise err
 
     if curve_max_t < valid_max_t - eps:
         mode_label = time_mode or 'absolute'
@@ -205,13 +215,19 @@ class MultiStateWindowStrategy(WindowSelectionStrategy):
         stream_id: str = 'unknown',
     ):
         if len(states) < 2:
-            raise ValueError(
-                f"MultiStateWindowStrategy richiede almeno 2 stati, ricevuti {len(states)}"
+            raise InvalidStrategyConfigError(
+                strategy_kind="window_multistate",
+                field="states",
+                value=len(states),
+                hint="MultiStateWindowStrategy richiede almeno 2 stati",
             )
         values = [v for v, _ in states]
         if values != sorted(values):
-            raise ValueError(
-                f"I valori degli stati devono essere in ordine crescente, ricevuti: {values}"
+            raise InvalidStrategyConfigError(
+                strategy_kind="window_multistate",
+                field="states",
+                value=values,
+                hint="i valori degli stati devono essere in ordine crescente",
             )
         _validate_curve_range(curve, duration, time_mode, stream_id)
         self._states = states
@@ -291,9 +307,10 @@ class WindowStrategyFactory:
             KeyError: se il nome non è nel registry
         """
         if name not in WINDOW_STRATEGY_REGISTRY:
-            raise KeyError(
-                f"WindowSelectionStrategy '{name}' non trovata. "
-                f"Disponibili: {sorted(WINDOW_STRATEGY_REGISTRY.keys())}"
+            raise StrategyNotFoundError(
+                strategy_kind="window_selection",
+                name=name,
+                available=list(WINDOW_STRATEGY_REGISTRY.keys()),
             )
         return WINDOW_STRATEGY_REGISTRY[name](**kwargs)
 

--- a/tests/controllers/test_density_controller.py
+++ b/tests/controllers/test_density_controller.py
@@ -168,7 +168,7 @@ class TestFindSelectedParam:
             'effective_density': 0.0,
         }
 
-        with pytest.raises(ValueError, match="Atteso esattamente 1"):
+        with pytest.raises(ValueError, match="density.*esclusivo"):
             _make_density_controller(mock_config, params)
 
     def test_raises_when_both_present(self, mock_config):
@@ -189,7 +189,7 @@ class TestFindSelectedParam:
             'effective_density': 0.0,
         }
 
-        with pytest.raises(ValueError, match="Atteso esattamente 1"):
+        with pytest.raises(ValueError, match="density.*esclusivo"):
             _make_density_controller(mock_config, params)
 
 

--- a/tests/controllers/test_pitch_controller.py
+++ b/tests/controllers/test_pitch_controller.py
@@ -158,7 +158,7 @@ class TestFindSelectedParam:
             'pitch_semitones': None,
         }
 
-        with pytest.raises(ValueError, match="Atteso esattamente 1"):
+        with pytest.raises(ValueError, match="pitch.*esclusivo"):
             _make_pitch_controller(mock_config, params)
 
     def test_raises_when_both_present(self, mock_config):
@@ -174,7 +174,7 @@ class TestFindSelectedParam:
             ),
         }
 
-        with pytest.raises(ValueError, match="Atteso esattamente 1"):
+        with pytest.raises(ValueError, match="pitch.*esclusivo"):
             _make_pitch_controller(mock_config, params)
 
 

--- a/tests/controllers/test_window_controller.py
+++ b/tests/controllers/test_window_controller.py
@@ -1141,23 +1141,23 @@ class TestCurveRangeValidation:
 
     def test_transition_normalized_curve_exceeds_one_raises(self):
         """time_mode=normalized, curve va a t=10 > 1.0 → ValueError."""
-        with pytest.raises(ValueError, match="supera il range valido"):
+        with pytest.raises(ValueError, match="strategia window.*curve"):
             self._make_transition([[0, 0], [10, 1]], time_mode='normalized')
 
     def test_multistate_normalized_curve_exceeds_one_raises(self):
         """time_mode=normalized, curve va a t=6 > 1.0 → ValueError."""
-        with pytest.raises(ValueError, match="supera il range valido"):
+        with pytest.raises(ValueError, match="strategia window.*curve"):
             self._make_multistate([[0, 0], [6, 0.3], [9, 0.7], [10, 1]],
                                    time_mode='normalized')
 
     def test_transition_absolute_curve_exceeds_duration_raises(self):
         """time_mode=absolute, duration=10, curve va a t=15 → ValueError."""
-        with pytest.raises(ValueError, match="supera il range valido"):
+        with pytest.raises(ValueError, match="strategia window.*curve"):
             self._make_transition([[0, 0], [15, 1]], duration=10.0)
 
     def test_multistate_absolute_curve_exceeds_duration_raises(self):
         """time_mode=absolute, duration=10, curve va a t=12 → ValueError."""
-        with pytest.raises(ValueError, match="supera il range valido"):
+        with pytest.raises(ValueError, match="strategia window.*curve"):
             self._make_multistate([[0, 0], [12, 1]], duration=10.0)
 
     def test_transition_normalized_curve_exactly_one_ok(self):
@@ -1351,9 +1351,10 @@ class TestWindowStrategyFactoryCreate:
         )
         assert isinstance(s, MultiStateWindowStrategy)
 
-    def test_create_unknown_name_raises_key_error(self):
+    def test_create_unknown_name_raises_strategy_not_found(self):
         from controllers.window_selection_strategy import WindowStrategyFactory
-        with pytest.raises(KeyError, match="non trovata"):
+        from shared.exceptions import StrategyNotFoundError
+        with pytest.raises(StrategyNotFoundError, match="non trovata"):
             WindowStrategyFactory.create('nonexistent_strategy')
 
 

--- a/tests/e2e/test_engine_errors_e2e.py
+++ b/tests/e2e/test_engine_errors_e2e.py
@@ -392,3 +392,82 @@ def test_e2e_invalid_window(tmp_path, cleanup_log):
     assert "Traceback" not in result.stdout
     assert "bogus_window_name_xyz" in result.stdout
     _assert_log_contains(yaml_abs, "InvalidWindowError", ["bogus_window_name_xyz"])
+
+
+# =============================================================================
+# Issue #46 - PR1: controllers raises -> EngineError (e2e)
+# =============================================================================
+
+YAML_CURVE_EXCEEDS_RANGE = f"""\
+composition:
+  title: "test curve exceeds range"
+streams:
+  - stream_id: "stream_curve_bad"
+    onset: 0.0
+    duration: 5
+    sample: "{REAL_SAMPLE}"
+    distribution_mode: 'gaussian'
+    density: 5
+    distribution: [[0,1],[1,1]]
+    pointer:
+      speed_ratio: 1.0
+    grain:
+      duration: 0.05
+      duration_range: 0.01
+      envelope:
+        from: hanning
+        to: expodec
+        curve: [[0, 0], [99, 1]]
+"""
+
+YAML_MULTISTATE_UNSORTED = f"""\
+composition:
+  title: "test multistate unsorted"
+streams:
+  - stream_id: "stream_ms_unsorted"
+    onset: 0.0
+    duration: 5
+    sample: "{REAL_SAMPLE}"
+    distribution_mode: 'gaussian'
+    density: 5
+    distribution: [[0,1],[1,1]]
+    pointer:
+      speed_ratio: 1.0
+    grain:
+      duration: 0.05
+      duration_range: 0.01
+      envelope:
+        states:
+          - [0.5, hanning]
+          - [0.2, bartlett]
+        curve: [[0, 0], [5, 1]]
+"""
+
+@pytest.mark.e2e
+def test_e2e_curve_exceeds_range(tmp_path, cleanup_log):
+    yaml_abs = _write_yaml(tmp_path, '46_curve_exceeds.yml', YAML_CURVE_EXCEEDS_RANGE)
+    cleanup_log.append(_log_path_for(yaml_abs))
+    result = _run(yaml_abs)
+    assert result.returncode != 0
+    assert "[ERRORE]" in result.stdout
+    assert "Traceback" not in result.stdout
+    assert "window" in result.stdout.lower()
+    _assert_log_contains(yaml_abs, "InvalidStrategyConfigError", ["window"])
+
+
+@pytest.mark.e2e
+def test_e2e_multistate_unsorted(tmp_path, cleanup_log):
+    """Multistate states non in ordine crescente -> InvalidStrategyConfigError.
+
+    Note: i casi multistate <2 stati e pitch/density exclusive group sono
+    coperti dai test unit -- la pipeline YAML li intercetta prima
+    (parse layer per multistate; orchestrator priorita' per pitch/density),
+    quindi non sono raggiungibili tramite e2e su src/main.py.
+    """
+    yaml_abs = _write_yaml(tmp_path, '46_ms_unsorted.yml', YAML_MULTISTATE_UNSORTED)
+    cleanup_log.append(_log_path_for(yaml_abs))
+    result = _run(yaml_abs)
+    assert result.returncode != 0
+    assert "[ERRORE]" in result.stdout
+    assert "Traceback" not in result.stdout
+    _assert_log_contains(yaml_abs, "InvalidStrategyConfigError", ["window_multistate"])

--- a/tests/shared/test_engine_exceptions.py
+++ b/tests/shared/test_engine_exceptions.py
@@ -452,3 +452,130 @@ def test_csound_render_error_context_lines():
     msg = err.user_message()
     assert "drone_a" in msg
     assert "configs/x.yml" in msg
+
+
+# =============================================================================
+# Issue #46 — PR1: controllers raises -> EngineError
+# =============================================================================
+
+def test_window_curve_range_violation_is_invalid_strategy_config():
+    """Curve breakpoint oltre range valido -> InvalidStrategyConfigError."""
+    from shared.exceptions import (
+        ConfigError, EngineError, InvalidStrategyConfigError,
+    )
+    from controllers.window_selection_strategy import _validate_curve_range
+    from envelopes.envelope import Envelope
+
+    curve = Envelope([[0.0, 0.0], [2.5, 1.0]])
+    with pytest.raises(InvalidStrategyConfigError) as excinfo:
+        _validate_curve_range(curve, duration=1.0, time_mode='normalized', stream_id='s1')
+    err = excinfo.value
+    assert isinstance(err, ConfigError)
+    assert isinstance(err, EngineError)
+    assert isinstance(err, ValueError)
+    assert err.stream_id == 's1'
+    msg = err.user_message()
+    assert "[ERRORE]" in msg
+    assert "window" in msg.lower()
+    assert "Stream:" in msg
+
+
+def test_multistate_too_few_states_is_invalid_strategy_config():
+    """MultiStateWindowStrategy con <2 stati -> InvalidStrategyConfigError."""
+    from shared.exceptions import InvalidStrategyConfigError
+    from controllers.window_selection_strategy import MultiStateWindowStrategy
+    from envelopes.envelope import Envelope
+
+    curve = Envelope([[0.0, 0.0], [1.0, 1.0]])
+    with pytest.raises(InvalidStrategyConfigError) as excinfo:
+        MultiStateWindowStrategy(states=[(0.0, 'hanning')], curve=curve)
+    err = excinfo.value
+    assert isinstance(err, ValueError)
+    msg = err.user_message()
+    assert "[ERRORE]" in msg
+    assert "almeno 2" in msg or "2" in msg
+
+
+def test_multistate_unsorted_states_is_invalid_strategy_config():
+    """Stati non in ordine crescente -> InvalidStrategyConfigError."""
+    from shared.exceptions import InvalidStrategyConfigError
+    from controllers.window_selection_strategy import MultiStateWindowStrategy
+    from envelopes.envelope import Envelope
+
+    curve = Envelope([[0.0, 0.0], [1.0, 1.0]])
+    with pytest.raises(InvalidStrategyConfigError) as excinfo:
+        MultiStateWindowStrategy(
+            states=[(0.5, 'a'), (0.2, 'b')],
+            curve=curve,
+        )
+    err = excinfo.value
+    msg = err.user_message()
+    assert "[ERRORE]" in msg
+    assert "crescente" in msg or "ordine" in msg.lower()
+
+
+def test_window_strategy_factory_unknown_name_is_strategy_not_found():
+    """Factory.create con nome ignoto -> StrategyNotFoundError (non KeyError)."""
+    from shared.exceptions import (
+        ConfigError, EngineError, StrategyNotFoundError,
+    )
+    from controllers.window_selection_strategy import WindowStrategyFactory
+
+    with pytest.raises(StrategyNotFoundError) as excinfo:
+        WindowStrategyFactory.create('bogus_strategy_name_xyz')
+    err = excinfo.value
+    assert isinstance(err, ConfigError)
+    assert isinstance(err, EngineError)
+    assert isinstance(err, ValueError)
+    msg = err.user_message()
+    assert "[ERRORE]" in msg
+    assert "bogus_strategy_name_xyz" in msg
+
+
+def test_window_registry_generate_unknown_is_invalid_window():
+    """generate_ftable_statement con nome ignoto -> InvalidWindowError."""
+    from shared.exceptions import ConfigError, InvalidWindowError
+    from controllers.window_registry import WindowRegistry
+
+    with pytest.raises(InvalidWindowError) as excinfo:
+        WindowRegistry.generate_ftable_statement(1, 'totally_fake_window_xyz')
+    err = excinfo.value
+    assert isinstance(err, ConfigError)
+    assert isinstance(err, ValueError)
+    msg = err.user_message()
+    assert "[ERRORE]" in msg
+    assert "totally_fake_window_xyz" in msg
+
+
+def test_pitch_controller_exclusive_group_violation_is_invalid_field_value():
+    """0 o >1 param pitch -> InvalidFieldValueError."""
+    from shared.exceptions import ConfigError, InvalidFieldValueError
+    from controllers.pitch_controller import PitchController, PITCH_STRATEGIES
+
+    pc = PitchController.__new__(PitchController)
+    pc._loaded_params = {}
+    with pytest.raises(InvalidFieldValueError) as excinfo:
+        pc._find_selected_param()
+    err = excinfo.value
+    assert isinstance(err, ConfigError)
+    assert isinstance(err, ValueError)
+    msg = err.user_message()
+    assert "[ERRORE]" in msg
+    assert "pitch" in msg.lower()
+
+
+def test_density_controller_exclusive_group_violation_is_invalid_field_value():
+    """0 o >1 param density -> InvalidFieldValueError."""
+    from shared.exceptions import ConfigError, InvalidFieldValueError
+    from controllers.density_controller import DensityController
+
+    dc = DensityController.__new__(DensityController)
+    dc._loaded_params = {}
+    with pytest.raises(InvalidFieldValueError) as excinfo:
+        dc._find_selected_param()
+    err = excinfo.value
+    assert isinstance(err, ConfigError)
+    assert isinstance(err, ValueError)
+    msg = err.user_message()
+    assert "[ERRORE]" in msg
+    assert "density" in msg.lower()


### PR DESCRIPTION
## Summary

Follow-up issue #46 (residui post-#38). Converte 7 `raise` user-facing nei `src/controllers/*` a sotto-classi `EngineError` gia' esistenti. Output utente pulito + log file con traceback strutturato.

## Changes

| File | Da | A |
|---|---|---|
| `controllers/window_selection_strategy.py` (`_validate_curve_range`) | `ValueError` | `InvalidStrategyConfigError(strategy_kind="window")` |
| `controllers/window_selection_strategy.py` (`MultiStateWindowStrategy.__init__`, x2) | `ValueError` | `InvalidStrategyConfigError(strategy_kind="window_multistate")` |
| `controllers/window_selection_strategy.py` (`WindowStrategyFactory.create`) | `KeyError` | `StrategyNotFoundError("window_selection")` |
| `controllers/window_registry.py` (`generate_ftable_statement`) | `ValueError` | `InvalidWindowError` |
| `controllers/pitch_controller.py` (`_find_selected_param`) | `ValueError` | `InvalidFieldValueError(field="pitch (gruppo esclusivo)")` |
| `controllers/density_controller.py` (`_find_selected_param`) | `ValueError` | `InvalidFieldValueError(field="density (gruppo esclusivo)")` |

## Backward compat

- `InvalidStrategyConfigError`, `StrategyNotFoundError`, `InvalidWindowError`, `InvalidFieldValueError` ereditano `ValueError` via `ConfigError(EngineError, ValueError)` -> tutti i `pytest.raises(ValueError)` pre-esistenti continuano a funzionare.
- Solo eccezione: `KeyError@WindowStrategyFactory.create` ora e' `StrategyNotFoundError(ValueError)`. Nessun caller `except KeyError` su questa API (verificato con grep).

## Test

- Unit: 7 nuovi test in `tests/shared/test_engine_exceptions.py` (isinstance + user_message + context).
- E2e: 2 nuovi test (`curve_exceeds_range`, `multistate_unsorted`). Casi multistate <2 e pitch/density exclusive non raggiungibili tramite pipeline YAML (parse layer / orchestrator priorita'), coperti da unit.
- Aggiornati `match=` in `test_pitch_controller`, `test_density_controller`, `test_window_controller` per i nuovi messaggi.

## Test plan

- [x] `make tests` (4168 passed)
- [x] `make e2e-tests` (51 passed)

## Follow-up

PR2 coprira' i raise rimanenti in `src/envelopes/envelope_segment.py` e `src/envelopes/time_distribution.py`.

Refs: #46