### PR TITLE
fix(visualizer): disegna envelope di num_voices, scatter e pointer_speed (issue #88, Fasi 1+2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   riguardava scatter/num_voices. Aggiunti: property `Stream.scatter` (simmetrica
   a `num_voices`), estrazione per nome esplicito nel visualizer, range/colore di
   `scatter`. Issue #88 (Fase 1).
+- `Stream.pointer_speed` era rotta: leggeva `self._pointer.speed.value`, ma il
+  `PointerController` espone `speed_ratio` (non `speed`) → `AttributeError` a ogni
+  chiamata. Corretta in `speed_ratio.value`. Inoltre `ScoreVisualizer` non
+  disegnava mai l'envelope di velocita' del pointer: lo schema lo definisce come
+  `pointer_speed_ratio` ma lo Stream espone la property `pointer_speed`, quindi il
+  ciclo sugli schemi lo saltava. Ora raccolto per nome esplicito sotto la chiave
+  `pointer_speed` (range/colore gia' presenti). Issue #88 (Fase 2).
 
 ### Modificato
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ## [Unreleased]
 
+### Corretto
+
+- `ScoreVisualizer` ora disegna gli envelope di `num_voices` e `scatter`. Questi
+  parametri sono `Parameter` privati dello Stream, fuori da ogni
+  `*_PARAMETER_SCHEMA`, quindi `_get_stream_envelopes` non li cercava mai: il
+  pannello envelope spariva del tutto se l'unica modulazione time-varying
+  riguardava scatter/num_voices. Aggiunti: property `Stream.scatter` (simmetrica
+  a `num_voices`), estrazione per nome esplicito nel visualizer, range/colore di
+  `scatter`. Issue #88 (Fase 1).
+
 ### Modificato
 
 - Default del parametro `volume` cambiato da `-6.0` a `0.0` dB. Gli stream che

--- a/src/core/stream.py
+++ b/src/core/stream.py
@@ -581,7 +581,8 @@ class Stream:
         
     @property
     def pointer_speed(self):
-        return self._pointer.speed.value
+        # Il PointerController espone `speed_ratio` (Parameter), non `speed`.
+        return self._pointer.speed_ratio.value
 
     @property
     def loop_start(self):

--- a/src/core/stream.py
+++ b/src/core/stream.py
@@ -618,7 +618,12 @@ class Stream:
     def num_voices(self):
         """Espone num_voices come Parameter (supporta Envelope time-varying)."""
         return self._num_voices
-            
+
+    @property
+    def scatter(self):
+        """Espone scatter come Parameter (supporta Envelope time-varying)."""
+        return self._scatter
+
     # =========================================================================
     # REPR
     # =========================================================================

--- a/src/rendering/score_visualizer.py
+++ b/src/rendering/score_visualizer.py
@@ -99,6 +99,7 @@ class ScoreVisualizer:
                 
                 # === VOICES ===
                 'num_voices': (1, 20),
+                'scatter': (0.0, 1.0),        # normalizzato (cluster→spread)
                 'voice_pitch_offset': (-48, 48),  # semitoni
                 'voice_pointer_offset': (-1.0, 1.0),  # normalizzato
                 'voice_pointer_range': (0.0, 1.0),    # normalizzato
@@ -135,6 +136,7 @@ class ScoreVisualizer:
                 
                 # === VOICES ===
                 'num_voices': '#e377c2',      # magenta
+                'scatter': '#17becf',         # teal
                 'voice_pitch_offset': '#c49c94',  # beige
                 'voice_pointer_offset': '#f7b6d2', # rosa chiaro
                 'voice_pointer_range': '#c7c7c7',  # grigio chiaro
@@ -899,6 +901,29 @@ class ScoreVisualizer:
                 envelopes['pitch'] = Envelope([[0, bp_values[0]], [stream.duration, bp_values[0]]])
         elif isinstance(pitch_value, (int, float)) and show_static:
             envelopes['pitch'] = Envelope([[0, pitch_value], [stream.duration, pitch_value]])
+
+        # =====================================================================
+        # VOICE / SCATTER: num_voices e scatter sono Parameter privati dello
+        # Stream, fuori da ogni *_PARAMETER_SCHEMA (issue #88). Vanno estratti
+        # per nome esplicito, con la stessa logica del valore principale
+        # (PART 1): Parameter → _value; solo Envelope dinamici, statici solo
+        # con show_static.
+        # =====================================================================
+        for name in ('num_voices', 'scatter'):
+            if not hasattr(stream, name):
+                continue
+            param = getattr(stream, name)
+            value = param._value if isinstance(param, Parameter) else param
+            if isinstance(value, Envelope):
+                bp_values = [bp[1] for bp in value.breakpoints]
+                is_static = len(set(bp_values)) == 1
+                if len(value.breakpoints) > 1 and not is_static:
+                    envelopes[name] = value
+                elif show_static:
+                    val = bp_values[0]
+                    envelopes[name] = Envelope([[0, val], [stream.duration, val]])
+            elif isinstance(value, (int, float)) and show_static:
+                envelopes[name] = Envelope([[0, value], [stream.duration, value]])
 
         return envelopes
 

--- a/src/rendering/score_visualizer.py
+++ b/src/rendering/score_visualizer.py
@@ -903,13 +903,17 @@ class ScoreVisualizer:
             envelopes['pitch'] = Envelope([[0, pitch_value], [stream.duration, pitch_value]])
 
         # =====================================================================
-        # VOICE / SCATTER: num_voices e scatter sono Parameter privati dello
-        # Stream, fuori da ogni *_PARAMETER_SCHEMA (issue #88). Vanno estratti
-        # per nome esplicito, con la stessa logica del valore principale
-        # (PART 1): Parameter → _value; solo Envelope dinamici, statici solo
-        # con show_static.
+        # ESTRAZIONE PER NOME ESPLICITO (issue #88). Parametri non raggiungibili
+        # dal ciclo sugli schemi:
+        #   - num_voices / scatter: Parameter privati dello Stream, fuori da ogni
+        #     *_PARAMETER_SCHEMA.
+        #   - pointer_speed: lo schema lo definisce come `pointer_speed_ratio`, ma
+        #     lo Stream espone la property `pointer_speed` → hasattr sul nome di
+        #     schema e' falso e il ciclo lo salta.
+        # Stessa logica del valore principale (PART 1): Parameter → _value; solo
+        # Envelope dinamici, statici solo con show_static.
         # =====================================================================
-        for name in ('num_voices', 'scatter'):
+        for name in ('num_voices', 'scatter', 'pointer_speed'):
             if not hasattr(stream, name):
                 continue
             param = getattr(stream, name)

--- a/src/rendering/score_visualizer.py
+++ b/src/rendering/score_visualizer.py
@@ -1202,6 +1202,8 @@ class ScoreVisualizer:
             'fill_factor': '',
             'distribution': '',
             'num_voices': ' voci',
+            'scatter': '',  # normalizzato 0-1, adimensionale
+            'scatter': '',  # normalizzato 0-1, adimensionale
             'pc_rand_reverse': '%',
         }
         

