### PR TITLE
feat: flag voices.pointer 'normalized' (issue #80)

### DIFF
--- a/.claude/rules/cross-repo-impact.md
+++ b/.claude/rules/cross-repo-impact.md
@@ -1,0 +1,31 @@
+# Impatto cross-repo su PGE-ls e PGE-ui
+
+PGE non vive isolato. Due repo dipendono dalla sua superficie pubblica:
+
+- `PGE-ls` (github.com/DMGiulioRomano/PGE-ls) — language server (pygls) che
+  edita/valida lo YAML del granular engine.
+- `PGE-ui` (github.com/DMGiulioRomano/PGE-ui) — interfaccia utente del granular
+  engine.
+
+## Quando applicare
+
+Per OGNI feature, modifica o fix che tocca una superficie osservabile da quei
+repo: sintassi/schema YAML, nuove chiavi o blocchi, bounds dei parametri, nomi
+di strategy/window/renderer, gerarchia errori, formati di output, CLI/flag,
+comportamento del rendering. Vale anche per refactoring che rinomina simboli
+pubblici o cambia messaggi d'errore parsati a valle.
+
+## Procedura
+
+1. Identifica cosa cambia nella superficie pubblica (YAML, errori, CLI, formati).
+2. Verifica se `PGE-ls` deve aggiornarsi (autocomplete, validazione, hover,
+   diagnostica, snippet) e se `PGE-ui` deve aggiornarsi (controlli, form,
+   visualizzazioni, default).
+3. Se c'è impatto, apri una issue nel repo interessato — una per repo:
+   ```bash
+   gh issue create -R DMGiulioRomano/PGE-ls  --title ... --body ...
+   gh issue create -R DMGiulioRomano/PGE-ui  --title ... --body ...
+   ```
+   La issue descrive la modifica PGE, il riferimento (issue/PR), e cosa va
+   aggiornato.
+4. Se non c'è impatto, dichiaralo esplicitamente nel riepilogo (niente issue).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   secondi. Default invariato (`normalized: false` → secondi), nessun breaking
   change sugli YAML esistenti. Vale per le strategie `linear` e `stochastic`;
   lo scaling avviene in `Stream._create_grain`, le strategy restano pure.
-  Risolve l'ambiguità di unità documentata in issue #80.
+  Il flag accetta solo `true`/`false`: un valore non-bool solleva
+  `InvalidFieldValueError` (nessuna coercion silenziosa, coerente con
+  `grain.reverse`). Risolve l'ambiguità di unità documentata in issue #80.
 
 - Flag `--format aiff|wav|flac` in `src/main.py` e variabile `FORMAT` nel
   Makefile: seleziona il formato audio di output (default `aiff`). Il formato

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Aggiunto
 
+- Flag `normalized` nel blocco `voices.pointer` (YAML): opt-in per interpretare
+  l'offset di pointer di voce come **frazione di `sample_dur_sec`** anziché in
+  secondi. Default invariato (`normalized: false` → secondi), nessun breaking
+  change sugli YAML esistenti. Vale per le strategie `linear` e `stochastic`;
+  lo scaling avviene in `Stream._create_grain`, le strategy restano pure.
+  Risolve l'ambiguità di unità documentata in issue #80.
+
 - Flag `--format aiff|wav|flac` in `src/main.py` e variabile `FORMAT` nel
   Makefile: seleziona il formato audio di output (default `aiff`). Il formato
   viene propagato a `NamingStrategy` (estensione file), `NumpyAudioRenderer`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,29 +14,9 @@ Inspired by Barry Truax's DMX-1000 (1988).
 
 **Prima di modificare un modulo esistente:** esegui `/impact-analysis`.
 
-**CRITICAL: Impatto cross-repo su PGE-ls e PGE-ui.**
-
-PGE non vive isolato. Due repo dipendono dalla sua superficie:
-
-- `PGE-ls` — language server (pygls) che edita/valida lo YAML del granular engine.
-- `PGE-ui` — interfaccia utente del granular engine.
-
-Per OGNI feature, modifica o fix che tocca una superficie osservabile da quei
-repo — sintassi/schema YAML, nuove chiavi o blocchi, bounds dei parametri,
-nomi di strategy/window/renderer, gerarchia errori, formati di output, CLI/flag,
-comportamento del rendering — esegui un'analisi d'impatto:
-
-1. Identifica cosa cambia nella superficie pubblica (YAML, errori, CLI, formati).
-2. Verifica se `PGE-ls` deve aggiornarsi (autocomplete, validazione, hover,
-   diagnostica, snippet) e se `PGE-ui` deve aggiornarsi (controlli, form,
-   visualizzazioni, default).
-3. Se c'è impatto, **apri una issue nel repo interessato** (`gh issue create -R
-   DMGiulioRomano/PGE-ls` / `-R DMGiulioRomano/PGE-ui`) che descriva la modifica
-   PGE, il riferimento (issue/PR), e cosa va aggiornato. Una issue per repo.
-4. Se non c'è impatto, dichiaralo esplicitamente nel riepilogo (niente issue).
-
-Vale anche per refactoring che rinomina simboli pubblici o cambia messaggi
-d'errore parsati a valle.
+**Impatto cross-repo:** ogni modifica alla superficie pubblica (YAML, errori,
+CLI, formati) richiede analisi d'impatto su `PGE-ls` e `PGE-ui` ed eventuale
+apertura di issue. Regola completa: @.claude/rules/cross-repo-impact.md
 
 ## Slash Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,30 @@ Inspired by Barry Truax's DMX-1000 (1988).
 
 **Prima di modificare un modulo esistente:** esegui `/impact-analysis`.
 
+**CRITICAL: Impatto cross-repo su PGE-ls e PGE-ui.**
+
+PGE non vive isolato. Due repo dipendono dalla sua superficie:
+
+- `PGE-ls` — language server (pygls) che edita/valida lo YAML del granular engine.
+- `PGE-ui` — interfaccia utente del granular engine.
+
+Per OGNI feature, modifica o fix che tocca una superficie osservabile da quei
+repo — sintassi/schema YAML, nuove chiavi o blocchi, bounds dei parametri,
+nomi di strategy/window/renderer, gerarchia errori, formati di output, CLI/flag,
+comportamento del rendering — esegui un'analisi d'impatto:
+
+1. Identifica cosa cambia nella superficie pubblica (YAML, errori, CLI, formati).
+2. Verifica se `PGE-ls` deve aggiornarsi (autocomplete, validazione, hover,
+   diagnostica, snippet) e se `PGE-ui` deve aggiornarsi (controlli, form,
+   visualizzazioni, default).
+3. Se c'è impatto, **apri una issue nel repo interessato** (`gh issue create -R
+   DMGiulioRomano/PGE-ls` / `-R DMGiulioRomano/PGE-ui`) che descriva la modifica
+   PGE, il riferimento (issue/PR), e cosa va aggiornato. Una issue per repo.
+4. Se non c'è impatto, dichiaralo esplicitamente nel riepilogo (niente issue).
+
+Vale anche per refactoring che rinomina simboli pubblici o cambia messaggi
+d'errore parsati a valle.
+
 ## Slash Commands
 
 - `/new-feature <nome>` — apre branch + avvia workflow TDD completo

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -463,8 +463,9 @@ voices:
 ```
 
 Il flag è opzionale e vale per `linear` e `stochastic`. Lo scaling avviene in
-`Stream._create_grain`; le strategy restituiscono il valore raw. Risolve l'ambiguità
-di unità storica (issue #80).
+`Stream._create_grain`; le strategy restituiscono il valore raw. Accetta solo
+`true`/`false`: un valore non booleano solleva `InvalidFieldValueError`. Risolve
+l'ambiguità di unità storica (issue #80).
 
 ---
 

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -7,7 +7,7 @@ sources:
   - src/engine/generator.py
   - src/parameters/
   - src/envelopes/
-last_synced_commit: 4c4fee4
+last_synced_commit: 6c1c2ec
 entry_for: [yaml-syntax, envelope-syntax]
 ---
 
@@ -448,6 +448,23 @@ voices:
     strategy: stochastic
     pointer_range: 0.2    # range massimo (scalare o envelope)
 ```
+
+**Unità dell'offset (`normalized`).** Di default l'offset di pointer è in
+**secondi** nel sample (coerente con `onset_offset`). Aggiungendo `normalized: true`
+al blocco `pointer`, lo stesso valore è interpretato come **frazione di
+`sample_dur_sec`** (es. `step: 0.12` → 12% del buffer):
+
+```yaml
+voices:
+  pointer:
+    strategy: linear
+    step: 0.12
+    normalized: true      # 0.12 = 12% del buffer (default: 0.12 secondi)
+```
+
+Il flag è opzionale e vale per `linear` e `stochastic`. Lo scaling avviene in
+`Stream._create_grain`; le strategy restituiscono il valore raw. Risolve l'ambiguità
+di unità storica (issue #80).
 
 ---
 

--- a/src/controllers/voice_manager.py
+++ b/src/controllers/voice_manager.py
@@ -51,7 +51,11 @@ class VoiceConfig:
 
     Attributes:
         pitch_offset:   offset in semitoni
-        pointer_offset: offset normalizzato sulla posizione nel sample
+        pointer_offset: offset sulla posizione di lettura nel sample. Unità
+                        decisa dal flag `normalized` del blocco pointer YAML:
+                        default = secondi nel sample; `normalized: true` =
+                        frazione di sample_dur_sec (lo scaling avviene in
+                        Stream._create_grain, che conosce sample_dur_sec).
         pan_offset:     offset in gradi rispetto al pan base dello stream
         onset_offset:   offset in secondi rispetto all'onset base
     """

--- a/src/core/stream.py
+++ b/src/core/stream.py
@@ -204,6 +204,12 @@ class Stream:
         from parameters.parameter import Parameter
         from parameters.parameter_definitions import GRANULAR_PARAMETERS
 
+        # Modalità unità del voice pointer offset:
+        #   False (default) → offset in secondi nel sample
+        #   True            → offset normalizzato (frazione di sample_dur_sec)
+        # Impostato dal flag `normalized:` nel blocco `pointer:` (vedi sotto).
+        self._voice_pointer_normalized = False
+
         v = params.get('voices', {})
         if not v:
             # Senza blocco voices, valori di default (nessun config necessario)
@@ -254,6 +260,8 @@ class Stream:
         if 'pointer' in v:
             kw = dict(v['pointer'])
             name = kw.pop('strategy')
+            # Flag di unità: config del blocco, non kwarg di strategy.
+            self._voice_pointer_normalized = bool(kw.pop('normalized', False))
             if name == 'stochastic':
                 kw['stream_id'] = self.stream_id
             kw = {k: _parse_strategy_kwarg(val, self.duration) for k, val in kw.items()}
@@ -434,7 +442,10 @@ class Stream:
         # grain.pointer_pos è la posizione reale di lettura: audio e partitura
         # usano lo stesso valore (issue #79).
         pointer_pos = self._pointer.calculate(elapsed_time, grain_dur, grain_reverse)
-        pointer_pos = (pointer_pos + voice_config.pointer_offset) % self.sample_dur_sec
+        voice_pointer_offset = voice_config.pointer_offset
+        if getattr(self, '_voice_pointer_normalized', False):
+            voice_pointer_offset *= self.sample_dur_sec
+        pointer_pos = (pointer_pos + voice_pointer_offset) % self.sample_dur_sec
 
         # === 3. VOLUME ===
         volume = self.volume.get_value(elapsed_time)

--- a/src/core/stream.py
+++ b/src/core/stream.py
@@ -261,7 +261,18 @@ class Stream:
             kw = dict(v['pointer'])
             name = kw.pop('strategy')
             # Flag di unità: config del blocco, non kwarg di strategy.
-            self._voice_pointer_normalized = bool(kw.pop('normalized', False))
+            # Solo bool puro: niente coercion silenziosa (cfr. grain.reverse,
+            # envelope_builder — il progetto valida i flag, non li forza).
+            raw_normalized = kw.pop('normalized', False)
+            if not isinstance(raw_normalized, bool):
+                err = InvalidFieldValueError(
+                    field='voices.pointer.normalized',
+                    value=raw_normalized,
+                    hint="normalized accetta solo true/false (default: false).",
+                )
+                err.stream_id = self.stream_id
+                raise err
+            self._voice_pointer_normalized = raw_normalized
             if name == 'stochastic':
                 kw['stream_id'] = self.stream_id
             kw = {k: _parse_strategy_kwarg(val, self.duration) for k, val in kw.items()}

--- a/src/strategies/voice_pointer_strategy.py
+++ b/src/strategies/voice_pointer_strategy.py
@@ -6,10 +6,17 @@ Strategy pattern per la distribuzione della posizione di lettura (pointer)
 delle voci nella sintesi granulare multi-voice.
 
 Responsabilità:
-- Calcolare l'offset di pointer (normalizzato 0.0-1.0) per una voce data al tempo t.
+- Calcolare l'offset di pointer (valore raw da YAML) per una voce data al tempo t.
 - Voce 0 restituisce sempre 0.0 (riferimento immutato).
 - Il valore è additivo con il pointer base di PointerController e il grain
   jitter già esistente (mod_range). Vedere pointer_controller.py.
+
+Unità dell'offset:
+- La strategy restituisce il valore raw (es. step=0.12) senza interpretarne
+  l'unità. L'interpretazione la decide Stream._create_grain dal flag `normalized`
+  del blocco pointer YAML: default = secondi nel sample; `normalized: true` =
+  frazione di sample_dur_sec. Lo scaling vive in Stream perché solo lì è nota
+  sample_dur_sec; la strategy resta pura.
 
 Layering pointer (da design doc):
   pointer_final = base_pointer(t)        # PointerController
@@ -43,8 +50,9 @@ class VoicePointerStrategy(ABC):
     """
     Strategy astratta per la distribuzione del pointer delle voci.
 
-    Il valore restituito è un offset normalizzato (tipicamente in [-1.0, 1.0])
-    rispetto alla posizione di lettura base dello stream.
+    Il valore restituito è l'offset raw da YAML rispetto alla posizione di
+    lettura base dello stream. L'unità (secondi o frazione di sample_dur_sec)
+    è decisa a valle da Stream._create_grain via flag `normalized`.
     Voce 0 restituisce sempre 0.0.
     """
 
@@ -59,7 +67,8 @@ class VoicePointerStrategy(ABC):
             time: tempo corrente in secondi (onset del grain).
 
         Returns:
-            Offset normalizzato (float). Voce 0 → sempre 0.0.
+            Offset raw (float), unità decisa a valle dal flag `normalized`.
+            Voce 0 → sempre 0.0.
         """
         pass
 

--- a/tests/core/test_stream_multivoice.py
+++ b/tests/core/test_stream_multivoice.py
@@ -91,6 +91,7 @@ def _make_stream(
     num_voices_fn=None,
     scatter_fn=None,
     density_side_effect=None,
+    voice_pointer_normalized=False,
 ):
     """Crea uno Stream con tutti i controller mockati e VoiceManager reale/mock.
 
@@ -115,6 +116,7 @@ def _make_stream(
     s._window_controller = _make_mock_window_controller()
 
     s._voice_manager = voice_manager or VoiceManager(max_voices=1)
+    s._voice_pointer_normalized = voice_pointer_normalized
 
     # density: supporta side_effect per simulare distribution > 0
     if density_side_effect is not None:
@@ -341,6 +343,63 @@ class TestGenerateGrainsVoiceOneOffsets:
         # Voce 1: 4.5 + 3.0 = 7.5 → 7.5 % 5.0 = 2.5
         voice_1_pointers = [g.pointer_pos for g in s.voices[1]]
         assert all(p == pytest.approx(2.5) for p in voice_1_pointers)
+
+    def test_normalized_linear_offset_scaled_by_sample_dur(self):
+        """normalized=True → step interpretato come frazione del buffer.
+
+        LinearPointerStrategy(step=0.2), sample_dur_sec=5.0, base=0.3.
+        Voce 1 offset normalizzato = 0.2 * 5.0 = 1.0 → pointer = 0.3 + 1.0 = 1.3.
+        """
+        from strategies.voice_pointer_strategy import LinearPointerStrategy
+        vm = VoiceManager(max_voices=2, pointer_strategy=LinearPointerStrategy(step=0.2))
+        s = _make_stream(duration=0.3, inter_onset=0.1, pointer_pos=0.3,
+                         voice_manager=vm, voice_pointer_normalized=True)
+        s.generate_grains()
+        voice_1_pointers = [g.pointer_pos for g in s.voices[1]]
+        assert all(p == pytest.approx(1.3) for p in voice_1_pointers)
+
+    def test_normalized_offset_rewrapped_into_buffer(self):
+        """normalized=True con offset oltre il buffer → re-wrap in [0, sample_dur).
+
+        step=0.6 normalizzato, sample_dur_sec=5.0 → offset=3.0; base=4.5
+        → 4.5 + 3.0 = 7.5 → 7.5 % 5.0 = 2.5. Wrap valido come in modalità secondi.
+        """
+        from strategies.voice_pointer_strategy import LinearPointerStrategy
+        vm = VoiceManager(max_voices=2, pointer_strategy=LinearPointerStrategy(step=0.6))
+        s = _make_stream(duration=0.3, inter_onset=0.1, pointer_pos=4.5,
+                         voice_manager=vm, voice_pointer_normalized=True)
+        s.generate_grains()
+        for voice_grains in s.voices:
+            for g in voice_grains:
+                assert 0.0 <= g.pointer_pos < s.sample_dur_sec
+        voice_1_pointers = [g.pointer_pos for g in s.voices[1]]
+        assert all(p == pytest.approx(2.5) for p in voice_1_pointers)
+
+    def test_normalized_stochastic_offset_scaled_by_sample_dur(self):
+        """normalized=True con stochastic → stesso cache[-1,1]*range, scalato per sample_dur_sec.
+
+        Stesso stream_id → stesso seed → stesso fattore di cache. L'offset
+        normalizzato deve essere quello in secondi moltiplicato per sample_dur_sec
+        (range piccolo + base centrata → nessun wrap a confondere il confronto).
+        """
+        from strategies.voice_pointer_strategy import StochasticPointerStrategy
+        vm_sec = VoiceManager(
+            max_voices=2,
+            pointer_strategy=StochasticPointerStrategy(pointer_range=0.1, stream_id='seed_x'),
+        )
+        vm_norm = VoiceManager(
+            max_voices=2,
+            pointer_strategy=StochasticPointerStrategy(pointer_range=0.1, stream_id='seed_x'),
+        )
+        s_sec = _make_stream(duration=0.3, inter_onset=0.1, pointer_pos=2.5, voice_manager=vm_sec)
+        s_norm = _make_stream(duration=0.3, inter_onset=0.1, pointer_pos=2.5,
+                              voice_manager=vm_norm, voice_pointer_normalized=True)
+        s_sec.generate_grains()
+        s_norm.generate_grains()
+        off_sec = s_sec.voices[1][0].pointer_pos - 2.5
+        off_norm = s_norm.voices[1][0].pointer_pos - 2.5
+        assert off_sec != pytest.approx(0.0)  # cache non nullo
+        assert off_norm == pytest.approx(off_sec * s_norm.sample_dur_sec)
 
     def test_voice_1_onset_offset_applied(self):
         """Voce 1 con LinearOnsetStrategy(step=0.5) → primo onset = onset + 0.0 + 0.5."""

--- a/tests/core/test_stream_voices_yaml.py
+++ b/tests/core/test_stream_voices_yaml.py
@@ -205,6 +205,23 @@ class TestVoicesPointerStrategy:
         assert s._voice_manager.get_voice_config(1, 0.0).pointer_offset == pytest.approx(0.1)
         assert s._voice_manager.get_voice_config(2, 0.0).pointer_offset == pytest.approx(0.2)
 
+    def test_pointer_normalized_default_false(self):
+        s = _build_stream({
+            'num_voices': 3,
+            'pointer': {'strategy': 'linear', 'step': 0.1},
+        })
+        assert s._voice_pointer_normalized is False
+
+    def test_pointer_normalized_flag_parsed(self):
+        """`normalized: true` impostato e rimosso dai kwarg della strategy."""
+        s = _build_stream({
+            'num_voices': 3,
+            'pointer': {'strategy': 'linear', 'step': 0.1, 'normalized': True},
+        })
+        assert s._voice_pointer_normalized is True
+        # La strategy resta pura: step ancora applicato, nessun errore kwarg.
+        assert s._voice_manager.get_voice_config(1, 0.0).pointer_offset == pytest.approx(0.1)
+
     def test_no_pointer_block_pointer_offset_zero(self):
         s = _build_stream({'num_voices': 3})
         for i in range(3):

--- a/tests/core/test_stream_voices_yaml.py
+++ b/tests/core/test_stream_voices_yaml.py
@@ -222,6 +222,15 @@ class TestVoicesPointerStrategy:
         # La strategy resta pura: step ancora applicato, nessun errore kwarg.
         assert s._voice_manager.get_voice_config(1, 0.0).pointer_offset == pytest.approx(0.1)
 
+    def test_pointer_normalized_non_bool_raises(self):
+        """`normalized` non-bool → InvalidFieldValueError (no coercion silenziosa)."""
+        from shared.exceptions import InvalidFieldValueError
+        with pytest.raises(InvalidFieldValueError):
+            _build_stream({
+                'num_voices': 3,
+                'pointer': {'strategy': 'linear', 'step': 0.1, 'normalized': 'flase'},
+            })
+
     def test_no_pointer_block_pointer_offset_zero(self):
         s = _build_stream({'num_voices': 3})
         for i in range(3):


### PR DESCRIPTION
## Contesto

Issue #80: incoerenza unità di `VoiceConfig.pointer_offset`. La doc lo dichiarava normalizzato 0.0–1.0, il codice lo sommava come secondi grezzi in `Stream._create_grain`.

## Scelta

Opzione C (non A né B): default in **secondi** (comportamento attuale invariato, nessun breaking sugli YAML esistenti) + flag opt-in `normalized: true` nel blocco `voices.pointer` per interpretare l'offset come **frazione di `sample_dur_sec`**.

## Modifiche

- `stream.py`: init `_voice_pointer_normalized=False`; `pop('normalized')` dal blocco pointer in `_init_voices`; scaling `*= sample_dur_sec` in `_create_grain` quando attivo. Le strategy restano pure (valore raw).
- Vale per `linear` e `stochastic`.
- Docstring `voice_manager.py` + `voice_pointer_strategy.py` allineate: risolvono l'incoerenza documentata in #80.
- Doc `yaml.md` (sezione unità + esempio), `CHANGELOG`.

## Test

6 nuovi test (TDD red→green): scaling linear/stochastic, parsing flag, default false, wrap `% sample_dur_sec` in entrambe le modalità. Suite completa: **4188 passed**.

Closes #80.