### PR TITLE
fix(cache): escludi solo/mute dal fingerprint dello stream (#108)

### DIFF
--- a/docs/explanation/caching.md
+++ b/docs/explanation/caching.md
@@ -5,7 +5,7 @@ status: stable
 tags: [caching, rendering, csound]
 sources:
   - src/rendering/stream_cache_manager.py
-last_synced_commit: 4c4fee4
+last_synced_commit: c65dfae
 ---
 
 # Stream Cache Manager — caching incrementale
@@ -28,7 +28,7 @@ Caching per-stream con fingerprint contenuto. Attivo solo con `STEMS=true CACHE=
 
 **API:**
 
-- `compute_fingerprint(stream_dict)` — SHA-256 del dict YAML raw dello stream
+- `compute_fingerprint(stream_dict)` — SHA-256 del dict YAML dello stream, escluse le chiavi non-audio in `FINGERPRINT_IGNORE_KEYS` (`solo`, `mute`): toggle di solo/mute cambia *quali* stream renderizzare, non il contenuto del singolo stem, quindi non deve marcarlo dirty (issue #108). `onset` resta invece incluso (divergenza nota col lato JS, PGE-ui #39)
 - `is_dirty(stream_dict, aif_path)` — True se stream_id assente, fingerprint cambiato, o file .aif assente
 - `update_after_build(stream_dicts)` — aggiorna manifest con fingerprint correnti
 - `garbage_collect(current_stream_ids, aif_dir, aif_prefix)` — rimuove dal manifest gli stream non più nel YAML; cancella `.aif` orfani

--- a/src/rendering/stream_cache_manager.py
+++ b/src/rendering/stream_cache_manager.py
@@ -5,7 +5,8 @@ StreamCacheManager
 Gestisce il caching incrementale degli stream granulari.
 
 Responsabilita':
-- Calcolare il fingerprint SHA-256 del dict YAML raw di ogni stream
+- Calcolare il fingerprint SHA-256 del dict YAML di ogni stream, escludendo
+  le chiavi non-audio (solo/mute, vedi FINGERPRINT_IGNORE_KEYS)
 - Persistere il manifest {stream_id: fingerprint} su disco come JSON
 - Decidere quali stream sono dirty (fingerprint cambiato o .aif assente)
 - Aggiornare il manifest dopo una build riuscita
@@ -20,6 +21,15 @@ import hashlib
 import json
 import os
 from typing import Dict, List, Optional
+
+
+# Chiavi escluse dal fingerprint: cambiano QUALI stream vengono renderizzati
+# (vedi Generator._filter_solo_mute), non il contenuto audio del singolo stem.
+# Includerle marcherebbe lo stem dirty a ogni toggle, forzando re-render inutili.
+# Allineato al lato JS di PGE-ui (backend.js FP_IGNORE). Issue #108.
+# NOTA: 'onset' resta volutamente FUORI da questo set — l'engine lo include
+# nell'hash (divergenza nota e accettata rispetto al JS, PGE-ui #39).
+FINGERPRINT_IGNORE_KEYS = frozenset({"solo", "mute"})
 
 
 class StreamCacheManager:
@@ -44,13 +54,20 @@ class StreamCacheManager:
         La serializzazione usa sort_keys=True per garantire stabilita'
         indipendentemente dall'ordine delle chiavi nel dict.
 
+        Le chiavi in FINGERPRINT_IGNORE_KEYS (solo/mute) vengono escluse: non
+        influenzano l'audio del singolo stem, solo quali stream renderizzare.
+
         Args:
             stream_dict: dict parametri dello stream dallo YAML
 
         Returns:
             Stringa esadecimale SHA-256 di 64 caratteri
         """
-        serialized = json.dumps(stream_dict, sort_keys=True)
+        filtered = {
+            k: v for k, v in stream_dict.items()
+            if k not in FINGERPRINT_IGNORE_KEYS
+        }
+        serialized = json.dumps(filtered, sort_keys=True)
         return hashlib.sha256(serialized.encode('utf-8')).hexdigest()
 
     # =========================================================================

--- a/tests/rendering/test_stream_cache_manager.py
+++ b/tests/rendering/test_stream_cache_manager.py
@@ -127,6 +127,71 @@ class TestFingerprintComputation:
 
 
 # =============================================================================
+# 1b. FINGERPRINT — ESCLUSIONE CHIAVI NON-AUDIO (issue #108)
+# =============================================================================
+
+class TestFingerprintIgnoresMuteSolo:
+    """
+    mute/solo cambiano QUALI stream vengono renderizzati (_filter_solo_mute),
+    non il contenuto audio del singolo stem: non devono entrare nel fingerprint.
+    Altrimenti il toggle del flag marca lo stem dirty e forza un re-render inutile.
+
+    Diventato osservabile da quando PGE-ui serializza mute/solo nello YAML
+    (PGE-ui #63). Riallinea l'engine al lato JS (backend.js FP_IGNORE). Issue #108.
+
+    onset resta FUORI scope: l'engine lo include nell'hash (divergenza nota e
+    accettata, PGE-ui #39).
+    """
+
+    def test_solo_presence_does_not_change_fingerprint(self, manager):
+        """Aggiungere solo:true non cambia il fingerprint dello stream."""
+        base = {'stream_id': 's1', 'volume': -6.0, 'sample': 'a.wav'}
+        with_solo = {**base, 'solo': True}
+        assert (
+            manager.compute_fingerprint(base)
+            == manager.compute_fingerprint(with_solo)
+        )
+
+    def test_mute_presence_does_not_change_fingerprint(self, manager):
+        """Aggiungere mute:true non cambia il fingerprint dello stream."""
+        base = {'stream_id': 's1', 'volume': -6.0, 'sample': 'a.wav'}
+        with_mute = {**base, 'mute': True}
+        assert (
+            manager.compute_fingerprint(base)
+            == manager.compute_fingerprint(with_mute)
+        )
+
+    def test_mute_and_solo_together_do_not_change_fingerprint(self, manager):
+        """mute e solo presenti insieme: nessun impatto sul fingerprint."""
+        base = {'stream_id': 's1', 'volume': -6.0}
+        flagged = {**base, 'mute': True, 'solo': True}
+        assert (
+            manager.compute_fingerprint(base)
+            == manager.compute_fingerprint(flagged)
+        )
+
+    def test_audio_field_change_still_changes_fingerprint(self, manager):
+        """Guardia anti-regressione: un campo audio (volume) cambia comunque
+        l'hash, anche con mute presente in entrambi i dict."""
+        d1 = {'stream_id': 's1', 'volume': -6.0, 'mute': True}
+        d2 = {'stream_id': 's1', 'volume': -12.0, 'mute': True}
+        assert manager.compute_fingerprint(d1) != manager.compute_fingerprint(d2)
+
+    def test_toggling_mute_does_not_mark_stream_dirty(self, manager, tmp_path):
+        """Dirty-check end-to-end: aggiungere mute non marca lo stem dirty se
+        il fingerprint precedente (senza mute) e' nel manifest e il .aif esiste.
+        Questo e' il sintomo esatto della issue #108."""
+        aif = str(tmp_path / 's1.aif')
+        open(aif, 'w').close()
+        original = {'stream_id': 's1', 'volume': -6.0}
+        # manifest salvato dal render precedente (prima del toggle)
+        manager.save({'s1': manager.compute_fingerprint(original)})
+        # ora l'utente attiva mute: lo YAML su disco contiene mute:true
+        toggled = {**original, 'mute': True}
+        assert manager.is_dirty(toggled, aif_path=aif) is False
+
+
+# =============================================================================
 # 2. CACHE PERSISTENCE
 # =============================================================================
 


### PR DESCRIPTION
Il toggle di solo/mute nello YAML marcava lo stem dirty e forzava un re-render inutile: compute_fingerprint faceva l'hash dell'intero dict raw, includendo le chiavi solo/mute. Queste cambiano *quali* stream vengono renderizzati (_filter_solo_mute), non il contenuto audio del singolo stem.

Introduce FINGERPRINT_IGNORE_KEYS = {solo, mute} e filtra il dict prima dell'hash. Riallinea l'engine al lato JS di PGE-ui (backend.js FP_IGNORE). onset resta volutamente incluso (divergenza nota e accettata, PGE-ui #39).

Per uno stream senza solo/mute l'hash resta identico: nessuna invalidazione spuria dei manifest cache esistenti.

https://claude.ai/code/session_01Xy8rjB84EqUgdxksGwZsK9