--- a/tests/core/test_stream.py
+++ b/tests/core/test_stream.py
@@ -57,8 +57,8 @@ def _make_mock_pointer():
     ptr = Mock()
     ptr.calculate = Mock(return_value=2.5)
     ptr.get_speed = Mock(return_value=1.0)
-    ptr.speed = Mock()
-    ptr.speed.value = 1.0
+    ptr.speed_ratio = Mock()
+    ptr.speed_ratio.value = 1.0
     ptr.loop_start = None
     ptr.loop_end = None
     ptr.loop_dur = None
@@ -944,9 +944,16 @@ class TestStreamProperties:
         assert s.distribution == 0.7
 
     def test_pointer_speed_property(self, stream_factory):
-        """pointer_speed espone .value dalla speed del pointer."""
+        """pointer_speed espone .value da speed_ratio del PointerController.
+
+        Il controller espone `speed_ratio` (Parameter), non `speed`: la property
+        deve leggere quello. Mock con spec per garantire che `.speed` non esista
+        (regressione issue #88: prima leggeva `_pointer.speed.value` → AttributeError)."""
         s = stream_factory()
-        s._pointer.speed.value = 2.0
+        ptr = Mock(spec=['speed_ratio'])
+        ptr.speed_ratio = Mock()
+        ptr.speed_ratio.value = 2.0
+        s._pointer = ptr
 
         assert s.pointer_speed == 2.0
 

--- a/tests/core/test_stream.py
+++ b/tests/core/test_stream.py
@@ -978,6 +978,14 @@ class TestStreamProperties:
 
         assert s.pitch_range == 2.0
 
+    def test_scatter_property(self, stream_factory):
+        """scatter espone il Parameter privato _scatter (simmetrico a num_voices)."""
+        s = stream_factory()
+        sentinel = _make_mock_parameter(0.0, 'scatter')
+        s._scatter = sentinel
+
+        assert s.scatter is sentinel
+
 
 
 # =============================================================================

--- a/tests/core/test_stream_multivoice.py
+++ b/tests/core/test_stream_multivoice.py
@@ -46,8 +46,8 @@ def _make_mock_pointer(return_value=0.5):
     ptr = Mock()
     ptr.calculate = Mock(return_value=return_value)
     ptr.get_speed = Mock(return_value=1.0)
