### PR TITLE
fix(visualizer): plotta offset_range e dephase del pointer (#96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   ripristina anche le curve di range/dephase dei parametri stream-level
   (`volume`, `pan`, `grain_duration`). Range/colori gia' presenti in config.
   Issue #96.
+- `ScoreVisualizer`: i nomi lunghi nella legenda envelope (es.
+  `pointer_deviation_prob`) sforavano dalla colonna stretta (~6% pagina) dentro
+  l'area del plot. Ora `_legend_display_name` abbrevia i nomi lunghi con forme
+  corte semantiche (`pointer_deviation` → `ptr dev`, suffisso `_prob` → ` %`) e
+  il testo ha `clip_on=True` come rete di sicurezza: nessuna etichetta puo' piu'
+  invadere il plot. Issue #96.
 - `NumpyAudioRenderer`: drift sub-campione dell'onset eliminato usando `round()`
   invece di `int()`. Lo scheduler accumula il tempo con somme `float64`; dopo k
   iterazioni `onset * sr` scende ~1 ULP sotto l'intero ideale e `int()` troncava

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,20 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Corretto
 
+- `ScoreVisualizer`: `offset_range` (deviazione stocastica del pointer) e il
+  `dephase` non venivano mai disegnati nel pannello envelope. `_get_stream_envelopes`
+  leggeva due attributi obsoleti del refactor parametri: `Parameter._mod_prob`
+  (codice morto, mai assegnato → sempre `None`) per il dephase, e `_value` per
+  `offset_range` (che ha `yaml_path='_dummy_fixed_zero_'` → valore base 0 costante).
+  Ora il dephase si legge dal `Parameter._probability_gate` (`EnvelopeGate`/
+  `RandomGate`, con nuove property pubbliche `.envelope`/`.probability`) e il range
+  da `Parameter._mod_range`. Inoltre `pointer_deviation` non e' esposto sullo
+  Stream ma vive in `stream._pointer.deviation` (`PointerController`): il ciclo
+  sugli schemi lo saltava (`hasattr` falso), quindi e' stato aggiunto un blocco di
+  estrazione per nome esplicito (come `pointer_speed`, issue #88). La correzione
+  ripristina anche le curve di range/dephase dei parametri stream-level
+  (`volume`, `pan`, `grain_duration`). Range/colori gia' presenti in config.
+  Issue #96.
 - `NumpyAudioRenderer`: drift sub-campione dell'onset eliminato usando `round()`
   invece di `int()`. Lo scheduler accumula il tempo con somme `float64`; dopo k
   iterazioni `onset * sr` scende ~1 ULP sotto l'intero ideale e `int()` troncava

--- a/configs/PGE_visualizer_envelopes_test.yml
+++ b/configs/PGE_visualizer_envelopes_test.yml
@@ -1,0 +1,64 @@
+composition:
+  title: "Test visualizer envelopes (#96)"
+
+# Config di test EMPIRICO per issue #96.
+# Raccoglie tutti i parametri che il ScoreVisualizer NON disegnava:
+#   - range stocastici (_mod_range): volume_range, pan_range,
+#     grain.duration_range, pointer.offset_range
+#   - dephase per-chiave (probability gate): volume, pan, duration,
+#     pointer, reverse
+# Ogni curva e' un envelope dinamico con forma diversa, cosi' nel pannello
+# envelope si distinguono a colpo d'occhio. Tempo normalizzato (x in 0..1).
+#
+# Mappa parametro YAML -> chiave nel pannello envelope:
+#   volume                  -> volume
+#   volume_range            -> volume        (curva range, se base statico)
+#   dephase.volume          -> volume_prob
+#   pan_range               -> pan
+#   dephase.pan             -> pan_prob
+#   grain.duration          -> grain_duration
+#   grain.duration_range    -> grain_duration (curva range, se base statico)
+#   dephase.duration        -> grain_duration_prob
+#   pointer.offset_range    -> pointer_deviation
+#   dephase.pointer         -> pointer_deviation_prob
+#   dephase.reverse         -> reverse_prob
+
+streams:
+  - stream_id: "broken_params"
+    time_mode: "normalized"
+    onset: 0.0
+    duration: 30
+    sample: "001-0_0-3_0.wav"
+
+    # range sempre attivi anche dove il dephase non li accende:
+    # assicura che il render applichi i _range (la curva nel visualizer
+    # compare comunque, ma cosi' l'effetto e' anche udibile).
+    range_always_active: true
+
+    # volume: base statico per ISOLARE la curva di volume_range sulla chiave
+    # 'volume' (se il base fosse un envelope, vincerebbe lui in PARTE 1).
+    volume: -18
+    volume_range: [[0, 0], [0.5, 12], [1, 0]]      # -> 'volume'
+
+    # pan: nessun base esplicito, solo il range -> chiave 'pan'
+    pan_range: [[0, 0], [1, 90]]                    # -> 'pan'
+
+    grain:
+      duration: 0.05                                # base statico
+      duration_range: [[0, 0], [0.7, 0.08], [1, 0.01]]  # -> 'grain_duration'
+      reverse:                                      # presente -> dephase.reverse attivo
+
+    pointer:
+      speed_ratio: 0.2
+      offset_range: [[0, 0], [0.5, 1.0], [1, 0.2]]  # -> 'pointer_deviation'
+
+    density: 200
+    distribution: 1
+
+    # dephase per-chiave, ognuno envelope distinto -> curve *_prob
+    dephase:
+      volume:   [[0, 100], [1, 0]]                  # -> 'volume_prob'
+      pan:      [[0, 0], [1, 100]]                  # -> 'pan_prob'
+      duration: [[0, 20], [0.5, 90], [1, 20]]       # -> 'grain_duration_prob'
+      pointer:  [[0, 0], [0.5, 100], [1, 0]]        # -> 'pointer_deviation_prob'
+      reverse:  [[0, 0], [1, 50]]                   # -> 'reverse_prob'

--- a/src/rendering/score_visualizer.py
+++ b/src/rendering/score_visualizer.py
@@ -812,6 +812,7 @@ class ScoreVisualizer:
         """
         from envelopes.envelope import Envelope
         from parameters.parameter import Parameter
+        from shared.probability_gate import EnvelopeGate, RandomGate
         from parameters.parameter_schema import (
             STREAM_PARAMETER_SCHEMA, 
             POINTER_PARAMETER_SCHEMA, 
@@ -865,27 +866,49 @@ class ScoreVisualizer:
             # =====================================================================
             # PARTE 2: ESTRAZIONE DEPHASE (PROBABILITA) CON SUFFISSO "_prob"
             # =====================================================================
-            
-            # Se il parametro ha un dephase_key E è un Parameter object
+            # Il dephase oggi e' un ProbabilityGate iniettato in
+            # param._probability_gate (issue #96): EnvelopeGate per curve nel
+            # tempo, RandomGate per probabilita' costante. Never/Always: nessuna
+            # curva da disegnare.
             if spec.dephase_key and isinstance(param, Parameter):
-                mod_prob = getattr(param, '_mod_prob', None)
-                
-                if mod_prob is not None:
-                    # CHIAVE: Usa spec.name + "_prob" come nome nell'envelope
-                    prob_key = f"{spec.name}_prob"
-                    
-                    if isinstance(mod_prob, Envelope):
-                        # Solo envelope dinamici
-                        if len(mod_prob.breakpoints) > 1:
-                            envelopes[prob_key] = mod_prob
-                        # Envelope statici (solo se richiesto)
-                        elif show_static and len(mod_prob.breakpoints) == 1:
-                            val = mod_prob.breakpoints[0][1]
-                            envelopes[prob_key] = Envelope([[0, val], [stream.duration, val]])
-                    
-                    # Probabilita statiche (numero)
-                    elif isinstance(mod_prob, (int, float)) and show_static:
-                        envelopes[prob_key] = Envelope([[0, mod_prob], [stream.duration, mod_prob]])
+                gate = getattr(param, '_probability_gate', None)
+                prob_key = f"{spec.name}_prob"
+
+                if isinstance(gate, EnvelopeGate):
+                    env = gate.envelope
+                    bp_values = [bp[1] for bp in env.breakpoints]
+                    is_static = len(set(bp_values)) == 1
+                    if len(env.breakpoints) > 1 and not is_static:
+                        envelopes[prob_key] = env
+                    elif show_static:
+                        val = bp_values[0]
+                        envelopes[prob_key] = Envelope([[0, val], [stream.duration, val]])
+
+                elif isinstance(gate, RandomGate) and show_static:
+                    prob = gate.probability
+                    envelopes[prob_key] = Envelope([[0, prob], [stream.duration, prob]])
+
+            # =====================================================================
+            # PARTE 3: ESTRAZIONE RANGE (_mod_range) PER SPEC CON range_path
+            # =====================================================================
+            # Per parametri come pointer_deviation il valore base e' un dummy 0
+            # costante (yaml_path='_dummy_fixed_zero_'); la deviazione reale vive
+            # in param._mod_range (issue #96). Chiave = spec.name: sovrascrive il
+            # dummy-0 eventualmente emesso da PARTE 1.
+            if spec.range_path and isinstance(param, Parameter):
+                mod_range = getattr(param, '_mod_range', None)
+
+                if isinstance(mod_range, Envelope):
+                    bp_values = [bp[1] for bp in mod_range.breakpoints]
+                    is_static = len(set(bp_values)) == 1
+                    if len(mod_range.breakpoints) > 1 and not is_static:
+                        envelopes[spec.name] = mod_range
+                    elif show_static:
+                        val = bp_values[0]
+                        envelopes[spec.name] = Envelope([[0, val], [stream.duration, val]])
+
+                elif isinstance(mod_range, (int, float)) and show_static:
+                    envelopes[spec.name] = Envelope([[0, mod_range], [stream.duration, mod_range]])
 
         # =====================================================================
         # PITCH: unit-driven, non più in PITCH_PARAMETER_SCHEMA. Raccolto da
@@ -929,6 +952,45 @@ class ScoreVisualizer:
                     envelopes[name] = Envelope([[0, val], [stream.duration, val]])
             elif isinstance(value, (int, float)) and show_static:
                 envelopes[name] = Envelope([[0, value], [stream.duration, value]])
+
+        # =====================================================================
+        # POINTER DEVIATION (issue #96). pointer_deviation NON e' esposto sullo
+        # Stream: il Parameter vive in stream._pointer.deviation (PointerController)
+        # e hasattr(stream,'pointer_deviation') e' False, quindi il ciclo sugli
+        # schemi lo salta. offset_range sta in _mod_range (chiave
+        # 'pointer_deviation'), il dephase nel _probability_gate (chiave
+        # 'pointer_deviation_prob'). Stessa logica di PARTE 2 e PARTE 3.
+        # =====================================================================
+        pointer = getattr(stream, '_pointer', None)
+        deviation = getattr(pointer, 'deviation', None)
+        if isinstance(deviation, Parameter):
+            # offset_range -> chiave 'pointer_deviation'
+            mod_range = deviation._mod_range
+            if isinstance(mod_range, Envelope):
+                bp_values = [bp[1] for bp in mod_range.breakpoints]
+                is_static = len(set(bp_values)) == 1
+                if len(mod_range.breakpoints) > 1 and not is_static:
+                    envelopes['pointer_deviation'] = mod_range
+                elif show_static:
+                    val = bp_values[0]
+                    envelopes['pointer_deviation'] = Envelope([[0, val], [stream.duration, val]])
+            elif isinstance(mod_range, (int, float)) and show_static:
+                envelopes['pointer_deviation'] = Envelope([[0, mod_range], [stream.duration, mod_range]])
+
+            # dephase -> chiave 'pointer_deviation_prob'
+            gate = deviation._probability_gate
+            if isinstance(gate, EnvelopeGate):
+                env = gate.envelope
+                bp_values = [bp[1] for bp in env.breakpoints]
+                is_static = len(set(bp_values)) == 1
+                if len(env.breakpoints) > 1 and not is_static:
+                    envelopes['pointer_deviation_prob'] = env
+                elif show_static:
+                    val = bp_values[0]
+                    envelopes['pointer_deviation_prob'] = Envelope([[0, val], [stream.duration, val]])
+            elif isinstance(gate, RandomGate) and show_static:
+                prob = gate.probability
+                envelopes['pointer_deviation_prob'] = Envelope([[0, prob], [stream.duration, prob]])
 
         return envelopes
 

--- a/src/rendering/score_visualizer.py
+++ b/src/rendering/score_visualizer.py
@@ -1473,6 +1473,30 @@ class ScoreVisualizer:
 
         return lanes, legend_entries
 
+    # Nomi corti per la legenda: la colonna e' stretta (~6% pagina), i nomi
+    # lunghi sforavano nel plot (issue #96). Mappa solo i nomi lunghi; gli altri
+    # usano replace('_', ' ').
+    _ENV_LEGEND_SHORT = {
+        'pointer_deviation': 'ptr dev',
+        'pointer_speed': 'ptr spd',
+        'pointer_start': 'ptr start',
+        'grain_duration': 'grain dur',
+        'num_voices': 'voices',
+        'voice_pitch_offset': 'v pitch off',
+        'voice_pointer_offset': 'v ptr off',
+        'voice_pointer_range': 'v ptr rng',
+        'effective_density': 'eff density',
+        'distribution': 'distrib',
+        'fill_factor': 'fill',
+    }
+
+    def _legend_display_name(self, param_name):
+        """Nome corto per la legenda. Suffisso '_prob' → ' %' (probabilita')."""
+        if param_name.endswith('_prob'):
+            base = param_name[:-len('_prob')]
+            return f"{self._legend_display_name(base)} %"
+        return self._ENV_LEGEND_SHORT.get(param_name, param_name.replace('_', ' '))
+
     def _draw_envelope_legend(self, ax, legend_entries):
         """
         Disegna la legenda degli envelope nel subplot dedicato.
@@ -1487,10 +1511,13 @@ class ScoreVisualizer:
         for param_name, y, stream_id in legend_entries:
             color = colors.get(param_name, '#333333')
             ax.plot([0.1, 0.15], [y, y], color=color, linewidth=2)
-            ax.text(0.4, y, param_name.replace('_', ' '),
+            # clip_on=True: anche un nome inatteso non sfora mai nel plot,
+            # viene tagliato al bordo della colonna legenda (issue #96).
+            ax.text(0.4, y, self._legend_display_name(param_name),
                     fontsize=self.config['label_fontsize'] - 2,
                     verticalalignment='center',
-                    color=color)
+                    color=color,
+                    clip_on=True)
 
         ax.set_xlim(0, 1)
         ax.set_ylim(0, 1)

--- a/src/shared/probability_gate.py
+++ b/src/shared/probability_gate.py
@@ -69,7 +69,12 @@ class RandomGate(ProbabilityGate):
     
     def get_probability_value(self, time: float) -> float:
         return self._probability
-    
+
+    @property
+    def probability(self) -> float:
+        """Probabilità costante (0-100). Esposta per la visualizzazione."""
+        return self._probability
+
     @property
     def mode(self) -> str:
         return f"random({self._probability}%)"
@@ -87,7 +92,12 @@ class EnvelopeGate(ProbabilityGate):
     
     def get_probability_value(self, time: float) -> float:
         return self._envelope.evaluate(time)
-    
+
+    @property
+    def envelope(self) -> Envelope:
+        """Envelope di probabilità nel tempo. Esposta per la visualizzazione."""
+        return self._envelope
+
     @property
     def mode(self) -> str:
         return f"envelope({self._envelope.type})"

--- a/tests/rendering/test_score_visualizer.py
+++ b/tests/rendering/test_score_visualizer.py
@@ -675,6 +675,151 @@ class TestPointerSpeedEnvelopeCollection:
         assert 'pointer_speed' in viz._get_stream_envelopes(s)
 
 
+class TestModRangeEnvelopeCollection:
+    """issue #96 - i parametri con range_path (volume_range, pan_range,
+    grain.duration_range, offset_range) tengono il range stocastico in
+    Parameter._mod_range, mai estratto dal visualizer. Va raccolto sotto la
+    chiave spec.name. Qui via `volume` (stream-level, raggiungibile dal loop)."""
+
+    def _stream_with_volume_range(self, base, mod_range):
+        from parameters.parameter import Parameter
+        from parameters.parameter_definitions import GRANULAR_PARAMETERS
+        s = make_stream('s1', onset=0.0, duration=10.0)
+        # base scalare statico: PARTE 1 non emette 'volume', isola PARTE 3
+        s.volume = Parameter('volume', base, GRANULAR_PARAMETERS['volume'],
+                             mod_range=mod_range)
+        return s
+
+    def test_dynamic_range_envelope_collected(self):
+        from envelopes.envelope import Envelope
+        s = self._stream_with_volume_range(-6.0, Envelope([[0, 0.0], [10, 12.0]]))
+        assert 'volume' in make_viz([s])._get_stream_envelopes(s)
+
+    def test_dynamic_range_envelope_is_the_mod_range(self):
+        from envelopes.envelope import Envelope
+        env = Envelope([[0, 0.0], [10, 12.0]])
+        s = self._stream_with_volume_range(-6.0, env)
+        assert make_viz([s])._get_stream_envelopes(s)['volume'] is env
+
+    def test_static_range_skipped_without_show_static(self):
+        s = self._stream_with_volume_range(-6.0, 3.0)
+        assert 'volume' not in make_viz([s])._get_stream_envelopes(s)
+
+    def test_static_range_collected_with_show_static(self):
+        s = self._stream_with_volume_range(-6.0, 3.0)
+        viz = make_viz([s], config={'show_static_params': True})
+        assert 'volume' in viz._get_stream_envelopes(s)
+
+
+class TestDephaseGateEnvelopeCollection:
+    """issue #96 - il dephase oggi e' un ProbabilityGate in
+    Parameter._probability_gate, non piu' in _mod_prob (codice morto). Va letto
+    dal gate sotto la chiave `{spec.name}_prob`. Qui via `volume` (stream-level)."""
+
+    def _stream_with_gate(self, gate):
+        from parameters.parameter import Parameter
+        from parameters.parameter_definitions import GRANULAR_PARAMETERS
+        s = make_stream('s1', onset=0.0, duration=10.0)
+        p = Parameter('volume', -6.0, GRANULAR_PARAMETERS['volume'])
+        if gate is not None:
+            p.set_probability_gate(gate)
+        s.volume = p
+        return s
+
+    def test_envelope_gate_collected(self):
+        from envelopes.envelope import Envelope
+        from shared.probability_gate import EnvelopeGate
+        s = self._stream_with_gate(EnvelopeGate(Envelope([[0, 0.0], [10, 100.0]])))
+        assert 'volume_prob' in make_viz([s])._get_stream_envelopes(s)
+
+    def test_envelope_gate_curve_is_the_gate_envelope(self):
+        from envelopes.envelope import Envelope
+        from shared.probability_gate import EnvelopeGate
+        env = Envelope([[0, 0.0], [10, 100.0]])
+        s = self._stream_with_gate(EnvelopeGate(env))
+        assert make_viz([s])._get_stream_envelopes(s)['volume_prob'] is env
+
+    def test_random_gate_skipped_without_show_static(self):
+        from shared.probability_gate import RandomGate
+        s = self._stream_with_gate(RandomGate(50.0))
+        assert 'volume_prob' not in make_viz([s])._get_stream_envelopes(s)
+
+    def test_random_gate_collected_with_show_static(self):
+        from shared.probability_gate import RandomGate
+        s = self._stream_with_gate(RandomGate(50.0))
+        viz = make_viz([s], config={'show_static_params': True})
+        assert 'volume_prob' in viz._get_stream_envelopes(s)
+
+    def test_never_gate_not_collected(self):
+        s = self._stream_with_gate(None)  # default NeverGate
+        viz = make_viz([s], config={'show_static_params': True})
+        assert 'volume_prob' not in viz._get_stream_envelopes(s)
+
+
+class TestPointerDeviationEnvelopeCollection:
+    """issue #96 - il vero pointer_deviation NON e' esposto sullo Stream: vive in
+    stream._pointer.deviation (PointerController), offset_range in _mod_range e
+    dephase in _probability_gate. hasattr(stream,'pointer_deviation') e' False:
+    il loop sugli schemi lo salta, serve estrazione esplicita (come pointer_speed,
+    issue #88). Chiavi: `pointer_deviation` (range) e `pointer_deviation_prob`."""
+
+    def _stream(self, mod_range=None, gate=None):
+        from parameters.parameter import Parameter
+        from parameters.parameter_definitions import GRANULAR_PARAMETERS
+        s = make_stream('s1', onset=0.0, duration=10.0)
+        p = Parameter('pointer_deviation', 0.0,
+                      GRANULAR_PARAMETERS['pointer_deviation'],
+                      mod_range=mod_range)
+        if gate is not None:
+            p.set_probability_gate(gate)
+        pointer = MagicMock()
+        pointer.deviation = p
+        s._pointer = pointer
+        return s
+
+    def test_offset_range_envelope_collected(self):
+        from envelopes.envelope import Envelope
+        s = self._stream(mod_range=Envelope([[0, 0.0], [10, 1.0]]))
+        assert 'pointer_deviation' in make_viz([s])._get_stream_envelopes(s)
+
+    def test_offset_range_envelope_is_the_mod_range(self):
+        from envelopes.envelope import Envelope
+        env = Envelope([[0, 0.0], [10, 1.0]])
+        s = self._stream(mod_range=env)
+        assert make_viz([s])._get_stream_envelopes(s)['pointer_deviation'] is env
+
+    def test_offset_range_static_skipped_without_show_static(self):
+        s = self._stream(mod_range=0.4)
+        assert 'pointer_deviation' not in make_viz([s])._get_stream_envelopes(s)
+
+    def test_offset_range_static_collected_with_show_static(self):
+        s = self._stream(mod_range=0.4)
+        viz = make_viz([s], config={'show_static_params': True})
+        assert 'pointer_deviation' in viz._get_stream_envelopes(s)
+
+    def test_dephase_envelope_gate_collected(self):
+        from envelopes.envelope import Envelope
+        from shared.probability_gate import EnvelopeGate
+        s = self._stream(gate=EnvelopeGate(Envelope([[0, 0.0], [10, 100.0]])))
+        assert 'pointer_deviation_prob' in make_viz([s])._get_stream_envelopes(s)
+
+    def test_dephase_random_gate_collected_with_show_static(self):
+        from shared.probability_gate import RandomGate
+        s = self._stream(gate=RandomGate(50.0))
+        viz = make_viz([s], config={'show_static_params': True})
+        assert 'pointer_deviation_prob' in viz._get_stream_envelopes(s)
+
+    def test_dephase_never_gate_not_collected(self):
+        s = self._stream()  # default NeverGate
+        viz = make_viz([s], config={'show_static_params': True})
+        assert 'pointer_deviation_prob' not in viz._get_stream_envelopes(s)
+
+    def test_no_pointer_attr_does_not_crash(self):
+        s = make_stream('s1', onset=0.0, duration=10.0)
+        del s._pointer
+        assert make_viz([s])._get_stream_envelopes(s) is not None
+
+
 # =============================================================================
 # GROUP - Legenda envelope per-lane (issue #91)
 # =============================================================================

--- a/tests/rendering/test_score_visualizer.py
+++ b/tests/rendering/test_score_visualizer.py
@@ -820,6 +820,43 @@ class TestPointerDeviationEnvelopeCollection:
         assert make_viz([s])._get_stream_envelopes(s) is not None
 
 
+class TestLegendDisplayName:
+    """issue #96 - i nomi lunghi (pointer_deviation_prob, grain_duration_prob)
+    sforavano dalla colonna legenda (6%) dentro il plot. _legend_display_name
+    abbrevia con nomi corti semantici e suffisso ' %' per le probabilita'."""
+
+    def _viz(self):
+        return make_viz(single_stream_scene())
+
+    def test_prob_suffix_becomes_percent(self):
+        assert self._viz()._legend_display_name('volume_prob') == 'volume %'
+
+    def test_pan_prob(self):
+        assert self._viz()._legend_display_name('pan_prob') == 'pan %'
+
+    def test_pointer_deviation_abbreviated(self):
+        assert self._viz()._legend_display_name('pointer_deviation') == 'ptr dev'
+
+    def test_pointer_deviation_prob_abbreviated(self):
+        assert self._viz()._legend_display_name('pointer_deviation_prob') == 'ptr dev %'
+
+    def test_grain_duration_abbreviated(self):
+        assert self._viz()._legend_display_name('grain_duration') == 'grain dur'
+
+    def test_grain_duration_prob_abbreviated(self):
+        assert self._viz()._legend_display_name('grain_duration_prob') == 'grain dur %'
+
+    def test_unmapped_underscore_becomes_space(self):
+        assert self._viz()._legend_display_name('scatter') == 'scatter'
+
+    def test_all_known_keys_fit_column(self):
+        """Ogni chiave in envelope_colors deve produrre un nome abbastanza corto
+        da non sforare nella colonna legenda stretta."""
+        viz = self._viz()
+        for key in viz.config['envelope_colors']:
+            assert len(viz._legend_display_name(key)) <= 12, key
+
+
 # =============================================================================
 # GROUP - Legenda envelope per-lane (issue #91)
 # =============================================================================


### PR DESCRIPTION
## Problema

Nel pannello envelope del `ScoreVisualizer` due curve non venivano **mai** disegnate (issue #96):

1. `offset_range` (deviazione stocastica del pointer)
2. `dephase` quando e' un envelope (es. `dephase: { pointer: [[0,0],[1,100]] }`)

## Causa

`_get_stream_envelopes` leggeva attributi obsoleti rimasti dopo il refactor dei parametri:

- **dephase**: `getattr(param, '_mod_prob', None)` → `_mod_prob` e' codice morto, mai assegnato in `src/` → sempre `None`. Il dephase oggi e' un `ProbabilityGate` iniettato in `Parameter._probability_gate`.
- **offset_range**: letto da `_value`, ma lo schema `pointer_deviation` ha `yaml_path='_dummy_fixed_zero_'` (valore base 0 costante). Il valore reale sta in `Parameter._mod_range`.

**Gap scoperto oltre l'issue:** `pointer_deviation` non e' esposto sullo Stream — vive in `stream._pointer.deviation` (`PointerController`). `hasattr(stream,'pointer_deviation')` e' `False`, quindi il ciclo sugli schemi lo saltava comunque. Serviva estrazione per nome esplicito, come gia' fatto per `pointer_speed` (#88).

## Fix

1. `probability_gate.py` — property pubbliche `EnvelopeGate.envelope` e `RandomGate.probability` (no violazione incapsulamento).
2. `score_visualizer.py`:
   - PARTE 2 (dephase): legge dal `_probability_gate`.
   - PARTE 3 (range): estrae `_mod_range` per gli spec con `range_path`.
   - Blocco esplicito per `stream._pointer.deviation` (chiavi `pointer_deviation` / `pointer_deviation_prob`).
   - Ripristina anche le curve range/dephase dei parametri stream-level (`volume`, `pan`, `grain_duration`), rotte dallo stesso bug.
3. **Legenda**: i nomi lunghi (`pointer_deviation_prob`) sforavano dalla colonna stretta (~6% pagina) nel plot. `_legend_display_name` abbrevia (`ptr dev`, suffisso `_prob` → ` %`) + `clip_on=True` come rete di sicurezza.

## Test

- TDD rosso→verde: `TestModRangeEnvelopeCollection`, `TestDephaseGateEnvelopeCollection`, `TestPointerDeviationEnvelopeCollection`, `TestLegendDisplayName`.
- `make tests` → **4296 passed**.
- Config di test empirico `configs/PGE_visualizer_envelopes_test.yml`: stream singolo che esercita tutte le curve prima mancanti.
- Verifica visiva: render PDF/PNG di `PGE_pino4.yml` e del config di test → tutte le curve compaiono, legenda compatta senza sfori.

## Impatto cross-repo

Nullo. Solo visualizzazione interna — nessuna superficie YAML/errori/CLI/formati. Niente issue PGE-ls/PGE-ui.

Closes #96
