### PR TITLE
fix(score-visualizer): un subplot per stream, non per sample (issue #…

### DIFF
--- a/src/rendering/score_visualizer.py
+++ b/src/rendering/score_visualizer.py
@@ -480,7 +480,13 @@ class ScoreVisualizer:
     # =========================================================================
 
     def render_page(self, page_idx):
-        """Renderizza pagina con subplot separati per ogni SAMPLE (non per stream)."""
+        """Renderizza pagina con subplot separati per ogni STREAM (non per sample).
+
+        issue #109: ogni stream ottiene il proprio subplot anche quando piu'
+        stream condividono lo stesso sample (la waveform viene ridisegnata in
+        ciascuno). Cosi' 4 stream producono 4 subplot anche se due puntano allo
+        stesso file, e le label non collidono piu' su un asse condiviso.
+        """
         
         layout = self.page_layouts[page_idx]
         page_start, page_end = layout['time_range']
@@ -500,19 +506,15 @@ class ScoreVisualizer:
         has_envelopes = any(self._get_stream_envelopes(s) for s in active_streams)
         
         # =========================================================================
-        # RAGGRUPPA STREAM PER SAMPLE_PATH
+        # UN SUBPLOT PER STREAM (issue #109)
         # =========================================================================
-        samples_dict = {}
-        for stream in active_streams:
-            path = stream.sample
-            if path not in samples_dict:
-                samples_dict[path] = []
-            samples_dict[path].append(stream)
-        
-        # Numero subplot = numero di sample unici
-        n_samples = len(samples_dict)
-        
-        if n_samples == 0:
+        # Niente raggruppamento per sample: ogni stream ha il proprio subplot.
+        # Stream che condividono lo stesso sample ottengono subplot separati e la
+        # waveform viene ridisegnata in ciascuno (ridondanza accettabile per
+        # leggibilita'); _load_waveform fa cache, quindi nessun re-read del file.
+        n_streams = len(active_streams)
+
+        if n_streams == 0:
             # Pagina vuota
             ax = fig.add_subplot(111)
             ax.text(0.5, 0.5, "Nessuno stream attivo",
@@ -530,17 +532,17 @@ class ScoreVisualizer:
         waveform_ratio = self.config['waveform_width_ratio']
         envelope_ratio = self.config['envelope_panel_ratio'] if has_envelopes else 0.0
         
-        # Altezza per sample (divisa equamente)
+        # Altezza per stream (divisa equamente)
         stream_total_ratio = 1.0 - envelope_ratio
-        sample_row_height = stream_total_ratio / n_samples
-        
+        stream_row_height = stream_total_ratio / n_streams
+
         # Crea height_ratios
         if has_envelopes:
-            height_ratios = [sample_row_height] * n_samples + [envelope_ratio]
-            n_rows = n_samples + 1
+            height_ratios = [stream_row_height] * n_streams + [envelope_ratio]
+            n_rows = n_streams + 1
         else:
-            height_ratios = [sample_row_height] * n_samples
-            n_rows = n_samples
+            height_ratios = [stream_row_height] * n_streams
+            n_rows = n_streams
         
         # GridSpec: n_rows righe × 2 colonne
         gs = fig.add_gridspec(
@@ -548,7 +550,7 @@ class ScoreVisualizer:
             width_ratios=[waveform_ratio, 1 - waveform_ratio],
             height_ratios=height_ratios,
             wspace=0.02,
-            hspace=0.0  # gap verticale tra sample
+            hspace=0.0  # gap verticale tra stream
         )
         
         # Margini
@@ -561,33 +563,34 @@ class ScoreVisualizer:
         )
         
         # =========================================================================
-        # DISEGNA SUBPLOT PER OGNI SAMPLE
+        # DISEGNA UN SUBPLOT PER OGNI STREAM
         # =========================================================================
-        for i, (sample_path, streams) in enumerate(samples_dict.items()):
-            # Crea subplot per questo sample
+        for i, stream in enumerate(active_streams):
+            # Crea subplot per questo stream
             ax_wave = fig.add_subplot(gs[i, 0])
             ax_grain = fig.add_subplot(gs[i, 1])
-            
-            # Ottieni durata sample
-            sample_duration = self._get_sample_duration(sample_path)
-            
-            # Disegna waveform UNA VOLTA (usa il primo stream solo per il path)
-            self._draw_waveform_full(ax_wave, streams[0], sample_duration)
-            
-            # Range colore pitch auto-zoomato sul subplot (tutti gli stream)
-            cents_range = self._compute_pitch_color_range(
-                streams, page_start, page_end)
 
-            # Disegna grani di TUTTI gli stream che usano questo sample
-            for stream in streams:
-                self._draw_loop_mask(ax_grain, stream, page_start, page_end, sample_duration)
-                self._draw_grains_full(ax_grain, stream, sample_duration,
-                                    page_start, page_end, cents_range)
-                self._draw_stream_label_full(ax_grain, stream, page_start, sample_duration)
+            # Sample e durata dello stream corrente
+            sample_path = stream.sample
+            sample_duration = self._get_sample_duration(sample_path)
+
+            # Disegna waveform del sample dello stream (ridisegnata per ogni
+            # subplot anche se il sample e' condiviso; _load_waveform fa cache).
+            self._draw_waveform_full(ax_wave, stream, sample_duration)
+
+            # Range colore pitch auto-zoomato sui grani di questo stream
+            cents_range = self._compute_pitch_color_range(
+                [stream], page_start, page_end)
+
+            # Disegna grani, loop mask e label dello stream
+            self._draw_loop_mask(ax_grain, stream, page_start, page_end, sample_duration)
+            self._draw_grains_full(ax_grain, stream, sample_duration,
+                                   page_start, page_end, cents_range)
+            self._draw_stream_label_full(ax_grain, stream, page_start, sample_duration)
 
             # Legenda della scala colore pitch (auto-zoomata o fissa)
             self._add_pitch_colorbar(fig, ax_grain, cents_range,
-                                     streams, page_start, page_end)
+                                     [stream], page_start, page_end)
             # Configura assi waveform
             ax_wave.set_ylim(-0.02, sample_duration+0.02)
             ax_wave.set_xlim(-1.1, 1.1)