-    ptr.speed = Mock()
-    ptr.speed.value = 1.0
+    ptr.speed_ratio = Mock()
+    ptr.speed_ratio.value = 1.0
     ptr.loop_start = None
     ptr.loop_end = None
     ptr.loop_dur = None

--- a/tests/rendering/test_score_visualizer.py
+++ b/tests/rendering/test_score_visualizer.py
@@ -595,3 +595,53 @@ class TestPitchEnvelopeCollection:
     def test_static_pitch_skipped_without_show_static(self):
         s = self._stream_with_pitch(0.0, 'semitones')
         assert 'pitch' not in make_viz([s])._get_stream_envelopes(s)
+
+
+class TestVoiceScatterEnvelopeCollection:
+    """num_voices e scatter non sono in nessuno schema *_PARAMETER_SCHEMA
+    (issue #88): vanno raccolti per nome esplicito in _get_stream_envelopes,
+    altrimenti i loro envelope non vengono mai disegnati."""
+
+    def _param(self, name, value):
+        from parameters.parameter import Parameter
+        from parameters.parameter_definitions import GRANULAR_PARAMETERS
+        return Parameter(name, value, GRANULAR_PARAMETERS[name])
+
+    def _stream(self, num_voices=None, scatter=None):
+        s = make_stream('s1', onset=0.0, duration=10.0)
+        # make_stream fa gia' `del s.num_voices`; scatter resta MagicMock.
+        if num_voices is not None:
+            s.num_voices = num_voices
+        if scatter is not None:
+            s.scatter = scatter
+        else:
+            del s.scatter
+        return s
+
+    def test_scatter_dynamic_envelope_collected(self):
+        from envelopes.envelope import Envelope
+        s = self._stream(scatter=self._param('scatter', Envelope([[0, 0.0], [10, 1.0]])))
+        assert 'scatter' in make_viz([s])._get_stream_envelopes(s)
+
+    def test_num_voices_dynamic_envelope_collected(self):
+        from envelopes.envelope import Envelope
+        s = self._stream(num_voices=self._param('num_voices', Envelope([[0, 1.0], [10, 8.0]])))
+        assert 'num_voices' in make_viz([s])._get_stream_envelopes(s)
+
+    def test_static_scatter_skipped_without_show_static(self):
+        from envelopes.envelope import Envelope
+        s = self._stream(scatter=self._param('scatter', Envelope([[0, 0.3], [10, 0.3]])))
+        assert 'scatter' not in make_viz([s])._get_stream_envelopes(s)
+
+    def test_static_scatter_collected_with_show_static(self):
+        from envelopes.envelope import Envelope
+        s = self._stream(scatter=self._param('scatter', Envelope([[0, 0.3], [10, 0.3]])))
+        viz = make_viz([s], config={'show_static_params': True})
+        assert 'scatter' in viz._get_stream_envelopes(s)
+
+    def test_has_envelopes_true_when_only_scatter_modulated(self):
+        """Regressione issue #88: il pannello envelope deve esistere anche se
+        l'unica modulazione time-varying e' scatter/num_voices."""
+        from envelopes.envelope import Envelope
+        s = self._stream(scatter=self._param('scatter', Envelope([[0, 0.0], [10, 1.0]])))
+        assert bool(make_viz([s])._get_stream_envelopes(s)) is True

--- a/tests/rendering/test_score_visualizer.py
+++ b/tests/rendering/test_score_visualizer.py
@@ -645,3 +645,31 @@ class TestVoiceScatterEnvelopeCollection:
         from envelopes.envelope import Envelope
         s = self._stream(scatter=self._param('scatter', Envelope([[0, 0.0], [10, 1.0]])))
         assert bool(make_viz([s])._get_stream_envelopes(s)) is True
+
+
+class TestPointerSpeedEnvelopeCollection:
+    """pointer_speed_ratio e' nello schema col nome `pointer_speed_ratio`, ma lo
+    Stream espone la property `pointer_speed`: hasattr(stream, 'pointer_speed_ratio')
+    e' falso, quindi il ciclo sugli schemi lo salta sempre (issue #88, Fase 2).
+    Va raccolto per nome esplicito sotto la chiave `pointer_speed`."""
+
+    def _stream(self, pointer_speed):
+        s = make_stream('s1', onset=0.0, duration=10.0)
+        s.pointer_speed = pointer_speed
+        return s
+
+    def test_pointer_speed_dynamic_envelope_collected(self):
+        from envelopes.envelope import Envelope
+        s = self._stream(Envelope([[0, -2.0], [10, 4.0]]))
+        assert 'pointer_speed' in make_viz([s])._get_stream_envelopes(s)
+
+    def test_static_pointer_speed_skipped_without_show_static(self):
+        from envelopes.envelope import Envelope
+        s = self._stream(Envelope([[0, 1.0], [10, 1.0]]))
+        assert 'pointer_speed' not in make_viz([s])._get_stream_envelopes(s)
+
+    def test_static_pointer_speed_collected_with_show_static(self):
+        from envelopes.envelope import Envelope
+        s = self._stream(Envelope([[0, 1.0], [10, 1.0]]))
+        viz = make_viz([s], config={'show_static_params': True})
+        assert 'pointer_speed' in viz._get_stream_envelopes(s)

