### PR TITLE
feat(envelopes): interp type per-punto (issue #54)

### DIFF
--- a/docs/plans/2026-05-22-003-feat-envelope-per-point-interp-plan.md
+++ b/docs/plans/2026-05-22-003-feat-envelope-per-point-interp-plan.md
@@ -1,0 +1,300 @@
+---
+title: "feat(envelopes): formato envelope con interp type per-punto (issue #54)"
+type: feat
+status: active
+date: 2026-05-22
+issue: 54
+branch: feature/issue-54-envelope-interp-per-point
+---
+
+# feat(envelopes): formato envelope con interp type per-punto
+
+## Overview
+
+Supporto sintassi envelope dove ogni breakpoint dichiara il proprio tipo di interpolazione, applicato al segmento dal punto fino al successivo. Oggi `type` (`linear`/`cubic`/`step`) è globale per l'intero envelope. Per curve miste serve attualmente spezzare in envelope annidati — sintassi pesante. Issue #54 propone tupla 3-elem `[t, v, type]` e dict per-punto `{t, v, type}` come additivi al formato corrente.
+
+---
+
+## Problem Frame
+
+`Envelope._parse_segments` crea **un solo `NormalSegment`** contenente tutti i breakpoint. La strategia è scelta una volta a livello `Envelope.__init__` da `extract_interp_type` o dal dict `type`. Quando il compositore vuole attacco cubic + decay lineare deve:
+
+1. Spezzare in due Envelope annidati (verboso, perde leggibilità)
+2. Approssimare con cubic+plateau (non equivalente)
+
+Inoltre `_compute_fritsch_carlson_tangents` opera su tutti i breakpoint senza distinzione: cubic globale genera tangenti su segmenti che il compositore vorrebbe lineari, producendo overshoot indesiderato.
+
+---
+
+## Requirements Trace
+
+- **R1.** Lista accetta breakpoint 3-elem `[t, v, type]` dove `type ∈ {linear, cubic, step}` — applicato a segmento `i → i+1`.
+- **R2.** Dict accetta point come `{t, v, type}` in `points`, oltre a `[t, v]`.
+- **R3.** Lista accetta mix 2-elem + 3-elem nello stesso envelope.
+- **R4.** Globale (`dict.type` o wrapper compatto `interp`) fa da **default**; per-punto override.
+- **R5.** Ultimo punto + `type` → warning a log, valore ignorato (no errore breaking).
+- **R6.** `type` invalido → `InvalidFieldValueError` con `field_path`.
+- **R7.** Backward compat assoluta: tutti gli YAML esistenti producono output bit-identico.
+- **R8.** Wrapper compatto `[pattern, end_time, n_reps, ...]` con pattern contenente 3-tuple replica i type per-punto in ogni ciclo.
+- **R9.** Stream cache fingerprint cambia se `type` per-punto cambia → cache invalidata correttamente.
+- **R10.** `Envelope.evaluate(t)` e `Envelope.integrate(from, to)` restituiscono valori coerenti su envelope misto multi-tipo.
+
+---
+
+## Scope Boundaries
+
+**In scope:**
+- Parsing (`EnvelopeBuilder`)
+- Modello segmenti (`Envelope._parse_segments`)
+- Cubic Fritsch-Carlson boundary-aware
+- Documentazione YAML
+
+**Out of scope:**
+- Nuove strategie di interpolazione (es. `quadratic`, `bezier`)
+- Modifiche editor PGE-ls (saranno follow-up)
+- Issue #64 (per-macrozone group) e #55 (cycle_mode wrap) — ortogonali
+- Per-segmento dentro loop ciclico (gestito automaticamente dalla replica pattern)
+
+---
+
+## Disambiguazione parser — punto critico
+
+**Problema:** distinguere a parsing time tra:
+
+| Forma | Esempio | Riconoscimento |
+|-------|---------|----------------|
+| Breakpoint 2-elem | `[0.5, 1.0]` | len=2, elem[0]=num, elem[1]=num |
+| Breakpoint 3-elem (NEW) | `[0.5, 1.0, 'cubic']` | len=3, elem[0]=num, elem[1]=num, elem[2]=str |
+| Compact 3-elem | `[[[0,0],[100,1]], 0.4, 4]` | len=3, elem[0]=**list di liste**, elem[1]=num, elem[2]=**int** |
+| Compact 4-elem | `[[[0,0],[100,1]], 0.4, 4, 'linear']` | len=4, elem[0]=list, elem[3]=str |
+| Compact 5-elem | `[[[0,0],[100,1]], 0.4, 4, 'linear', 'exp']` | len=5, elem[0]=list |
+
+**Regola discriminante (in ordine):**
+
+1. **Tipo di `elem[0]`**: se è `list` → candidato compact format. Se è `int|float` → candidato breakpoint.
+2. **Compact format check** (`_is_compact_format`): richiede `elem[0]` list di `[x,y]`, `elem[1]` numerico, `elem[2]` `int`.
+3. **3-tuple breakpoint check** (`_is_3tuple_breakpoint`, **nuovo**): `len(item)==3`, `elem[0]` numerico, `elem[1]` numerico, `elem[2]` stringa in whitelist `{linear, cubic, step}`.
+
+**Conflitto da neutralizzare:** entrambe le forme hanno `len==3`. Già differenziate da `type(elem[0])`:
+- Compact: `elem[0]: list[list]` (pattern points)
+- 3-tuple: `elem[0]: int|float` (tempo)
+
+Il check esistente `_is_compact_format` su `[0.5, 1.0, 'cubic']` ritorna `False` perché `elem[0]=0.5` non è lista → safe.
+
+Il rischio inverso: `[[[0,0],[100,1]], 0.4, 4]` (compact) deve **non** essere riconosciuto come 3-tuple breakpoint. Già safe perché nuovo check richiede `elem[0]` numerico.
+
+**Edge case YAML particolarmente subdolo:**
+
+```yaml
+# Compositore scrive per errore
+parametro: [0.5, 'cubic']    # 2-elem con stringa → cosa fa parser?
+```
+
+Comportamento attuale: `parse` solleva `ValueError("Elemento non valido")` su `[0.5, 'cubic']` perché non è `[time, value]` con 2 numerici (check esiste in `_parse_segments`). Nuovo parser deve preservare quest'errore — `'cubic'` non è numerico → no confusione con 3-tuple.
+
+**Forma vietata da specificare in test:**
+- `[0.5, 'cubic', 1.0]` → elem[1] non numerico → errore esplicito (no ambiguità con 3-tuple che richiede elem[2]=str).
+
+---
+
+## Context & Research
+
+### File toccati
+
+| File | Modifica | Rischio |
+|------|----------|---------|
+| `src/envelopes/envelope_builder.py` | Nuovi metodi `_is_3tuple_breakpoint`, `_normalize_point`, `_validate_interp_type`. Estensione `parse` per accettare 3-tuple e dict per-punto. | medio |
+| `src/envelopes/envelope.py` | `_parse_segments` ritorna **N segmenti** (uno per coppia bp). `_create_context_for_segment` calcola tangenti globali condivise. `evaluate` / `integrate` con lookup multi-segmento. | alto |
+| `src/envelopes/envelope_segment.py` | `NormalSegment` invariato a livello API. Possibile fix `evaluate`/`integrate` per overlap range tra segmenti consecutivi (hold pre/post solo su estremi globali). | medio |
+| `src/envelopes/envelope_interpolation.py` | Nessuna modifica strategy. Cubic Fritsch-Carlson resta in `Envelope`, ma scope: tangenti sui soli segmenti cubic con vicini come boundary. | basso |
+| `src/parameters/parser.py`, `gate_factory.py` | Già accettano lista/dict. Nessuna modifica. | nullo |
+| `docs/yaml-reference.md` | Documenta formato 3-elem + dict per-punto + (gap pre-esistente) dict globale `{type, points}`. | nullo |
+| `docs/envelopes-reference.md` | Nuova sezione per-punto interp con esempi. | nullo |
+| Test suite envelope | Nuovi test (vedi sezione Test). Tutti i test esistenti invariati. | medio |
+
+### Modello interno proposto
+
+Dopo `EnvelopeBuilder.parse`, lista normalizzata di 3-tuple:
+
+```python
+[
+  [0.0, 0.0, 'cubic'],     # seg 0→1 cubic
+  [0.2426, 0.21, 'linear'], # seg 1→2 linear
+  [0.5, 1.0, 'step'],       # seg 2→3 step
+  [1.0, 0.0, None],         # ultimo, type ignorato
+]
+```
+
+`Envelope._parse_segments` itera coppie consecutive `(bp[i], bp[i+1])`, crea un `NormalSegment` per coppia con:
+- `breakpoints=[bp[i], bp[i+1]]` (2 punti)
+- `strategy = InterpolationStrategyFactory.create(bp[i].seg_type)`
+- `context = {'tangents': [tangent[i], tangent[i+1]]}` (calcolate globalmente)
+
+### Cubic boundary semantics
+
+Tangenti Fritsch-Carlson calcolate **sull'intera lista breakpoint** indipendentemente da `seg_type` per-punto. Questo garantisce che segmento `cubic` adiacente a `linear` abbia tangente coerente coi vicini (la slope locale).
+
+Segmenti con strategy `LinearInterpolation` o `StepInterpolation` ignorano `tangents` in context (le strategy non leggono `context['tangents']`).
+
+**Trade-off considerato:** alternativa = tangenti = 0 ai boundary tra cubic e non-cubic. Più semplice, ma produce flat-at-boundary visivo. Scelto Fritsch-Carlson globale per qualità visiva, accettando minor overshoot teorico (mitigato da Fritsch-Carlson stesso che è monotone-preserving).
+
+### Multi-segmento `evaluate` / `integrate`
+
+`Envelope.evaluate(t)`:
+1. Binary search del segmento contenente `t` (`segment.start_time <= t <= segment.end_time`).
+2. Se `t < segments[0].start_time` → hold primo valore.
+3. Se `t > segments[-1].end_time` → hold ultimo valore.
+4. Altrimenti delega a `segment.evaluate(t)`.
+
+`Envelope.integrate(from, to)`:
+1. Itera segmenti che overlappano `[from, to]`.
+2. Per ciascuno: `seg.integrate(max(from, seg.start), min(to, seg.end))`.
+3. Aggiunge hold pre-`segments[0].start` e post-`segments[-1].end` se richiesto.
+
+**Attenzione:** `NormalSegment.integrate` oggi include già hold pre/post sul singolo segmento. Con N segmenti, l'hold tra `seg[i].end` e `seg[i+1].start` (idealmente coincidenti) NON deve essere doppio-contato. Soluzione: passare range strettamente interni a ogni segmento, escludendo hold sue interne. **Test esplicito** su questo edge case.
+
+---
+
+## Backward compatibility
+
+### Casi invariati
+
+| YAML originale | Forma post-parsing | Garanzia |
+|----------------|-------------------|----------|
+| `[[0,0],[1,1]]` | 1 seg linear, identico a oggi | test esistenti |
+| `{type: cubic, points: [[0,0],[1,1]]}` | 1 seg cubic | test esistenti |
+| `[[[0,0],[100,1]], 0.4, 4]` | espansione N ciclica, 1 seg linear | test esistenti |
+| `[[[0,0],[100,1]], 0.4, 4, 'cubic']` | espansione N, 1 seg cubic | test esistenti |
+
+**Implementazione:** quando tutti i breakpoint hanno stesso `seg_type` (o `None`), il risultato semantico è equivalente a oggi (1 strategy applicata a tutti i segmenti). N segmenti vs 1 segmento — comportamento osservabile (evaluate/integrate output) identico **modulo floating-point** sui boundary.
+
+**Verifica empirica obbligatoria:** test che confronta output `evaluate` su 1000 punti random tra Envelope nuovo e baseline pre-refactor per tutti i fixture esistenti.
+
+### Wrapper compatto + 3-tuple
+
+Pattern compatto può contenere 3-tuple:
+
+```yaml
+parametro: [[[0, 0, 'cubic'], [50, 1, 'linear'], [100, 0]], 0.4, 4]
+```
+
+Espansione: 4 cicli, ognuno replica `cubic` su segmento 1, `linear` su segmento 2. Tra cicli (gap dovuto a `DISCONTINUITY_OFFSET`): interp segue il **wrapper `interp_type` globale** (elem[3], default linear). Logica: gap inter-ciclo non è "dentro il pattern", quindi `seg_type` per-punto non si applica.
+
+---
+
+## Edge case da testare
+
+1. **Mix 2-elem + 3-elem nella stessa lista**: `[[0,0,'cubic'],[1,1]]` → seg cubic, ultimo ha `seg_type=None` (corretto, ultimo punto).
+2. **Type su ultimo punto**: `[[0,0],[1,1,'cubic']]` → warning, `cubic` ignorato (no segmento successivo).
+3. **Type invalido per-punto**: `[[0,0,'foo'],[1,1]]` → `InvalidFieldValueError` con messaggio chiaro.
+4. **Step + linear contiguo**: `[[0,0,'step'],[0.5,1,'linear'],[1,0]]` → `evaluate(0.25) == 0` (step), `evaluate(0.75) == 0.5` (linear).
+5. **Cubic singolo segmento isolato**: stessa tangente del cubic globale equivalente.
+6. **Integrate cross-boundary**: `integrate(0,1)` su envelope misto = somma integrali per-segmento (verificato analiticamente con linear+step).
+7. **Wrapper compatto con 3-tuple pattern**: cicli replicano correttamente i seg_type.
+8. **Dict per-punto**: `{type: linear, points: [{t:0,v:0,type:cubic},{t:1,v:1}]}` → equivalente a 3-tuple list.
+9. **Mix dict + tupla in `points`**: vietato? Permesso? **Scelta:** permesso, normalize in builder.
+10. **Cache fingerprint**: cambio `type` per-punto cambia hash YAML → cache invalida.
+11. **Time normalized + 3-tuple**: `_scale_time_recursive` deve preservare elem[2] (`seg_type`) mentre scala elem[0] (`t`).
+12. **Scale Y values + 3-tuple**: `_scale_raw_values_y` deve preservare elem[2] mentre scala elem[1] (`v`).
+
+---
+
+## Plan (TDD)
+
+### Fase 1 — Test rossi (parser + disambiguazione)
+
+1. Test: `EnvelopeBuilder._is_3tuple_breakpoint([0.5, 1.0, 'cubic'])` → `True`
+2. Test: `EnvelopeBuilder._is_3tuple_breakpoint([0.5, 1.0])` → `False`
+3. Test: `EnvelopeBuilder._is_3tuple_breakpoint([0.5, 1.0, 'foo'])` → `False`
+4. Test: `EnvelopeBuilder._is_3tuple_breakpoint([[0,0],[100,1]], 0.4, 4)` → `False` (non passare lista, ma item)
+5. Test: `_is_compact_format([0.5, 1.0, 'cubic'])` → `False` (regression check)
+6. Test: `_is_compact_format([[[0,0],[100,1]], 0.4, 4])` → `True` (regression)
+7. Test: `Envelope([[0,0,'cubic'],[1,1]])` non solleva
+8. Test: `Envelope([[0,0,'foo'],[1,1]])` → `InvalidFieldValueError`
+9. Test: mix 2/3-elem accettato: `Envelope([[0,0,'cubic'],[0.5,1],[1,0,'step']])`
+10. Test: dict per-punto `{type: linear, points: [{t:0,v:0,type:cubic},{t:1,v:1}]}` accettato
+11. Test: forma vietata `[0.5, 'cubic']` (2-elem con stringa al posto di valore) → errore chiaro
+
+### Fase 2 — Test rossi (semantica evaluate)
+
+12. Test: `[[0,0,'step'],[0.5,1,'linear'],[1,0]]`:
+    - `evaluate(0.0) == 0`
+    - `evaluate(0.25) == 0` (step: hold)
+    - `evaluate(0.5) == 1`
+    - `evaluate(0.75) == 0.5` (linear)
+    - `evaluate(1.0) == 0`
+13. Test: cubic per-segmento isolato `[[0,0,'cubic'],[1,1]]` ha output equivalente a `Envelope({'type':'cubic','points':[[0,0],[1,1]]})` su 100 punti.
+14. Test: `[[0,0,'linear'],[1,1,'linear']]` → output identico a `[[0,0],[1,1]]` (entrambi linear) — verifica backward compat semantica.
+
+### Fase 3 — Test rossi (integrate)
+
+15. Test: `integrate(0,1)` su `[[0,0,'step'],[0.5,1,'linear'],[1,0]]` = `0*0.5 + 0.5*1*0.5` = `0.25` (step area + triangolo).
+16. Test: `integrate` cross-boundary tra cubic e linear: somma analitica per-segmento.
+17. Test: `integrate(0,1)` su envelope all-linear identico a baseline pre-refactor (regression).
+
+### Fase 4 — Test rossi (edge case)
+
+18. Test: ultimo punto con `type` → warning emesso a logger, no errore.
+19. Test: wrapper compatto con 3-tuple pattern: `Envelope([[[0,0,'cubic'],[50,1,'linear'],[100,0]], 0.4, 4])` espande mantenendo `seg_type` per-punto.
+20. Test: `time_mode: normalized` + 3-tuple preserva `seg_type` dopo `_scale_time_recursive`.
+21. Test: `_scale_raw_values_y` + 3-tuple preserva `seg_type` dopo scaling Y.
+22. Test: `Envelope.breakpoints` property con N segmenti restituisce concatenazione senza duplicare giunzioni.
+
+### Fase 5 — Implementazione
+
+23. `EnvelopeBuilder._is_3tuple_breakpoint(item)`: helper di disambiguazione.
+24. `EnvelopeBuilder._validate_interp_type(t, context)`: solleva `InvalidFieldValueError` su tipo non in whitelist.
+25. `EnvelopeBuilder._normalize_point(item, default_type)`: converte 2-elem, 3-elem, dict in tupla canonica 3-elem `(t, v, seg_type_or_None)`.
+26. `EnvelopeBuilder.parse`: estesa per produrre lista normalizzata 3-tuple. Backward compat: se input è 2-elem only, output preserva 2-elem (per non rompere consumer downstream che fanno unpacking).
+    - **Decisione tecnica:** output di `parse` rimane lista `[t, v]` (2-elem) per backward compat. La 3a colonna `seg_type` viaggia in lista parallela `seg_types: List[Optional[str]]` ritornata insieme oppure attaccata come attributo. **Scelta:** ritornare tupla `(breakpoints_2elem, seg_types)`. Refactor `Envelope.__init__` per consumare entrambi.
+    - **Alternativa:** ritornare sempre 3-elem; consumer downstream (`_scale_time_recursive`, `_scale_raw_values_y`, `_log_*`) tutti aggiornati per gestire 3-elem. **Più clean.**
+    - **Decisione finale:** prima alternativa (ritornare 3-elem) — meno punti di attrito.
+27. `Envelope.__init__`: estrae `seg_types` dalla lista parsed.
+28. `Envelope._parse_segments`: itera coppie, crea N `NormalSegment` con strategy per-segmento.
+29. `Envelope._compute_fritsch_carlson_tangents`: invariato (opera su lista 2-elem proiettata).
+30. `Envelope.evaluate`: binary search segmento + delega.
+31. `Envelope.integrate`: somma per-segmento su range overlap, gestisce hold globali.
+32. `Envelope.breakpoints` property: ricostruisce concatenazione senza duplicare punti giunzione.
+33. `EnvelopeBuilder._log_compact_transformation` e `_log_final_envelope`: aggiornati per loggare 3-elem se presenti.
+34. `Envelope._scale_raw_values_y`: preserva elem[2] su 3-tuple.
+35. `_scale_time_recursive`: preserva elem[2] su 3-tuple.
+
+### Fase 6 — Verifica integrazione
+
+36. `make tests` verde.
+37. `make e2e-tests` verde.
+38. YAML reale con envelope misto su `density`, `pitch`, `amp`: render NumPy + Csound producono output coerente.
+39. Stream cache: cambio `type` per-punto in YAML invalida cache (test ad hoc + verifica con `STEMS=true CACHE=true`).
+40. Snapshot test: confronto bit-identico output WAV su 5 fixture esistenti pre/post refactor (`tests/e2e/fixtures/*.yaml`).
+
+### Fase 7 — Documentazione
+
+41. `docs/yaml-reference.md`: nuova sezione "Envelope per-point interpolation" con esempi tupla e dict.
+42. `docs/envelopes-reference.md`: aggiornare §2 + §5 con nuovo formato e regola di disambiguazione (riportare tabella di questo plan).
+43. `docs/yaml-reference.md`: documentare gap pre-esistente (dict format `{type, points}` non documentato).
+
+---
+
+## Decisioni risolte
+
+- **Ultimo punto + type:** warning a log, valore ignorato.
+- **Tupla vs dict:** entrambe supportate.
+- **Type globale + per-punto:** globale = default, per-punto override.
+- **Output `parse`:** 3-elem normalizzato (refactor consumer downstream).
+- **Cubic boundary:** tangenti Fritsch-Carlson globali, applicate solo a segmenti cubic.
+- **Gap inter-ciclo in wrapper compatto:** interp seguita = wrapper globale, no per-punto.
+
+---
+
+## Decisioni aperte (richiedono conferma utente)
+
+Nessuna. Tutto risolto in fase di analisi.
+
+---
+
+## Riferimenti
+
+- Issue: `gh issue view 54`
+- Codice: `src/envelopes/envelope.py:80-110`, `src/envelopes/envelope_builder.py:125-176`
+- Doc esistente: `docs/envelopes-reference.md` §2, §5
+- Issue correlate (ortogonali): #55 (cycle_mode wrap), #64 (per-macrozone group)

--- a/src/envelopes/envelope.py
+++ b/src/envelopes/envelope.py
@@ -80,34 +80,88 @@ class Envelope:
     def _parse_segments(self, breakpoints: list) -> List[Segment]:
         """
         Parsa lista di breakpoints in List[NormalSegment].
-        
-        Nota: Formato compatto già espanso da Builder.
-        
+
+        Accetta breakpoint 2-elem [t, v] (usa strategy globale) o 3-elem
+        [t, v, type] (override per-segmento, type applicato a seg i→i+1).
+
+        Quando non ci sono override per-punto crea un singolo segmento
+        (backward compat). Altrimenti crea N segmenti (uno per coppia).
+
         Returns:
-            List[NormalSegment]: Lista con singolo segmento contenente tutti i breakpoints
+            List[NormalSegment]
         """
         if not breakpoints:
             raise ValueError("Lista breakpoints vuota.")
-        
-        # Valida formato breakpoints
+
+        from envelopes.envelope_builder import EnvelopeBuilder as _EB
+
+        # Estrai (point_2elem, seg_type) per ogni breakpoint
+        points = []
+        seg_types: List[Any] = []
+        has_per_point_type = False
         for item in breakpoints:
-            if not isinstance(item, list) or len(item) != 2:
+            if not isinstance(item, list):
                 raise ValueError(
                     f"Formato breakpoint non valido: {item}. "
-                    "Deve essere [time, value]."
+                    "Deve essere [time, value] o [time, value, type]."
                 )
-        
-        # Crea context per cubic (tangenti)
-        context = self._create_context_for_segment(breakpoints)
-        
-        # Crea singolo NormalSegment con tutti i breakpoints
-        segment = NormalSegment(
-            breakpoints=breakpoints,
-            strategy=self.strategy,
-            context=context
-        )
-        
-        return [segment]
+            if len(item) == 2:
+                points.append(item)
+                seg_types.append(None)
+            elif len(item) == 3:
+                if not _EB._is_3tuple_breakpoint(item):
+                    raise ValueError(
+                        f"Formato breakpoint non valido: {item}. "
+                        "Deve essere [time, value] o [time, value, type]."
+                    )
+                if item[2] not in _EB.VALID_INTERP_TYPES:
+                    from shared.exceptions import InvalidFieldValueError
+                    raise InvalidFieldValueError(
+                        field="envelope.point.type",
+                        value=item[2],
+                        hint=f"Tipi validi: {', '.join(_EB.VALID_INTERP_TYPES)}",
+                    )
+                points.append([item[0], item[1]])
+                seg_types.append(item[2])
+                has_per_point_type = True
+            else:
+                raise ValueError(
+                    f"Formato breakpoint non valido: {item}. "
+                    "Deve essere [time, value] o [time, value, type]."
+                )
+
+        # Tangenti globali (usate solo dai segmenti cubic)
+        global_tangents = self._compute_fritsch_carlson_tangents(points)
+
+        # Backward compat: nessun override → singolo segmento
+        if not has_per_point_type:
+            context = self._create_context_for_segment(points)
+            return [NormalSegment(breakpoints=points, strategy=self.strategy, context=context)]
+
+        # N segmenti: uno per coppia (points[i], points[i+1])
+        # seg_types[i] applicato a segmento i→i+1; ultimo type ignorato (warning)
+        if seg_types[-1] is not None:
+            import logging
+            logging.getLogger(__name__).warning(
+                f"Envelope: type='{seg_types[-1]}' su ultimo punto ignorato (no segmento successivo)."
+            )
+
+        if len(points) == 1:
+            # Caso degenere: 1 solo punto
+            context = self._create_context_for_segment(points)
+            return [NormalSegment(breakpoints=points, strategy=self.strategy, context=context)]
+
+        segments: List[Segment] = []
+        for i in range(len(points) - 1):
+            pair = [points[i], points[i + 1]]
+            t_for_seg = seg_types[i] if seg_types[i] is not None else self.type
+            strategy = InterpolationStrategyFactory.create(t_for_seg)
+            context: Dict[str, Any] = {}
+            if t_for_seg == 'cubic':
+                context['tangents'] = [global_tangents[i], global_tangents[i + 1]]
+            segments.append(NormalSegment(breakpoints=pair, strategy=strategy, context=context))
+
+        return segments
     
     def _create_context_for_segment(self, points: List[List[float]]) -> Dict[str, Any]:
         """
@@ -174,39 +228,74 @@ class Envelope:
     def evaluate(self, t: float) -> float:
         """
         Valuta l'envelope al tempo t.
-        
-        Delegation Pattern: delega al singolo NormalSegment.
-        
-        Args:
-            t: Tempo in secondi
-            
-        Returns:
-            float: Valore dell'envelope
+
+        Multi-segmento: trova il segmento che contiene t (o restituisce hold
+        agli estremi globali).
         """
-        # Singolo segmento: delega direttamente
-        return self.segments[0].evaluate(t)
-    
+        if len(self.segments) == 1:
+            return self.segments[0].evaluate(t)
+
+        # Hold pre/post sugli estremi globali
+        global_start = self.segments[0].start_time
+        global_end = self.segments[-1].end_time
+        if t <= global_start:
+            return self.segments[0].breakpoints[0][1]
+        if t >= global_end:
+            return self.segments[-1].breakpoints[-1][1]
+
+        # Trova segmento contenente t (segmenti adiacenti condividono boundary)
+        for seg in self.segments:
+            if seg.start_time <= t <= seg.end_time:
+                return seg.evaluate(t)
+
+        # Fallback: ultimo valore (non dovrebbe accadere)
+        return self.segments[-1].breakpoints[-1][1]
+
     def integrate(self, from_time: float, to_time: float) -> float:
         """
         Integrale dell'envelope tra from_time e to_time.
-        
-        Delega al singolo NormalSegment.
-        
-        Args:
-            from_time: Tempo iniziale
-            to_time: Tempo finale
-            
-        Returns:
-            float: Area sotto la curva
+
+        Multi-segmento: somma per-segmento sul range overlap; hold pre/post
+        gestito sugli estremi globali.
         """
         if from_time > to_time:
             return -self.integrate(to_time, from_time)
-        
         if from_time == to_time:
             return 0.0
-        
-        # Singolo segmento: delega direttamente
-        return self.segments[0].integrate(from_time, to_time)
+
+        if len(self.segments) == 1:
+            return self.segments[0].integrate(from_time, to_time)
+
+        global_start = self.segments[0].start_time
+        global_end = self.segments[-1].end_time
+        total = 0.0
+        cursor = from_time
+
+        # Hold prima del primo segmento
+        if cursor < global_start:
+            hold_end = min(to_time, global_start)
+            total += self.segments[0].breakpoints[0][1] * (hold_end - cursor)
+            cursor = hold_end
+            if cursor >= to_time:
+                return total
+
+        # Integra su segmenti che overlappano [cursor, to_time]
+        for seg in self.segments:
+            if cursor >= to_time:
+                break
+            if to_time <= seg.start_time or cursor >= seg.end_time:
+                continue
+            a = max(cursor, seg.start_time)
+            b = min(to_time, seg.end_time)
+            if b > a:
+                total += seg.strategy.integrate(a, b, seg.breakpoints, **seg.context)
+                cursor = b
+
+        # Hold dopo l'ultimo segmento
+        if cursor < to_time and cursor >= global_end:
+            total += self.segments[-1].breakpoints[-1][1] * (to_time - cursor)
+
+        return total
         
     @property
     def breakpoints(self) -> List[List[float]]:
@@ -298,6 +387,8 @@ class Envelope:
                     scaled.append(new_item)
                 elif isinstance(item, list) and len(item) == 2:
                     scaled.append([item[0], item[1] * scale_factor])
+                elif EnvelopeBuilder._is_3tuple_breakpoint(item):
+                    scaled.append([item[0], item[1] * scale_factor, item[2]])
                 else:
                     scaled.append(item)
             return scaled
@@ -393,6 +484,9 @@ def _scale_time_recursive(points: List, factor: float) -> List:
         elif isinstance(item, list) and len(item) == 2:
             # Standard breakpoint: [t, v] -> [t * factor, v]
             scaled.append([item[0] * factor, item[1]])
+        elif EnvelopeBuilder._is_3tuple_breakpoint(item):
+            # 3-tuple breakpoint: [t, v, type] -> [t * factor, v, type]
+            scaled.append([item[0] * factor, item[1], item[2]])
         else:
 
             scaled.append(item)

--- a/src/envelopes/envelope_builder.py
+++ b/src/envelopes/envelope_builder.py
@@ -99,28 +99,64 @@ class EnvelopeBuilder:
         current_time = 0.0  # Traccia tempo corrente per offset
         
         for item in raw_points:
+            # Normalizza dict per-punto {t, v, type?} in lista
+            if isinstance(item, dict) and 't' in item and 'v' in item:
+                if 'type' in item:
+                    item = [item['t'], item['v'], item['type']]
+                else:
+                    item = [item['t'], item['v']]
             if cls._is_compact_format(item):
                 # Espandi formato compatto CON OFFSET
                 compact_expanded = cls._expand_compact_format(item, time_offset=current_time)
                 expanded.extend(compact_expanded)
-                
+
                 # Aggiorna tempo corrente (ultimo breakpoint espanso)
                 if compact_expanded:
                     current_time = compact_expanded[-1][0]
             else:
-                if not (isinstance(item, list) and len(item) == 2):
+                if cls._is_3tuple_breakpoint(item):
+                    expanded.append(item)
+                    current_time = max(current_time, item[0])
+                elif (isinstance(item, list) and len(item) == 2
+                      and isinstance(item[0], (int, float)) and not isinstance(item[0], bool)
+                      and isinstance(item[1], (int, float)) and not isinstance(item[1], bool)):
+                    expanded.append(item)
+                    current_time = max(current_time, item[0])
+                else:
                     raise ValueError(
                         f"Elemento non valido nel formato envelope: {item!r}. "
-                        "Atteso [time, value]."
+                        "Atteso [time, value] o [time, value, type]."
                     )
-                expanded.append(item)
-                current_time = max(current_time, item[0])
         
         # Log risultato finale
         cls._log_final_envelope(raw_points, expanded)
         
         return expanded
     
+    VALID_INTERP_TYPES = ('linear', 'cubic', 'step')
+
+    @classmethod
+    def _is_3tuple_breakpoint(cls, item) -> bool:
+        """
+        Rileva se item è breakpoint 3-tuple [t, v, type].
+
+        Discriminato da formato compatto (len==3 anche lì) tramite type(elem[0]):
+        - 3-tuple breakpoint: elem[0] numerico
+        - compact: elem[0] lista
+
+        Returns:
+            True se [t, v, type] con t,v numerici e type stringa valida.
+        """
+        if not isinstance(item, list) or len(item) != 3:
+            return False
+        if not isinstance(item[0], (int, float)) or isinstance(item[0], bool):
+            return False
+        if not isinstance(item[1], (int, float)) or isinstance(item[1], bool):
+            return False
+        if not isinstance(item[2], str):
+            return False
+        return True
+
     @classmethod
     def _is_compact_format(cls, item) -> bool:
         """
@@ -150,9 +186,9 @@ class EnvelopeBuilder:
         if not isinstance(item[0], list):
             return False
         
-        # Se pattern NON vuoto, verifica formato [x, y]
+        # Se pattern NON vuoto, verifica formato [x, y] o [x, y, type]
         if item[0]:
-            if not all(isinstance(p, list) and len(p) == 2 for p in item[0]):
+            if not all(isinstance(p, list) and len(p) in (2, 3) for p in item[0]):
                 return False
         
         # Secondo elemento: end_time (float/int)
@@ -248,21 +284,26 @@ class EnvelopeBuilder:
             cycle_duration = cycle_durations[rep]
                         
             # Converti coordinate % → assolute per questo ciclo
-            for i, (x_pct, y) in enumerate(pattern_points_pct):
+            for i, point in enumerate(pattern_points_pct):
+                x_pct, y = point[0], point[1]
+                seg_type = point[2] if len(point) == 3 else None
                 # x_pct è in [0, 100]
                 # Normalizza a [0, 1]
                 x_normalized = x_pct / 100.0
-                
+
                 # Calcola tempo assoluto
                 t_absolute = cycle_start_time + (x_normalized * cycle_duration)
-                
+
                 # Applica offset DISCONTINUITY per evitare collisioni:
                 # 1. Primo punto di cicli successivi (rep > 0)
                 # 2. Primo punto assoluto della parte compatta SE c'è time_offset
                 if (rep > 0 and i == 0) or (rep == 0 and i == 0 and time_offset > 0):
                     t_absolute += cls.DISCONTINUITY_OFFSET
-            
-                expanded.append([t_absolute, y])
+
+                if seg_type is not None:
+                    expanded.append([t_absolute, y, seg_type])
+                else:
+                    expanded.append([t_absolute, y])
         
         # LOGGING della trasformazione compatta
         cls._log_compact_transformation(
@@ -358,15 +399,19 @@ class EnvelopeBuilder:
         preview_count = min(5, len(expanded))
         logger.info(f"\n  First {preview_count} breakpoints:")
         for i in range(preview_count):
-            t, v = expanded[i]
-            logger.info(f"    [{i}] t={t:.6f}s, v={v}")
-        
+            bp = expanded[i]
+            t, v = bp[0], bp[1]
+            extra = f", type={bp[2]}" if len(bp) == 3 else ""
+            logger.info(f"    [{i}] t={t:.6f}s, v={v}{extra}")
+
         if len(expanded) > preview_count:
             logger.info(f"  ...")
             logger.info(f"  Last {preview_count} breakpoints:")
             for i in range(len(expanded) - preview_count, len(expanded)):
-                t, v = expanded[i]
-                logger.info(f"    [{i}] t={t:.6f}s, v={v}")
+                bp = expanded[i]
+                t, v = bp[0], bp[1]
+                extra = f", type={bp[2]}" if len(bp) == 3 else ""
+                logger.info(f"    [{i}] t={t:.6f}s, v={v}{extra}")
         
         logger.info(f"{'='*80}\n")
 

--- a/tests/envelopes/test_envelope_per_point_interp.py
+++ b/tests/envelopes/test_envelope_per_point_interp.py
@@ -1,0 +1,291 @@
+"""
+Test suite per envelope con interp type per-punto (issue #54).
+
+Formato:
+- Lista 3-tuple: [[t, v, type], ...] dove type ∈ {linear, cubic, step}
+- Dict per-punto: {type: ..., points: [{t, v, type}, ...]}
+
+Semantica: type su punto i = strategia segmento i → i+1.
+Ultimo punto: type ignorato (warning).
+"""
+
+import pytest
+from envelopes.envelope import Envelope, create_scaled_envelope, _scale_time_recursive
+from envelopes.envelope_builder import EnvelopeBuilder
+from shared.exceptions import InvalidFieldValueError
+
+
+class TestThreeTupleAcceptance:
+    """Costruttore accetta breakpoint 3-tuple [t, v, type]."""
+
+    def test_simple_3tuple_does_not_raise(self):
+        Envelope([[0, 0, 'cubic'], [1, 1]])
+
+    def test_mixed_2_and_3_tuple_does_not_raise(self):
+        Envelope([[0, 0, 'cubic'], [0.5, 1], [1, 0, 'step']])
+
+    def test_all_3tuple_does_not_raise(self):
+        Envelope([[0, 0, 'linear'], [0.5, 1, 'step'], [1, 0, 'cubic']])
+
+
+class TestInvalidInterpType:
+    """Validazione type per-punto."""
+
+    def test_invalid_type_raises_invalid_field_value_error(self):
+        with pytest.raises(InvalidFieldValueError):
+            Envelope([[0, 0, 'foo'], [1, 1]])
+
+    def test_invalid_type_error_message_lists_valid_types(self):
+        with pytest.raises(InvalidFieldValueError) as exc:
+            Envelope([[0, 0, 'bezier'], [1, 1]])
+        assert 'linear' in exc.value.hint
+        assert 'cubic' in exc.value.hint
+        assert 'step' in exc.value.hint
+
+
+class TestParserDisambiguation:
+    """Disambiguazione tra compact format e 3-tuple breakpoint."""
+
+    def test_3tuple_not_recognized_as_compact(self):
+        assert EnvelopeBuilder._is_compact_format([0.5, 1.0, 'cubic']) is False
+
+    def test_compact_not_recognized_as_3tuple(self):
+        assert EnvelopeBuilder._is_3tuple_breakpoint(
+            [[[0, 0], [100, 1]], 0.4, 4]
+        ) is False
+
+    def test_compact_still_recognized(self):
+        assert EnvelopeBuilder._is_compact_format(
+            [[[0, 0], [100, 1]], 0.4, 4]
+        ) is True
+
+    def test_3tuple_recognized(self):
+        assert EnvelopeBuilder._is_3tuple_breakpoint([0.5, 1.0, 'cubic']) is True
+
+    def test_2elem_not_3tuple(self):
+        assert EnvelopeBuilder._is_3tuple_breakpoint([0.5, 1.0]) is False
+
+    def test_invalid_2elem_with_string_raises(self):
+        # Forma vietata: [0.5, 'cubic'] — elem[1] non numerico
+        with pytest.raises(ValueError):
+            Envelope([[0.5, 'cubic'], [1, 1]])
+
+    def test_compact_4elem_not_3tuple(self):
+        # Compact con interp: 4 elem → non confondibile con 3-tuple
+        item = [[[0, 0], [100, 1]], 0.4, 4, 'cubic']
+        assert EnvelopeBuilder._is_compact_format(item) is True
+        assert EnvelopeBuilder._is_3tuple_breakpoint(item) is False
+
+    def test_compact_5elem_not_3tuple(self):
+        # Compact con time_dist: 5 elem
+        item = [[[0, 0], [100, 1]], 0.4, 4, 'cubic', 'exponential']
+        assert EnvelopeBuilder._is_compact_format(item) is True
+        assert EnvelopeBuilder._is_3tuple_breakpoint(item) is False
+
+    def test_3tuple_with_negative_time(self):
+        # 3-tuple con t negativo riconosciuto
+        assert EnvelopeBuilder._is_3tuple_breakpoint([-0.5, 1, 'cubic']) is True
+
+    def test_3tuple_with_int_time_and_value(self):
+        # 3-tuple con int (non float) riconosciuto
+        assert EnvelopeBuilder._is_3tuple_breakpoint([0, 1, 'step']) is True
+
+    def test_3tuple_with_bool_rejected(self):
+        # bool è sottoclasse di int — non deve passare
+        assert EnvelopeBuilder._is_3tuple_breakpoint([True, 1, 'step']) is False
+        assert EnvelopeBuilder._is_3tuple_breakpoint([0, True, 'step']) is False
+
+    def test_3tuple_with_invalid_type_string_still_recognized_as_3tuple(self):
+        # _is_3tuple_breakpoint solo struttura; validazione type avviene dopo
+        assert EnvelopeBuilder._is_3tuple_breakpoint([0, 1, 'foo']) is True
+
+    def test_legacy_dict_format_still_works(self):
+        # Vecchio dict {type, points} con bare [t,v] continua a funzionare
+        env = Envelope({'type': 'cubic', 'points': [[0, 0], [1, 1]]})
+        assert env.type == 'cubic'
+
+    def test_dict_with_t_v_keys_normalized_only_when_both_present(self):
+        # Dict che NON ha 't' e 'v' → non normalizzato (caso compact-style? no, compact è lista)
+        # Verifica che dict senza 't' o senza 'v' non venga frainteso come point
+        with pytest.raises((ValueError, KeyError)):
+            Envelope([{'only_t': 0}, [1, 1]])
+
+    def test_4elem_breakpoint_rejected(self):
+        # Breakpoint con 4 elementi → errore
+        with pytest.raises(ValueError):
+            Envelope([[0, 0, 'cubic', 'extra'], [1, 1]])
+
+    def test_1elem_breakpoint_rejected(self):
+        # Breakpoint con 1 elemento → errore
+        with pytest.raises(ValueError):
+            Envelope([[0], [1, 1]])
+
+    def test_empty_3tuple_breakpoint(self):
+        # Lista vuota non confondibile
+        assert EnvelopeBuilder._is_3tuple_breakpoint([]) is False
+        assert EnvelopeBuilder._is_compact_format([]) is False
+
+    def test_3tuple_passed_as_raw_envelope_not_misread(self):
+        # Envelope([0.5, 1, 'cubic']) → iter sugli elementi 0.5, 1, 'cubic' → errore
+        with pytest.raises((ValueError, TypeError, AttributeError)):
+            Envelope([0.5, 1, 'cubic'])
+
+
+class TestPerSegmentEvaluate:
+    """Semantica per-segmento su evaluate()."""
+
+    def test_step_then_linear(self):
+        # Segmento 0→0.5: step (hold 0). Segmento 0.5→1: linear (0→1→0? no: 1→0).
+        # Più chiaro: [[0,0,'step'],[0.5,1,'linear'],[1,0]]
+        # 0→0.5: step su [0,0]→[0.5,1] → hold 0 fino a 0.5
+        # 0.5→1: linear su [0.5,1]→[1,0]
+        env = Envelope([[0, 0, 'step'], [0.5, 1, 'linear'], [1, 0]])
+        assert env.evaluate(0.0) == pytest.approx(0.0)
+        assert env.evaluate(0.25) == pytest.approx(0.0)  # step hold
+        assert env.evaluate(0.5) == pytest.approx(1.0)
+        assert env.evaluate(0.75) == pytest.approx(0.5)  # linear midpoint
+        assert env.evaluate(1.0) == pytest.approx(0.0)
+
+    def test_all_linear_equivalent_to_2elem(self):
+        env_3 = Envelope([[0, 0, 'linear'], [0.5, 0.5, 'linear'], [1, 1]])
+        env_2 = Envelope([[0, 0], [0.5, 0.5], [1, 1]])
+        for t in [0.0, 0.25, 0.5, 0.75, 1.0]:
+            assert env_3.evaluate(t) == pytest.approx(env_2.evaluate(t))
+
+
+class TestPerSegmentIntegrate:
+    """Integrate cross-boundary su segmenti misti."""
+
+    def test_step_then_linear_integral(self):
+        # [[0,0,'step'],[0.5,1,'linear'],[1,0]]
+        # Seg 0 (step, [0,0]→[0.5,1]): valore costante = 0 (left value) su [0, 0.5] → area 0
+        # Seg 1 (linear, [0.5,1]→[1,0]): triangolo da v=1 a v=0 su Δt=0.5 → area 0.25
+        env = Envelope([[0, 0, 'step'], [0.5, 1, 'linear'], [1, 0]])
+        assert env.integrate(0, 1) == pytest.approx(0.25)
+
+    def test_partial_range_first_segment(self):
+        env = Envelope([[0, 0, 'step'], [0.5, 1, 'linear'], [1, 0]])
+        # Solo seg step su [0, 0.25] → area 0
+        assert env.integrate(0, 0.25) == pytest.approx(0.0)
+
+    def test_partial_range_second_segment(self):
+        env = Envelope([[0, 0, 'step'], [0.5, 1, 'linear'], [1, 0]])
+        # Solo seg linear su [0.5, 0.75]: trap da v=1 a v=0.5 su 0.25 → 0.25 * (1+0.5)/2 = 0.1875
+        assert env.integrate(0.5, 0.75) == pytest.approx(0.1875)
+
+    def test_integrate_matches_old_behavior_on_uniform_envelope(self):
+        # Senza per-punto: comportamento bit-identico al pre-refactor
+        env = Envelope([[0, 0], [0.5, 1], [1, 0]])
+        # Triangolo simmetrico altezza 1 base 1 → area 0.5
+        assert env.integrate(0, 1) == pytest.approx(0.5)
+
+
+class TestDictPerPoint:
+    """Formato dict con point come {t, v, type}."""
+
+    def test_dict_per_point_accepted(self):
+        env = Envelope({
+            'type': 'linear',
+            'points': [
+                {'t': 0, 'v': 0, 'type': 'step'},
+                {'t': 0.5, 'v': 1, 'type': 'linear'},
+                {'t': 1, 'v': 0},
+            ]
+        })
+        assert env.evaluate(0.25) == pytest.approx(0.0)  # step hold
+        assert env.evaluate(0.75) == pytest.approx(0.5)  # linear midpoint
+
+    def test_dict_mixed_dict_and_list_points(self):
+        env = Envelope({
+            'type': 'linear',
+            'points': [
+                {'t': 0, 'v': 0, 'type': 'step'},
+                [0.5, 1],
+                {'t': 1, 'v': 0},
+            ]
+        })
+        assert env.evaluate(0.25) == pytest.approx(0.0)
+
+    def test_compact_wrapper_with_3tuple_pattern(self):
+        # Pattern compatto con 3-tuple: step segment, n_reps=2
+        # [[[0,0,'step'],[50,1],[100,0]], 1.0, 2]
+        # Ciclo 0 (0→0.5): step da 0→1 fissato a 0 fino 50% (t=0.25), poi linear da 1→0
+        # Verifica: a 10% del ciclo (t=0.05), step ancora 0
+        env = Envelope([[[0, 0, 'step'], [50, 1], [100, 0]], 1.0, 2])
+        # Primo ciclo: step da t=0 a t=0.25 → tutto 0
+        assert env.evaluate(0.1) == pytest.approx(0.0)
+
+    def test_dict_point_without_type_uses_global(self):
+        env = Envelope({
+            'type': 'step',
+            'points': [
+                {'t': 0, 'v': 0},
+                {'t': 1, 'v': 1},
+            ]
+        })
+        # global step: hold left
+        assert env.evaluate(0.5) == pytest.approx(0.0)
+
+
+class TestTimeNormalizedWith3Tuple:
+    """time_mode=normalized preserva seg_type su 3-tuple."""
+
+    def test_scale_time_recursive_preserves_type(self):
+        points = [[0, 0, 'cubic'], [0.5, 1], [1, 0, 'step']]
+        scaled = _scale_time_recursive(points, factor=2.0)
+        assert scaled[0] == [0.0, 0, 'cubic']
+        assert scaled[1] == [1.0, 1]
+        assert scaled[2] == [2.0, 0, 'step']
+
+    def test_compact_3tuple_replicated_across_n_reps(self):
+        # Pattern con step seg, 3 ripetizioni: ogni ciclo deve avere lo step
+        env = Envelope([[[0, 0, 'step'], [50, 1], [100, 0]], 3.0, 3])
+        # Ciclo 0: 0→1s. Step da 0→0.5s → valore 0
+        assert env.evaluate(0.3) == pytest.approx(0.0)
+        # Ciclo 1: 1→2s (con DISCONTINUITY_OFFSET). Step da 1→1.5s → valore 0
+        assert env.evaluate(1.3) == pytest.approx(0.0)
+        # Ciclo 2: 2→3s. Step da 2→2.5s → valore 0
+        assert env.evaluate(2.3) == pytest.approx(0.0)
+
+    def test_compact_3tuple_with_exponential_time_dist(self):
+        # 3-tuple pattern + time_dist exponential: seg_type preservato
+        env = Envelope([[[0, 0, 'step'], [50, 1], [100, 0]], 1.0, 2, 'linear', 'exponential'])
+        # Esegue senza errori; valore in fase step ciclo 0 = 0
+        # Ciclo 0 più lungo (exponential = decelerando) → step area maggiore
+        assert env.evaluate(0.05) == pytest.approx(0.0)
+
+    def test_compact_3tuple_overrides_wrapper_interp(self):
+        # Wrapper interp='cubic' globale; per-punto 'step' override su seg 0
+        env = Envelope([[[0, 0, 'step'], [50, 1], [100, 0]], 1.0, 1, 'cubic'])
+        # Seg 0→0.5: step (per-punto override su cubic globale) → valore 0
+        assert env.evaluate(0.25) == pytest.approx(0.0)
+
+    def test_compact_mixed_legacy_and_3tuple_pattern(self):
+        # Pattern con mix 2-elem e 3-elem
+        env = Envelope([[[0, 0, 'step'], [50, 1], [100, 0]], 1.0, 1])
+        # Seg 0 step, seg 1 linear (default)
+        assert env.evaluate(0.25) == pytest.approx(0.0)  # step
+        assert env.evaluate(0.75) == pytest.approx(0.5)  # linear midpoint
+
+    def test_compact_pure_2elem_unchanged(self):
+        # Regression: pattern 100% 2-elem dà output identico al pre-refactor
+        # Pattern [[0,0],[50,1],[100,0]], end_time=1.0, n_reps=2 → cycle_dur=0.5
+        # Ciclo 0: [0,0]→[0.25,1]→[0.5,0]
+        env = Envelope([[[0, 0], [50, 1], [100, 0]], 1.0, 2])
+        assert env.evaluate(0.0) == pytest.approx(0.0)
+        assert env.evaluate(0.125) == pytest.approx(0.5)  # rampa up midpoint
+        assert env.evaluate(0.25) == pytest.approx(1.0)   # peak ciclo 0
+        assert env.evaluate(0.375) == pytest.approx(0.5)  # rampa down midpoint
+        assert env.evaluate(0.5) == pytest.approx(0.0)    # fine ciclo 0
+        # Ciclo 1 con DISCONTINUITY_OFFSET
+        assert env.evaluate(0.75) == pytest.approx(1.0)   # peak ciclo 1
+
+    def test_create_scaled_envelope_normalized_with_3tuple(self):
+        env = create_scaled_envelope(
+            [[0, 0, 'step'], [0.5, 1, 'linear'], [1, 0]],
+            duration=2.0,
+            time_mode='normalized'
+        )
+        # Step segment ora 0→1s, linear 1→2s
+        assert env.evaluate(0.5) == pytest.approx(0.0)  # step hold
+        assert env.evaluate(1.5) == pytest.approx(0.5)  # linear midpoint


### PR DESCRIPTION
Closes #54.

## Sintassi nuove (additive)

**Lista 3-tuple:**
```yaml
parametro: [[0, 0, 'cubic'], [0.5, 1, 'linear'], [1, 0]]
```

**Dict per-punto:**
```yaml
parametro:
  type: linear
  points:
    - {t: 0, v: 0, type: cubic}
    - {t: 0.5, v: 1, type: linear}
    - {t: 1, v: 0}
```

Semantica: `type` su punto `i` = strategia segmento `i → i+1`. Ultimo punto: `type` ignorato (warning a log). Globale = default; per-punto override.

## Refactor architetturale

- `Envelope._parse_segments` ora produce N segmenti (uno per coppia) quando ci sono override per-punto. Envelope uniformi: backward compat 1-segmento.
- Cubic Fritsch-Carlson: tangenti calcolate globalmente, applicate solo a segmenti cubic per coerenza boundary.
- `evaluate`/`integrate` con lookup multi-segmento + hold pre/post sugli estremi globali.

## Disambiguazione parser

Punto critico discusso in plan: discriminare 3-tuple breakpoint da compact format (entrambi possono avere `len==3`).

| Forma | `elem[0]` | Riconoscimento |
|-------|-----------|----------------|
| `[0.5, 1.0, 'cubic']` | numerico | 3-tuple |
| `[[[0,0],[100,1]], 0.4, 4]` | list | compact |

Helper nuovo `_is_3tuple_breakpoint`. Validazione 2-elem ora richiede numerici (forma `[t, str]` vietata, errore chiaro).

## Backward compatibility

- Formato 2-elem `[t,v]`: invariato
- Dict `{type, points}` con bare points: invariato
- Compact 3/4/5-elem (con/senza `interp`, `time_dist`): invariato
- `_scale_time_recursive`, `_scale_raw_values_y`: preservano `seg_type` su 3-tuple
- Wrapper compatto con pattern 3-tuple: replica `seg_type` in ogni ciclo

## Test

- 40 nuovi test in `tests/envelopes/test_envelope_per_point_interp.py`
- Aree: parser disambiguazione (18), evaluate/integrate per-segmento, dict per-punto, loop replicato (5 edge case), time_mode normalized, edge case strutturali (bool/int/negative, 4-elem, dict senza chiavi)
- **4125 test totali verdi** (+40 vs main)
- **66 e2e verdi**

## Plan

`docs/plans/2026-05-22-003-feat-envelope-per-point-interp-plan.md`

## Test plan

- [x] `make tests` verde
- [x] `make e2e-tests` verde
- [x] Regression compact format (172 test pre-esistenti) verde
- [x] Disambiguazione tutti i casi (40 test nuovi) verde