@@ -605,8 +608,8 @@ class ScoreVisualizer:
             ax_grain.tick_params(axis='y', labelsize=self.config['label_fontsize'] - 1)
             ax_grain.grid(True, alpha=0.3, linestyle='--')
             
-            # X label solo sull'ultimo sample (se non ci sono envelope)
-            if i == n_samples - 1 and not has_envelopes:
+            # X label solo sull'ultimo stream (se non ci sono envelope)
+            if i == n_streams - 1 and not has_envelopes:
                 ax_grain.set_xlabel("Tempo (s)", fontsize=self.config['label_fontsize'])
             else:
                 ax_grain.set_xticklabels([])
@@ -615,7 +618,7 @@ class ScoreVisualizer:
         # SUBPLOT ENVELOPE (se presenti)
         # =========================================================================
         if has_envelopes:
-            ax_env = fig.add_subplot(gs[n_samples, 1])
+            ax_env = fig.add_subplot(gs[n_streams, 1])
 
             # Layout condiviso lane/legenda (issue #91): stesso ordinamento e
             # stesse y, cosi' la legenda non appare mirrorata rispetto alle curve.
@@ -661,7 +664,7 @@ class ScoreVisualizer:
 
             # Legenda envelope (per-lane, allineata alle curve — issue #91)
             if legend_entries:
-                ax_legend = fig.add_subplot(gs[n_samples, 0])
+                ax_legend = fig.add_subplot(gs[n_streams, 0])
                 self._draw_envelope_legend(ax_legend, legend_entries)
         # =========================================================================
         # TITOLO

--- a/tests/rendering/test_score_visualizer.py
+++ b/tests/rendering/test_score_visualizer.py
@@ -166,6 +166,18 @@ def gap_scene():
     ]
 
 
+def issue_109_shared_sample_scene():
+    """Caso PGE_pino2.yml (issue #109): 4 stream, tutti onset 0, di cui due
+    (texture2 e stream3) condividono lo stesso sample. Pre-fix: 3 subplot
+    (un sample unico ciascuno) e label di texture2 sovrascritta da stream3."""
+    return [
+        make_stream('texture2', onset=0.0, duration=20.0, sample='001-0_0-3_0.wav'),
+        make_stream('texture3', onset=0.0, duration=20.0, sample='001-29_5-7_5.wav'),
+        make_stream('stream3',  onset=0.0, duration=20.0, sample='001-0_0-3_0.wav'),
+        make_stream('stream4',  onset=0.0, duration=20.0, sample='001-8_5-4_5.wav'),
+    ]
+
+
 # =============================================================================
 # GROUP 1 - Pipeline analyze → render_all (scenario singolo stream)
 # =============================================================================
@@ -480,10 +492,18 @@ class TestConfigPropagation:
 
 
 # =============================================================================
-# GROUP 9 - Multi-sample subplot layout
+# GROUP 9 - Subplot layout: un subplot per STREAM (issue #109)
 # =============================================================================
 
-class TestMultiSampleLayout:
+class TestPerStreamLayout:
+    """issue #109 - il visualizer deve produrre un subplot per ogni STREAM, non
+    per sample unico. Stream che condividono lo stesso sample ottengono subplot
+    separati (waveform ridisegnata in ciascuno); le label non collidono piu'."""
+
+    @staticmethod
+    def _wave_axes(fig):
+        """Assi waveform: uno per subplot/stream (ylabel 'Sample (s)\\n<path>')."""
+        return [ax for ax in fig.axes if ax.get_ylabel().startswith('Sample (s)')]
 
     def test_two_different_samples_produce_at_least_two_axes(self):
         viz = make_viz(two_sample_scene(), config={'page_duration': 30.0})
