### PR TITLE
ScoreVisualizer: flag --plot-envelopes per selezionare quali envelope plottare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Aggiunto
 
+- Flag CLI `--plot-envelopes nomi,csv` (variabile Make `PLOT_ENVELOPES`):
+  filtro selettivo degli envelope nella partitura PDF. Default (flag assente):
+  tutti gli envelope, come prima. Con flag: solo i nomi elencati vengono
+  plottati, per osservazioni chirurgiche di singoli parametri. Il filtro
+  agisce sulle chiavi del dict di `_get_stream_envelopes` (copre valori
+  principali, `*_prob`, range, `pitch`, parametri voce) ed è ortogonale a
+  `--show-static` (uno statico elencato appare solo con entrambe le flag).
+  Nomi non validi: messaggio con elenco dei validi + exit 1. Universo dei
+  nomi = nuova costante `PLOT_ENVELOPE_KEYS` (chiavi di `ENVELOPE_COLORS`,
+  estratto a livello modulo in `score_visualizer.py`). Issue #101.
 - Variabile Make `GRAIN_JSON` (default `false`): espone la flag CLI
   `--grain-json` nel sistema di flag del Makefile, seguendo il pattern delle
   altre flag (`STEMS`, `CACHE`, `AUTOVISUAL`, ...). Attiva solo con

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,9 @@ REAPER_REUSE_TAB ?= false
 AUTOPEN ?= true
 AUTOVISUAL ?= false
 SHOWSTATIC ?= false
+# Filtro envelope nella partitura, nomi comma-separated (issue #101).
+# Vuoto = tutti. Es: PLOT_ENVELOPES=pitch,density (richiede AUTOVISUAL=true)
+PLOT_ENVELOPES ?=
 FILE ?= PGE_test
 TEST ?= false
 PRECLEAN ?=true

--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ The test suite covers unit tests for every module and end-to-end pipeline valida
 | `CACHE` | `true` | Skip unchanged streams when `STEMS=true` |
 | `CACHEDIR` | `cache` | Directory for stream fingerprint manifests |
 | `GRAIN_JSON` | `false` | Export per-stream grain JSON sidecar (requires `STEMS=true`) |
+| `PLOT_ENVELOPES` | _(empty)_ | Comma-separated envelope names to plot in the PDF score; empty = all (requires `AUTOVISUAL=true`) |
 
 Example:
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -6,7 +6,7 @@ tags: [cli, flags, make, rendering, export]
 sources:
   - src/main.py
   - make/build.mk
-last_synced_commit: 9ee6b58
+last_synced_commit: 9eb9c14
 entry_for: [cli-flags, build-flags]
 ---
 
@@ -73,6 +73,7 @@ Senza argomenti: stampa usage ed esce con codice 1.
 | `--message-level N` | `134` | — | message level di Csound |
 | `--sco-dir DIR` | `generated` | — | destinazione `.sco` (attivo solo con `--keep-sco`) |
 | `--reaper-path FILE` | `{yaml_basename}.rpp` | `REAPER_PATH` | percorso del progetto Reaper |
+| `--plot-envelopes nomi` | tutti | `PLOT_ENVELOPES` | filtro selettivo degli envelope nella partitura: nomi comma-separated (es. `pitch,density,volume_prob`); nome non valido: messaggio con elenco dei validi + exit 1 |
 
 ## Bounds
 
@@ -93,6 +94,12 @@ Vincoli tra flag e comportamento nelle combinazioni non valide:
 - **`--keep-sco` / `--sco-dir`** hanno effetto solo con `--renderer csound`
   (il renderer numpy non produce `.sco`).
 - **`--show-static`** ha effetto solo insieme a `--visualize`.
