### PR TITLE
feat(makefile): REAPER_REUSE_TAB per reload single-tab (issue #59)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Aggiunto
 
+- Flag `REAPER_REUSE_TAB` nel `Makefile` (default `false`): se `true` con
+  `REAPER=true`, prima di aprire il `.rpp` aggiornato lo script Lua
+  `generated/open_reaper_tab.lua` scorre le tab REAPER aperte (`EnumProjects`)
+  e chiude solo quella con path assoluto matching (action `40860` "Close
+  current project tab"), poi apre nuova tab (action `40859`). Le altre tab
+  restano intatte. Alternativa meno distruttiva ad `AUTOKILL_REAPER` per
+  rebuild ripetuti dello stesso YAML. Risolve issue #59.
+- Refactor `make/build.mk`: estratta macro `emit_open_reaper_lua` condivisa
+  da `autopen_stems` e `autopen_single` per centralizzare la generazione
+  dello ReaScript Lua (branch condizionale su `REAPER_REUSE_TAB`).
 - Supporto Fedora / RHEL / Rocky / AlmaLinux nel branch `dnf` di
   `make install-system-deps` (issue #58). Installa `python3` + `sox`;
   stampa istruzioni per Csound (non disponibile nei repo Fedora / RPM

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ CACHEDIR := cache
 # --- Flags configurabili ---
 AUTOKILL ?= true
 AUTOKILL_REAPER ?= false
+# Issue #59: chiude tab esistente con stesso path prima di aprire nuova tab.
+# Ortogonale a AUTOKILL_REAPER (che ha precedenza se true).
+REAPER_REUSE_TAB ?= false
 AUTOPEN ?= true
 AUTOVISUAL ?= false
 SHOWSTATIC ?= true
@@ -121,6 +124,7 @@ help:
 	@echo "  REAPER=true/false        - Esporta progetto Reaper .rpp"
 	@echo "  REAPER_PATH=file.rpp     - Path output .rpp (default: \$$(FILE).rpp)"
 	@echo "  AUTOKILL_REAPER=true/false - Chiudi REAPER prima del build e riapri dopo"
+	@echo "  REAPER_REUSE_TAB=true/false - Chiudi tab esistente stesso .rpp e riapri (single-tab reload)"
 
 .PHONY: install-system-deps check-system-deps
 

--- a/docs/plans/2026-05-22-001-feat-reaper-reuse-tab-plan.md
+++ b/docs/plans/2026-05-22-001-feat-reaper-reuse-tab-plan.md
@@ -1,0 +1,179 @@
+# Plan: REAPER_REUSE_TAB — reload single-tab senza autokill
+
+**Data:** 2026-05-22
+**Branch:** `feat/reaper-reuse-tab`
+**Issue:** [#59](https://github.com/DMGiulioRomano/PythonGranularEngine/issues/59)
+**Tipo:** feature
+**Dipende da:** issue #17 (PR già mergiata: `fix/reaper-autokill-multitab`)
+
+## Obiettivo
+
+Aggiungere flag `REAPER_REUSE_TAB=true` (default `false`) che, prima di aprire
+il `.rpp` aggiornato, chiude la tab REAPER che già punta a quel path assoluto e
+ne apre una nuova con lo stesso file. Altre tab restano intatte.
+
+Caso d'uso: rebuild dello stesso YAML con REAPER aperto, senza ricorrere a
+`AUTOKILL_REAPER=true` (che chiude TUTTO REAPER perdendo le altre tab e le
+modifiche manuali non salvate).
+
+## Stato attuale (impact analysis)
+
+### File coinvolti
+
+| File | Ruolo attuale | Modifica |
+|------|---------------|----------|
+| `Makefile` L52-53 | flag `AUTOKILL`, `AUTOKILL_REAPER` | aggiungere `REAPER_REUSE_TAB ?= false` accanto |
+| `Makefile` L121-123 (`help`) | help vars REAPER | aggiungere riga `REAPER_REUSE_TAB=true/false` |
+| `make/build.mk` L74-92 | macro `autopen_stems` (genera `open_reaper_tab.lua`) | branch condizionale: se `REAPER_REUSE_TAB=true` emette anche loop `EnumProjects` + `SelectProjectInstance` + action `40860` prima del `40859` |
+| `make/build.mk` L94-112 | macro `autopen_single` (idem) | identica modifica della `autopen_stems` |
+| `docs/reaper-workflow.md` | doc workflow REAPER | nuova sezione `## REAPER_REUSE_TAB`, aggiornare tabella env vars |
+| `docs/reaper-workflow.md` riga 12 | tabella env vars | aggiungere riga `REAPER_REUSE_TAB` |
+| `tests/e2e/test_reaper_makefile_e2e.py` | E2E del flusso REAPER (skip se REAPER non installato) | nuovo test che verifica generazione `.lua` con clausola `EnumProjects` + `40860` quando `REAPER_REUSE_TAB=true` |
+| `CHANGELOG.md` | changelog | entry `### Added` per `REAPER_REUSE_TAB` |
+
+### File NON toccati
+
+- `src/main.py`, `src/export/reaper_project_writer.py`: nessuna logica di
+  apertura tab, solo scrittura `.rpp`. Niente impatto.
+- `tests/test_main.py`, `tests/export/test_reaper_project_writer.py`: idem.
+- `make/utils.mk` (target `reaper-stop`): usato solo da `AUTOKILL_REAPER=true`;
+  `REAPER_REUSE_TAB` è ortogonale.
+
+### Interazioni con flag esistenti
+
+Matrice attesa (da issue #59, replicata + estesa):
+
+| `REAPER_REUSE_TAB` | `AUTOKILL_REAPER` | Effetto su rebuild stesso YAML |
+|---|---|---|
+| `false` (default) | `false` | nuova tab + vecchia tab stale (comportamento attuale post-#17) |
+| `true`            | `false` | chiude tab con path matching, apre nuova con stesso path. Altre tab intatte |
+| qualsiasi         | `true`  | `AUTOKILL_REAPER` ha precedenza: quit REAPER + riapre (perde tutto) — `REAPER_REUSE_TAB` ignorato |
+
+`AUTOKILL_REAPER=true` ha precedenza perché elimina del tutto il problema
+(processo morto, niente tab da riusare). Documentare esplicitamente.
+
+## Design
+
+### Script Lua generato (condizionale)
+
+Modalità default (`REAPER_REUSE_TAB=false`, immutata):
+
+```lua
+reaper.Main_OnCommand(40859, 0)         -- New project tab
+reaper.Main_openProject("/abs/path/brano.rpp")
+```
+
+Modalità `REAPER_REUSE_TAB=true`:
+
+```lua
+local target = "/abs/path/brano.rpp"
+local i = 0
+while true do
+  local proj, path = reaper.EnumProjects(i)
+  if proj == nil then break end
+  if path == target then
+    reaper.SelectProjectInstance(proj)
+    reaper.Main_OnCommand(40860, 0)     -- Close current project tab
+    break
+  end
+  i = i + 1
+end
+reaper.Main_OnCommand(40859, 0)         -- New project tab
+reaper.Main_openProject(target)
+```
+
+Action ID `40860` = "File: Close current project tab" (stabile, ReaScript API).
+Loop while + `EnumProjects(i)` finche' ritorna `nil`: ReaScript NON espone
+`CountProjects` (errore originale del primo draft); il terminatore corretto
+e' il `nil` ritornato dall'API quando `i` supera l'ultimo indice.
+
+Se la tab non esiste (primo build di quel YAML in sessione), il loop non fa
+nulla e il comportamento collassa nella modalità default — niente regressioni.
+
+### Generazione Makefile
+
+In `make/build.mk`, sostituire il `printf` corrente con un blocco shell
+condizionale:
+
+```make
+if [ "$(REAPER_REUSE_TAB)" = "true" ]; then \
+  printf 'local target = "%s"\nfor i = 0, reaper.CountProjects() - 1 do\n  local _, path = reaper.EnumProjects(i)\n  if path == target then\n    reaper.SelectProjectInstance(reaper.EnumProjects(i))\n    reaper.Main_OnCommand(40860, 0)\n    break\n  end\nend\nreaper.Main_OnCommand(40859, 0)\nreaper.Main_openProject(target)\n' "$$abs_rpp" \
+    > $(GENDIR)/open_reaper_tab.lua; \
+else \
+  printf 'reaper.Main_OnCommand(40859, 0)\nreaper.Main_openProject("%s")\n' "$$abs_rpp" \
+    > $(GENDIR)/open_reaper_tab.lua; \
+fi
+```
+
+Replicato identicamente in `autopen_stems` e `autopen_single`.
+
+Alternativa scartata: heredoc esterno con file template fisso + `sed` per
+sostituire `__TARGET__`. Riduce duplicazione ma introduce file `.lua.tmpl` da
+mantenere; il `printf` inline è coerente con lo stile #17.
+
+## Test plan (TDD)
+
+E2E (richiede `make e2e-tests` con REAPER installato):
+
+1. **Test rosso `test_reaper_reuse_tab_generates_close_clause`**:
+   - `make REAPER=true REAPER_REUSE_TAB=true AUTOPEN=false ...`
+   - Verifica che `$(GENDIR)/open_reaper_tab.lua` contenga `EnumProjects`,
+     `SelectProjectInstance`, `Main_OnCommand(40860`.
+
+2. **Test rosso `test_reaper_default_skips_close_clause`**:
+   - Stesso target senza `REAPER_REUSE_TAB`.
+   - Verifica che il `.lua` NON contenga `EnumProjects` (regression guard sul
+     comportamento #17).
+
+3. **Test rosso `test_reaper_reuse_tab_lua_syntax_valid`** (se `lua` o `luac`
+   disponibile): `luac -p $(GENDIR)/open_reaper_tab.lua` exit code 0. Skip
+   se interprete Lua non installato.
+
+Verde: implementare il branch `REAPER_REUSE_TAB=true` nelle due macro.
+
+Refactor: estrarre il `printf` duplicato in una funzione make (`define
+emit_open_reaper_lua`) se la duplicazione tra `autopen_stems` e
+`autopen_single` supera la soglia di tolleranza dopo il diff.
+
+Unit/integration: nessun nuovo unit test (logica puramente shell/Make).
+`make tests` deve continuare a passare invariato.
+
+## Acceptance (da issue)
+
+1. `REAPER_REUSE_TAB=true make all` su YAML già aperto in tab → tab sostituita,
+   altre tab restano. Verificato manualmente su macOS con REAPER 7.x.
+2. Action ID `40860` verificato su REAPER >= 6.80 (stesso minimo già richiesto
+   per `40859`).
+3. `REAPER_REUSE_TAB=false` (default) genera `.lua` identico bit-per-bit
+   all'attuale (test #2 in test plan).
+4. `docs/reaper-workflow.md` aggiornato.
+5. `make help` mostra `REAPER_REUSE_TAB=true/false`.
+
+## Rischi
+
+- **Action ID `40860` rinominata/rimossa**: stabile dal 2010, rischio
+  trascurabile. ReaScript API conserva ID legacy.
+- **Path matching case-sensitive su macOS**: `EnumProjects` ritorna il path
+  così come REAPER l'ha salvato in memoria. Su HFS+/APFS case-insensitive il
+  match string `==` può fallire se la tab è stata aperta con cap differenti.
+  Mitigazione: documentare; eventuale `string.lower()` su entrambi i lati se
+  emerge come problema reale (non ora, YAGNI).
+- **Tab con modifiche non salvate**: action `40860` chiude la tab corrente. Se
+  ci sono unsaved changes REAPER mostra il dialog di salvataggio (stesso
+  comportamento di un Cmd+W manuale). Da documentare.
+- **Race condition `40860` → `40859`**: i due `Main_OnCommand` sono sincroni
+  nell'event loop REAPER; non serve `defer`.
+
+## Out of scope
+
+- Detection automatica modifiche `onset/duration` (sempre rebuild).
+- Sync bidirezionale REAPER → YAML.
+- Auto-save della tab prima di chiuderla.
+
+## Riferimenti
+
+- Issue [#59](https://github.com/DMGiulioRomano/PythonGranularEngine/issues/59)
+- Issue parent [#17](https://github.com/DMGiulioRomano/PythonGranularEngine/issues/17)
+- Plan precedente: `docs/plans/done/2026-05-15-001-fix-reaper-autokill-multitab-plan.md`
+- ReaScript API: [`Main_OnCommand`](https://www.reaper.fm/sdk/reascript/reascripthelp.html#Main_OnCommand), [`EnumProjects`](https://www.reaper.fm/sdk/reascript/reascripthelp.html#EnumProjects), [`SelectProjectInstance`](https://www.reaper.fm/sdk/reascript/reascripthelp.html#SelectProjectInstance), [`CountProjects`](https://www.reaper.fm/sdk/reascript/reascripthelp.html#CountProjects)
+- REAPER action IDs: `40859` New project tab, `40860` Close current project tab

--- a/docs/reaper-workflow.md
+++ b/docs/reaper-workflow.md
@@ -10,6 +10,7 @@ audio, abilitando l'ascolto e l'editing immediato del materiale generato.
 | `REAPER` | `true` | Se `true`, il pipeline scrive un `.rpp` accanto agli `.aif`. |
 | `REAPER_PATH` | `$(FILE).rpp` | Path output del `.rpp`. Il default lega il nome del progetto al nome del YAML — ogni YAML apre una propria tab in REAPER. |
 | `AUTOKILL_REAPER` | `false` | Se `true` con `REAPER=true`, chiude REAPER prima del build, riscrive il `.rpp`, poi riapre REAPER. Utile quando si modificano `onset` o `duration` degli stream e REAPER ha gia' il progetto aperto. |
+| `REAPER_REUSE_TAB` | `false` | Se `true` con `REAPER=true`, prima di aprire il `.rpp` chiude la tab REAPER esistente con stesso path assoluto. Reload single-tab senza chiudere tutto REAPER (issue #59). |
 | `AUTOPEN` | `true` | Se `true`, apre il `.rpp` in REAPER alla fine del build. |
 
 ## Multi-tab automatico
@@ -59,6 +60,46 @@ vengono perse senza prompt. Scelta intenzionale per garantire automazione non
 bloccante — `osascript ... quit` veniva intercettato da REAPER che mostrava
 comunque il dialog "Save changes?".
 
+## Quando usare `REAPER_REUSE_TAB`
+
+Alternativa meno distruttiva a `AUTOKILL_REAPER`. Caso d'uso: rebuild ripetuti
+dello stesso YAML con REAPER aperto su piu' progetti.
+
+Con `REAPER_REUSE_TAB=true` lo script Lua, prima di creare una nuova tab, scorre
+le tab aperte (`reaper.EnumProjects`) e chiude solo quella che punta allo stesso
+path assoluto del `.rpp` corrente (action `40860` "Close current project tab").
+Le altre tab restano intatte.
+
+```lua
+local target = "/abs/path/brano.rpp"
+local i = 0
+while true do
+  local proj, path = reaper.EnumProjects(i)
+  if proj == nil then break end             -- terminator: ReaScript API non espone CountProjects
+  if path == target then
+    reaper.SelectProjectInstance(proj)
+    reaper.Main_OnCommand(40860, 0)         -- Close current project tab
+    break
+  end
+  i = i + 1
+end
+reaper.Main_OnCommand(40859, 0)             -- New project tab
+reaper.Main_openProject(target)
+```
+
+Se la tab non esiste (prima apertura del YAML in sessione), il loop e' no-op
+e il comportamento collassa nel default (singola tab nuova).
+
+**Precedenza flag:** `AUTOKILL_REAPER=true` ha precedenza su `REAPER_REUSE_TAB`
+— se REAPER viene chiuso prima del build, non c'e' tab da riusare.
+
+**Limitazioni:**
+- Path matching e' `==` esatto: se la tab e' stata aperta con cap differenti
+  su filesystem case-insensitive (HFS+/APFS) il match puo' fallire.
+- Action `40860` chiude la tab corrente; se contiene modifiche non salvate
+  REAPER mostra il dialog di salvataggio (stesso comportamento di un Cmd+W
+  manuale).
+
 ## Requisiti
 
 - macOS: REAPER installato in `/Applications/REAPER.app`.
@@ -71,7 +112,7 @@ operativo (puo' sostituire il progetto corrente invece di aprire una tab).
 
 ## Riferimenti
 
-- Issue [#17](https://github.com/DMGiulioRomano/PythonGranularEngine/issues/17)
-- Plan: `docs/plans/done/2026-05-15-001-fix-reaper-autokill-multitab-plan.md`
+- Issue [#17](https://github.com/DMGiulioRomano/PythonGranularEngine/issues/17), [#59](https://github.com/DMGiulioRomano/PythonGranularEngine/issues/59)
+- Plan: `docs/plans/done/2026-05-15-001-fix-reaper-autokill-multitab-plan.md`, `docs/plans/2026-05-22-001-feat-reaper-reuse-tab-plan.md`
 - [REAPER CLI flags](https://github.com/ReaTeam/Doc/blob/master/REAPER-CLI.md)
 - [ReaScript API](https://www.reaper.fm/sdk/reascript/reascript.php)

--- a/make/build.mk
+++ b/make/build.mk
@@ -71,17 +71,30 @@ endif
 # esecuzione genera al volo un ReaScript Lua che esegue action 40859
 # (New project tab) + Main_openProject(<abs path>). Multi-tab deterministico,
 # indipendente dalle pref utente (issue #17). Fallback: open -a REAPER.
+# emit_open_reaper_lua: scrive $(GENDIR)/open_reaper_tab.lua usando $$abs_rpp.
+# Se REAPER_REUSE_TAB=true, prepend clausola che chiude eventuale tab con
+# path matching (action 40860) prima di aprire nuova tab (action 40859).
+# Issue #59.
+define emit_open_reaper_lua
+mkdir -p $(GENDIR); \
+rpp_dir="$$(dirname "$(REAPER_PATH)")"; \
+rpp_base="$$(basename "$(REAPER_PATH)")"; \
+abs_rpp="$$(cd "$$rpp_dir" 2>/dev/null && pwd)/$$rpp_base"; \
+if [ "$(REAPER_REUSE_TAB)" = "true" ]; then \
+	printf 'local target = "%s"\nlocal i = 0\nwhile true do\n  local proj, path = reaper.EnumProjects(i)\n  if proj == nil then break end\n  if path == target then\n    reaper.SelectProjectInstance(proj)\n    reaper.Main_OnCommand(40860, 0)\n    break\n  end\n  i = i + 1\nend\nreaper.Main_OnCommand(40859, 0)\nreaper.Main_openProject(target)\n' "$$abs_rpp" \
+		> $(GENDIR)/open_reaper_tab.lua; \
+else \
+	printf 'reaper.Main_OnCommand(40859, 0)\nreaper.Main_openProject("%s")\n' "$$abs_rpp" \
+		> $(GENDIR)/open_reaper_tab.lua; \
+fi; \
+"$(REAPER_BIN)" -nonewinst "$(GENDIR)/open_reaper_tab.lua"
+endef
+
 define autopen_stems
 @if [ "$(AUTOPEN)" = "true" ] && [ "$(OPEN_CMD)" != "" ]; then \
 	if [ "$(REAPER)" = "true" ]; then \
 		if [ "$(HAS_REAPER)" = "true" ] && $(REAPER_PGREP) >/dev/null 2>&1; then \
-			mkdir -p $(GENDIR); \
-			rpp_dir="$$(dirname "$(REAPER_PATH)")"; \
-			rpp_base="$$(basename "$(REAPER_PATH)")"; \
-			abs_rpp="$$(cd "$$rpp_dir" 2>/dev/null && pwd)/$$rpp_base"; \
-			printf 'reaper.Main_OnCommand(40859, 0)\nreaper.Main_openProject("%s")\n' "$$abs_rpp" \
-				> $(GENDIR)/open_reaper_tab.lua; \
-			"$(REAPER_BIN)" -nonewinst "$(GENDIR)/open_reaper_tab.lua"; \
+			$(emit_open_reaper_lua); \
 		else \
 			$(OPEN_REAPER_CMD) "$(REAPER_PATH)"; \
 		fi; \
@@ -95,13 +108,7 @@ define autopen_single
 @if [ "$(AUTOPEN)" = "true" ] && [ "$(OPEN_CMD)" != "" ]; then \
 	if [ "$(REAPER)" = "true" ]; then \
 		if [ "$(HAS_REAPER)" = "true" ] && $(REAPER_PGREP) >/dev/null 2>&1; then \
-			mkdir -p $(GENDIR); \
-			rpp_dir="$$(dirname "$(REAPER_PATH)")"; \
-			rpp_base="$$(basename "$(REAPER_PATH)")"; \
-			abs_rpp="$$(cd "$$rpp_dir" 2>/dev/null && pwd)/$$rpp_base"; \
-			printf 'reaper.Main_OnCommand(40859, 0)\nreaper.Main_openProject("%s")\n' "$$abs_rpp" \
-				> $(GENDIR)/open_reaper_tab.lua; \
-			"$(REAPER_BIN)" -nonewinst "$(GENDIR)/open_reaper_tab.lua"; \
+			$(emit_open_reaper_lua); \
 		else \
 			$(OPEN_REAPER_CMD) "$(REAPER_PATH)"; \
 		fi; \

--- a/tests/e2e/test_reaper_makefile_e2e.py
+++ b/tests/e2e/test_reaper_makefile_e2e.py
@@ -136,6 +136,87 @@ class TestAutokillReaperWiring:
 
 
 @pytest.mark.e2e
+class TestReaperReuseTabFlag:
+    """
+    Flag REAPER_REUSE_TAB=true emette ReaScript Lua con clausola di chiusura
+    tab esistente (action 40860 + EnumProjects) prima della new tab (40859).
+
+    Issue: #59 — REAPER_REUSE_TAB flag per reload single-tab senza autokill
+    """
+
+    # Strategia test: make -n espande sempre entrambi i rami shell di un
+    # `if`, quindi cercare letteralmente `Main_OnCommand(40860` nello stdout
+    # darebbe falso-positivo per il default. Verifichiamo invece la guard
+    # `if [ "<val>" = "true" ]; then printf 'local target ...` che riflette
+    # il valore di REAPER_REUSE_TAB al momento dell'espansione make.
+    _REUSE_GUARD_RE = (
+        r'if \[ "(?P<val>true|false)" = "true" \];\s*then\s+'
+        r'printf \'local target'
+    )
+
+    def test_reuse_tab_true_selects_close_branch(self):
+        """
+        Con REAPER_REUSE_TAB=true la guard del branch reuse vale "true",
+        quindi il printf con EnumProjects + 40860 verra' eseguito a runtime.
+        """
+        import re
+        result = _run_make([
+            '-n', 'all',
+            'FILE=foo',
+            'REAPER=true',
+            'AUTOPEN=true',
+            'PRECLEAN=false',
+            'REAPER_REUSE_TAB=true',
+        ])
+        assert result.returncode == 0, (
+            f"`make -n all` fallito.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        m = re.search(self._REUSE_GUARD_RE, result.stdout)
+        assert m is not None, (
+            f"Guard REAPER_REUSE_TAB non trovata.\nstdout: {result.stdout}"
+        )
+        assert m.group('val') == 'true', (
+            f"REAPER_REUSE_TAB=true atteso guard 'true', got '{m.group('val')}'.\n"
+            f"stdout: {result.stdout}"
+        )
+        # Il printf del branch reuse deve includere action 40860 e EnumProjects
+        assert "Main_OnCommand(40860" in result.stdout
+        assert "EnumProjects" in result.stdout
+        # Regression: reaper.CountProjects NON esiste in ReaScript API.
+        # Loop deve usare while + EnumProjects(i) == nil come terminator.
+        assert "CountProjects" not in result.stdout, (
+            f"reaper.CountProjects non esiste in ReaScript API: usare "
+            f"while + EnumProjects(i)==nil.\nstdout: {result.stdout}"
+        )
+
+    def test_reuse_tab_default_selects_new_tab_branch(self):
+        """
+        Default (REAPER_REUSE_TAB non settato): guard reuse vale "false",
+        verra' eseguito solo il printf legacy (action 40859).
+        Regression guard sul comportamento issue #17.
+        """
+        import re
+        result = _run_make([
+            '-n', 'all',
+            'FILE=foo',
+            'REAPER=true',
+            'AUTOPEN=true',
+            'PRECLEAN=false',
+        ])
+        assert result.returncode == 0
+        m = re.search(self._REUSE_GUARD_RE, result.stdout)
+        assert m is not None, (
+            f"Guard REAPER_REUSE_TAB non trovata.\nstdout: {result.stdout}"
+        )
+        assert m.group('val') == 'false', (
+            f"REAPER_REUSE_TAB default atteso guard 'false', got '{m.group('val')}'.\n"
+            f"stdout: {result.stdout}"
+        )
+        # Action 40859 (New tab) deve restare presente in entrambi i rami
+        assert "Main_OnCommand(40859" in result.stdout
+
+
+@pytest.mark.e2e
 class TestReaperPathDefault:
     """Default REAPER_PATH = $(FILE).rpp per multi-tab per YAML."""
 


### PR DESCRIPTION
Closes #59.

## Summary

- Nuovo flag `REAPER_REUSE_TAB=true` (default `false`): chiude la tab REAPER con path assoluto matching prima di aprire nuova tab dello stesso `.rpp`. Reload single-tab senza chiudere tutto REAPER (vs `AUTOKILL_REAPER`).
- Refactor: estratta macro `emit_open_reaper_lua` in `make/build.mk` condivisa da `autopen_stems` e `autopen_single`.
- Loop Lua usa pattern `while true` + `EnumProjects(i) == nil` (ReaScript API NON espone `reaper.CountProjects`).

## Matrice comportamento

| `REAPER_REUSE_TAB` | `AUTOKILL_REAPER` | Effetto rebuild stesso YAML |
|---|---|---|
| `false` (default) | `false` | nuova tab + vecchia stale (post-#17) |
| `true`            | `false` | chiude tab con path matching, apre nuova. Altre tab intatte |
| qualsiasi         | `true`  | `AUTOKILL_REAPER` ha precedenza: quit REAPER + riapre |

## Script Lua generato (modalita' reuse)

```lua
local target = "/abs/path/brano.rpp"
local i = 0
while true do
  local proj, path = reaper.EnumProjects(i)
  if proj == nil then break end
  if path == target then
    reaper.SelectProjectInstance(proj)
    reaper.Main_OnCommand(40860, 0)   -- Close current project tab
    break
  end
  i = i + 1
end
reaper.Main_OnCommand(40859, 0)       -- New project tab
reaper.Main_openProject(target)
```

## Files

- `Makefile` — flag `REAPER_REUSE_TAB ?= false` + riga `help`
- `make/build.mk` — macro `emit_open_reaper_lua` con branch condizionale
- `docs/reaper-workflow.md` — sezione "Quando usare REAPER_REUSE_TAB" + limitazioni
- `docs/plans/2026-05-22-001-feat-reaper-reuse-tab-plan.md` — plan
- `CHANGELOG.md` — entry Aggiunto
- `tests/e2e/test_reaper_makefile_e2e.py` — classe `TestReaperReuseTabFlag` (2 test) con regression guard su `CountProjects`

## Test plan

- [x] `make tests` → 4085 passed
- [x] `pytest tests/e2e/test_reaper_makefile_e2e.py -m e2e` → 7 passed, 1 skipped (REAPER attivo durante run)
- [x] Verifica manuale macOS: `REAPER_REUSE_TAB=true make all FILE=PGE_test` con REAPER aperto su 2 tab → tab `PGE_test.rpp` sostituita, altra tab intatta
- [ ] CI

## Riferimenti

- Issue [#59](https://github.com/DMGiulioRomano/PythonGranularEngine/issues/59), parent [#17](https://github.com/DMGiulioRomano/PythonGranularEngine/issues/17)
- ReaScript API: [`EnumProjects`](https://www.reaper.fm/sdk/reascript/reascripthelp.html#EnumProjects), [`SelectProjectInstance`](https://www.reaper.fm/sdk/reascript/reascripthelp.html#SelectProjectInstance), [`Main_OnCommand`](https://www.reaper.fm/sdk/reascript/reascripthelp.html#Main_OnCommand)
- Action IDs: `40859` New project tab, `40860` Close current project tab