@@ -492,19 +512,57 @@ class TestMultiSampleLayout:
             fig = viz.render_page(0)
         assert len(fig.axes) >= 2
 
-    def test_two_streams_same_sample_on_single_subplot(self):
+    def test_two_streams_same_sample_produce_two_subplots(self):
+        """Due stream sullo stesso sample → due subplot separati, non piu'
+        collassati in uno solo dal raggruppamento per sample path."""
         viz = make_viz(two_stream_single_sample_scene(),
                        config={'page_duration': 40.0})
         with patch('soundfile.read', return_value=(FAKE_AUDIO, SR)):
             viz.analyze()
-            fig1 = viz.render_page(0)
-        two_sample_viz = make_viz(two_sample_scene(),
-                                  config={'page_duration': 40.0})
+            fig = viz.render_page(0)
+        assert len(self._wave_axes(fig)) == 2
+
+    def test_subplot_count_equals_stream_count_not_sample_count(self):
+        """Caso PGE_pino2.yml: 4 stream di cui 2 condividono il sample → 4
+        subplot (pre-fix: 3, uno per sample unico)."""
+        viz = make_viz(issue_109_shared_sample_scene(),
+                       config={'page_duration': 30.0})
         with patch('soundfile.read', return_value=(FAKE_AUDIO, SR)):
-            two_sample_viz.analyze()
-            fig2 = two_sample_viz.render_page(0)
-        # due sample → piu' assi della versione con un solo sample
-        assert len(fig2.axes) >= len(fig1.axes)
+            viz.analyze()
+            fig = viz.render_page(0)
+        assert len(self._wave_axes(fig)) == 4
+
+    def test_each_stream_gets_its_own_subplot(self):
+        """Generale: N stream tutti su sample distinti → N subplot (invariato
+        rispetto al raggruppamento, ma ora garantito dal conteggio stream)."""
+        viz = make_viz(two_sample_scene(), config={'page_duration': 30.0})
+        with patch('soundfile.read', return_value=(FAKE_AUDIO, SR)):
+            viz.analyze()
+            fig = viz.render_page(0)
+        assert len(self._wave_axes(fig)) == 2
+
+    def test_shared_sample_stream_labels_do_not_collide(self):
+        """Root cause #2: con un subplot per stream ogni label vive su un asse
+        dedicato — due stream con stesso sample e stesso onset non si
+        sovrascrivono piu'."""
+        streams = issue_109_shared_sample_scene()
+        ids = {s.stream_id for s in streams}
+        viz = make_viz(streams, config={'page_duration': 30.0})
+        with patch('soundfile.read', return_value=(FAKE_AUDIO, SR)):
+            viz.analyze()
+            fig = viz.render_page(0)
+        # Per ogni asse, le label-stream presenti come testo.
+        label_sets = []
+        for ax in fig.axes:
+            here = {t.get_text() for t in ax.texts if t.get_text() in ids}
+            if here:
+                label_sets.append(here)
+        # Ogni stream_id compare almeno una volta.
+        assert set().union(*label_sets) == ids
+        # Nessun asse porta piu' di una label-stream (niente collisione).
+        assert all(len(s) == 1 for s in label_sets)
+        # Una label-bearing axis per stream (un subplot per stream).
+        assert len(label_sets) == len(streams)
 
     def test_slot_assignments_populated_for_all_active_streams(self):
         streams = two_stream_single_sample_scene()


### PR DESCRIPTION
…109)

render_page raggruppava gli stream per sample path unico: stream che condividevano lo stesso file audio collassavano in un solo subplot e le loro label si sovrascrivevano (stesso onset -> stessa coordinata, la seconda copriva la prima).

Ora ogni stream ottiene il proprio subplot (gs[i,0] waveform / gs[i,1] grani); la waveform del sample viene ridisegnata in ciascuno (cache in _load_waveform invariata, nessun re-read del file). La collisione delle label e' risolta come effetto collaterale: ogni label vive su un asse dedicato.

- 4 stream -> 4 subplot anche con sample condivisi
- pitch color autozoom e colorbar calcolati per-stream ([stream])
- indici riga envelope aggiornati a n_streams

Cross-repo: nessun impatto. PGE-ui (GrainScore.jsx) gia' rende una lane per stream, il PDF ora e' allineato; PGE-ls non coinvolto.

TDD: TestPerStreamLayout (riscritto da TestMultiSampleLayout) copre conteggio subplot = stream e non-collisione label sul caso PGE_pino2.

https://claude.ai/code/session_01MZ5SKUeKea5wSRmjjHgHvG