### PR TITLE
config(showcase): pulizia PGE_scatter_experiments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Modificato
 
+- Config showcase `configs/PGE_scatter_experiments.yml`: rimosso lo stream
+  duplicato `s01_cluster_equidistant1`, ripuliti i flag `solo`/`mute` residui e
+  aggiunto `time_mode: normalized` dove mancante. Solo dati di esempio, nessun
+  impatto sul codice.
 - Default del parametro `volume` cambiato da `-6.0` a `0.0` dB. Gli stream che
   non specificano `volume` ora rendono a 0 dB invece di -6 dB. Issue #87.
 

--- a/configs/PGE_scatter_experiments.yml
+++ b/configs/PGE_scatter_experiments.yml
@@ -45,26 +45,7 @@ streams:
       pan:
         strategy: linear
         spread: 60.0
-  - stream_id: "s01_cluster_equidistant1"
-    onset: 0.0
-    duration: 30.0
-    sample: "weNeedToTalkAboutIt.wav"
-    density: 12
-    distribution: 0.0
-    grain:
-      duration: .2
-    voices:
-      num_voices: 4
-        #- [0.0, 1]
-        #- [15.0, 10.0]
-        #- [30.0, 1]
-      scatter: 0.0
-      pitch:
-        strategy: step
-        step: 3.0
-      pan:
-        strategy: linear
-        spread: 60.0
+
 
   # S2: cluster Truax — distribution=1, scatter=0
   # Le voci avanzano all'unisono ma con iot distribuito (Truax).
@@ -74,6 +55,7 @@ streams:
     duration: 30.0
     sample: "001-0_0-3_0.wav"
     density: 12
+    time_mode: "normalized"
     distribution: 1.0
     distribution_mode: "gaussian"
     grain:
@@ -141,6 +123,7 @@ streams:
   - stream_id: "s04_fully_independent1-"
     onset: 107.0
     duration: 30.0
+    mute:
     sample: "001-37_0-4_5.wav"
     time_mode: "normalized"
     density: 5
@@ -157,7 +140,6 @@ streams:
       speed_ratio:
         time_unit: absolute
         points: [[0.0, 0.04], [0.5, 0.006], [1.0, 0.006]]
-    solo:
     voices:
       num_voices: 5
       pointer: {strategy: linear, step: .2}
@@ -186,7 +168,6 @@ streams:
       speed_ratio: 
         - [0.0, .02]
         - [.5, 0.006]
-    solo:
     voices:
       num_voices: 5
       pointer: {strategy: linear, step: .2}


### PR DESCRIPTION
## Cosa

Pulizia del config showcase `configs/PGE_scatter_experiments.yml`:

- Rimosso lo stream duplicato `s01_cluster_equidistant1`.
- Ripuliti i flag `solo`/`mute` residui dagli stream `s04_*`.
- Aggiunto `time_mode: normalized` dove mancante.

Solo dati di esempio: nessun impatto sul codice. Nessun test referenzia questo file. `make tests`: 4247 passed.

## Impatto cross-repo

Nessuno (PGE-ls / PGE-ui): e' un config di esempio, non cambia sintassi/superficie pubblica.
