### PR TITLE
Rendi configurabile la durata pagina del plot partitura

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,8 @@ SHOWSTATIC ?= false
 # Filtro envelope nella partitura, nomi comma-separated (issue #101).
 # Vuoto = tutti. Es: PLOT_ENVELOPES=pitch,density (richiede AUTOVISUAL=true)
 PLOT_ENVELOPES ?=
+# Durata (secondi) di una pagina nel plot della partitura (richiede AUTOVISUAL=true)
+PAGE_DURATION ?= 15
 FILE ?= PGE_test
 TEST ?= false
 PRECLEAN ?=true
@@ -127,6 +129,7 @@ help:
 	@echo "  AUTOKILL=true/false  - Auto-chiudi RX prima di build"
 	@echo "  AUTOPEN=true/false   - Auto-apri file generati"
 	@echo "  AUTOVISUAL=true/false- Genera visualizzazioni PDF"
+	@echo "  PAGE_DURATION=secondi - Durata pagina nel plot partitura (default: 15, richiede AUTOVISUAL=true)"
 	@echo "  TEST=true/false      - Build tutti i file o solo FILE"
 	@echo "  CLEAN_RPP=true/false - make clean rimuove anche .rpp (default: false, preserva lavoro REAPER)"
 	@echo "  REAPER=true/false        - Esporta progetto Reaper .rpp"

--- a/make/build.mk
+++ b/make/build.mk
@@ -43,6 +43,11 @@ ifneq ($(strip $(PLOT_ENVELOPES)),)
 PYFLAGS += --plot-envelopes $(PLOT_ENVELOPES)
 endif
 
+# 2c. Se PAGE_DURATION e' definito, aggiungi --page-duration
+ifneq ($(strip $(PAGE_DURATION)),)
+PYFLAGS += --page-duration $(PAGE_DURATION)
+endif
+
 # 3. Se REAPER e' true, aggiungi --reaper (esporta .rpp Reaper)
 ifeq ($(REAPER), true)
 PYFLAGS += --reaper

--- a/src/main.py
+++ b/src/main.py
@@ -123,6 +123,7 @@ def main():
         print(
             "Uso: python main.py <file.yml> [output.aif] "
             "[--visualize] [--show-static] [--plot-envelopes nomi,csv] "
+            "[--page-duration SECONDI] "
             "[--per-stream] "
             "[--renderer csound|numpy] "
             "[--format aiff|wav|flac] "
@@ -145,6 +146,20 @@ def main():
 
     do_visualize = '--visualize' in sys.argv or '-v' in sys.argv
     show_static = '--show-static' in sys.argv or '-s' in sys.argv
+
+    # --page-duration SECONDI: durata (secondi) di una pagina della partitura.
+    page_duration = 15.0
+    if '--page-duration' in sys.argv:
+        idx = sys.argv.index('--page-duration')
+        if idx + 1 < len(sys.argv):
+            try:
+                page_duration = float(sys.argv[idx + 1])
+            except ValueError:
+                print(f"--page-duration non valido: '{sys.argv[idx + 1]}'. Deve essere un numero.")
+                sys.exit(1)
+            if page_duration <= 0:
+                print(f"--page-duration deve essere positivo, ricevuto: {page_duration}")
+                sys.exit(1)
 
     # --plot-envelopes nomi,comma-separated (issue #101): filtro selettivo
     # degli envelope nella partitura. None = tutti (default).
@@ -351,7 +366,7 @@ def main():
             print("\nGenerazione partitura grafica...")
             pdf_file = output_file.rsplit('.', 1)[0] + '.pdf'
             viz = ScoreVisualizer(generator, config={
-                'page_duration': 15.0,
+                'page_duration': page_duration,
                 'show_static_params': show_static,
                 'envelope_filter': plot_envelopes,
             })

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -450,6 +450,54 @@ class TestPlotEnvelopesFlag:
 
 
 # =============================================================================
+# TEST FLAG --page-duration
+# =============================================================================
+
+class TestPageDurationFlag:
+    """
+    --page-duration SECONDI imposta page_duration nella config di
+    ScoreVisualizer. Default: 15.0. Valore non numerico: exit 1.
+    """
+
+    def _get_viz_config(self, mocks, argv):
+        with patch.object(sys, 'argv', argv):
+            mocks['main'].main()
+        _, kwargs = mocks['ScoreVisualizer'].call_args
+        return kwargs['config']
+
+    def test_default_page_duration_is_15(self, mocks):
+        config = self._get_viz_config(
+            mocks,
+            ['main.py', 'test.yml', 'out.aif', '--visualize']
+        )
+        assert config.get('page_duration') == 15.0
+
+    def test_custom_page_duration(self, mocks):
+        config = self._get_viz_config(
+            mocks,
+            ['main.py', 'test.yml', 'out.aif', '--visualize',
+             '--page-duration', '20']
+        )
+        assert config.get('page_duration') == 20.0
+
+    def test_invalid_page_duration_exits_with_1(self, mocks):
+        with patch.object(sys, 'argv',
+                          ['main.py', 'test.yml', 'out.aif', '--visualize',
+                           '--page-duration', 'abc']):
+            with pytest.raises(SystemExit) as exc_info:
+                mocks['main'].main()
+        assert exc_info.value.code == 1
+
+    def test_non_positive_page_duration_exits_with_1(self, mocks):
+        with patch.object(sys, 'argv',
+                          ['main.py', 'test.yml', 'out.aif', '--visualize',
+                           '--page-duration', '0']):
+            with pytest.raises(SystemExit) as exc_info:
+                mocks['main'].main()
+        assert exc_info.value.code == 1
+
+
+# =============================================================================
 # TEST GESTIONE ERRORI
 # =============================================================================
 


### PR DESCRIPTION
## Summary
- Aggiunge `--page-duration SECONDI` a `main.py` (default `15.0`, invariato rispetto al comportamento precedente, hardcoded), validato come float positivo
- Aggiunge la variabile Make `PAGE_DURATION ?= 15`, propagata in `PYFLAGS` (`make/build.mk`) per tutte le combinazioni `STEMS` x `RENDERER`, seguendo lo stesso pattern di `PLOT_ENVELOPES`
- Aggiorna `make help` con la nuova variabile

## Test plan
- [x] `make tests` (4328 passed, 2 skipped)
- [x] Nuova classe `TestPageDurationFlag` in `tests/test_main.py` (default 15.0, valore custom, valore non numerico → exit 1, valore ≤0 → exit 1) — TDD rosso→verde
- [x] `make -n` dry-run su tutti i 4 rami `STEMS`/`RENDERER` per confermare la propagazione di `--page-duration`

## Impatto cross-repo
Nessuno: modifica additiva e retrocompatibile (nuovo flag/variabile opzionali con default = comportamento attuale), riguarda solo l'output PDF di visualizzazione/debug; non tocca schema YAML, gerarchia errori né formati output.

https://claude.ai/code/session_01TkXaHjATju7se9RZUGbGHm

---
_Generated by [Claude Code](https://claude.ai/code/session_01TkXaHjATju7se9RZUGbGHm)_