--- a/tests/rendering/test_score_visualizer.py
+++ b/tests/rendering/test_score_visualizer.py
@@ -94,6 +94,8 @@ def make_stream(stream_id='s1', onset=0.0, duration=10.0,
     del s.pointer_start
     del s.density
     del s.num_voices
+    del s.scatter
+    del s.pointer_speed
     return s
 
 def make_generator(streams):
@@ -609,13 +611,11 @@ class TestVoiceScatterEnvelopeCollection:
 
     def _stream(self, num_voices=None, scatter=None):
         s = make_stream('s1', onset=0.0, duration=10.0)
-        # make_stream fa gia' `del s.num_voices`; scatter resta MagicMock.
+        # make_stream fa gia' `del s.num_voices` e `del s.scatter`: assenti di default.
         if num_voices is not None:
             s.num_voices = num_voices
         if scatter is not None:
             s.scatter = scatter
-        else:
-            del s.scatter
         return s
 
     def test_scatter_dynamic_envelope_collected(self):


### PR DESCRIPTION
Risolve la issue #88: nel `ScoreVisualizer` alcuni envelope non venivano mai disegnati. Include Fase 1 (num_voices + scatter) e Fase 2 (pointer_speed).

## Vincolo comune

Gli `*_PARAMETER_SCHEMA` sono la source of truth del parsing (controller + orchestrator). Non vanno toccati. I parametri mancanti vengono raccolti per **nome esplicito** in `_get_stream_envelopes`, dopo il ciclo sugli schemi.

## Fase 1 — num_voices + scatter

`num_voices` e `scatter` sono `Parameter` privati dello Stream, parsati a mano dal blocco `voices:` e fuori da ogni schema, quindi `_get_stream_envelopes` non li cercava mai. Se l'unica modulazione time-varying riguardava questi parametri, il pannello envelope spariva del tutto.

- `src/core/stream.py`: property `scatter` che espone `_scatter` (simmetrica a `num_voices`).
- `src/rendering/score_visualizer.py`: estrazione esplicita di `num_voices`/`scatter` + range (`0.0-1.0`) e colore per `scatter`.

## Fase 2 — pointer_speed

Doppio bug:
1. La property `Stream.pointer_speed` leggeva `self._pointer.speed.value`, ma il `PointerController` espone `speed_ratio` (Parameter), non `speed` → `AttributeError` a ogni chiamata.
2. Lo schema definisce il parametro come `pointer_speed_ratio`, ma lo Stream espone la property `pointer_speed`: `hasattr(stream, 'pointer_speed_ratio')` e' falso → il ciclo sugli schemi lo saltava sempre, l'envelope non era disegnabile.

- `src/core/stream.py`: property `pointer_speed` corretta in `speed_ratio.value`.
- `src/rendering/score_visualizer.py`: `pointer_speed` aggiunto all'estrazione per nome esplicito (range/colore gia' presenti).

## Test (TDD)

- `tests/core/test_stream.py`: `test_scatter_property`; `test_pointer_speed_property` riscritto per asserire l'interfaccia reale (`speed_ratio`, mock con spec senza `speed`). Mock pointer dei fixture allineati.
- `tests/rendering/test_score_visualizer.py`: `TestVoiceScatterEnvelopeCollection` (dinamici raccolti, statici esclusi/inclusi con `show_static`, `has_envelopes` True con sola modulazione scatter) e `TestPointerSpeedEnvelopeCollection`.

`make tests`: 4256 passed.

## Fuori scope

Fase 3 (offset per-voce `voice_pitch_offset`/`voice_pointer_offset`/`voice_pointer_range`): richiede estrazione dedicata dalle voice strategy, non sono Envelope sullo Stream.

## Impatto cross-repo

Nessuno su PGE-ls / PGE-ui: nessuna chiave/bound/errore/CLI/strategy nuovi — cambia solo cosa viene disegnato nel PDF di partitura.

Closes #88
