### PR TITLE
fix(score-visualizer): floor del range colore pitch a 1 semitono (100c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,19 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Aggiunto
 
+- Score visualizer: auto-zoom del range colore pitch per-subplot
+  (`pitch_color_autozoom`, default attivo). Il colore dei grani normalizza
+  `1200*log2(pitch_ratio)` sul min/max in cents dei grani visibili nel
+  subplot (sample+pagina) invece del range fisso `pitch_range` (0.5, 2.0):
+  il micro-detune ±12 cents (issue #95) diventa visibile nel PDF. Colormap
+  default `coolwarm` → `turbo` (gradazioni più dense). Nuova colorbar per
+  subplot con la scala pitch (cents con auto-zoom, ratio col range fisso).
+  `pitch_color_autozoom: {enabled: false}` ripristina il comportamento
+  precedente; nessuna modifica a YAML/CLI.
 - Detune implicito del pitch nel dephase per le unità EDO (`semitones`,
   `cents`, `quarter_tone`, `eighth_tone`, `edo: N`): con pitch sotto `dephase`
   **senza** `range` esplicito, ogni grano selezionato dal gate riceve un
-  micro-detune continuo uniforme in ±6 cents, applicato in ratio-space dopo la
+  micro-detune continuo uniforme in ±12 cents, applicato in ratio-space dopo la
   quantizzazione di griglia (`UnitPitchStrategy`), con clamp ai bounds ±3
   ottave. Prima era un no-op silenzioso (`default_jitter=0.0` quantizzato).
   Il path con `range` esplicito, il path `ratio` (jitter ±0.005 storico) e il
@@ -21,7 +30,7 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   attributo `PitchUnit.implicit_detune_cents`; nuova API pubblica
   `Parameter.has_explicit_range` / `Parameter.variation_allowed(time)`.
   **Nota retroattiva**: brani con `dephase` globale e pitch EDO senza range
-  iniziano a muovere il pitch (±6c per grano). Issue #95.
+  iniziano a muovere il pitch (±12c per grano). Issue #95.
 - Flag CLI `--plot-envelopes nomi,csv` (variabile Make `PLOT_ENVELOPES`):
   filtro selettivo degli envelope nella partitura PDF. Default (flag assente):
   tutti gli envelope, come prima. Con flag: solo i nomi elencati vengono

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Aggiunto
 
+- Detune implicito del pitch nel dephase per le unità EDO (`semitones`,
+  `cents`, `quarter_tone`, `eighth_tone`, `edo: N`): con pitch sotto `dephase`
+  **senza** `range` esplicito, ogni grano selezionato dal gate riceve un
+  micro-detune continuo uniforme in ±6 cents, applicato in ratio-space dopo la
+  quantizzazione di griglia (`UnitPitchStrategy`), con clamp ai bounds ±3
+  ottave. Prima era un no-op silenzioso (`default_jitter=0.0` quantizzato).
+  Il path con `range` esplicito, il path `ratio` (jitter ±0.005 storico) e il
+  path voci restano invariati. Nuova costante `EDO_IMPLICIT_DETUNE_CENTS` e
+  attributo `PitchUnit.implicit_detune_cents`; nuova API pubblica
+  `Parameter.has_explicit_range` / `Parameter.variation_allowed(time)`.
+  **Nota retroattiva**: brani con `dephase` globale e pitch EDO senza range
+  iniziano a muovere il pitch (±6c per grano). Issue #95.
 - Flag CLI `--plot-envelopes nomi,csv` (variabile Make `PLOT_ENVELOPES`):
   filtro selettivo degli envelope nella partitura PDF. Default (flag assente):
   tutti gli envelope, come prima. Con flag: solo i nomi elencati vengono

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   il micro-detune ±12 cents (issue #95) diventa visibile nel PDF. Colormap
   default `coolwarm` → `turbo` (gradazioni più dense). Nuova colorbar per
   subplot con la scala pitch (cents con auto-zoom, ratio col range fisso).
+  Floor sullo span del range colore: 1 semitono (`min_span_cents: 100`),
+  cosi' uno scarto di pochi cents tra i grani non occupa l'intera colormap
+  con un gradiente di colore esagerato.
   `pitch_color_autozoom: {enabled: false}` ripristina il comportamento
   precedente; nessuna modifica a YAML/CLI.
 - Detune implicito del pitch nel dephase per le unità EDO (`semitones`,

--- a/configs/PGE_detune_implicito_test.yml
+++ b/configs/PGE_detune_implicito_test.yml
@@ -1,0 +1,171 @@
+# PGE_detune_implicito_test.yml
+#
+# Test empirico del detune implicito ±12 cents (issue #95, branch
+# claude/eloquent-gauss-rmu3v1).
+#
+# Cosa fa la feature:
+#   pitch su unità EDO (semitones/cents/quarter_tone/eighth_tone/edo:N) messo
+#   sotto `dephase` SENZA `range` esplicito → ogni grano selezionato dal gate
+#   riceve un micro-detune continuo uniforme in ±12 cents, applicato in
+#   ratio-space DOPO la quantizzazione di griglia.
+#
+#   Prima era un no-op silenzioso. Ora muove il pitch.
+#
+# Come ascoltare:
+#   density alta + grani sovrapposti → il detune produce uno shimmer/chorus
+#   continuo (battimenti) sui grani toccati. Tutti gli stream usano lo stesso
+#   sample e lo stesso pitch base (+7 st) per confronto A/B onesto.
+#   Stream sfalsati nel tempo: ascolta uno alla volta.
+#
+# Build:  make FILE=PGE_detune_implicito_test
+#   (RENDERER=numpy se non vuoi csound)
+
+composition:
+  title: "detune implicito ±12 cents — test empirico (issue #95)"
+
+duration: 80
+bpm: 120
+
+streams:
+
+  # --- 1. CONTROLLO SECCO — nessun dephase, nessun detune ----------------------
+  # Riferimento: +7 semitoni puliti, pitch fermo. Nessuno shimmer.
+  - stream_id: "1_controllo_secco"
+    onset: 0
+    duration: 8
+    sample: 001-0-27_9.wav
+    density: 40
+    pointer:
+      start: 14
+      speed_ratio: 0
+    grain: {duration: 0.1, envelope: hanning}
+    pitch:
+      semitones: 7
+    volume: -6
+
+  # --- 2. FEATURE dephase 50% — metà grani detunati ----------------------------
+  # Stesso +7 st, ma 50% dei grani prende ±12c continuo. Shimmer intermittente.
+  - stream_id: "2_detune_dephase_50"
+    onset: 10
+    duration: 8
+    sample: 001-0-27_9.wav
+    density: 40
+    pointer:
+      start: 14
+      speed_ratio: 0
+    grain: {duration: 0.1, envelope: hanning}
+    pitch:
+      semitones: 7            # nessun range → scatta il detune implicito
+    dephase:
+      pitch: 50
+    volume: -6
+
+  # --- 3. FEATURE dephase 100% — TUTTI i grani detunati ------------------------
+  # Caso più udibile: chorus/battimenti continui attorno a +7 st.
+  - stream_id: "3_detune_dephase_100"
+    onset: 20
+    duration: 8
+    sample: 001-0-27_9.wav
+    density: 40
+    pointer:
+      start: 14
+      speed_ratio: 0
+    grain: {duration: 0.1, envelope: hanning}
+    pitch:
+      semitones: 7
+    dephase:
+      pitch: 100
+    volume: -6
+
+  # --- 4. CONTROPROVA range:0 — il detune NON deve scattare --------------------
+  # range esplicito (anche 0) disabilita il detune implicito. Deve suonare
+  # IDENTICO allo stream 1 (pitch fermo), nonostante dephase 100.
+  - stream_id: "4_range_zero_no_detune"
+    onset: 30
+    duration: 8
+    sample: 001-0-27_9.wav
+    density: 40
+    pointer:
+      start: 14
+      speed_ratio: 0
+    grain: {duration: 0.1, envelope: hanning}
+    pitch:
+      semitones: 7
+      range: 0               # esplicito → niente detune implicito
+    dephase:
+      pitch: 100
+    volume: -6
+
+  # --- 5. CONFRONTO range:1 quantizzato — variazione a gradi interi ------------
+  # Con range esplicito vale la variazione QUANTIZZATA di griglia: salti di
+  # 1 semitono interi, NON micro-detune. Per sentire la differenza di natura
+  # (salti vs shimmer continuo).
+  - stream_id: "5_range_uno_quantizzato"
+    onset: 40
+    duration: 8
+    sample: 001-0-27_9.wav
+    density: 40
+    pointer:
+      start: 14
+      speed_ratio: 0
+    grain: {duration: 0.1, envelope: hanning}
+    pitch:
+      semitones: 7
+      range: 1               # ±1 semitono a salti interi
+    dephase:
+      pitch: 100
+    volume: -6
+
+  # --- 6. PATH RATIO — jitter storico ±0.005 (non EDO) -------------------------
+  # ratio non è EDO: implicit_detune_cents=0. Resta il jitter storico ±0.005
+  # sul moltiplicatore. Diverso meccanismo, lasciato invariato dalla feature.
+  - stream_id: "6_ratio_jitter_storico"
+    onset: 50
+    duration: 8
+    sample: 001-0-27_9.wav
+    density: 40
+    pointer:
+      start: 14
+      speed_ratio: 0
+    grain: {duration: 0.1, envelope: hanning}
+    pitch:
+      ratio: 1.498           # ~quinta giusta, no range
+    dephase:
+      pitch: 100
+    volume: -6
+
+  # --- 7. EDO ARBITRARIO 31-EDO — detune anche su griglie non standard ---------
+  # Conferma che il detune ±12c vale per qualsiasi unità EDO, non solo semitoni.
+  - stream_id: "7_edo31_detune"
+    onset: 60
+    duration: 8
+    sample: 001-0-27_9.wav
+    density: 40
+    pointer:
+      start: 14
+      speed_ratio: 0
+    grain: {duration: 0.1, envelope: hanning}
+    pitch:
+      edo: 31
+      value: 18              # 18 gradi di 31-EDO, no range → detune ±12c
+    dephase:
+      pitch: 100
+    volume: -6
+
+  # --- 8. cents — unità EDO a 1200 divisioni -----------------------------------
+  # +700 cents (= +7 st) sotto dephase 100, no range → ±12c. Confronto diretto
+  # con lo stream 3 (stesso pitch effettivo, unità diversa, stesso detune).
+  - stream_id: "8_cents_detune"
+    onset: 70
+    duration: 8
+    sample: 001-0-27_9.wav
+    density: 40
+    pointer:
+      start: 14
+      speed_ratio: 0
+    grain: {duration: 0.1, envelope: hanning}
+    pitch:
+      cents: 700
+    dephase:
+      pitch: 100
+    volume: -6

--- a/configs/PGE_pitch_units_showcase.yml
+++ b/configs/PGE_pitch_units_showcase.yml
@@ -17,7 +17,7 @@
 #     (validazione strict, niente silent default). Chiavi valide: 6 unità + `range`.
 #
 # Gli stream sono sfalsati nel tempo (onset crescente) per poterli ascoltare
-# uno alla volta. Sample: 001-0-27_9.wav (presente in refs/).
+# uno alla volta. Sample: weNeedToTalkAboutIt.wav (presente in refs/).
 
 duration: 185
 bpm: 120
@@ -32,7 +32,7 @@ streams:
   - stream_id: "A1_semitones_scalar"
     onset: 0
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch:
@@ -44,7 +44,7 @@ streams:
   - stream_id: "A2_semitones_envelope"
     onset: 5
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch:
@@ -55,7 +55,7 @@ streams:
   - stream_id: "A3_semitones_range"
     onset: 10
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     dephase: 100              # forza l'applicazione della variazione stocastica
     grain: {duration: 0.05, envelope: hanning}
@@ -68,7 +68,7 @@ streams:
   - stream_id: "A4_cents"
     onset: 15
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch:
@@ -79,7 +79,7 @@ streams:
   - stream_id: "A5_quarter_tone"
     onset: 20
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch:
@@ -90,7 +90,7 @@ streams:
   - stream_id: "A6_eighth_tone"
     onset: 25
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch:
@@ -101,7 +101,7 @@ streams:
   - stream_id: "A7_edo_31"
     onset: 30
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch:
@@ -113,7 +113,7 @@ streams:
   - stream_id: "A8_ratio_scalar"
     onset: 35
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch:
@@ -124,7 +124,7 @@ streams:
   - stream_id: "A9_ratio_envelope"
     onset: 40
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch:
@@ -135,7 +135,7 @@ streams:
   - stream_id: "A10_ratio_range"
     onset: 45
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     dephase: 100
     grain: {duration: 0.05, envelope: hanning}
@@ -156,7 +156,7 @@ streams:
   - stream_id: "B1_step_semitones"
     onset: 50
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch: {semitones: 0}
@@ -171,7 +171,7 @@ streams:
   - stream_id: "B2_step_cents"
     onset: 55
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch: {semitones: 0}
@@ -187,7 +187,7 @@ streams:
   - stream_id: "B3_step_edo31"
     onset: 60
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch: {semitones: 0}
@@ -203,7 +203,7 @@ streams:
   - stream_id: "B4_step_ratio"
     onset: 65
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch: {ratio: 1.0}
@@ -219,7 +219,7 @@ streams:
   - stream_id: "B5_range_semitones"
     onset: 70
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch: {semitones: 0}
@@ -234,7 +234,7 @@ streams:
   - stream_id: "B6_range_eighth_tone"
     onset: 75
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch: {semitones: 0}
@@ -250,7 +250,7 @@ streams:
   - stream_id: "B7_stochastic_semitones"
     onset: 80
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch: {semitones: 0}
@@ -265,7 +265,7 @@ streams:
   - stream_id: "B8_stochastic_cents"
     onset: 85
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch: {semitones: 0}
@@ -355,7 +355,7 @@ streams:
   - stream_id: "A11_edo_envelope"
     onset: 110
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch:
@@ -371,7 +371,7 @@ streams:
   - stream_id: "B13_step_quarter_tone"
     onset: 115
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch: {semitones: 0}
@@ -387,7 +387,7 @@ streams:
   - stream_id: "B14_step_eighth_tone"
     onset: 120
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch: {semitones: 0}
@@ -403,7 +403,7 @@ streams:
   - stream_id: "B15_range_cents"
     onset: 125
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch: {semitones: 0}
@@ -419,7 +419,7 @@ streams:
   - stream_id: "B16_range_quarter_tone"
     onset: 130
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch: {semitones: 0}
@@ -435,7 +435,7 @@ streams:
   - stream_id: "B17_range_edo31"
     onset: 135
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch: {semitones: 0}
@@ -453,7 +453,7 @@ streams:
   - stream_id: "B18_range_ratio"
     onset: 140
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch: {ratio: 1.0}
@@ -469,7 +469,7 @@ streams:
   - stream_id: "B19_stochastic_quarter_tone"
     onset: 145
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch: {semitones: 0}
@@ -485,7 +485,7 @@ streams:
   - stream_id: "B20_stochastic_eighth_tone"
     onset: 150
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch: {semitones: 0}
@@ -501,7 +501,7 @@ streams:
   - stream_id: "B21_stochastic_edo31"
     onset: 155
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch: {semitones: 0}
@@ -519,7 +519,7 @@ streams:
   - stream_id: "B22_stochastic_ratio"
     onset: 160
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch: {ratio: 1.0}
@@ -536,7 +536,7 @@ streams:
   - stream_id: "B23_step_envelope"
     onset: 165
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch: {semitones: 0}
@@ -552,7 +552,7 @@ streams:
   - stream_id: "B24_range_envelope"
     onset: 170
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch: {semitones: 0}
@@ -569,7 +569,7 @@ streams:
   - stream_id: "B25_cents_base_step_voices"
     onset: 175
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch:
@@ -586,7 +586,7 @@ streams:
   - stream_id: "B26_ratio_base_stochastic_ratio_voices"
     onset: 180
     duration: 4
-    sample: 001-0-27_9.wav
+    sample: weNeedToTalkAboutIt.wav
     density: 20
     grain: {duration: 0.05, envelope: hanning}
     pitch:

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -371,6 +371,27 @@ dephase:
   pan: 50
 ```
 
+### Detune implicito del pitch (senza `range`)
+
+Quando il pitch è sotto dephase **senza** `range` esplicito, ai grani che il
+gate seleziona si applica un micro-detune continuo:
+
+- unità EDO (`semitones`, `cents`, `quarter_tone`, `eighth_tone`, `edo: N`):
+  ±6 cents uniformi per grano, applicati in ratio-space **dopo** la
+  quantizzazione di griglia (il ratio risultante resta nei bounds ±3 ottave);
+- `ratio`: jitter implicito ±0.005 sul moltiplicatore (comportamento storico).
+
+```yaml
+pitch:
+  semitones: 7            # nessun range dichiarato
+dephase:
+  pitch: 50               # 50% dei grani: 7 st ± max 6 cents (continuo)
+```
+
+Con `range` esplicito (anche `range: 0`) il detune implicito non si applica:
+vale la variazione quantizzata di griglia dichiarata dall'utente. Il path
+voci (`voices.pitch`) non è mai interessato dal detune.
+
 ---
 
 ## Blocco Voices (Multi-Voice)

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -377,7 +377,7 @@ Quando il pitch è sotto dephase **senza** `range` esplicito, ai grani che il
 gate seleziona si applica un micro-detune continuo:
 
 - unità EDO (`semitones`, `cents`, `quarter_tone`, `eighth_tone`, `edo: N`):
-  ±6 cents uniformi per grano, applicati in ratio-space **dopo** la
+  ±12 cents uniformi per grano, applicati in ratio-space **dopo** la
   quantizzazione di griglia (il ratio risultante resta nei bounds ±3 ottave);
 - `ratio`: jitter implicito ±0.005 sul moltiplicatore (comportamento storico).
 
@@ -385,7 +385,7 @@ gate seleziona si applica un micro-detune continuo:
 pitch:
   semitones: 7            # nessun range dichiarato
 dephase:
-  pitch: 50               # 50% dei grani: 7 st ± max 6 cents (continuo)
+  pitch: 50               # 50% dei grani: 7 st ± max 12 cents (continuo)
 ```
 
 Con `range` esplicito (anche `range: 0`) il detune implicito non si applica:

--- a/src/parameters/parameter.py
+++ b/src/parameters/parameter.py
@@ -65,7 +65,23 @@ class Parameter:
     def set_probability_gate(self, gate: ProbabilityGate):
         """Setter per dependency injection."""
         self._probability_gate = gate
-    
+
+    @property
+    def has_explicit_range(self) -> bool:
+        """True se l'utente ha dichiarato un range esplicito (anche 0):
+        in quel caso il jitter/detune implicito non si applica."""
+        return self._mod_range is not None
+
+    def variation_allowed(self, time: float) -> bool:
+        """
+        Interroga il gate dephase senza applicare la variazione.
+
+        Nota: sui gate stocastici ogni chiamata è un draw indipendente da
+        quello interno a get_value(); nel path implicito EDO quel draw è
+        inerte (ampiezza 0), quindi questo è l'unico effetto osservabile.
+        """
+        return self._probability_gate.should_apply(time)
+
     def get_value(self, time: float) -> float:
         """
         Calcola il valore finale del parametro al tempo specificato.

--- a/src/parameters/parameter_orchestrator.py
+++ b/src/parameters/parameter_orchestrator.py
@@ -69,9 +69,8 @@ class ParameterOrchestrator:
         param = self._param_factory.create_smart_parameter(param_spec, yaml_data)
 
         # Controlla se range è esplicitato
-        has_explicit_range = False
-        has_explicit_range = param._mod_range is not None
-        
+        has_explicit_range = param.has_explicit_range
+
         # 2. Crea il ProbabilityGate corrispondente
         gate = GateFactory.create_gate(
             dephase=self._config.dephase,       
@@ -112,7 +111,7 @@ class ParameterOrchestrator:
             dephase=self._config.dephase,
             param_key=dephase_key,
             default_prob=DEFAULT_PROB,
-            has_explicit_range=(param._mod_range is not None),
+            has_explicit_range=param.has_explicit_range,
             range_always_active=self._config.range_always_active,
             duration=self._config.context.duration,
             time_mode=self._config.time_mode,

--- a/src/parameters/pitch_unit.py
+++ b/src/parameters/pitch_unit.py
@@ -23,6 +23,14 @@ from typing import Callable, Dict, Optional, Union
 from parameters.parameter_definitions import ParameterBounds
 from shared.exceptions import InvalidFieldValueError
 
+# Detune implicito del dephase per le unità EDO (issue #95): semi-ampiezza in
+# cents (±N) del micro-detune continuo applicato in ratio-space da
+# UnitPitchStrategy quando il pitch è sotto dephase senza range esplicito.
+# Non può vivere in default_jitter: il value-space EDO è quantizzato e un
+# jitter sub-grado arrotonderebbe a 0 (no-op), un grado intero sarebbe una
+# trasposizione piena.
+EDO_IMPLICIT_DETUNE_CENTS = 6.0
+
 
 class PitchUnit(ABC):
     """
@@ -35,6 +43,10 @@ class PitchUnit(ABC):
 
     name: str
     symbol: str
+
+    # Semi-ampiezza (±N cents) del detune implicito in ratio-space, campionato
+    # continuo per grano da UnitPitchStrategy nel path dephase senza range.
+    implicit_detune_cents: float = 0.0
 
     @abstractmethod
     def to_ratio(self, value: float) -> float:
@@ -65,6 +77,8 @@ class EdoUnit(PitchUnit):
     I bounds del valore sono ±3 ottave, cioè ±(3·divisions), con variazione
     quantizzata (gradi interi). Il valore neutro è 0 (2^0 = 1).
     """
+
+    implicit_detune_cents = EDO_IMPLICIT_DETUNE_CENTS
 
     def __init__(self, divisions: int, name: str = 'edo', symbol: Optional[str] = None):
         if not isinstance(divisions, int) or isinstance(divisions, bool) or divisions <= 0:

--- a/src/parameters/pitch_unit.py
+++ b/src/parameters/pitch_unit.py
@@ -29,7 +29,7 @@ from shared.exceptions import InvalidFieldValueError
 # Non può vivere in default_jitter: il value-space EDO è quantizzato e un
 # jitter sub-grado arrotonderebbe a 0 (no-op), un grado intero sarebbe una
 # trasposizione piena.
-EDO_IMPLICIT_DETUNE_CENTS = 6.0
+EDO_IMPLICIT_DETUNE_CENTS = 12.0
 
 
 class PitchUnit(ABC):

--- a/src/rendering/score_visualizer.py
+++ b/src/rendering/score_visualizer.py
@@ -4,7 +4,9 @@
 
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
+from matplotlib.cm import ScalarMappable
 from matplotlib.collections import PatchCollection
+from matplotlib.colors import Normalize
 from matplotlib.backends.backend_pdf import PdfPages
 import numpy as np
 import soundfile as sf
@@ -94,9 +96,17 @@ class ScoreVisualizer:
             'margins_mm': 20,
             
             # Grani
-            'grain_colormap': 'coolwarm',    # pitch_ratio → colore
+            'grain_colormap': 'turbo',       # pitch_ratio → colore
             'grain_alpha_range': (0.3, 1.0), # volume → alpha
-            'pitch_range': (0.5, 2.0),       # range per normalizzare colori
+            'pitch_range': (0.5, 2.0),       # range fisso (fallback senza autozoom)
+            # Auto-zoom del range colore pitch: normalizza sul min/max in cents
+            # dei grani visibili nel subplot (sample+pagina) invece del range
+            # fisso — rende visibile il micro-detune ±6 cents (issue #95).
+            'pitch_color_autozoom': {
+                'enabled': True,
+                'pad_ratio': 0.1,        # margine per lato: 10% dello span
+                'min_span_cents': 2.0,   # floor: evita div/0 su span nullo
+            },
             'volume_range': (-60, 0),        # dB range per normalizzare alpha
             'min_grain_width_pts': 1,        # larghezza minima visibile
             
@@ -366,10 +376,83 @@ class ScoreVisualizer:
     # MAPPING VISUALI
     # =========================================================================
     
-    def _pitch_to_color(self, pitch_ratio):
-        """Mappa pitch_ratio → colore dal colormap."""
-        p_min, p_max = self.config['pitch_range']
-        normalized = (pitch_ratio - p_min) / (p_max - p_min)
+    def _compute_pitch_color_range(self, streams, page_start, page_end):
+        """
+        Range colore pitch auto-zoomato per il subplot: (lo, hi) in cents
+        calcolato sui grani visibili nella finestra di pagina di TUTTI gli
+        stream del subplot. None se autozoom disabilitato o nessun grano
+        (fallback al range fisso pitch_range).
+        """
+        az = self.config['pitch_color_autozoom']
+        if not az.get('enabled', False):
+            return None
+
+        cents = []
+        for stream in streams:
+            for voice_grains in stream.voices:
+                for g in voice_grains:
+                    if not (g.onset < page_end and (g.onset + g.duration) > page_start):
+                        continue
+                    ratio = abs(g.pitch_ratio)
+                    if ratio <= 0:
+                        continue
+                    cents.append(1200.0 * np.log2(ratio))
+
+        if not cents:
+            return None
+
+        c_min, c_max = min(cents), max(cents)
+        span = max(c_max - c_min, az['min_span_cents'])
+        center = (c_min + c_max) / 2.0
+        half = span / 2.0 + az['pad_ratio'] * span
+        return (center - half, center + half)
+
+    def _add_pitch_colorbar(self, fig, ax, cents_range, streams,
+                            page_start, page_end):
+        """
+        Colorbar compatta con la scala colore pitch del subplot.
+
+        Con cents_range (auto-zoom attivo): scala in cents zoomata.
+        Senza: scala fissa pitch_range in ratio, solo se il subplot ha grani
+        visibili (cents_range None copre anche il caso zero grani).
+        """
+        if cents_range is not None:
+            norm = Normalize(cents_range[0], cents_range[1])
+            label = 'pitch (cents)'
+        else:
+            has_grains = any(
+                g.onset < page_end and (g.onset + g.duration) > page_start
+                for s in streams
+                for voice_grains in s.voices
+                for g in voice_grains
+            )
+            if not has_grains:
+                return
+            p_min, p_max = self.config['pitch_range']
+            norm = Normalize(p_min, p_max)
+            label = 'pitch (ratio)'
+
+        cbar = fig.colorbar(
+            ScalarMappable(norm=norm, cmap=self.cmap),
+            ax=ax, fraction=0.03, pad=0.01
+        )
+        cbar.set_label(label, fontsize=self.config['label_fontsize'] - 1)
+        cbar.ax.tick_params(labelsize=self.config['label_fontsize'] - 2)
+
+    def _pitch_to_color(self, pitch_ratio, cents_range=None):
+        """
+        Mappa pitch_ratio → colore dal colormap.
+
+        cents_range=(lo, hi): normalizza 1200*log2(ratio) nel range zoomato
+        (auto-zoom per-subplot). None: fallback sul range fisso pitch_range.
+        """
+        if cents_range is not None and pitch_ratio > 0:
+            lo, hi = cents_range
+            cents = 1200.0 * np.log2(pitch_ratio)
+            normalized = (cents - lo) / (hi - lo)
+        else:
+            p_min, p_max = self.config['pitch_range']
+            normalized = (pitch_ratio - p_min) / (p_max - p_min)
         normalized = np.clip(normalized, 0, 1)
         return self.cmap(normalized)
     
@@ -481,12 +564,20 @@ class ScoreVisualizer:
             # Disegna waveform UNA VOLTA (usa il primo stream solo per il path)
             self._draw_waveform_full(ax_wave, streams[0], sample_duration)
             
+            # Range colore pitch auto-zoomato sul subplot (tutti gli stream)
+            cents_range = self._compute_pitch_color_range(
+                streams, page_start, page_end)
+
             # Disegna grani di TUTTI gli stream che usano questo sample
             for stream in streams:
                 self._draw_loop_mask(ax_grain, stream, page_start, page_end, sample_duration)
-                self._draw_grains_full(ax_grain, stream, sample_duration, 
-                                    page_start, page_end)
+                self._draw_grains_full(ax_grain, stream, sample_duration,
+                                    page_start, page_end, cents_range)
                 self._draw_stream_label_full(ax_grain, stream, page_start, sample_duration)
+
+            # Legenda della scala colore pitch (auto-zoomata o fissa)
+            self._add_pitch_colorbar(fig, ax_grain, cents_range,
+                                     streams, page_start, page_end)
             # Configura assi waveform
             ax_wave.set_ylim(-0.02, sample_duration+0.02)
             ax_wave.set_xlim(-1.1, 1.1)
@@ -598,8 +689,12 @@ class ScoreVisualizer:
         )
 
 
-    def _draw_grains_full(self, ax, stream, sample_duration, page_start, page_end):
-        """Disegna grani con coordinate Y assolute nel sample."""
+    def _draw_grains_full(self, ax, stream, sample_duration, page_start,
+                          page_end, cents_range=None):
+        """Disegna grani con coordinate Y assolute nel sample.
+
+        cents_range: range colore auto-zoomato del subplot (vedi
+        _compute_pitch_color_range); None = range fisso."""
         
         all_grains = [grain for voice_grains in stream.voices for grain in voice_grains]
 
@@ -663,7 +758,8 @@ class ScoreVisualizer:
             polygons.append(poly)
             
             # Colore
-            color = list(self._pitch_to_color(abs(grain.pitch_ratio)))
+            color = list(self._pitch_to_color(abs(grain.pitch_ratio),
+                                              cents_range))
             color[3] = self._volume_to_alpha(grain.volume)
             colors.append(color)
         

--- a/src/rendering/score_visualizer.py
+++ b/src/rendering/score_visualizer.py
@@ -105,7 +105,11 @@ class ScoreVisualizer:
             'pitch_color_autozoom': {
                 'enabled': True,
                 'pad_ratio': 0.1,        # margine per lato: 10% dello span
-                'min_span_cents': 2.0,   # floor: evita div/0 su span nullo
+                # floor: 1 semitono. Senza questo minimo, una manciata di
+                # cents di scarto reale produrrebbe uno span quasi nullo e
+                # quindi un gradiente di colore esagerato (l'intera colormap)
+                # per una differenza musicalmente trascurabile.
+                'min_span_cents': 100.0,
             },
             'volume_range': (-60, 0),        # dB range per normalizzare alpha
             'min_grain_width_pts': 1,        # larghezza minima visibile

--- a/src/rendering/score_visualizer.py
+++ b/src/rendering/score_visualizer.py
@@ -109,7 +109,7 @@ class ScoreVisualizer:
                 # cents di scarto reale produrrebbe uno span quasi nullo e
                 # quindi un gradiente di colore esagerato (l'intera colormap)
                 # per una differenza musicalmente trascurabile.
-                'min_span_cents': 100.0,
+                'min_span_cents': 50.0,
             },
             'volume_range': (-60, 0),        # dB range per normalizzare alpha
             'min_grain_width_pts': 1,        # larghezza minima visibile

--- a/src/strategies/strategie.py
+++ b/src/strategies/strategie.py
@@ -4,6 +4,7 @@ Definisce le interfacce Strategy per tutti i controller.
 Ogni strategia incapsula completamente il calcolo di un valore.
 """
 
+import random
 from abc import ABC, abstractmethod
 from typing import Optional, Union
 from parameters.parameter import Parameter
@@ -42,15 +43,34 @@ class UnitPitchStrategy(PitchStrategy):
     quarti/ottavi di tono, EDO arbitrari e ratio sono tutti casi di questa.
 
         ratio(t) = unit.to_ratio(param.get_value(t))
+
+    Detune implicito (issue #95): se l'unità dichiara implicit_detune_cents > 0,
+    il param non ha range esplicito e il gate dephase concede l'apply per il
+    grano, il ratio quantizzato viene moltiplicato per 2^(c/1200) con c uniforme
+    continuo in ±implicit_detune_cents, poi richiuso nei bounds ratio dell'unità.
+    Il detune opera sul ratio positivo: l'eventuale negazione reverse resta a
+    valle in PitchController.
     """
 
     def __init__(self, param: Parameter, unit: PitchUnit, name: str):
         self._param = param
         self._unit = unit
         self._name = name
+        # bounds in ratio-space: il detune bypassa il clamp value-space di
+        # Parameter, va richiuso qui
+        bounds = unit.value_bounds()
+        self._ratio_min = unit.to_ratio(bounds.min_val)
+        self._ratio_max = unit.to_ratio(bounds.max_val)
 
     def calculate(self, elapsed_time: float) -> float:
-        return self._unit.to_ratio(self._param.get_value(elapsed_time))
+        ratio = self._unit.to_ratio(self._param.get_value(elapsed_time))
+        cents = self._unit.implicit_detune_cents
+        if (cents > 0.0
+                and not self._param.has_explicit_range
+                and self._param.variation_allowed(elapsed_time)):
+            ratio *= 2.0 ** (random.uniform(-cents, cents) / 1200.0)
+            ratio = max(self._ratio_min, min(self._ratio_max, ratio))
+        return ratio
 
     @property
     def name(self) -> str:

--- a/tests/parameters/test_parameter_dephase_api.py
+++ b/tests/parameters/test_parameter_dephase_api.py
@@ -1,0 +1,60 @@
+# tests/parameters/test_parameter_dephase_api.py
+"""
+Test dell'API pubblica di Parameter usata dal detune implicito (issue #95):
+
+- has_explicit_range: True se l'utente ha dichiarato `range` nello YAML
+  (mod_range non None), False se il param usa il jitter implicito.
+- variation_allowed(time): interroga il gate dephase senza applicare
+  la variazione — usata da UnitPitchStrategy per il detune per-grano.
+"""
+
+import pytest
+
+from parameters.parameter import Parameter
+from parameters.parameter_definitions import ParameterBounds
+from shared.probability_gate import NeverGate, AlwaysGate
+
+BOUNDS = ParameterBounds(
+    min_val=-36.0, max_val=36.0,
+    min_range=0.0, max_range=36.0,
+    default_jitter=0.0,
+    variation_mode='quantized',
+)
+
+
+# =============================================================================
+# has_explicit_range
+# =============================================================================
+
+def test_has_explicit_range_false_without_mod_range():
+    assert Parameter('p', 0.0, BOUNDS).has_explicit_range is False
+
+
+def test_has_explicit_range_true_with_mod_range():
+    assert Parameter('p', 0.0, BOUNDS, mod_range=2.0).has_explicit_range is True
+
+
+def test_has_explicit_range_true_with_zero_range():
+    # range dichiarato esplicitamente a 0 resta esplicito: l'utente ha chiesto
+    # "nessuna variazione", il detune implicito non deve scattare
+    assert Parameter('p', 0.0, BOUNDS, mod_range=0.0).has_explicit_range is True
+
+
+# =============================================================================
+# variation_allowed
+# =============================================================================
+
+def test_variation_allowed_default_gate_is_never():
+    assert Parameter('p', 0.0, BOUNDS).variation_allowed(0.0) is False
+
+
+def test_variation_allowed_with_always_gate():
+    p = Parameter('p', 0.0, BOUNDS)
+    p.set_probability_gate(AlwaysGate())
+    assert p.variation_allowed(0.0) is True
+
+
+def test_variation_allowed_with_never_gate():
+    p = Parameter('p', 0.0, BOUNDS, mod_range=2.0)
+    p.set_probability_gate(NeverGate())
+    assert p.variation_allowed(0.5) is False

--- a/tests/parameters/test_pitch_unit.py
+++ b/tests/parameters/test_pitch_unit.py
@@ -198,6 +198,49 @@ def test_materialize_ratio_non_positive_amount_is_identity(amount):
 
 
 # =============================================================================
+# implicit_detune_cents — detune implicito in ratio-space (issue #95)
+# =============================================================================
+# Il detune NON vive in default_jitter (value-space quantizzato: sub-grado
+# arrotonda a 0, un grado intero è una trasposizione enorme). È una costante
+# in cents (semi-ampiezza ±N) applicata da UnitPitchStrategy in ratio-space,
+# solo nel path dephase senza range esplicito.
+
+@pytest.mark.parametrize("divisions", [12, 24, 48, 1200, 31])
+def test_edo_implicit_detune_is_six_cents(divisions):
+    # ±6 cents per ogni griglia EDO, indipendente dalle divisioni
+    assert EdoUnit(divisions).implicit_detune_cents == 6.0
+
+
+def test_ratio_implicit_detune_is_zero():
+    # RatioUnit ha già il jitter implicito in value-space (default_jitter=0.005):
+    # detune ratio-space a 0 per evitare doppia applicazione
+    assert RatioUnit().implicit_detune_cents == 0.0
+
+
+@pytest.mark.parametrize("preset,expected", [
+    ('semitones', 6.0), ('cents', 6.0), ('quarter_tone', 6.0),
+    ('eighth_tone', 6.0), ('ratio', 0.0),
+])
+def test_preset_implicit_detune(preset, expected):
+    assert make_pitch_unit(preset).implicit_detune_cents == expected
+
+
+def test_edo_default_jitter_stays_zero():
+    # regressione: il detune non passa dai bounds — il path esplicito
+    # quantizzato resta invariato
+    assert EdoUnit(12).value_bounds().default_jitter == 0.0
+
+
+@pytest.mark.parametrize("unit", [EdoUnit(12), EdoUnit(31), RatioUnit()])
+def test_materialize_is_deterministic_no_detune(unit):
+    # regressione issue #95: il detune vive solo in UnitPitchStrategy,
+    # mai nella materializzazione del path voci
+    a = unit.materialize(1.0, 3.0)
+    b = unit.materialize(1.0, 3.0)
+    assert a == b
+
+
+# =============================================================================
 # name / symbol — identità dell'unità (per mode e visualizer futuro)
 # =============================================================================
 

--- a/tests/parameters/test_pitch_unit.py
+++ b/tests/parameters/test_pitch_unit.py
@@ -10,7 +10,9 @@ Modulo sotto test:
 
 import pytest
 
-from parameters.pitch_unit import EdoUnit, RatioUnit, make_pitch_unit
+from parameters.pitch_unit import (
+    EDO_IMPLICIT_DETUNE_CENTS, EdoUnit, RatioUnit, make_pitch_unit,
+)
 from parameters.parameter_definitions import ParameterBounds
 from shared.exceptions import InvalidFieldValueError
 
@@ -206,9 +208,10 @@ def test_materialize_ratio_non_positive_amount_is_identity(amount):
 # solo nel path dephase senza range esplicito.
 
 @pytest.mark.parametrize("divisions", [12, 24, 48, 1200, 31])
-def test_edo_implicit_detune_is_six_cents(divisions):
-    # ±6 cents per ogni griglia EDO, indipendente dalle divisioni
-    assert EdoUnit(divisions).implicit_detune_cents == 6.0
+def test_edo_implicit_detune_matches_constant(divisions):
+    # stessa semi-ampiezza per ogni griglia EDO, indipendente dalle divisioni
+    assert EdoUnit(divisions).implicit_detune_cents == EDO_IMPLICIT_DETUNE_CENTS
+    assert EDO_IMPLICIT_DETUNE_CENTS > 0
 
 
 def test_ratio_implicit_detune_is_zero():
@@ -218,8 +221,11 @@ def test_ratio_implicit_detune_is_zero():
 
 
 @pytest.mark.parametrize("preset,expected", [
-    ('semitones', 6.0), ('cents', 6.0), ('quarter_tone', 6.0),
-    ('eighth_tone', 6.0), ('ratio', 0.0),
+    ('semitones', EDO_IMPLICIT_DETUNE_CENTS),
+    ('cents', EDO_IMPLICIT_DETUNE_CENTS),
+    ('quarter_tone', EDO_IMPLICIT_DETUNE_CENTS),
+    ('eighth_tone', EDO_IMPLICIT_DETUNE_CENTS),
+    ('ratio', 0.0),
 ])
 def test_preset_implicit_detune(preset, expected):
     assert make_pitch_unit(preset).implicit_detune_cents == expected

--- a/tests/rendering/test_score_visualizer.py
+++ b/tests/rendering/test_score_visualizer.py
@@ -1146,7 +1146,7 @@ class TestPitchColorAutozoom:
         az = viz.config['pitch_color_autozoom']
         assert az['enabled'] is True
         assert az['pad_ratio'] > 0
-        assert az['min_span_cents'] > 0
+        assert az['min_span_cents'] == 100.0  # 1 semitono
 
     def test_range_from_visible_grains_min_max_cents(self):
         """Range = [min, max] in cents dei grani visibili, con pad per lato."""
@@ -1173,6 +1173,20 @@ class TestPitchColorAutozoom:
         expected_half = az['min_span_cents'] / 2.0 + az['pad_ratio'] * az['min_span_cents']
         assert (lo + hi) / 2.0 == pytest.approx(center)
         assert hi - lo == pytest.approx(2 * expected_half)
+
+    def test_floor_enforces_minimum_semitone_span(self):
+        """Una differenza reale minima (12 cents, grani a ±6c) non deve
+        produrre uno span quasi nullo: il floor garantisce almeno un
+        semitono (100 cents), cosi' pochi cents di scarto non occupano
+        l'intera colormap."""
+        s = make_stream('s1', n_grains=0)
+        s.voices = [[
+            make_grain(onset=1.0, pitch_ratio=2.0 ** (-6.0 / 1200.0)),
+            make_grain(onset=2.0, pitch_ratio=2.0 ** (6.0 / 1200.0)),
+        ]]
+        viz = make_viz([s])
+        lo, hi = viz._compute_pitch_color_range([s], 0.0, 10.0)
+        assert hi - lo >= 100.0
 
     def test_grains_outside_page_excluded(self):
         """Grano fuori finestra di pagina non influenza il range."""
@@ -1242,6 +1256,18 @@ class TestPitchColorAutozoom:
         return [s]
 
     @staticmethod
+    def _semitone_detuned_scene():
+        """Stream con due grani a ±60 cents (scarto reale 120 cents,
+        oltre il floor di un semitono)."""
+        s = make_stream('s1', onset=0.0, duration=10.0,
+                        sample='piano.wav', n_grains=0)
+        s.voices = [[
+            make_grain(onset=1.0, pitch_ratio=2.0 ** (-60.0 / 1200.0)),
+            make_grain(onset=2.0, pitch_ratio=2.0 ** (60.0 / 1200.0)),
+        ]]
+        return [s]
+
+    @staticmethod
     def _grain_facecolors(fig):
         """Facecolors della PatchCollection dei grani (zorder=2)."""
         from matplotlib.collections import PatchCollection
@@ -1251,15 +1277,28 @@ class TestPitchColorAutozoom:
                     return coll.get_facecolors()
         return None
 
-    def test_render_page_applies_zoomed_colors(self):
-        """End-to-end: nel PDF i due grani a ±6c hanno colori distinti."""
+    def test_render_page_micro_detune_colors_stay_close(self):
+        """End-to-end: con il floor di un semitono (100 cents), due grani
+        a ±6c (12 cents di scarto reale, ben sotto il floor) restano in una
+        banda ristretta della colormap — niente piu' salto cromatico
+        estremo per pochi cents di differenza."""
         viz = make_viz(self._detuned_scene(), config={'page_duration': 30.0})
         with patch('soundfile.read', return_value=(FAKE_AUDIO, SR)):
             figs = viz.render_all()
         colors = self._grain_facecolors(figs[0])
         assert colors is not None and len(colors) == 2
-        # RGB (no alpha: dipende dal volume) chiaramente diversi
-        assert np.abs(colors[0][:3] - colors[1][:3]).max() > 0.3
+        # RGB (no alpha: dipende dal volume) restano vicini
+        assert np.abs(colors[0][:3] - colors[1][:3]).max() < 0.4
+
+    def test_render_page_above_semitone_detune_still_distinct(self):
+        """Uno scarto reale >= 1 semitono (qui 120 cents) supera il floor:
+        i colori restano chiaramente distinti, come prima della modifica."""
+        viz = make_viz(self._semitone_detuned_scene(), config={'page_duration': 30.0})
+        with patch('soundfile.read', return_value=(FAKE_AUDIO, SR)):
+            figs = viz.render_all()
+        colors = self._grain_facecolors(figs[0])
+        assert colors is not None and len(colors) == 2
+        assert np.abs(colors[0][:3] - colors[1][:3]).max() > 0.5
 
     def test_render_page_fixed_colors_when_disabled(self):
         """Autozoom off: i due grani a ±6c restano indistinguibili."""

--- a/tests/rendering/test_score_visualizer.py
+++ b/tests/rendering/test_score_visualizer.py
@@ -1126,3 +1126,166 @@ class TestEnvelopeFilter:
         assert PLOT_ENVELOPE_KEYS == frozenset(viz.config['envelope_colors'])
         assert 'pitch' in PLOT_ENVELOPE_KEYS
         assert 'volume_prob' in PLOT_ENVELOPE_KEYS
+
+
+# =============================================================================
+# GROUP - Pitch color auto-zoom (colormap turbo + range dinamico per-subplot)
+# =============================================================================
+
+class TestPitchColorAutozoom:
+    """Auto-zoom del range colore pitch: il colore dei grani usa min/max in
+    cents dei pitch_ratio visibili nel subplot invece del range fisso
+    pitch_range (0.5, 2.0) — rende visibile il micro-detune ±6 cents."""
+
+    def test_default_colormap_is_turbo(self):
+        viz = make_viz([make_stream()])
+        assert viz.config['grain_colormap'] == 'turbo'
+
+    def test_default_config_has_pitch_color_autozoom(self):
+        viz = make_viz([make_stream()])
+        az = viz.config['pitch_color_autozoom']
+        assert az['enabled'] is True
+        assert az['pad_ratio'] > 0
+        assert az['min_span_cents'] > 0
+
+    def test_range_from_visible_grains_min_max_cents(self):
+        """Range = [min, max] in cents dei grani visibili, con pad per lato."""
+        s = make_stream('s1', n_grains=0)
+        s.voices = [[
+            make_grain(onset=1.0, pitch_ratio=1.0),   # 0 cents
+            make_grain(onset=2.0, pitch_ratio=2.0),   # 1200 cents
+        ]]
+        viz = make_viz([s])
+        lo, hi = viz._compute_pitch_color_range([s], 0.0, 10.0)
+        pad = viz.config['pitch_color_autozoom']['pad_ratio'] * 1200.0
+        assert lo == pytest.approx(0.0 - pad)
+        assert hi == pytest.approx(1200.0 + pad)
+
+    def test_range_floor_on_identical_ratios(self):
+        """Grani tutti allo stesso ratio: span = min_span_cents, centrato."""
+        s = make_stream('s1', n_grains=0)
+        s.voices = [[make_grain(onset=1.0, pitch_ratio=1.5),
+                     make_grain(onset=2.0, pitch_ratio=1.5)]]
+        viz = make_viz([s])
+        lo, hi = viz._compute_pitch_color_range([s], 0.0, 10.0)
+        az = viz.config['pitch_color_autozoom']
+        center = 1200.0 * np.log2(1.5)
+        expected_half = az['min_span_cents'] / 2.0 + az['pad_ratio'] * az['min_span_cents']
+        assert (lo + hi) / 2.0 == pytest.approx(center)
+        assert hi - lo == pytest.approx(2 * expected_half)
+
+    def test_grains_outside_page_excluded(self):
+        """Grano fuori finestra di pagina non influenza il range."""
+        s = make_stream('s1', n_grains=0)
+        s.voices = [[
+            make_grain(onset=1.0, pitch_ratio=1.0),
+            make_grain(onset=50.0, pitch_ratio=4.0),  # fuori pagina [0, 10]
+        ]]
+        viz = make_viz([s])
+        lo, hi = viz._compute_pitch_color_range([s], 0.0, 10.0)
+        # range centrato su 0 cents (ratio 1.0), il grano a 4.0 non conta
+        assert (lo + hi) / 2.0 == pytest.approx(0.0)
+
+    def test_range_spans_multiple_streams(self):
+        """Min/max calcolati su tutti gli stream del subplot."""
+        s1 = make_stream('s1', n_grains=0)
+        s1.voices = [[make_grain(onset=1.0, pitch_ratio=1.0)]]
+        s2 = make_stream('s2', n_grains=0)
+        s2.voices = [[make_grain(onset=2.0, pitch_ratio=2.0)]]
+        viz = make_viz([s1, s2])
+        lo, hi = viz._compute_pitch_color_range([s1, s2], 0.0, 10.0)
+        assert lo < 0.0 < 1200.0 < hi
+
+    def test_disabled_returns_none(self):
+        s = make_stream('s1', n_grains=4)
+        viz = make_viz([s], config={'pitch_color_autozoom': {'enabled': False}})
+        assert viz._compute_pitch_color_range([s], 0.0, 10.0) is None
+
+    def test_no_grains_returns_none(self):
+        s = make_stream('s1', n_grains=0)
+        viz = make_viz([s])
+        assert viz._compute_pitch_color_range([s], 0.0, 10.0) is None
+
+    def test_pitch_to_color_without_range_uses_fixed_fallback(self):
+        """cents_range=None → normalizzazione sul range fisso pitch_range."""
+        viz = make_viz([make_stream()])
+        expected = viz.cmap(np.clip((1.0 - 0.5) / (2.0 - 0.5), 0, 1))
+        assert viz._pitch_to_color(1.0) == expected
+
+    def test_detuned_grains_get_distinct_colors_with_autozoom(self):
+        """Due grani a ±6 cents: colori chiaramente diversi con range zoomato,
+        quasi identici col range fisso."""
+        viz = make_viz([make_stream()])
+        r_lo = 2.0 ** (-6.0 / 1200.0)   # -6 cents
+        r_hi = 2.0 ** (6.0 / 1200.0)    # +6 cents
+
+        # range fisso: indistinguibili
+        c1_fixed = np.array(viz._pitch_to_color(r_lo))
+        c2_fixed = np.array(viz._pitch_to_color(r_hi))
+        assert np.abs(c1_fixed - c2_fixed).max() < 0.05
+
+        # range zoomato su ±6c (con pad): ben distinti
+        cents_range = (-7.2, 7.2)
+        c1 = np.array(viz._pitch_to_color(r_lo, cents_range))
+        c2 = np.array(viz._pitch_to_color(r_hi, cents_range))
+        assert np.abs(c1 - c2).max() > 0.3
+
+    @staticmethod
+    def _detuned_scene():
+        """Stream con due grani a ±6 cents attorno a ratio 1.0."""
+        s = make_stream('s1', onset=0.0, duration=10.0,
+                        sample='piano.wav', n_grains=0)
+        s.voices = [[
+            make_grain(onset=1.0, pitch_ratio=2.0 ** (-6.0 / 1200.0)),
+            make_grain(onset=2.0, pitch_ratio=2.0 ** (6.0 / 1200.0)),
+        ]]
+        return [s]
+
+    @staticmethod
+    def _grain_facecolors(fig):
+        """Facecolors della PatchCollection dei grani (zorder=2)."""
+        from matplotlib.collections import PatchCollection
+        for ax in fig.axes:
+            for coll in ax.collections:
+                if isinstance(coll, PatchCollection) and coll.get_zorder() == 2:
+                    return coll.get_facecolors()
+        return None
+
+    def test_render_page_applies_zoomed_colors(self):
+        """End-to-end: nel PDF i due grani a ±6c hanno colori distinti."""
+        viz = make_viz(self._detuned_scene(), config={'page_duration': 30.0})
+        with patch('soundfile.read', return_value=(FAKE_AUDIO, SR)):
+            figs = viz.render_all()
+        colors = self._grain_facecolors(figs[0])
+        assert colors is not None and len(colors) == 2
+        # RGB (no alpha: dipende dal volume) chiaramente diversi
+        assert np.abs(colors[0][:3] - colors[1][:3]).max() > 0.3
+
+    def test_render_page_fixed_colors_when_disabled(self):
+        """Autozoom off: i due grani a ±6c restano indistinguibili."""
+        viz = make_viz(self._detuned_scene(),
+                       config={'page_duration': 30.0,
+                               'pitch_color_autozoom': {'enabled': False}})
+        with patch('soundfile.read', return_value=(FAKE_AUDIO, SR)):
+            figs = viz.render_all()
+        colors = self._grain_facecolors(figs[0])
+        assert colors is not None and len(colors) == 2
+        assert np.abs(colors[0][:3] - colors[1][:3]).max() < 0.05
+
+    @staticmethod
+    def _colorbar_axes(fig):
+        return [ax for ax in fig.axes if ax.get_label() == '<colorbar>']
+
+    def test_render_page_adds_pitch_colorbar(self):
+        """Ogni subplot con grani ha una colorbar che mostra la scala pitch."""
+        viz = make_viz(self._detuned_scene(), config={'page_duration': 30.0})
+        with patch('soundfile.read', return_value=(FAKE_AUDIO, SR)):
+            figs = viz.render_all()
+        assert len(self._colorbar_axes(figs[0])) == 1
+
+    def test_no_colorbar_without_grains(self):
+        s = make_stream('s1', onset=0.0, duration=10.0, n_grains=0)
+        viz = make_viz([s], config={'page_duration': 30.0})
+        with patch('soundfile.read', return_value=(FAKE_AUDIO, SR)):
+            figs = viz.render_all()
+        assert len(self._colorbar_axes(figs[0])) == 0

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -1107,11 +1107,12 @@ class TestUnitPitchImplicitDetune:
     e il gate dephase concede l'apply per il grano.
     """
 
-    # semi-ampiezza ±6 cents -> banda moltiplicativa del ratio
-    BAND = 2.0 ** (6.0 / 1200.0)
+    # semi-ampiezza ±EDO_IMPLICIT_DETUNE_CENTS -> banda moltiplicativa del ratio
+    from parameters.pitch_unit import EDO_IMPLICIT_DETUNE_CENTS as _DETUNE_CENTS
+    BAND = 2.0 ** (_DETUNE_CENTS / 1200.0)
 
     def test_edo_implicit_gated_detunes_within_band(self):
-        """EDO senza range + gate aperto: ratio dentro ±6 cents, non identico."""
+        """EDO senza range + gate aperto: ratio dentro la banda, non identico."""
         param = _make_param(0.0, gate=AlwaysGate())
         strategy = _semitones_strategy(param)
         ratios = [strategy.calculate(0.0) for _ in range(300)]

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -64,6 +64,7 @@ PITCH_RATIO_BOUNDS = ParameterBounds(
 # per usarle come basi dei mock (cosi' isinstance() funziona)
 from parameters.parameter import Parameter as _RealParameter
 from envelopes.envelope import Envelope as _RealEnvelope
+from shared.probability_gate import NeverGate, AlwaysGate
 
 class MockParameter(_RealParameter):
     """
@@ -71,12 +72,17 @@ class MockParameter(_RealParameter):
     NON chiama super().__init__() per evitare side effects.
     """
     def __init__(self, value, name='mock_param', bounds=None,
-                 owner_id='test', **kwargs):
+                 owner_id='test', mod_range=None, gate=None, **kwargs):
         # Bypass completo del costruttore reale
         self._value = value
         self.name = name
         self.bounds = bounds
         self.owner_id = owner_id
+        # Stato dephase: default = nessun range esplicito, gate chiuso.
+        # Con NeverGate i test storici restano passthrough esatti
+        # (nessun detune implicito, issue #95).
+        self._mod_range = mod_range
+        self._probability_gate = gate if gate is not None else NeverGate()
 
     @property
     def value(self):
@@ -176,9 +182,9 @@ from parameters.pitch_unit import EdoUnit, RatioUnit
 # HELPERS
 # =============================================================================
 
-def _make_param(value, name='test_param', bounds=None):
+def _make_param(value, name='test_param', bounds=None, **kwargs):
     """Crea un MockParameter con defaults ragionevoli."""
-    return MockParameter(value=value, name=name, bounds=bounds)
+    return MockParameter(value=value, name=name, bounds=bounds, **kwargs)
 
 
 def _make_envelope_param(breakpoints, name='test_param'):
@@ -1089,6 +1095,85 @@ class TestEdgeCases:
         assert r1 != r2
         assert r1 == pytest.approx(2.0)
         assert r2 == pytest.approx(2 ** (7/12))
+
+# =============================================================================
+# GRUPPO 14: DETUNE IMPLICITO IN RATIO-SPACE (issue #95)
+# =============================================================================
+
+class TestUnitPitchImplicitDetune:
+    """
+    Detune continuo ±implicit_detune_cents applicato da UnitPitchStrategy
+    DOPO la quantizzazione EDO, solo se il param non ha range esplicito
+    e il gate dephase concede l'apply per il grano.
+    """
+
+    # semi-ampiezza ±6 cents -> banda moltiplicativa del ratio
+    BAND = 2.0 ** (6.0 / 1200.0)
+
+    def test_edo_implicit_gated_detunes_within_band(self):
+        """EDO senza range + gate aperto: ratio dentro ±6 cents, non identico."""
+        param = _make_param(0.0, gate=AlwaysGate())
+        strategy = _semitones_strategy(param)
+        ratios = [strategy.calculate(0.0) for _ in range(300)]
+        assert all(1.0 / self.BAND <= r <= self.BAND for r in ratios)
+        assert any(r != pytest.approx(1.0, abs=1e-12) for r in ratios)
+
+    def test_detune_is_continuous_not_quantized(self):
+        """Il campionamento è continuo (float uniforme), non a cents interi."""
+        param = _make_param(0.0, gate=AlwaysGate())
+        strategy = _semitones_strategy(param)
+        ratios = {strategy.calculate(0.0) for _ in range(300)}
+        assert len(ratios) > 50
+
+    def test_detune_centered_on_quantized_value(self):
+        """Il detune si sovrappone al valore EDO quantizzato (base 7 st)."""
+        param = _make_param(7.0, gate=AlwaysGate())
+        strategy = _semitones_strategy(param)
+        nominal = 2.0 ** (7.0 / 12.0)
+        for _ in range(300):
+            r = strategy.calculate(0.0)
+            assert nominal / self.BAND <= r <= nominal * self.BAND
+
+    def test_edo_implicit_closed_gate_no_detune(self):
+        """Gate chiuso: passthrough esatto (regressione no-op deliberato)."""
+        param = _make_param(7.0, gate=NeverGate())
+        strategy = _semitones_strategy(param)
+        expected = 2.0 ** (7.0 / 12.0)
+        for _ in range(20):
+            assert strategy.calculate(0.0) == pytest.approx(expected)
+
+    def test_edo_explicit_range_no_detune(self):
+        """Range esplicito: il detune implicito NON scatta (path invariato)."""
+        param = _make_param(7.0, mod_range=2.0, gate=AlwaysGate())
+        strategy = _semitones_strategy(param)
+        expected = 2.0 ** (7.0 / 12.0)
+        for _ in range(20):
+            assert strategy.calculate(0.0) == pytest.approx(expected)
+
+    def test_ratio_unit_no_strategy_detune(self):
+        """RatioUnit: il jitter implicito vive già in value-space
+        (default_jitter), nessun detune aggiuntivo in strategy."""
+        param = _make_param(1.5, gate=AlwaysGate())
+        strategy = _ratio_strategy(param)
+        for _ in range(20):
+            assert strategy.calculate(0.0) == pytest.approx(1.5)
+
+    def test_detune_clamped_at_upper_ratio_bound(self):
+        """Base a +36 st (ratio 8.0): il detune non supera mai il bound."""
+        param = _make_param(36.0, gate=AlwaysGate())
+        strategy = _semitones_strategy(param)
+        ratios = [strategy.calculate(0.0) for _ in range(300)]
+        assert all(r <= 8.0 for r in ratios)
+        assert all(r >= 8.0 / self.BAND for r in ratios)
+
+    def test_detune_clamped_at_lower_ratio_bound(self):
+        """Base a -36 st (ratio 0.125): il detune non scende sotto il bound."""
+        param = _make_param(-36.0, gate=AlwaysGate())
+        strategy = _semitones_strategy(param)
+        ratios = [strategy.calculate(0.0) for _ in range(300)]
+        assert all(r >= 0.125 for r in ratios)
+        assert all(r <= 0.125 * self.BAND for r in ratios)
+
 
 # =============================================================================
 # TEST COPERTURA CORPI ABSTRACT (righe 22, 28, 34, 90, 95)


### PR DESCRIPTION
min_span_cents passa da 2 a 50 cents (1/2 semitono): uno scarto di pochi cents tra grani non occupa piu' l'intera colormap con un gradiente esagerato. Differenze >= 1 semitono restano chiaramente distinte.