+- **`--plot-envelopes`** ha effetto solo insieme a `--visualize`; la
+  validazione dei nomi avviene comunque (nome ignoto → exit 1 anche senza
+  `--visualize`). Il filtro è ortogonale a `--show-static`: un parametro
+  statico elencato nel filtro appare solo se c'è anche `--show-static`.
+  Nomi validi = chiavi di `ENVELOPE_COLORS`
+  (`src/rendering/score_visualizer.py`, costante `PLOT_ENVELOPE_KEYS`).
 - Le flag con valore leggono il token successivo in `sys.argv`; se manca,
   la flag viene ignorata senza errore.
 
@@ -111,6 +118,12 @@ make all FILE=brano STEMS=true CACHE=true GRAIN_JSON=true RENDERER=numpy
 
 # Debug csound: conserva gli .sco intermedi
 python src/main.py configs/brano.yml --renderer csound --keep-sco --sco-dir generated
+
+# Partitura con i soli envelope di pitch e density
+python src/main.py configs/brano.yml --visualize --plot-envelopes pitch,density
+
+# Equivalente via Make
+make all FILE=brano AUTOVISUAL=true PLOT_ENVELOPES=pitch,density
 ```
 
 ## Versionato da

--- a/make/build.mk
+++ b/make/build.mk
@@ -38,6 +38,11 @@ ifeq ($(SHOWSTATIC), true)
 PYFLAGS += --show-static
 endif
 
+# 2b. Se PLOT_ENVELOPES e' non-vuoto, aggiungi --plot-envelopes (issue #101)
+ifneq ($(strip $(PLOT_ENVELOPES)),)
+PYFLAGS += --plot-envelopes $(PLOT_ENVELOPES)
+endif
+
 # 3. Se REAPER e' true, aggiungi --reaper (esporta .rpp Reaper)
 ifeq ($(REAPER), true)
 PYFLAGS += --reaper

--- a/src/main.py
+++ b/src/main.py
@@ -10,7 +10,7 @@ from shared.logger import (
 )
 from shared.exceptions import EngineError
 from engine.generator import Generator
-from rendering.score_visualizer import ScoreVisualizer
+from rendering.score_visualizer import ScoreVisualizer, PLOT_ENVELOPE_KEYS
 
 
 def _handle_engine_error(err: EngineError) -> None:
@@ -122,7 +122,8 @@ def main():
     if len(sys.argv) < 2:
         print(
             "Uso: python main.py <file.yml> [output.aif] "
-            "[--visualize] [--show-static] [--per-stream] "
+            "[--visualize] [--show-static] [--plot-envelopes nomi,csv] "
+            "[--per-stream] "
             "[--renderer csound|numpy] "
             "[--format aiff|wav|flac] "
             "[--orc-path PATH] [--incdir DIR] [--ssdir DIR] [--sfdir DIR] "
@@ -144,6 +145,25 @@ def main():
 
     do_visualize = '--visualize' in sys.argv or '-v' in sys.argv
     show_static = '--show-static' in sys.argv or '-s' in sys.argv
+
+    # --plot-envelopes nomi,comma-separated (issue #101): filtro selettivo
+    # degli envelope nella partitura. None = tutti (default).
+    plot_envelopes = None
+    if '--plot-envelopes' in sys.argv:
+        idx = sys.argv.index('--plot-envelopes')
+        if idx + 1 < len(sys.argv):
+            plot_envelopes = {
+                name.strip()
+                for name in sys.argv[idx + 1].split(',')
+                if name.strip()
+            }
+            unknown = plot_envelopes - PLOT_ENVELOPE_KEYS
+            if unknown:
+                print(
+                    f"Envelope non validi: {', '.join(sorted(unknown))}. "
+                    f"Validi: {', '.join(sorted(PLOT_ENVELOPE_KEYS))}"
+                )
+                sys.exit(1)
     per_stream = '--per-stream' in sys.argv or '-p' in sys.argv
     use_cache = '--cache' in sys.argv
     reaper_export = '--reaper' in sys.argv
@@ -333,6 +353,7 @@ def main():
             viz = ScoreVisualizer(generator, config={
                 'page_duration': 15.0,
                 'show_static_params': show_static,
+                'envelope_filter': plot_envelopes,
             })
             viz.export_pdf(pdf_file)
 

--- a/src/rendering/score_visualizer.py
+++ b/src/rendering/score_visualizer.py
@@ -13,6 +13,49 @@ from math import ceil
 # Path samples (stesso del progetto)
 PATHSAMPLES = './refs/'
 
+# Colori di default degli envelope. A livello modulo perche' le sue chiavi
+# sono l'universo dei nomi plottabili: main.py le usa per validare
+# --plot-envelopes (issue #101).
+ENVELOPE_COLORS = {
+    # === OUTPUT ===
+    'volume': '#e41a1c',          # rosso
+    'volume_prob': '#fb9a99',     # rosso chiaro
+    'pan': '#4daf4a',             # verde
+    'pan_prob': '#b2df8a',        # verde chiaro
+
+    # === GRAIN ===
+    'grain_duration': '#377eb8',  # blu
+    'grain_duration_prob': '#a6cee3',  # blu chiaro
+    'reverse': '#999999',         # grigio
+    'reverse_prob': '#cccccc',    # grigio chiarissimo
+
+    # === POINTER ===
+    'pointer_start': '#8dd3c7',   # celeste
+    'pointer_speed': '#a65628',   # marrone
+    'pointer_deviation': '#fb8072',  # salmone
+    'pointer_deviation_prob': '#fdb462',  # arancione chiaro
+    'loop_dur': '#bebada',        # lavanda
+
+    # === PITCH ===
+    'pitch': '#984ea3',           # viola (unit-driven, qualsiasi unità)
+
+    # === DENSITY ===
+    'density': '#ff7f00',         # arancio
+    'fill_factor': '#f781bf',     # rosa
+    'distribution': '#999999',    # grigio
+    'effective_density': '#ffed6f',  # giallo
+
+    # === VOICES ===
+    'num_voices': '#e377c2',      # magenta
+    'scatter': '#17becf',         # teal
+    'voice_pitch_offset': '#c49c94',  # beige
+    'voice_pointer_offset': '#f7b6d2', # rosa chiaro
+    'voice_pointer_range': '#c7c7c7',  # grigio chiaro
+}
+
+# Nomi validi per il filtro --plot-envelopes / envelope_filter (issue #101)
+PLOT_ENVELOPE_KEYS = frozenset(ENVELOPE_COLORS)
+
 
 class ScoreVisualizer:
     """
@@ -41,6 +84,9 @@ class ScoreVisualizer:
         default_config = {
             # Se True, mostra anche i valori costanti
             'show_static_params': False,
+            # Filtro selettivo: None = tutti gli envelope; altrimenti set/lista
+            # di nomi — solo quelli elencati vengono plottati (issue #101)
+            'envelope_filter': None,
             # Paginazione
             'page_duration': 30.0,           # secondi per pagina
             'page_size': (420, 297),         # A3 in mm
@@ -105,42 +151,7 @@ class ScoreVisualizer:
                 'voice_pointer_range': (0.0, 1.0),    # normalizzato
             },
 
-            'envelope_colors': {
-                # === OUTPUT ===
-                'volume': '#e41a1c',          # rosso
-                'volume_prob': '#fb9a99',     # rosso chiaro
-                'pan': '#4daf4a',             # verde
-                'pan_prob': '#b2df8a',        # verde chiaro
-                
-                # === GRAIN ===
-                'grain_duration': '#377eb8',  # blu
-                'grain_duration_prob': '#a6cee3',  # blu chiaro
-                'reverse': '#999999',         # grigio
-                'reverse_prob': '#cccccc',    # grigio chiarissimo
-                
-                # === POINTER ===
-                'pointer_start': '#8dd3c7',   # celeste
-                'pointer_speed': '#a65628',   # marrone
-                'pointer_deviation': '#fb8072',  # salmone
-                'pointer_deviation_prob': '#fdb462',  # arancione chiaro
-                'loop_dur': '#bebada',        # lavanda
-                
-                # === PITCH ===
-                'pitch': '#984ea3',           # viola (unit-driven, qualsiasi unità)
-
-                # === DENSITY ===
-                'density': '#ff7f00',         # arancio
-                'fill_factor': '#f781bf',     # rosa
-                'distribution': '#999999',    # grigio
-                'effective_density': '#ffed6f',  # giallo
-                
-                # === VOICES ===
-                'num_voices': '#e377c2',      # magenta
-                'scatter': '#17becf',         # teal
-                'voice_pitch_offset': '#c49c94',  # beige
-                'voice_pointer_offset': '#f7b6d2', # rosa chiaro
-                'voice_pointer_range': '#c7c7c7',  # grigio chiaro
-            },
+            'envelope_colors': dict(ENVELOPE_COLORS),
             'envelope_panel_ratio': 0.3,      # 30% altezza per envelope
 
             # Auto-zoom degli envelope a range ampio: se il movimento reale
@@ -991,6 +1002,16 @@ class ScoreVisualizer:
             elif isinstance(gate, RandomGate) and show_static:
                 prob = gate.probability
                 envelopes['pointer_deviation_prob'] = Envelope([[0, prob], [stream.duration, prob]])
+
+        # =====================================================================
+        # FILTRO SELETTIVO (issue #101). Applicato sulle chiavi del dict finale
+        # cosi' copre ogni path di estrazione (main, _prob, _mod_range, pitch,
+        # nomi espliciti). Il filtro interseca: non forza la visibilita' degli
+        # statici, che restano governati da show_static_params.
+        # =====================================================================
+        env_filter = self.config.get('envelope_filter')
+        if env_filter is not None:
+            envelopes = {k: v for k, v in envelopes.items() if k in env_filter}
 
         return envelopes
 

--- a/tests/rendering/test_score_visualizer.py
+++ b/tests/rendering/test_score_visualizer.py
@@ -1048,3 +1048,81 @@ class TestEnvelopeAutozoom:
             viz._draw_envelopes(ax, s, y_base=0.0, y_height=1.0,
                                 page_start=0.0, page_end=10.0)
         assert not viz._current_display_ranges
+
+
+# =============================================================================
+# GROUP - Filtro selettivo degli envelope (issue #101)
+# =============================================================================
+
+class TestEnvelopeFilter:
+    """issue #101 - config `envelope_filter`: se non-None, _get_stream_envelopes
+    ritorna solo le chiavi elencate; default None = nessun filtro (tutte)."""
+
+    def _stream(self):
+        """Stream con due envelope dinamici: pitch e pointer_speed."""
+        from envelopes.envelope import Envelope
+        from parameters.pitch_unit import make_pitch_unit
+        s = make_stream('s1', onset=0.0, duration=10.0)
+        s.pitch_value = Envelope([[0, 0.0], [10, 12.0]])
+        s.pitch_unit = make_pitch_unit('semitones')
+        s.pointer_speed = Envelope([[0, -2.0], [10, 4.0]])
+        return s
+
+    def test_filter_keeps_only_listed_keys(self):
+        s = self._stream()
+        viz = make_viz([s], config={'envelope_filter': {'pitch'}})
+        assert set(viz._get_stream_envelopes(s)) == {'pitch'}
+
+    def test_no_filter_keeps_all_keys(self):
+        """Default (envelope_filter assente/None) = comportamento attuale."""
+        s = self._stream()
+        envs = make_viz([s])._get_stream_envelopes(s)
+        assert set(envs) == {'pitch', 'pointer_speed'}
+
+    def test_filter_does_not_force_static_visibility(self):
+        """Il filtro interseca: uno statico elencato resta fuori senza
+        show_static_params (la distinzione STATIC e' ortogonale)."""
+        from envelopes.envelope import Envelope
+        s = make_stream('s1', onset=0.0, duration=10.0)
+        s.pointer_speed = Envelope([[0, 1.0], [10, 1.0]])  # statico
+        viz = make_viz([s], config={'envelope_filter': {'pointer_speed'}})
+        assert 'pointer_speed' not in viz._get_stream_envelopes(s)
+
+    def test_filter_with_show_static_keeps_listed_static(self):
+        from envelopes.envelope import Envelope
+        s = make_stream('s1', onset=0.0, duration=10.0)
+        s.pointer_speed = Envelope([[0, 1.0], [10, 1.0]])  # statico
+        viz = make_viz([s], config={'envelope_filter': {'pointer_speed'},
+                                    'show_static_params': True})
+        assert set(viz._get_stream_envelopes(s)) == {'pointer_speed'}
+
+    def test_filter_applies_to_prob_keys(self):
+        """Le chiavi derivate (`*_prob`, dal ProbabilityGate) sono filtrabili
+        come le altre: il filtro agisce sul dict finale."""
+        from envelopes.envelope import Envelope
+        from parameters.parameter import Parameter
+        from parameters.parameter_definitions import GRANULAR_PARAMETERS
+        from shared.probability_gate import EnvelopeGate
+        s = make_stream('s1', onset=0.0, duration=10.0)
+        p = Parameter('volume', Envelope([[0, -20.0], [10, 0.0]]),
+                      GRANULAR_PARAMETERS['volume'])
+        p.set_probability_gate(EnvelopeGate(Envelope([[0, 0.0], [10, 100.0]])))
+        s.volume = p
+        viz = make_viz([s], config={'envelope_filter': {'volume_prob'}})
+        assert set(viz._get_stream_envelopes(s)) == {'volume_prob'}
+
+    def test_filter_key_absent_from_stream_is_ignored(self):
+        """Chiave valida nel filtro ma senza envelope nello stream: nessun
+        errore, semplicemente assente dal risultato."""
+        s = self._stream()
+        viz = make_viz([s], config={'envelope_filter': {'pitch', 'density'}})
+        assert set(viz._get_stream_envelopes(s)) == {'pitch'}
+
+    def test_plot_envelope_keys_is_the_color_universe(self):
+        """PLOT_ENVELOPE_KEYS (usata da main.py per validare --plot-envelopes)
+        coincide con le chiavi di envelope_colors: unica fonte dei nomi."""
+        from rendering.score_visualizer import PLOT_ENVELOPE_KEYS
+        viz = make_viz([make_stream()])
+        assert PLOT_ENVELOPE_KEYS == frozenset(viz.config['envelope_colors'])
+        assert 'pitch' in PLOT_ENVELOPE_KEYS
+        assert 'volume_prob' in PLOT_ENVELOPE_KEYS

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -41,6 +41,10 @@ def _make_mock_score_visualizer_module():
     mock_instance = MagicMock()
     mock_cls.return_value = mock_instance
     mod.ScoreVisualizer = mock_cls
+    # Universo finto ma realistico dei nomi validi per --plot-envelopes:
+    # main.py lo importa per la validazione (issue #101)
+    mod.PLOT_ENVELOPE_KEYS = frozenset(
+        {'volume', 'pitch', 'density', 'volume_prob'})
     return mod, mock_cls, mock_instance
 
 
@@ -390,6 +394,59 @@ class TestShowStaticFlag:
         with patch.object(sys, 'argv', ['main.py', 'test.yml', 'out.aif', '--show-static']):
             mocks['main'].main()
         mocks['ScoreVisualizer'].assert_not_called()
+
+
+# =============================================================================
+# TEST FLAG --plot-envelopes (issue #101)
+# =============================================================================
+
+class TestPlotEnvelopesFlag:
+    """
+    --plot-envelopes nomi,separati,da,virgola seleziona quali envelope
+    plottare: la config di ScoreVisualizer riceve envelope_filter (set).
+    Senza flag: envelope_filter = None (tutti). Nomi non validi: exit 1.
+    """
+
+    def _get_viz_config(self, mocks, argv):
+        with patch.object(sys, 'argv', argv):
+            mocks['main'].main()
+        _, kwargs = mocks['ScoreVisualizer'].call_args
+        return kwargs['config']
+
+    def test_flag_sets_envelope_filter(self, mocks):
+        config = self._get_viz_config(
+            mocks,
+            ['main.py', 'test.yml', 'out.aif', '--visualize',
+             '--plot-envelopes', 'volume,pitch']
+        )
+        assert config.get('envelope_filter') == {'volume', 'pitch'}
+
+    def test_without_flag_filter_is_none(self, mocks):
+        """Senza --plot-envelopes tutti gli envelope restano attivi."""
+        config = self._get_viz_config(
+            mocks,
+            ['main.py', 'test.yml', 'out.aif', '--visualize']
+        )
+        assert config.get('envelope_filter') is None
+
+    def test_unknown_name_exits_with_1(self, mocks):
+        with patch.object(sys, 'argv',
+                          ['main.py', 'test.yml', 'out.aif', '--visualize',
+                           '--plot-envelopes', 'volume,banana']):
+            with pytest.raises(SystemExit) as exc_info:
+                mocks['main'].main()
+        assert exc_info.value.code == 1
+
+    def test_unknown_name_prints_offender_and_valid_names(self, mocks, capsys):
+        with patch.object(sys, 'argv',
+                          ['main.py', 'test.yml', 'out.aif', '--visualize',
+                           '--plot-envelopes', 'banana']):
+            with pytest.raises(SystemExit):
+                mocks['main'].main()
+        out = capsys.readouterr().out
+        assert 'banana' in out
+        # elenco dei nomi validi (dal mock PLOT_ENVELOPE_KEYS)
+        assert 'volume_prob' in out
 
 
 # =============================================================================


### PR DESCRIPTION
Chiude #101.

## Cosa fa

Nuovo flag CLI `--plot-envelopes nomi,csv` (variabile Make `PLOT_ENVELOPES`): filtro selettivo degli envelope plottati nella partitura PDF. Default (flag assente): tutti gli envelope, comportamento invariato. Con flag: solo i nomi elencati — osservazione chirurgica di singoli parametri.

```bash
python src/main.py configs/brano.yml --visualize --plot-envelopes pitch,density
make all FILE=brano AUTOVISUAL=true PLOT_ENVELOPES=pitch,density
```

## Come

- **ScoreVisualizer**: nuova chiave config `envelope_filter: set | None`; il filtro si applica sulle chiavi del dict finale di `_get_stream_envelopes`, coprendo tutti i path di estrazione (valore principale, `*_prob`, `_mod_range`, `pitch`, nomi espliciti). Ortogonale a `show_static_params`: uno statico elencato appare solo con entrambe.
- **`ENVELOPE_COLORS` / `PLOT_ENVELOPE_KEYS`**: dict colori estratto a costante di modulo; le sue chiavi sono l'universo dei nomi validi, usato da main.py per la validazione (unica fonte).
- **main.py**: parsing token-lookahead (pattern `--renderer`); nome ignoto → messaggio con elenco dei validi + exit 1 (pattern `--format`).
- **Make**: `PLOT_ENVELOPES` non-vuota accumula la flag in `PYFLAGS` (pattern `FORMAT`).
- **Docs**: `docs/reference/cli.md` (tabella, vincoli, esempi), README Build Flags, CHANGELOG.

## Test

- 11 test nuovi (TDD rosso→verde): 7 su `TestEnvelopeFilter` (visualizer), 4 su `TestPlotEnvelopesFlag` (main).
- Suite completa: 4326 passed.
- Smoke e2e: render reale `PGE_test` con `--plot-envelopes pitch,density` → PDF generato.
- Validazione CLI verificata a mano: `--plot-envelopes banana,pitch` → exit 1 con elenco nomi validi.

## Impatto cross-repo

- PGE-ls: nessuno (YAML invariato).
- PGE-ui: DMGiulioRomano/PGE-ui#31 (valutare esposizione filtro in UI).
