### PR TITLE
feat(install): supporto Fedora/RHEL + fix e2e naming (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ---
 
+## [Unreleased]
+
+### Aggiunto
+
+- Supporto Fedora / RHEL / Rocky / AlmaLinux nel branch `dnf` di
+  `make install-system-deps` (issue #58). Installa `python3` + `sox`;
+  stampa istruzioni per Csound (non disponibile nei repo Fedora / RPM
+  Fusion — usare `RENDERER=numpy` o compilare dai sorgenti).
+- README: sezione dedicata "Fedora / RHEL / Rocky / AlmaLinux" con
+  istruzioni install e nota Csound; righe Fedora/RHEL nella tabella
+  compatibilità Python; voce Fedora/RHEL nella tabella "Platform Support".
+
+### Corretto
+
+- Naming dei file stem `.aif` in STEMS mode: separatore tra basename del
+  progetto e `stream_id` cambiato da `_` a `__` (issue #56), per
+  allinearsi al protocollo del server PGE-ui (`server.py` glob,
+  `backend.js` fetch URL). Senza il fix la UI mostrava "no stems · render
+  first" anche dopo render completati, e la riproduzione audio nel
+  browser ritornava 404. Vedi
+  `docs/plans/done/2026-05-21-001-fix-stem-naming-double-underscore-plan.md`.
+
+---
+
 ## [v3.8.0] — "Arch/Manjaro compat + Cartridge removal" — 2026-05-12
 
 ### Aggiunto

--- a/Makefile
+++ b/Makefile
@@ -134,8 +134,15 @@ else ifeq ($(OS), Linux)
 	elif command -v apt >/dev/null 2>&1; then \
 		echo "[DEPS] Debian/Ubuntu — uso apt..."; \
 		sudo apt update && sudo apt install -y python3.12 python3.12-venv sox csound; \
+	elif command -v dnf >/dev/null 2>&1; then \
+		echo "[DEPS] Fedora/RHEL — uso dnf..."; \
+		sudo dnf install -y python3 sox; \
+		echo ""; \
+		echo "[DEPS] NOTA: Csound non è disponibile nei repo Fedora/RPM Fusion."; \
+		echo "[DEPS]   Opzione 1 (consigliata su Fedora): usa RENDERER=numpy (nessuna dipendenza Csound)."; \
+		echo "[DEPS]   Opzione 2: compila Csound dai sorgenti (https://github.com/csound/csound)."; \
 	else \
-		echo "ERRORE: package manager non supportato (né pacman né apt trovato)."; \
+		echo "ERRORE: package manager non supportato (pacman/apt/dnf non trovati)."; \
 		exit 1; \
 	fi
 else

--- a/README.md
+++ b/README.md
@@ -64,6 +64,24 @@ sudo pacman -Sy python sox csound
 
 `pacman -Sy python` installa la versione corrente di sistema (oggi 3.14, verificata >= 3.12). La detection del Makefile riconosce automaticamente `python3.12`..`python3.16` versionati e, in fallback, `python3` generico.
 
+### Fedora / RHEL / Rocky / AlmaLinux
+
+```bash
+sudo dnf install -y python3 sox
+```
+
+- **Fedora 40+** include `python3` >= 3.12 nei repo principali (Fedora 42 → 3.13.x).
+- **RHEL 9 / Rocky 9 / AlmaLinux 9**: il `python3` di sistema è 3.9. Installa esplicitamente `python3.12`:
+
+  ```bash
+  sudo dnf install -y python3.12 sox
+  ```
+
+> **Csound su Fedora.** Csound non è presente nei repo Fedora ufficiali né in RPM Fusion (free/nonfree), e le release upstream non distribuiscono binari Linux. Due opzioni:
+>
+> 1. **Consigliata**: usa il renderer NumPy puro (`make FILE=my-config RENDERER=numpy all`). Non richiede Csound.
+> 2. **Compila Csound dai sorgenti** seguendo le istruzioni in [github.com/csound/csound](https://github.com/csound/csound) (richiede `cmake`, `libsndfile-devel`, ecc., installabili via `dnf install -y cmake libsndfile-devel flex bison`).
+
 ### Compatibilità Python
 
 | OS | Comando install | Versione attesa | Detection |
@@ -72,6 +90,8 @@ sudo pacman -Sy python sox csound
 | Ubuntu 24.04+ | `apt install python3.12` | 3.12 esatta | `python3.12` versionato |
 | Debian 12 stable | `python3` di sistema (>= 3.12) o `pyenv` | varia | fallback `python3` |
 | Arch / Manjaro | `pacman -Sy python` | corrente (3.14+) | `python3.14` versionato o `python3` |
+| Fedora 40+ | `dnf install python3` | 3.12+ (3.13 su F41+) | fallback `python3` |
+| RHEL 9 / Rocky 9 / AlmaLinux 9 | `dnf install python3.12` | 3.12 esatta | `python3.12` versionato |
 
 Il Makefile cerca nell'ordine `python3.12..python3.16` e poi `python3` generico (se versione >= 3.12). Versioni Python future (3.17+) saranno coperte dal fallback automatico fino al refresh della lista esplicita.
 
@@ -333,6 +353,8 @@ Trims `refs/001.wav` starting at 5.0 seconds for 20 seconds using `sox` and save
 |---|---|
 | macOS (Apple Silicon / Intel) | Supported |
 | Linux (Debian / Ubuntu) | Supported |
+| Linux (Arch / Manjaro) | Supported |
+| Linux (Fedora / RHEL / Rocky / AlmaLinux) | Supported (renderer NumPy out-of-the-box; Csound da sorgenti) |
 | Windows (native) | Not supported |
 | Windows (WSL2) | Should work, not tested |
 

--- a/docs/plans/2026-05-21-002-feat-fedora-system-requirements-plan.md
+++ b/docs/plans/2026-05-21-002-feat-fedora-system-requirements-plan.md
@@ -1,0 +1,325 @@
+---
+title: "feat: supporto Fedora/RHEL nelle system requirements"
+type: feat
+status: active
+date: 2026-05-21
+---
+
+# feat: supporto Fedora/RHEL nelle system requirements
+
+## Overview
+
+Il repository documenta e automatizza l'installazione delle dipendenze di
+sistema (Python >= 3.12, `sox`, `csound`) per macOS (Homebrew),
+Debian/Ubuntu (apt) e Arch/Manjaro (pacman). Manca completamente il
+supporto per la famiglia **Fedora / RHEL / Rocky / AlmaLinux** (package
+manager `dnf`/`yum`) e, opzionalmente, **openSUSE** (`zypper`).
+
+Effetto pratico: su una macchina Fedora pulita, `make install-system-deps`
+stampa `"ERRORE: package manager non supportato (né pacman né apt
+trovato)."` e l'utente deve installare manualmente le dipendenze, indovinando
+i nomi dei pacchetti. La sezione README non gli dà alcuna indicazione.
+
+Obiettivo: aggiungere supporto Fedora (dnf) nel Makefile e nel README, in
+modo coerente con quanto già fatto per Arch/Manjaro nel plan
+`docs/plans/done/2026-05-12-001-fix-python-detection-arch-manjaro-plan.md`.
+
+---
+
+## Problem Frame
+
+Utente su Fedora vuole eseguire `make e2e-tests` o anche solo `make all`.
+Pipeline attuale:
+
+1. `make setup` → `check-system-deps`
+2. `check-system-deps` cerca `python` >= 3.12, `sox`, `csound` (se
+   `RENDERER=csound`) → tutti potenzialmente assenti su Fedora fresco.
+3. L'utente prova `make install-system-deps` → fallisce con
+   `"package manager non supportato"`.
+4. README sezione **System requirements** non menziona Fedora. La tabella
+   "Compatibilità Python" non ha riga Fedora.
+
+### Cause radice
+
+- **B1** [Makefile:124-143](Makefile#L124-L143) — `install-system-deps`
+  branch Linux gestisce solo `pacman` e `apt`; nessun ramo `dnf` o
+  `zypper`.
+- **B2** [README.md:46-75](README.md#L46-L75) — sezione "System requirements"
+  ha solo macOS, Debian/Ubuntu, Arch/Manjaro. Mancano Fedora e openSUSE.
+- **B3** [README.md:334-335](README.md#L334-L335) — tabella "Tested
+  Platforms" non lista Fedora.
+
+---
+
+## Requirements Trace
+
+- **R1.** Su Fedora 40+/41/42 (o RHEL 9+/Rocky 9+/AlmaLinux 9+),
+  `make install-system-deps` installa Python (>= 3.12), `sox`, `csound`
+  senza errori.
+- **R2.** `make check-system-deps` post-install passa verde su Fedora.
+- **R3.** README ha una sezione "Fedora / RHEL" parallela a quella
+  "Arch Linux / Manjaro", con comando one-liner e nota sui pacchetti
+  Csound.
+- **R4.** Tabella "Compatibilità Python" del README ha una riga
+  Fedora con versione attesa e modalità di detection.
+- **R5.** Nessuna regressione su macOS, Debian/Ubuntu, Arch/Manjaro.
+- **R6.** Documentato il fallback per `csound` se assente da repo
+  ufficiali (rpm fusion? compile from source?).
+
+### Out of Scope
+
+- Supporto openSUSE (`zypper`): può essere un follow-up se richiesto;
+  numericamente l'utenza target è marginale rispetto a Fedora/RHEL.
+- Supporto Windows nativo: già fuori scope dell'intero progetto.
+- Configurare un container CI Fedora: utile ma in PR successiva (vedi
+  "Follow-up").
+- Risolvere singoli bug di rendering rilevati durante l'e2e su un'altra
+  macchina (sono indipendenti dalla mancanza di setup Fedora).
+
+---
+
+## Context & Research
+
+### Stato attuale (verificato il 2026-05-21)
+
+- `Makefile:124-143` discrimina `Darwin` vs `Linux`; il branch Linux usa
+  prima `pacman`, poi `apt`, altrimenti errore.
+- `README.md:36-75` ha sezioni `macOS`, `Linux (Debian / Ubuntu)`,
+  `Arch Linux / Manjaro`, `Compatibilità Python`.
+- `make/test.mk:5-25` detection Python: già gestisce `python3.12..3.16` e
+  fallback `python3` — non serve toccare.
+
+### Pacchetti Fedora (verificati empiricamente su `fedora:42`, 2026-05-21)
+
+- `python3` su Fedora 42: **3.13.13** (repo `updates`) ✓ >= 3.12.
+- `sox`: **14.4.2.0-41.fc42** (repo `fedora`) ✓.
+- `csound`: **NON disponibile** nei repo Fedora ufficiali (`fedora`,
+  `updates`), né in **RPM Fusion Free**, né in **RPM Fusion Nonfree**.
+  Verificato con `dnf search csound` su container `fedora:42` dopo
+  abilitazione di entrambi i repo RPM Fusion.
+- Le release upstream Csound (<https://github.com/csound/csound/releases>)
+  distribuiscono solo binari per **macOS, Windows, Android, iOS, ARM**.
+  Niente Linux x86_64 binary.
+
+**Conseguenza operativa:**
+Su Fedora il renderer Csound non è installabile da package manager. Due
+strade per l'utente:
+
+1. **Renderer NumPy** (consigliato su Fedora): `make FILE=my-config
+   RENDERER=numpy all`. Nessuna dipendenza Csound.
+2. **Compilazione Csound dai sorgenti**: clone del repo upstream + build
+   CMake. Dipendenze build via dnf: `cmake libsndfile-devel flex bison`.
+
+**Comando install pacchetti gestiti da dnf:**
+```bash
+sudo dnf install -y python3 sox
+```
+
+Per RHEL/Rocky/AlmaLinux 9 e versioni dove `python3` < 3.12, fallback a
+`python3.12` esplicito:
+```bash
+sudo dnf install -y python3.12 sox
+```
+
+### Detection package manager nel Makefile
+
+Aggiungere un terzo branch dopo `pacman`/`apt`, prima dell'errore finale:
+
+```make
+elif command -v dnf >/dev/null 2>&1; then \
+    echo "[DEPS] Fedora/RHEL — uso dnf..."; \
+    sudo dnf install -y python3 sox csound; \
+```
+
+Nota: `dnf` è disponibile anche su RHEL 8+/Rocky 8+/AlmaLinux 8+; su CentOS
+Stream e Fedora rolling è il package manager primario. Non serve un check
+separato per `yum` (alias di `dnf` su versioni recenti).
+
+### Detection Python su Fedora
+
+`make/test.mk` cerca già `python3.12..python3.16` e fallback `python3` (con
+version check >= 3.12). Su:
+
+- **Fedora 42 (oggi)**: `python3` → 3.13.x ✓ fallback OK.
+- **Fedora 41**: `python3` → 3.13.x ✓.
+- **Fedora 40**: `python3` → 3.12.x ✓.
+- **RHEL 9 / Rocky 9 / AlmaLinux 9**: `python3` → 3.9 (KO). Serve
+  `python3.12` esplicito (`sudo dnf install python3.12`); il binary
+  installato è `python3.12` versionato → detection lo trova in lista
+  esplicita.
+
+### Institutional Learnings
+
+- Pattern già consolidato nel plan #51 (Arch/Manjaro): la detection Python
+  è generica (range versioni + fallback), basta aggiungere il branch
+  package manager in `install-system-deps` e la riga README. Questo plan
+  segue lo stesso schema, riducendo il rischio di regressioni.
+
+### External References
+
+- Fedora package search: <https://packages.fedoraproject.org/>
+- RPM Fusion (per csound recente, se necessario): <https://rpmfusion.org/>
+- Csound official downloads: <https://csound.com/download.html>
+
+---
+
+## Approach
+
+1. **Verifica empirica preliminare** — su un sistema Fedora (oppure
+   container `fedora:42`), eseguire `dnf info python3 sox csound` per
+   confermare:
+   - Versione `python3` (>= 3.12).
+   - Disponibilità di `sox` e `csound` nei repo ufficiali.
+   - Eventuale necessità di abilitare RPM Fusion per `csound`.
+2. **Patch Makefile** — aggiungere branch `dnf` in
+   `install-system-deps` tra `apt` ed errore finale.
+3. **Patch README** — nuova sezione "Fedora / RHEL" parallela ad "Arch
+   Linux / Manjaro"; riga in tabella "Compatibilità Python"; riga in
+   "Tested Platforms".
+4. **Test (manuale)** — su VM o container Fedora 42 pulito:
+   ```
+   make install-system-deps
+   make setup
+   make tests
+   make all  # con un YAML semplice
+   ```
+   Atteso: tutti exit code 0.
+5. **TDD (opzionale)** — estendere
+   `tests/test_makefile_python_detection.py` con uno scenario
+   `python3-only` (Fedora) che verifica la detection del Makefile, sulla
+   linea dei test già presenti per Arch/Manjaro.
+6. **Aggiornamento CHANGELOG** — entry sotto la prossima release minor.
+
+### Alternative scartate
+
+- **Container per ogni distro nel Makefile** — troppo invasivo; gli utenti
+  Fedora vogliono installare nativamente, non orchestrare Docker.
+- **Script `install.sh` esterno al Makefile** — duplicherebbe logica già
+  presente in `install-system-deps`. Meglio estendere il branch esistente.
+- **Skip del supporto Fedora aspettando una richiesta esplicita** — il
+  numero di sviluppatori e ricercatori che usano Fedora è significativo
+  (RedHat, ambiente accademico CNR/INFN), il costo marginale del fix è
+  basso.
+
+---
+
+## File da modificare
+
+### Codice / build
+
+1. **[Makefile](Makefile)** — branch `install-system-deps`:
+   ```make
+   else ifeq ($(OS), Linux)
+       @if command -v pacman >/dev/null 2>&1; then \
+           ...
+       elif command -v apt >/dev/null 2>&1; then \
+           ...
+       elif command -v dnf >/dev/null 2>&1; then \
+           echo "[DEPS] Fedora/RHEL — uso dnf..."; \
+           sudo dnf install -y python3 sox; \
+           echo ""; \
+           echo "[DEPS] NOTA: Csound non è disponibile nei repo Fedora/RPM Fusion."; \
+           echo "[DEPS]   Opzione 1 (consigliata su Fedora): usa RENDERER=numpy."; \
+           echo "[DEPS]   Opzione 2: compila Csound dai sorgenti (https://github.com/csound/csound)."; \
+       else \
+           echo "ERRORE: package manager non supportato (pacman/apt/dnf non trovati)."; \
+           exit 1; \
+       fi
+   ```
+
+### Documentazione
+
+2. **[README.md](README.md)** — nuova sezione `### Fedora / RHEL` dopo
+   `### Arch Linux / Manjaro`:
+   ```markdown
+   ### Fedora / RHEL / Rocky / AlmaLinux
+
+   ```bash
+   sudo dnf install -y python3 sox csound
+   ```
+
+   - **Fedora 40+** include `python3` >= 3.12 nei repo principali.
+   - **RHEL 9 / Rocky 9 / AlmaLinux 9**: il `python3` di sistema è 3.9;
+     installa esplicitamente `python3.12`:
+     ```bash
+     sudo dnf install -y python3.12 sox csound
+     ```
+   - **Csound**: se la versione disponibile su `dnf` è troppo vecchia per
+     le tue esigenze, scarica una release recente da
+     [csound.com](https://csound.com/download.html) o usa RPM Fusion.
+   ```
+
+3. **[README.md](README.md)** — tabella "Compatibilità Python", aggiungere
+   riga:
+   ```markdown
+   | Fedora 40+ | `dnf install python3` | 3.12+ (3.13 su F41+) | fallback `python3` |
+   | RHEL 9 / Rocky 9 | `dnf install python3.12` | 3.12 esatta | `python3.12` versionato |
+   ```
+
+4. **[README.md:334-335](README.md#L334-L335)** — sezione "Tested
+   Platforms": aggiungere
+   ```markdown
+   | Linux (Fedora / RHEL) | Supported |
+   ```
+
+### Test (opzionale TDD)
+
+5. **[tests/test_makefile_python_detection.py](tests/test_makefile_python_detection.py)**
+   — nuovo scenario:
+   ```python
+   def test_python3_fedora_scenario(self, tmp_path):
+       """PATH minimal con solo 'python3' presente (Fedora default):
+       il Makefile deve trovare python3 via fallback se versione >= 3.12.
+       """
+       # crea fake python3 wrapper >= 3.12, verifica check-python OK
+   ```
+
+### CHANGELOG
+
+6. **CHANGELOG.md** — entry sotto prossima release minor:
+   ```markdown
+   ### Added
+   - Supporto Fedora/RHEL in `make install-system-deps` (via `dnf`).
+   - Sezione README "Fedora / RHEL / Rocky / AlmaLinux" con istruzioni
+     install e nota su Csound.
+   ```
+
+---
+
+## Rollout Plan
+
+1. Branch `feat/fedora-system-requirements`.
+2. Verifica empirica pacchetti Fedora (docker o VM).
+3. Patch Makefile + README + CHANGELOG.
+4. `make tests` verde (su macchina sviluppatore, non Fedora).
+5. Smoke test su container Fedora 42 (`podman run --rm fedora:42 ...`).
+6. PR verso `main`, link a questa issue.
+7. Merge + bump patch (es. `v3.8.1` o `v3.9.0` se accorpato con altri
+   feat).
+
+---
+
+## Risks
+
+- **R-rischio basso** — Csound nei repo Fedora potrebbe essere troppo
+  vecchio per alcuni utenti. Mitigato dalla nota README su release
+  alternative.
+- **R-rischio basso** — RHEL 9 ha `python3` = 3.9 di sistema. Il branch
+  Makefile installa `python3` generico → non >= 3.12. Mitigato istruendo
+  RHEL/Rocky/AlmaLinux a usare `python3.12` esplicito (vedi README e
+  branch dnf alternativo).
+- **R-rischio molto basso** — `dnf` ha sintassi compatibile con `yum`;
+  nessuna distro target attuale richiede `yum` separato.
+
+---
+
+## Follow-up
+
+- **CI matrix Fedora** — aggiungere job GitHub Actions su container
+  `fedora:42` (e RHEL UBI 9) per prevenire regressioni future. PR
+  separata.
+- **Supporto openSUSE (`zypper`)** — aggiungere quarto branch se
+  richiesto.
+- **Detect RHEL e suggerire `python3.12` automaticamente** — se `dnf` è
+  presente ma `python3` < 3.12, fallback a `python3.12` esplicito senza
+  intervento manuale.

--- a/make/build.mk
+++ b/make/build.mk
@@ -122,7 +122,7 @@ CSOUND_FLAGS := \
 	--orc-path $(CSDIR)/main.orc \
 	--incdir $(PWD_DIR)/$(INCDIR) \
 	--ssdir $(PWD_DIR)/$(SSDIR) \
-	--sfdir $(PWD_DIR)/$(SFDIR) \
+	--sfdir $(abspath $(SFDIR)) \
 	--log-dir $(LOGDIR)
 
 ifeq ($(CACHE), true)
@@ -177,7 +177,7 @@ CSOUND_FLAGS := \
 	--orc-path $(CSDIR)/main.orc \
 	--incdir $(PWD_DIR)/$(INCDIR) \
 	--ssdir $(PWD_DIR)/$(SSDIR) \
-	--sfdir $(PWD_DIR)/$(SFDIR) \
+	--sfdir $(abspath $(SFDIR)) \
 	--log-dir $(LOGDIR)
 
 .PHONY: all

--- a/tests/e2e/test_cache_e2e.py
+++ b/tests/e2e/test_cache_e2e.py
@@ -22,9 +22,15 @@ Esegui con:
 
 import json
 import os
+import shutil
 import subprocess
 
 import pytest
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("csound") is None,
+    reason="csound non disponibile (Fedora/RHEL: usa RENDERER=numpy)",
+)
 
 PROJECT_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(__file__), '..', '..')
@@ -158,8 +164,8 @@ class TestFirstBuild:
         assert result.returncode == 0, f"make fallito:\n{output}"
 
         sfdir = tmp_path / "output"
-        assert (sfdir / "e2e_test_s1.aif").exists(), "s1.aif non trovato"
-        assert (sfdir / "e2e_test_s2.aif").exists(), "s2.aif non trovato"
+        assert (sfdir / "e2e_test__s1.aif").exists(), "s1.aif non trovato"
+        assert (sfdir / "e2e_test__s2.aif").exists(), "s2.aif non trovato"
 
     def test_manifest_created_with_both_streams(self, tmp_path):
         """Il manifest JSON contiene le entry per s1 e s2."""
@@ -301,13 +307,13 @@ class TestGarbageCollection:
         _write_yaml(tmp_path, _YAML_TWO_STREAMS)
         r1, _ = _make_build(tmp_path)
         assert r1.returncode == 0
-        assert (tmp_path / "output" / "e2e_test_s2.aif").exists()
+        assert (tmp_path / "output" / "e2e_test__s2.aif").exists()
 
         _write_yaml(tmp_path, _YAML_ONE_STREAM)
         r2, output2 = _make_build(tmp_path)
         assert r2.returncode == 0
 
-        assert not (tmp_path / "output" / "e2e_test_s2.aif").exists(), \
+        assert not (tmp_path / "output" / "e2e_test__s2.aif").exists(), \
             "s2.aif orfano non cancellato"
 
     def test_orphan_manifest_entry_removed(self, tmp_path):
@@ -358,5 +364,5 @@ class TestGarbageCollection:
         r2, _ = _make_build(tmp_path)
         assert r2.returncode == 0
 
-        assert (tmp_path / "output" / "e2e_test_s1.aif").exists(), \
+        assert (tmp_path / "output" / "e2e_test__s1.aif").exists(), \
             "s1.aif cancellato per errore dalla GC"

--- a/tests/e2e/test_engine_errors_e2e.py
+++ b/tests/e2e/test_engine_errors_e2e.py
@@ -13,6 +13,7 @@ e non materiale di lavoro dell'engine.
 import os
 import shutil
 import subprocess
+import sys
 
 import pytest
 
@@ -75,7 +76,7 @@ streams:
       reverse: true
 """
 
-REAL_SAMPLE = "001-0_0-3_0.wav"
+REAL_SAMPLE = "pino.wav"
 
 
 YAML_INVALID_PARAM_FORMAT = f"""\
@@ -183,7 +184,7 @@ def _write_yaml(tmp_path, name: str, content: str) -> str:
 
 def _run(yaml_path: str) -> subprocess.CompletedProcess:
     return subprocess.run(
-        ['python', 'src/main.py', yaml_path],
+        [sys.executable, 'src/main.py', yaml_path],
         cwd=PROJECT_ROOT,
         capture_output=True,
         text=True,
@@ -371,7 +372,7 @@ def test_e2e_invalid_renderer(tmp_path, cleanup_log):
     yaml_abs = _write_yaml(tmp_path, '09_invalid_renderer.yml', YAML_VALID_RENDERER)
     cleanup_log.append(_log_path_for(yaml_abs))
     result = subprocess.run(
-        ['python', 'src/main.py', yaml_abs, '--renderer', 'bogus'],
+        [sys.executable, 'src/main.py', yaml_abs, '--renderer', 'bogus'],
         cwd=PROJECT_ROOT, capture_output=True, text=True, timeout=60,
     )
     assert result.returncode != 0

--- a/tests/e2e/test_numpy_renderer_e2e.py
+++ b/tests/e2e/test_numpy_renderer_e2e.py
@@ -186,8 +186,8 @@ class TestNumpyStems:
         assert result.returncode == 0, f"make fallito:\n{output}"
 
         sfdir = tmp_path / "output"
-        assert (sfdir / "e2e_numpy_test_s1.aif").exists(), "s1.aif non trovato"
-        assert (sfdir / "e2e_numpy_test_s2.aif").exists(), "s2.aif non trovato"
+        assert (sfdir / "e2e_numpy_test__s1.aif").exists(), "s1.aif non trovato"
+        assert (sfdir / "e2e_numpy_test__s2.aif").exists(), "s2.aif non trovato"
 
     def test_no_mix_file_created(self, tmp_path):
         """In STEMS mode non viene creato il file mix (senza suffisso stream)."""

--- a/tests/e2e/test_reaper_export_e2e.py
+++ b/tests/e2e/test_reaper_export_e2e.py
@@ -204,8 +204,8 @@ class TestReaperStemsExport:
         result, output, _ = _make_build(tmp_path, stems=True)
         assert result.returncode == 0, f"make fallito:\n{output}"
         sfdir = tmp_path / "output"
-        assert (sfdir / "e2e_reaper_test_s1.aif").exists(), "s1.aif non trovato"
-        assert (sfdir / "e2e_reaper_test_s2.aif").exists(), "s2.aif non trovato"
+        assert (sfdir / "e2e_reaper_test__s1.aif").exists(), "s1.aif non trovato"
+        assert (sfdir / "e2e_reaper_test__s2.aif").exists(), "s2.aif non trovato"
 
 
 # =============================================================================

--- a/tests/test_makefile_python_detection.py
+++ b/tests/test_makefile_python_detection.py
@@ -61,13 +61,56 @@ def _make_fake_python(tmp_path: Path, name: str, version: str) -> Path:
     return bin_path
 
 
+def _make_fake_which(tmp_path: Path) -> None:
+    """
+    Crea un `which` falso in tmp_path che cerca solo in tmp_path.
+
+    Previene che `$(shell which pythonX.Y)` nel Makefile trovi binari di sistema
+    (es. /usr/bin/python3.12) quando il test vuole un PATH isolato.
+    """
+    script = textwrap.dedent(f"""\
+        #!/bin/sh
+        if [ -x "{tmp_path}/$1" ]; then
+            echo "{tmp_path}/$1"
+            exit 0
+        fi
+        exit 1
+    """)
+    bin_path = tmp_path / "which"
+    bin_path.write_text(script)
+    bin_path.chmod(0o755)
+
+
+def _make_python3_sentinel(tmp_path: Path) -> None:
+    """
+    Crea un python3 sentinel in tmp_path che fallisce sempre.
+
+    Blocca il fallback `$(shell python3 -c ...)` del Makefile dal trovare
+    python3 di sistema quando il test simula assenza di Python valido.
+    Solo creato se python3 non è già presente in tmp_path.
+    """
+    script = textwrap.dedent("""\
+        #!/bin/sh
+        exit 1
+    """)
+    bin_path = tmp_path / "python3"
+    bin_path.write_text(script)
+    bin_path.chmod(0o755)
+
+
 def _run_make(target: str, env_path: str, extra_env: dict | None = None) -> subprocess.CompletedProcess:
     """
     Esegue `make -n <target>` con PATH controllato.
 
     Include /usr/bin:/bin in PATH per permettere a make stesso di trovare shell/sed/awk.
-    Aggiunge tmp_path in testa per priorità.
+    Aggiunge tmp_path in testa con `which` falso per isolare la detection Python
+    dai binari di sistema (es. /usr/bin/python3.12 su Fedora).
     """
+    env_path_obj = Path(env_path)
+    _make_fake_which(env_path_obj)
+    if not (env_path_obj / "python3").exists():
+        _make_python3_sentinel(env_path_obj)
+
     env = os.environ.copy()
     env["PATH"] = f"{env_path}:/usr/bin:/bin"
     if extra_env:


### PR DESCRIPTION
## Summary

Risolve la mancanza di supporto Fedora/RHEL nelle system requirements (#58) e completa l'allineamento dei test e2e al fix di naming (#56).

## Commit 1 — feat(install): supporto Fedora/RHEL via dnf

- **Makefile**: nuovo branch `dnf` in `install-system-deps` (installa `python3` + `sox`; logga istruzioni per Csound).
- **README**: nuova sezione "Fedora / RHEL / Rocky / AlmaLinux" + righe nelle tabelle "Compatibilità Python" e "Platform Support".
- **CHANGELOG**: entry sezione `[Unreleased]`.
- **Plan**: `docs/plans/2026-05-21-002-feat-fedora-system-requirements-plan.md`.

**Findings empirici (`fedora:42`, 2026-05-21):**
- `python3` 3.13.13 ✓, `sox` 14.4.2.0 ✓.
- `csound` NON disponibile nei repo Fedora ufficiali né in RPM Fusion (free/nonfree). Le release upstream Csound non distribuiscono binari Linux x86_64.
- Strategia documentata: usare `RENDERER=numpy` oppure compilare Csound dai sorgenti.

## Commit 2 — fix(tests,build): allinea e2e a `__` + isola detection Python

- `tests/e2e/{cache,numpy_renderer,reaper_export}_e2e.py`: assertion filename `_` → `__` (segue il fix #56) + `skipif csound` su `test_cache_e2e`.
- `tests/e2e/test_engine_errors_e2e.py`: `REAL_SAMPLE = pino.wav`, `sys.executable` invece di `python` hardcoded.
- `tests/test_makefile_python_detection.py`: nuove utility `_make_fake_which` e `_make_python3_sentinel` per isolare la detection Python del Makefile dai binari di sistema (sblocca i 3 fail pre-esistenti su Fedora dove `/usr/bin/python3.13` era visibile).
- `make/build.mk`: `--sfdir` usa `$(abspath $(SFDIR))` invece di `$(PWD_DIR)/$(SFDIR)` per supportare path già assoluti passati da test e2e (tmp_path).

## Tests

- `make tests`: 4082 pass, 3 fail Makefile detection pre-esistenti su questa macchina (gestiti dal commit 2, ma serve verifica su sistema target Fedora). Su sistemi non-Fedora dove `/usr/bin/python3.X` di sistema non interferisce, i 3 test dovrebbero passare con il fix di isolamento PATH.
- `make e2e-tests`: non eseguito sulla macchina di sviluppo (manca Csound). Il commit 2 introduce `skipif csound` su `test_cache_e2e` per permettere l'esecuzione su Fedora.

## Test plan

- [ ] Smoke test su container `fedora:42` pulito:
  ```
  podman run --rm -v "$PWD":/repo:Z -w /repo fedora:42 bash -c "
    dnf install -y make sudo findutils &&
    make install-system-deps &&
    make setup &&
    make tests &&
    make FILE=PGE_test RENDERER=numpy all
  "
  ```
- [ ] Verifica su VM Fedora 42 nativa che `make all RENDERER=numpy` produca file `.aif` validi.
- [ ] Verifica su RHEL 9 / Rocky 9 che il fallback a `python3.12` esplicito funzioni.

Closes #58
Refs #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)