### PR TITLE
fix(engine): envelopes raises -> EngineError (issue #46, PR2)

### DIFF
--- a/src/envelopes/envelope_segment.py
+++ b/src/envelopes/envelope_segment.py
@@ -46,7 +46,12 @@ class Segment(ABC):
             context: Additional data (e.g., {'tangents': [...]})
         """
         if len(breakpoints) < 1:
-            raise ValueError("Segment must have at least one breakpoint")
+            from shared.exceptions import InvalidFieldValueError
+            raise InvalidFieldValueError(
+                field="breakpoints",
+                value=breakpoints,
+                hint="Segment richiede almeno un breakpoint",
+            )
         
         # Sort by time
         self.breakpoints = sorted(breakpoints, key=lambda p: p[0])

--- a/src/envelopes/time_distribution.py
+++ b/src/envelopes/time_distribution.py
@@ -52,9 +52,23 @@ class TimeDistributionStrategy(ABC):
     def _validate_inputs(self, total_time: float, n_reps: int):
         """Validazione comune."""
         if n_reps < 1:
-            raise ValueError(f"n_reps deve essere >= 1, ricevuto: {n_reps}")
+            from shared.exceptions import ParameterBoundError
+            raise ParameterBoundError(
+                param_name="n_reps",
+                value_type="value",
+                min_bound=1,
+                max_bound=None,
+                value=n_reps,
+            )
         if total_time <= 0:
-            raise ValueError(f"total_time deve essere > 0, ricevuto: {total_time}")
+            from shared.exceptions import ParameterBoundError
+            raise ParameterBoundError(
+                param_name="total_time",
+                value_type="value",
+                min_bound=0,
+                max_bound=None,
+                value=total_time,
+            )
 
 
 # =============================================================================
@@ -101,7 +115,14 @@ class ExponentialDistribution(TimeDistributionStrategy):
             rate: Tasso di decadimento (>1 = accelera, <1 = rallenta)
         """
         if rate <= 0:
-            raise ValueError(f"rate deve essere > 0, ricevuto: {rate}")
+            from shared.exceptions import ParameterBoundError
+            raise ParameterBoundError(
+                param_name="rate",
+                value_type="value",
+                min_bound=0,
+                max_bound=None,
+                value=rate,
+            )
         self.rate = rate
     
     def calculate_distribution(

--- a/tests/envelopes/test_envelope_segment.py
+++ b/tests/envelopes/test_envelope_segment.py
@@ -176,7 +176,7 @@ class TestEdgeCasesAndValidation:
     
     def test_segment_requires_at_least_one_breakpoint(self, linear_strategy):
         """Segment richiede almeno 1 breakpoint."""
-        with pytest.raises(ValueError, match="at least one breakpoint"):
+        with pytest.raises(ValueError, match="breakpoints"):
             NormalSegment([], linear_strategy)
         
     def test_breakpoints_sorted_automatically(self, linear_strategy):

--- a/tests/envelopes/test_time_distribution.py
+++ b/tests/envelopes/test_time_distribution.py
@@ -83,7 +83,7 @@ class TestExponentialDistribution:
     
     def test_invalid_rate(self):
         """Rate <= 0 solleva errore."""
-        with pytest.raises(ValueError, match="rate deve essere > 0"):
+        with pytest.raises(ValueError, match="rate.*fuori bounds"):
             ExponentialDistribution(rate=0.0)
 
 
@@ -384,17 +384,17 @@ class TestEdgeCases:
         """n_reps < 1 solleva errore."""
         dist = LinearDistribution()
         
-        with pytest.raises(ValueError, match="n_reps deve essere >= 1"):
+        with pytest.raises(ValueError, match="n_reps.*fuori bounds"):
             dist.calculate_distribution(30.0, 0)
     
     def test_invalid_total_time(self):
         """total_time <= 0 solleva errore."""
         dist = LinearDistribution()
         
-        with pytest.raises(ValueError, match="total_time deve essere > 0"):
+        with pytest.raises(ValueError, match="total_time.*fuori bounds"):
             dist.calculate_distribution(0.0, 5)
         
-        with pytest.raises(ValueError, match="total_time deve essere > 0"):
+        with pytest.raises(ValueError, match="total_time.*fuori bounds"):
             dist.calculate_distribution(-10.0, 5)
 
 

--- a/tests/shared/test_engine_exceptions.py
+++ b/tests/shared/test_engine_exceptions.py
@@ -579,3 +579,69 @@ def test_density_controller_exclusive_group_violation_is_invalid_field_value():
     msg = err.user_message()
     assert "[ERRORE]" in msg
     assert "density" in msg.lower()
+
+
+# =============================================================================
+# Issue #46 — PR2: envelopes raises -> EngineError
+# =============================================================================
+
+def test_envelope_segment_empty_breakpoints_is_invalid_field_value():
+    """Segment senza breakpoint -> InvalidFieldValueError."""
+    from shared.exceptions import ConfigError, InvalidFieldValueError
+    from envelopes.envelope_segment import NormalSegment
+    from envelopes.envelope_interpolation import LinearInterpolation
+
+    with pytest.raises(InvalidFieldValueError) as excinfo:
+        NormalSegment(breakpoints=[], strategy=LinearInterpolation())
+    err = excinfo.value
+    assert isinstance(err, ConfigError)
+    assert isinstance(err, ValueError)
+    msg = err.user_message()
+    assert "[ERRORE]" in msg
+    assert "breakpoint" in msg.lower()
+
+
+def test_time_distribution_invalid_n_reps_is_parameter_bound():
+    """n_reps < 1 -> ParameterBoundError."""
+    from shared.exceptions import ConfigError, ParameterBoundError
+    from envelopes.time_distribution import LinearDistribution
+
+    dist = LinearDistribution()
+    with pytest.raises(ParameterBoundError) as excinfo:
+        dist.calculate_distribution(total_time=10.0, n_reps=0)
+    err = excinfo.value
+    assert isinstance(err, ConfigError)
+    assert isinstance(err, ValueError)
+    msg = err.user_message()
+    assert "[ERRORE]" in msg
+    assert "n_reps" in msg
+    assert "fuori bounds" in msg
+
+
+def test_time_distribution_invalid_total_time_is_parameter_bound():
+    """total_time <= 0 -> ParameterBoundError."""
+    from shared.exceptions import ParameterBoundError
+    from envelopes.time_distribution import LinearDistribution
+
+    dist = LinearDistribution()
+    with pytest.raises(ParameterBoundError) as excinfo:
+        dist.calculate_distribution(total_time=0.0, n_reps=5)
+    err = excinfo.value
+    assert isinstance(err, ValueError)
+    msg = err.user_message()
+    assert "[ERRORE]" in msg
+    assert "total_time" in msg
+
+
+def test_exponential_distribution_invalid_rate_is_parameter_bound():
+    """rate <= 0 -> ParameterBoundError."""
+    from shared.exceptions import ParameterBoundError
+    from envelopes.time_distribution import ExponentialDistribution
+
+    with pytest.raises(ParameterBoundError) as excinfo:
+        ExponentialDistribution(rate=0.0)
+    err = excinfo.value
+    assert isinstance(err, ValueError)
+    msg = err.user_message()
+    assert "[ERRORE]" in msg
+    assert "rate" in msg


### PR DESCRIPTION
## Summary

Completa l'issue #46 convertendo i 4 raise user-facing rimanenti in `src/envelopes/*` a sotto-classi `EngineError` gia' esistenti.

## Changes

| File:linea | Da | A |
|---|---|---|
| `envelopes/envelope_segment.py:49` (`Segment.__init__`) | `ValueError` | `InvalidFieldValueError(field="breakpoints")` |
| `envelopes/time_distribution.py:55` (`_validate_inputs`) | `ValueError` | `ParameterBoundError(param_name="n_reps", min_bound=1)` |
| `envelopes/time_distribution.py:57` (`_validate_inputs`) | `ValueError` | `ParameterBoundError(param_name="total_time", min_bound=0)` |
| `envelopes/time_distribution.py:104` (`ExponentialDistribution.__init__`) | `ValueError` | `ParameterBoundError(param_name="rate", min_bound=0)` |

## Backward compat

`InvalidFieldValueError` e `ParameterBoundError` ereditano `ValueError` via `ConfigError(EngineError, ValueError)` -> tutti i `pytest.raises(ValueError)` pre-esistenti continuano a funzionare. Aggiornato solo il pattern `match=` nei test esistenti per riflettere i nuovi messaggi.

## Test

- Unit: 4 nuovi test in `tests/shared/test_engine_exceptions.py` (isinstance + user_message).
- Aggiornati 4 match string in `tests/envelopes/test_envelope_segment.py` e `tests/envelopes/test_time_distribution.py`.
- Nessun e2e: i target sono input runtime interni (non parametri YAML diretti), quindi non raggiungibili via `src/main.py`.

## Test plan

- [x] `make tests` (4172 passed)
- [x] `make e2e-tests` (51 passed)

## Closes

Closes #46 (insieme a PR #47).

Refs: #46