### PR TITLE
feat(score-visualizer): offset per-voce nella partitura (issue #90, F…

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -52,6 +52,7 @@ Senza argomenti: stampa usage ed esce con codice 1.
 |------|-------|---------|----------------|---------|
 | `--visualize` | `-v` | off | `AUTOVISUAL` | esporta partitura grafica PDF accanto all'output |
 | `--show-static` | `-s` | off | `SHOWSTATIC` | include i parametri statici nella partitura |
+| `--show-voice-offsets` | — | off | `SHOWVOICEOFFSETS` | disegna gli offset per-voce nella partitura: una curva per voce per `voice_pitch_offset` e `voice_pointer_offset`, piu' la curva singola di `voice_pointer_range` (vedi [[yaml]] blocco `voices`) |
 | `--per-stream` | `-p` | off | `STEMS` | un file audio per stream (stems) invece del mix singolo |
 | `--cache` | — | off | `CACHE` | build incrementale per stream (richiede `--per-stream`, vedi [[caching]]) |
 | `--reaper` | — | off | `REAPER` | esporta progetto Reaper `.rpp` (vedi [[reaper]]) |
@@ -94,6 +95,10 @@ Vincoli tra flag e comportamento nelle combinazioni non valide:
 - **`--keep-sco` / `--sco-dir`** hanno effetto solo con `--renderer csound`
   (il renderer numpy non produce `.sco`).
 - **`--show-static`** ha effetto solo insieme a `--visualize`.
+- **`--show-voice-offsets`** ha effetto solo insieme a `--visualize`. Gli
+  offset per-voce vengono campionati dalle voice strategy
+  (`VoiceManager.get_voice_config`) e disegnati come una curva per voce
+  (voce 0 = riferimento, esclusa). Gating indipendente da `--show-static`.
 - **`--plot-envelopes`** ha effetto solo insieme a `--visualize`; la
   validazione dei nomi avviene comunque (nome ignoto → exit 1 anche senza
   `--visualize`). Il filtro è ortogonale a `--show-static`: un parametro

--- a/make/build.mk
+++ b/make/build.mk
@@ -38,6 +38,11 @@ ifeq ($(SHOWSTATIC), true)
 PYFLAGS += --show-static
 endif
 
+# 2a. Se SHOWVOICEOFFSETS e' true, aggiungi --show-voice-offsets (issue #90)
+ifeq ($(SHOWVOICEOFFSETS), true)
+PYFLAGS += --show-voice-offsets
+endif
+
 # 2b. Se PLOT_ENVELOPES e' non-vuoto, aggiungi --plot-envelopes (issue #101)
 ifneq ($(strip $(PLOT_ENVELOPES)),)
 PYFLAGS += --plot-envelopes $(PLOT_ENVELOPES)

--- a/src/main.py
+++ b/src/main.py
@@ -122,7 +122,8 @@ def main():
     if len(sys.argv) < 2:
         print(
             "Uso: python main.py <file.yml> [output.aif] "
-            "[--visualize] [--show-static] [--plot-envelopes nomi,csv] "
+            "[--visualize] [--show-static] [--show-voice-offsets] "
+            "[--plot-envelopes nomi,csv] "
             "[--page-duration SECONDI] "
             "[--per-stream] "
             "[--renderer csound|numpy] "
@@ -146,6 +147,9 @@ def main():
 
     do_visualize = '--visualize' in sys.argv or '-v' in sys.argv
     show_static = '--show-static' in sys.argv or '-s' in sys.argv
+    # --show-voice-offsets: disegna gli offset per-voce (una curva per voce)
+    # nella partitura. Issue #90, Fase 3. Ha effetto solo con --visualize.
+    show_voice_offsets = '--show-voice-offsets' in sys.argv
 
     # --page-duration SECONDI: durata (secondi) di una pagina della partitura.
     page_duration = 15.0
@@ -368,6 +372,7 @@ def main():
             viz = ScoreVisualizer(generator, config={
                 'page_duration': page_duration,
                 'show_static_params': show_static,
+                'show_voice_offsets': show_voice_offsets,
                 'envelope_filter': plot_envelopes,
             })
             viz.export_pdf(pdf_file)

--- a/src/rendering/score_visualizer.py
+++ b/src/rendering/score_visualizer.py
@@ -10,6 +10,7 @@ from matplotlib.colors import Normalize
 from matplotlib.backends.backend_pdf import PdfPages
 import numpy as np
 import soundfile as sf
+import re
 from math import ceil
 
 # Path samples (stesso del progetto)
@@ -86,6 +87,11 @@ class ScoreVisualizer:
         default_config = {
             # Se True, mostra anche i valori costanti
             'show_static_params': False,
+            # Se True, disegna gli offset per-voce (voice_pitch_offset /
+            # voice_pointer_offset come una curva per voce, voice_pointer_range
+            # come curva singola dello spread). Fase 3 issue #90. Gating
+            # indipendente da show_static_params.
+            'show_voice_offsets': False,
             # Filtro selettivo: None = tutti gli envelope; altrimenti set/lista
             # di nomi — solo quelli elencati vengono plottati (issue #101)
             'envelope_filter': None,
@@ -1104,24 +1110,129 @@ class ScoreVisualizer:
                 envelopes['pointer_deviation_prob'] = Envelope([[0, prob], [stream.duration, prob]])
 
         # =====================================================================
+        # OFFSET PER-VOCE (issue #90, Fase 3). voice_pitch_offset /
+        # voice_pointer_offset / voice_pointer_range non sono Envelope sullo
+        # Stream: sono config delle voice strategy, calcolati on-the-fly da
+        # VoiceManager.get_voice_config(voice_index, time). Raccolti come curve
+        # per-voce solo col flag show_voice_offsets (gating dedicato, non
+        # governato da show_static_params).
+        # =====================================================================
+        if self.config.get('show_voice_offsets'):
+            envelopes.update(self._get_voice_offset_envelopes(stream))
+
+        # =====================================================================
         # FILTRO SELETTIVO (issue #101). Applicato sulle chiavi del dict finale
         # cosi' copre ogni path di estrazione (main, _prob, _mod_range, pitch,
-        # nomi espliciti). Il filtro interseca: non forza la visibilita' degli
-        # statici, che restano governati da show_static_params.
+        # nomi espliciti, offset per-voce). Confronto sul nome base cosi' un
+        # filtro 'voice_pitch_offset' cattura tutte le tracce '__vN'. Il filtro
+        # interseca: non forza la visibilita' degli statici, che restano
+        # governati da show_static_params.
         # =====================================================================
         env_filter = self.config.get('envelope_filter')
         if env_filter is not None:
-            envelopes = {k: v for k, v in envelopes.items() if k in env_filter}
+            envelopes = {
+                k: v for k, v in envelopes.items()
+                if self._base_param_name(k) in env_filter
+            }
 
         return envelopes
+
+    @staticmethod
+    def _base_param_name(key):
+        """Nome base di una chiave envelope: strippa il suffisso per-voce '__vN'
+        (issue #90). 'voice_pitch_offset__v2' -> 'voice_pitch_offset'; chiavi
+        senza suffisso restano invariate. Serve a risolvere colore/range/filtro
+        delle curve per-voce sul parametro base."""
+        return re.sub(r'__v\d+$', '', key)
+
+    def _get_voice_offset_envelopes(self, stream):
+        """
+        Estrae gli offset per-voce come curve disegnabili (issue #90, Fase 3).
+
+        - voice_pitch_offset__vN: una curva per voce (semitoni), campionando
+          VoiceConfig.pitch_factor su una griglia temporale e convertendo il
+          fattore di ratio in semitoni (12*log2). Voce 0 = riferimento, esclusa.
+        - voice_pointer_offset__vN: una curva per voce (offset raw), da
+          VoiceConfig.pointer_offset.
+        - voice_pointer_range: curva singola dello spread, dal parametro
+          pointer_range della pointer strategy stocastica (se presente).
+
+        num_voices time-varying: la voce i appare solo nella finestra in cui e'
+        attiva (int(num_voices(t)) > i), troncando la curva. Le curve
+        identicamente nulle vengono saltate (nessuna informazione).
+        """
+        from envelopes.envelope import Envelope
+
+        vm = getattr(stream, '_voice_manager', None)
+        if vm is None:
+            return {}
+
+        max_voices = int(getattr(vm, 'max_voices', 1))
+        if max_voices < 2 and getattr(vm, '_pointer_strategy', None) is None:
+            return {}
+
+        duration = stream.duration
+        grid = np.linspace(0.0, duration, 33)
+
+        num_voices_param = getattr(stream, 'num_voices', None)
+
+        def active_count(t):
+            if num_voices_param is None:
+                return max_voices
+            try:
+                val = num_voices_param.get_value(t)
+            except AttributeError:
+                val = num_voices_param
+            return max(1, min(max_voices, int(val)))
+
+        has_pitch = getattr(vm, '_pitch_strategy', None) is not None
+        has_pointer = getattr(vm, '_pointer_strategy', None) is not None
+
+        result = {}
+
+        def _nonzero(points):
+            return len(points) >= 2 and any(abs(v) > 1e-9 for _, v in points)
+
+        for i in range(1, max_voices):
+            pitch_pts = []
+            pointer_pts = []
+            for t in grid:
+                if active_count(t) <= i:
+                    continue
+                vc = vm.get_voice_config(i, float(t))
+                if has_pitch:
+                    factor = vc.pitch_factor
+                    semis = float(12.0 * np.log2(factor)) if factor > 0 else 0.0
+                    pitch_pts.append([float(t), semis])
+                if has_pointer:
+                    pointer_pts.append([float(t), float(vc.pointer_offset)])
+            if has_pitch and _nonzero(pitch_pts):
+                result[f'voice_pitch_offset__v{i}'] = Envelope(pitch_pts)
+            if has_pointer and _nonzero(pointer_pts):
+                result[f'voice_pointer_offset__v{i}'] = Envelope(pointer_pts)
+
+        # voice_pointer_range: ampiezza dello spread, esposta dalla pointer
+        # strategy stocastica come parametro pointer_range (float o Envelope).
+        if has_pointer:
+            prange = getattr(vm._pointer_strategy, 'pointer_range', None)
+            if isinstance(prange, Envelope):
+                if any(abs(bp[1]) > 1e-9 for bp in prange.breakpoints):
+                    result['voice_pointer_range'] = prange
+            elif isinstance(prange, (int, float)) and abs(prange) > 1e-9:
+                result['voice_pointer_range'] = Envelope(
+                    [[0, prange], [duration, prange]])
+
+        return result
 
     def _full_range(self, param_name):
         """
         Range pieno (min, max) di un parametro, o None se non disponibile.
 
         pitch è unit-driven (bounds dall'unità attiva); gli altri vengono da
-        config['envelope_ranges'].
+        config['envelope_ranges']. Le chiavi per-voce ('__vN', issue #90) usano
+        il range del parametro base.
         """
+        param_name = self._base_param_name(param_name)
         if param_name == 'pitch':
             unit = getattr(self, '_current_pitch_unit', None)
             if unit is not None:
@@ -1153,7 +1264,9 @@ class ScoreVisualizer:
 
         result = {}
         for param_name, envelope in envelopes.items():
-            if param_name == 'pan' or param_name not in params:
+            # Le chiavi per-voce ('__vN', #90) ereditano autozoom/range dal base.
+            base_name = self._base_param_name(param_name)
+            if base_name == 'pan' or base_name not in params:
                 continue
             full = self._full_range(param_name)
             if full is None:
@@ -1202,8 +1315,11 @@ class ScoreVisualizer:
         Returns:
             float: valore normalizzato 0-1
         """
+        # Le curve per-voce ('__vN', #90) si normalizzano col range del base;
+        # il display range (auto-zoom) resta indicizzato per chiave piena.
+        base_name = self._base_param_name(param_name)
         # PITCH unit-driven: i bounds vengono dall'unità attiva, non dai range statici.
-        if param_name == 'pitch':
+        if base_name == 'pitch':
             unit = getattr(self, '_current_pitch_unit', None)
             if unit is not None:
                 b = unit.value_bounds()
@@ -1216,7 +1332,7 @@ class ScoreVisualizer:
         display_ranges = getattr(self, '_current_display_ranges', None) or {}
         if param_name in display_ranges:
             min_val, max_val = display_ranges[param_name]
-            if param_name == 'pan':
+            if base_name == 'pan':
                 value = ((value + 180) % 360) - 180
             if max_val != min_val:
                 return np.clip((value - min_val) / (max_val - min_val), 0, 1)
@@ -1224,11 +1340,11 @@ class ScoreVisualizer:
 
         ranges = self.config['envelope_ranges']
 
-        if param_name in ranges:
-            min_val, max_val = ranges[param_name]
+        if base_name in ranges:
+            min_val, max_val = ranges[base_name]
 
             # Pan è ciclico: gestisci valori fuori range
-            if param_name == 'pan':
+            if base_name == 'pan':
                 # Normalizza a -180..180 usando modulo
                 value = ((value + 180) % 360) - 180
 
@@ -1300,8 +1416,8 @@ class ScoreVisualizer:
             envelopes, stream, t_start, t_end)
 
         for param_name, envelope in envelopes.items():
-            # Colore
-            color = colors.get(param_name, '#333333')
+            # Colore (curve per-voce '__vN' usano il colore del base, #90)
+            color = colors.get(self._base_param_name(param_name), '#333333')
 
             # Envelope per-segmento eterogeneo (issue #68): rendering per-segmento
             if self._is_per_segment_heterogeneous(envelope):
@@ -1574,7 +1690,11 @@ class ScoreVisualizer:
             y_base = y_that_stream + gap_ratio
             y_height = env_slot_height
 
-            env_types = sorted(envelopes.keys())
+            # Le curve per-voce ('__vN', #90) collassano a una sola voce di
+            # legenda per parametro base: N tracce, una etichetta.
+            env_types = sorted(
+                dict.fromkeys(self._base_param_name(k) for k in envelopes)
+            )
             lanes.append({
                 'stream': stream,
                 'stream_id': stream.stream_id,
@@ -1630,7 +1750,7 @@ class ScoreVisualizer:
         colors = self.config['envelope_colors']
 
         for param_name, y, stream_id in legend_entries:
-            color = colors.get(param_name, '#333333')
+            color = colors.get(self._base_param_name(param_name), '#333333')
             ax.plot([0.1, 0.15], [y, y], color=color, linewidth=2)
             # clip_on=True: anche un nome inatteso non sfora mai nel plot,
             # viene tagliato al bordo della colonna legenda (issue #96).

--- a/tests/rendering/test_score_visualizer.py
+++ b/tests/rendering/test_score_visualizer.py
@@ -675,6 +675,133 @@ class TestPointerSpeedEnvelopeCollection:
         assert 'pointer_speed' in viz._get_stream_envelopes(s)
 
 
+class TestVoiceOffsetEnvelopeCollection:
+    """Fase 3 issue #90: gli offset per-voce (voice_pitch_offset,
+    voice_pointer_offset, voice_pointer_range) non sono Envelope sullo Stream
+    ma config delle voice strategy, calcolati da
+    VoiceManager.get_voice_config(voice_index, time). Vengono raccolti come
+    curve per-voce SOLO col flag show_voice_offsets; la voce 0 (riferimento)
+    e' sempre esclusa."""
+
+    def _stream_with_vm(self, voice_manager, num_voices=None):
+        s = make_stream('s1', onset=0.0, duration=10.0)
+        s._voice_manager = voice_manager
+        if num_voices is not None:
+            s.num_voices = num_voices
+        return s
+
+    def _num_voices_param(self, value):
+        from parameters.parameter import Parameter
+        from parameters.parameter_definitions import GRANULAR_PARAMETERS
+        return Parameter('num_voices', value, GRANULAR_PARAMETERS['num_voices'])
+
+    def _vm_pitch(self, max_voices=3, step=3.0):
+        from controllers.voice_manager import VoiceManager
+        from strategies.voice_pitch_strategy import StepPitchStrategy
+        return VoiceManager(max_voices=max_voices,
+                            pitch_strategy=StepPitchStrategy(step=step))
+
+    def _vm_pointer_linear(self, max_voices=3, step=0.05):
+        from controllers.voice_manager import VoiceManager
+        from strategies.voice_pointer_strategy import LinearPointerStrategy
+        return VoiceManager(max_voices=max_voices,
+                            pointer_strategy=LinearPointerStrategy(step=step))
+
+    # --- gating col flag ---
+
+    def test_voice_offsets_absent_without_flag(self):
+        s = self._stream_with_vm(self._vm_pitch())
+        env = make_viz([s])._get_stream_envelopes(s)
+        assert not any(k.startswith('voice_pitch_offset') for k in env)
+
+    def test_voice_pitch_offset_per_voice_collected_with_flag(self):
+        s = self._stream_with_vm(self._vm_pitch())
+        env = make_viz([s], config={'show_voice_offsets': True})._get_stream_envelopes(s)
+        assert 'voice_pitch_offset__v1' in env
+        assert 'voice_pitch_offset__v2' in env
+        assert 'voice_pitch_offset__v0' not in env  # voce 0 = riferimento
+
+    def test_voice_pitch_offset_values_in_semitones(self):
+        s = self._stream_with_vm(self._vm_pitch(step=3.0))
+        env = make_viz([s], config={'show_voice_offsets': True})._get_stream_envelopes(s)
+        assert env['voice_pitch_offset__v1'].evaluate(0.0) == pytest.approx(3.0, abs=1e-6)
+        assert env['voice_pitch_offset__v2'].evaluate(0.0) == pytest.approx(6.0, abs=1e-6)
+
+    def test_voice_pointer_offset_per_voice_collected_with_flag(self):
+        s = self._stream_with_vm(self._vm_pointer_linear(step=0.05))
+        env = make_viz([s], config={'show_voice_offsets': True})._get_stream_envelopes(s)
+        assert env['voice_pointer_offset__v1'].evaluate(0.0) == pytest.approx(0.05, abs=1e-6)
+        assert env['voice_pointer_offset__v2'].evaluate(0.0) == pytest.approx(0.10, abs=1e-6)
+
+    def test_voice_pointer_range_single_curve_from_stochastic(self):
+        from envelopes.envelope import Envelope
+        from controllers.voice_manager import VoiceManager
+        from strategies.voice_pointer_strategy import StochasticPointerStrategy
+        rng = Envelope([[0, 0.1], [10, 0.5]])
+        vm = VoiceManager(
+            max_voices=3,
+            pointer_strategy=StochasticPointerStrategy(pointer_range=rng, stream_id='s1'),
+        )
+        s = self._stream_with_vm(vm)
+        env = make_viz([s], config={'show_voice_offsets': True})._get_stream_envelopes(s)
+        assert env['voice_pointer_range'] is rng
+
+    def test_no_voice_offsets_when_single_voice(self):
+        s = self._stream_with_vm(self._vm_pitch(max_voices=1))
+        env = make_viz([s], config={'show_voice_offsets': True})._get_stream_envelopes(s)
+        assert not any(k.startswith('voice_pitch_offset') for k in env)
+
+    def test_no_curve_when_no_strategy(self):
+        from controllers.voice_manager import VoiceManager
+        s = self._stream_with_vm(VoiceManager(max_voices=3))  # nessuna strategy
+        env = make_viz([s], config={'show_voice_offsets': True})._get_stream_envelopes(s)
+        assert not any(k.startswith('voice_pitch_offset') for k in env)
+        assert not any(k.startswith('voice_pointer_offset') for k in env)
+
+    def test_no_voice_manager_no_crash(self):
+        s = make_stream('s1', onset=0.0, duration=10.0)
+        s._voice_manager = None
+        env = make_viz([s], config={'show_voice_offsets': True})._get_stream_envelopes(s)
+        assert not any(k.startswith('voice_') for k in env)
+
+    def test_time_varying_num_voices_truncates_high_voice(self):
+        from envelopes.envelope import Envelope
+        # num_voices sale da 1 a 4: la voce 2 e' attiva solo nella seconda meta'.
+        vm = self._vm_pitch(max_voices=4)
+        nv = self._num_voices_param(Envelope([[0, 1.0], [10, 4.0]]))
+        s = self._stream_with_vm(vm, num_voices=nv)
+        env = make_viz([s], config={'show_voice_offsets': True})._get_stream_envelopes(s)
+        assert 'voice_pitch_offset__v2' in env
+        assert env['voice_pitch_offset__v2'].breakpoints[0][0] > 0.0
+
+    def test_has_envelopes_true_when_only_voice_offsets(self):
+        s = self._stream_with_vm(self._vm_pitch())
+        assert bool(make_viz([s], config={'show_voice_offsets': True})._get_stream_envelopes(s)) is True
+
+
+class TestBaseParamName:
+    """_base_param_name strippa il suffisso __vN: serve a risolvere
+    colore/range/filtro sul nome base per le curve per-voce (Fase 3 #90)."""
+
+    def test_strips_voice_suffix(self):
+        assert ScoreVisualizer._base_param_name('voice_pitch_offset__v2') == 'voice_pitch_offset'
+
+    def test_noop_on_plain_name(self):
+        assert ScoreVisualizer._base_param_name('pitch') == 'pitch'
+
+    def test_filter_by_base_keeps_per_voice_keys(self):
+        from controllers.voice_manager import VoiceManager
+        from strategies.voice_pitch_strategy import StepPitchStrategy
+        vm = VoiceManager(max_voices=3, pitch_strategy=StepPitchStrategy(step=3.0))
+        s = make_stream('s1', onset=0.0, duration=10.0)
+        s._voice_manager = vm
+        env = make_viz([s], config={
+            'show_voice_offsets': True,
+            'envelope_filter': {'voice_pitch_offset'},
+        })._get_stream_envelopes(s)
+        assert 'voice_pitch_offset__v1' in env
+
+
 class TestModRangeEnvelopeCollection:
     """issue #96 - i parametri con range_path (volume_range, pan_range,
     grain.duration_range, offset_range) tengono il range stocastico in
@@ -1146,7 +1273,7 @@ class TestPitchColorAutozoom:
         az = viz.config['pitch_color_autozoom']
         assert az['enabled'] is True
         assert az['pad_ratio'] > 0
-        assert az['min_span_cents'] == 100.0  # 1 semitono
+        assert az['min_span_cents'] == 50.0  # mezzo semitono
 
     def test_range_from_visible_grains_min_max_cents(self):
         """Range = [min, max] in cents dei grani visibili, con pad per lato."""
@@ -1176,8 +1303,8 @@ class TestPitchColorAutozoom:
 
     def test_floor_enforces_minimum_semitone_span(self):
         """Una differenza reale minima (12 cents, grani a ±6c) non deve
-        produrre uno span quasi nullo: il floor garantisce almeno un
-        semitono (100 cents), cosi' pochi cents di scarto non occupano
+        produrre uno span quasi nullo: il floor garantisce almeno mezzo
+        semitono (50 cents), cosi' pochi cents di scarto non occupano
         l'intera colormap."""
         s = make_stream('s1', n_grains=0)
         s.voices = [[
@@ -1186,7 +1313,7 @@ class TestPitchColorAutozoom:
         ]]
         viz = make_viz([s])
         lo, hi = viz._compute_pitch_color_range([s], 0.0, 10.0)
-        assert hi - lo >= 100.0
+        assert hi - lo >= 50.0
 
     def test_grains_outside_page_excluded(self):
         """Grano fuori finestra di pagina non influenza il range."""
@@ -1278,17 +1405,19 @@ class TestPitchColorAutozoom:
         return None
 
     def test_render_page_micro_detune_colors_stay_close(self):
-        """End-to-end: con il floor di un semitono (100 cents), due grani
+        """End-to-end: con il floor di mezzo semitono (50 cents), due grani
         a ±6c (12 cents di scarto reale, ben sotto il floor) restano in una
         banda ristretta della colormap — niente piu' salto cromatico
-        estremo per pochi cents di differenza."""
+        estremo per pochi cents di differenza. Resta comunque sotto il caso
+        macro (>= 1 semitono), distinto in
+        test_render_page_above_semitone_detune_still_distinct."""
         viz = make_viz(self._detuned_scene(), config={'page_duration': 30.0})
         with patch('soundfile.read', return_value=(FAKE_AUDIO, SR)):
             figs = viz.render_all()
         colors = self._grain_facecolors(figs[0])
         assert colors is not None and len(colors) == 2
-        # RGB (no alpha: dipende dal volume) restano vicini
-        assert np.abs(colors[0][:3] - colors[1][:3]).max() < 0.4
+        # RGB (no alpha: dipende dal volume) restano nella stessa banda
+        assert np.abs(colors[0][:3] - colors[1][:3]).max() < 0.7
 
     def test_render_page_above_semitone_detune_still_distinct(self):
         """Uno scarto reale >= 1 semitono (qui 120 cents) supera il floor:


### PR DESCRIPTION
…ase 3)

Aggiunge il flag --show-voice-offsets (config show_voice_offsets) che disegna gli offset per-voce nel pannello envelope come una curva per voce:

- voice_pitch_offset__vN / voice_pointer_offset__vN campionati da VoiceManager.get_voice_config(voice_index, t) su una griglia temporale (pitch_factor convertito in semitoni); voce 0 = riferimento, esclusa.
- voice_pointer_range come curva singola dello spread (pointer strategy stocastica). num_voices time-varying tronca la curva alla finestra attiva.

Le chiavi per-voce usano il suffisso __vN; nuovo helper _base_param_name risolve colore/range/filtro/legenda sul nome base, con la legenda collassata a una entry per parametro base. Plumbing CLI in main.py e Make (SHOWVOICEOFFSETS), doc in docs/reference/cli.md.

Allinea inoltre i 3 test di TestPitchColorAutozoom a min_span_cents=50, cambiato a mano senza aggiornare i test.

https://claude.ai/code/session_019x4s5wiBTgFmRQVbT8j7hH