### PR TITLE
fix(score-visualizer): curve envelope data-driven, elimina clipping a…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,16 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Corretto
 
+- fix(score-visualizer): curve envelope data-driven, rimosso il clipping ai
+  range fissi (pan resta ciclico). Le curve envelope venivano normalizzate su
+  `envelope_ranges` fissi e clippate a `[0,1]`: quando i valori reali superavano
+  il tetto del range (es. `density` con loop 400↔1000 g/s, tetto fisso 200), ogni
+  valore collassava a 1.0 e la curva appariva piatta pur essendo corretta. Ora
+  ogni curva scala sull'escursione reale dei suoi valori nella finestra visibile
+  (min/max + padding 5%), senza alcun clamp. Generalizza a tutti i parametri
+  l'auto-zoom prima limitato a una whitelist; `pan` resta ciclico su `(-180,180)`
+  con wrap modulo. Config: `envelope_autozoom` sostituito da `envelope_display`
+  (`pad_ratio`, `samples`). Nessun impatto su YAML/CLI/errori/bounds. (issue #114)
 - `ScoreVisualizer`: `offset_range` (deviazione stocastica del pointer) e il
   `dephase` non venivano mai disegnati nel pannello envelope. `_get_stream_envelopes`
   leggeva due attributi obsoleti del refactor parametri: `Parameter._mod_prob`

--- a/src/rendering/score_visualizer.py
+++ b/src/rendering/score_visualizer.py
@@ -134,7 +134,9 @@ class ScoreVisualizer:
             'stream_gap_ratio': 0.05,        # gap tra stream (5% dell'altezza)
             'label_fontsize': 8,
             'title_fontsize': 12,
-            # Envelope ranges (per normalizzazione)
+            # Envelope ranges. Dopo issue #114 (scaling data-driven) solo 'pan'
+            # è ancora consultato per lo scaling delle curve (ciclico, ±180);
+            # le altre entry restano per riferimento/back-compat, non più usate.
             'envelope_ranges': {
                 # === OUTPUT ===
                 'volume': (-90, 0),           # dB
@@ -174,19 +176,13 @@ class ScoreVisualizer:
             'envelope_colors': dict(ENVELOPE_COLORS),
             'envelope_panel_ratio': 0.3,      # 30% altezza per envelope
 
-            # Auto-zoom degli envelope a range ampio: se il movimento reale
-            # occupa una banda stretta del range fisso, restringe il range di
-            # display a `factor` x l'escursione reale (centrato), clampato al
-            # range pieno. floor = min_span_ratio x range pieno (evita zoom
-            # estremo su micro-movimenti). pan sempre escluso (ciclico).
-            'envelope_autozoom': {
-                'enabled': True,
-                'factor': 2.0,
-                'min_span_ratio': 0.04,
-                'params': {
-                    'pointer_speed', 'volume', 'density', 'loop_dur',
-                    'grain_duration', 'pitch', 'voice_pitch_offset',
-                },
+            # Scaling data-driven puro delle curve envelope (issue #114): ogni
+            # curva scala sull'escursione reale dei suoi valori nella finestra
+            # visibile (min/max + padding), senza alcun clamp ai range fissi.
+            # Si applica a tutti i parametri; pan resta ciclico (escluso).
+            'envelope_display': {
+                'pad_ratio': 0.05,      # margine sopra/sotto: 5% dell'escursione
+                'samples': 128,         # densità campionamento (cattura overshoot cubic)
             },
         }
         
@@ -1227,136 +1223,77 @@ class ScoreVisualizer:
 
         return result
 
-    def _full_range(self, param_name):
-        """
-        Range pieno (min, max) di un parametro, o None se non disponibile.
-
-        pitch è unit-driven (bounds dall'unità attiva); gli altri vengono da
-        config['envelope_ranges']. Le chiavi per-voce ('__vN', issue #90) usano
-        il range del parametro base.
-        """
-        param_name = self._base_param_name(param_name)
-        if param_name == 'pitch':
-            unit = getattr(self, '_current_pitch_unit', None)
-            if unit is not None:
-                b = unit.value_bounds()
-                if b.max_val is not None and b.max_val != b.min_val:
-                    return (b.min_val, b.max_val)
-            return None
-        rng = self.config['envelope_ranges'].get(param_name)
-        if rng is None or rng[0] == rng[1]:
-            return None
-        return (rng[0], rng[1])
-
     def _compute_display_ranges(self, envelopes, stream, t_start, t_end):
         """
-        Calcola, per ogni envelope a range ampio, un range di display ristretto
-        all'escursione reale (auto-zoom). Vedi config['envelope_autozoom'].
+        Calcola, per ogni envelope (tranne pan), il range di display data-driven:
+        l'escursione reale (min/max) dei valori nella finestra visibile, più un
+        padding (config['envelope_display']['pad_ratio']). Issue #114.
+
+        Nessun clamp ai range fissi: ogni curva scala sulla propria escursione.
+        pan resta ciclico (escluso, usa il range fisso ±180).
 
         Returns:
-            dict {param_name: (disp_min, disp_max)} solo per i parametri zoomati.
+            dict {param_name: (disp_min, disp_max)} per ogni parametro non-pan.
         """
-        cfg = self.config.get('envelope_autozoom', {})
-        if not cfg.get('enabled', False):
-            return {}
-
-        params = cfg.get('params', set())
-        factor = cfg.get('factor', 2.0)
-        min_span_ratio = cfg.get('min_span_ratio', 0.04)
+        cfg = self.config['envelope_display']
+        pad_ratio = cfg['pad_ratio']
+        n = cfg['samples']
         stream_start = stream.onset
 
         result = {}
         for param_name, envelope in envelopes.items():
-            # Le chiavi per-voce ('__vN', #90) ereditano autozoom/range dal base.
-            base_name = self._base_param_name(param_name)
-            if base_name == 'pan' or base_name not in params:
-                continue
-            full = self._full_range(param_name)
-            if full is None:
-                continue
-            full_min, full_max = full
-            full_span = full_max - full_min
+            # Le chiavi per-voce ('__vN', #90) ereditano dal parametro base.
+            if self._base_param_name(param_name) == 'pan':
+                continue  # pan ciclico: range fisso (-180, 180)
 
             # Escursione reale nella finestra visibile: campiona densamente la
-            # curva (cattura overshoot cubic) e includi i breakpoint.
+            # curva (cattura overshoot cubic) e includi i breakpoint interni.
             t_rel0 = max(0.0, t_start - stream_start)
             t_rel1 = max(t_rel0, t_end - stream_start)
-            samples = [envelope.evaluate(t) for t in np.linspace(t_rel0, t_rel1, 64)]
+            samples = [envelope.evaluate(t) for t in np.linspace(t_rel0, t_rel1, n)]
             samples += [v for t, v in envelope.breakpoints if t_rel0 <= t <= t_rel1]
             if not samples:
                 continue
             v_min, v_max = min(samples), max(samples)
-            span_real = v_max - v_min
-            center = (v_min + v_max) / 2.0
-
-            floor = min_span_ratio * full_span
-            disp_span = min(max(factor * span_real, floor), full_span)
-            if disp_span >= full_span:
-                continue  # no-op: il movimento riempie già il range pieno
-
-            half = disp_span / 2.0
-            disp_min = center - half
-            disp_max = center + half
-            # Trasla dentro [full_min, full_max] mantenendo l'ampiezza.
-            if disp_min < full_min:
-                disp_min, disp_max = full_min, full_min + disp_span
-            elif disp_max > full_max:
-                disp_min, disp_max = full_max - disp_span, full_max
-
-            result[param_name] = (disp_min, disp_max)
+            span = v_max - v_min
+            if span <= 1e-12:
+                pad = max(abs(v_min) * pad_ratio, 1e-6)  # envelope costante: centra
+            else:
+                pad = span * pad_ratio
+            result[param_name] = (v_min - pad, v_max + pad)
 
         return result
 
     def _normalize_envelope_value(self, param_name, value):
         """
-        Normalizza un valore di envelope a 0-1 usando i range fissi.
-        
+        Normalizza un valore di envelope a 0-1 sul range di display data-driven
+        attivo (issue #114). Nessun clamp ai range fissi tranne per pan.
+
         Args:
             param_name: nome del parametro
             value: valore da normalizzare
-            
-        Returns:
-            float: valore normalizzato 0-1
-        """
-        # Le curve per-voce ('__vN', #90) si normalizzano col range del base;
-        # il display range (auto-zoom) resta indicizzato per chiave piena.
-        base_name = self._base_param_name(param_name)
-        # PITCH unit-driven: i bounds vengono dall'unità attiva, non dai range statici.
-        if base_name == 'pitch':
-            unit = getattr(self, '_current_pitch_unit', None)
-            if unit is not None:
-                b = unit.value_bounds()
-                if b.max_val is not None and b.max_val != b.min_val:
-                    return np.clip((value - b.min_val) / (b.max_val - b.min_val), 0, 1)
-            return np.clip(value, 0, 1)
 
-        # Auto-zoom: se è attivo un display range per questo parametro, usalo al
-        # posto del range fisso (la curva sfrutta tutta l'altezza della lane).
+        Returns:
+            float: valore normalizzato (tipicamente 0-1; pan è clippato).
+        """
+        # Le curve per-voce ('__vN', #90) si normalizzano col base.
+        base = self._base_param_name(param_name)
+
+        # pan resta ciclico: wrap modulo su ±180 e clamp (range fisso).
+        if base == 'pan':
+            min_val, max_val = self.config['envelope_ranges']['pan']
+            value = ((value + 180) % 360) - 180
+            return np.clip((value - min_val) / (max_val - min_val), 0, 1)
+
+        # Range di display data-driven (popolato da _draw_envelopes per tutti i
+        # parametri tranne pan). Nessun clip: la curva scala sulla sua escursione.
         display_ranges = getattr(self, '_current_display_ranges', None) or {}
         if param_name in display_ranges:
             min_val, max_val = display_ranges[param_name]
-            if base_name == 'pan':
-                value = ((value + 180) % 360) - 180
             if max_val != min_val:
-                return np.clip((value - min_val) / (max_val - min_val), 0, 1)
-            return np.clip(value, 0, 1)
-
-        ranges = self.config['envelope_ranges']
-
-        if base_name in ranges:
-            min_val, max_val = ranges[base_name]
-
-            # Pan è ciclico: gestisci valori fuori range
-            if base_name == 'pan':
-                # Normalizza a -180..180 usando modulo
-                value = ((value + 180) % 360) - 180
-
-            # Normalizza
-            normalized = (value - min_val) / (max_val - min_val)
-            return np.clip(normalized, 0, 1)
-        else:
-            # Fallback: assume già normalizzato
-            return np.clip(value, 0, 1)
+                return (value - min_val) / (max_val - min_val)   # NESSUN clip
+            return 0.5                                            # costante: centro corsia
+        return 0.5  # fallback difensivo (draw imposta sempre i display range)
 
     @staticmethod
     def _segment_strategy_name(segment) -> str:

--- a/tests/rendering/test_score_visualizer.py
+++ b/tests/rendering/test_score_visualizer.py
@@ -1106,14 +1106,14 @@ class TestEnvelopeLegendPerLane:
 
 
 # =============================================================================
-# GROUP - Envelope auto-zoom (range ampi)
+# GROUP - Envelope display range (data-driven, issue #114)
 # =============================================================================
 
-class TestEnvelopeAutozoom:
-    """Per i parametri a range ampio, se il movimento reale dell'inviluppo
-    occupa solo una banda stretta del range fisso, la curva va riscalata a un
-    range di display ~2x l'escursione reale (centrato), così il movimento
-    diventa visibile invece di restare schiacciato."""
+class TestEnvelopeDisplayRange:
+    """Scaling data-driven puro delle curve envelope: ogni curva scala
+    sull'escursione reale dei suoi valori nella finestra visibile (min/max +
+    padding), senza alcun clamp ai range fissi. Generalizza a tutti i
+    parametri (pan resta ciclico). Issue #114."""
 
     def test_normalize_uses_active_display_range(self):
         """Quando _current_display_ranges contiene il parametro, la
@@ -1124,55 +1124,53 @@ class TestEnvelopeAutozoom:
         assert viz._normalize_envelope_value('pointer_speed', 0.5) == pytest.approx(0.5)
         assert viz._normalize_envelope_value('pointer_speed', 0.7) == pytest.approx(1.0)
 
-    def test_small_movement_zooms_to_double_span(self):
-        """pointer_speed (range fisso -4..16) che si muove 2.0->6.0:
-        display span = 2x escursione = 8, centrato a 4 -> [0, 8]."""
+    def test_small_movement_data_driven_with_padding(self):
+        """pointer_speed che si muove 2.0->6.0: range data-driven sull'escursione
+        reale (span 4) con padding 5% -> (1.8, 6.2)."""
         from envelopes.envelope import Envelope
         s = make_stream('s1', onset=0.0, duration=10.0)
         envelopes = {'pointer_speed': Envelope([[0, 2.0], [10, 6.0]])}
         ranges = make_viz([s])._compute_display_ranges(
             envelopes, s, s.onset, s.onset + s.duration)
         lo, hi = ranges['pointer_speed']
-        assert (lo, hi) == pytest.approx((0.0, 8.0))
+        assert (lo, hi) == pytest.approx((1.8, 6.2))
 
-    def test_large_movement_is_noop(self):
-        """Movimento che riempie gran parte del range pieno: 2x supera il range
-        -> nessuno zoom (parametro assente dai display ranges)."""
+    def test_large_movement_also_data_driven(self):
+        """Movimento ampio: niente più no-op. Il range segue l'escursione reale
+        (span 16) col padding 5% -> (-2.8, 14.8)."""
         from envelopes.envelope import Envelope
         s = make_stream('s1', onset=0.0, duration=10.0)
         envelopes = {'pointer_speed': Envelope([[0, -2.0], [10, 14.0]])}
         ranges = make_viz([s])._compute_display_ranges(
             envelopes, s, s.onset, s.onset + s.duration)
-        assert 'pointer_speed' not in ranges
+        lo, hi = ranges['pointer_speed']
+        assert (lo, hi) == pytest.approx((-2.8, 14.8))
 
-    def test_floor_prevents_extreme_zoom(self):
-        """Micro-movimento: il display span non scende sotto
-        min_span_ratio x range pieno (no divisione per zero, no zoom estremo)."""
+    def test_range_exceeds_legacy_ceiling(self):
+        """density con loop 400<->1000 g/s: il range data-driven supera il vecchio
+        tetto fisso (1, 200), prova diretta del bug. span 600, padding 5% -> 30."""
         from envelopes.envelope import Envelope
         s = make_stream('s1', onset=0.0, duration=10.0)
-        # pointer_speed range pieno 20 -> floor = 0.04*20 = 0.8
-        envelopes = {'pointer_speed': Envelope([[0, 1.0], [10, 1.001]])}
+        envelopes = {'density': Envelope([[0, 400.0], [10, 1000.0]])}
         ranges = make_viz([s])._compute_display_ranges(
             envelopes, s, s.onset, s.onset + s.duration)
-        lo, hi = ranges['pointer_speed']
-        assert (hi - lo) == pytest.approx(0.8)
+        lo, hi = ranges['density']
+        assert (lo, hi) == pytest.approx((370.0, 1030.0))
+        assert hi > 200.0  # ben oltre il vecchio tetto fisso
 
-    def test_window_clamped_within_full_range(self):
-        """Movimento vicino al bordo del range pieno: la finestra resta dentro
-        i bound mantenendo l'ampiezza."""
+    def test_param_now_data_driven(self):
+        """Qualsiasi parametro (non solo la vecchia whitelist) ottiene un range
+        data-driven: pointer_deviation 0.4->0.5 -> (0.395, 0.505)."""
         from envelopes.envelope import Envelope
         s = make_stream('s1', onset=0.0, duration=10.0)
-        # pointer_speed full max = 16; movimento 14->16 span 2, 2x=4
-        envelopes = {'pointer_speed': Envelope([[0, 14.0], [10, 16.0]])}
+        envelopes = {'pointer_deviation': Envelope([[0, 0.4], [10, 0.5]])}
         ranges = make_viz([s])._compute_display_ranges(
             envelopes, s, s.onset, s.onset + s.duration)
-        lo, hi = ranges['pointer_speed']
-        assert hi <= 16.0
-        assert (hi - lo) == pytest.approx(4.0)
-        assert (lo, hi) == pytest.approx((12.0, 16.0))
+        lo, hi = ranges['pointer_deviation']
+        assert (lo, hi) == pytest.approx((0.395, 0.505))
 
     def test_pan_excluded(self):
-        """pan è ciclico: mai zoomato."""
+        """pan è ciclico: mai data-driven (resta sul range fisso -180..180)."""
         from envelopes.envelope import Envelope
         s = make_stream('s1', onset=0.0, duration=10.0)
         envelopes = {'pan': Envelope([[0, -10.0], [10, 10.0]])}
@@ -1180,46 +1178,61 @@ class TestEnvelopeAutozoom:
             envelopes, s, s.onset, s.onset + s.duration)
         assert 'pan' not in ranges
 
-    def test_param_not_in_list_excluded(self):
-        """Parametro fuori dalla lista autozoom: range fisso invariato."""
-        from envelopes.envelope import Envelope
-        s = make_stream('s1', onset=0.0, duration=10.0)
-        envelopes = {'pointer_deviation': Envelope([[0, 0.4], [10, 0.5]])}
-        ranges = make_viz([s])._compute_display_ranges(
-            envelopes, s, s.onset, s.onset + s.duration)
-        assert 'pointer_deviation' not in ranges
+    def test_no_clipping_above_old_density_range(self):
+        """Cuore del bug: con display range sull'envelope 400<->1000, i due
+        estremi non collassano più (prima clippavano entrambi a 1.0)."""
+        viz = make_viz([make_stream('s1', onset=0.0, duration=10.0)])
+        viz._current_display_ranges = {'density': (370.0, 1030.0)}
+        lo = viz._normalize_envelope_value('density', 400.0)
+        hi = viz._normalize_envelope_value('density', 1000.0)
+        assert lo < hi
+        assert hi == pytest.approx((1000.0 - 370.0) / (1030.0 - 370.0))
 
-    def test_disabled_returns_empty(self):
+    def test_constant_envelope_centered(self):
+        """Envelope costante: il valore si normalizza al centro corsia (0.5),
+        sia via display range degenere sia via padding minimo."""
         from envelopes.envelope import Envelope
         s = make_stream('s1', onset=0.0, duration=10.0)
-        viz = make_viz([s], config={'envelope_autozoom': {'enabled': False}})
-        envelopes = {'pointer_speed': Envelope([[0, 2.0], [10, 6.0]])}
+        viz = make_viz([s])
+        envelopes = {'density': Envelope([[0, 50.0], [10, 50.0]])}
         ranges = viz._compute_display_ranges(
             envelopes, s, s.onset, s.onset + s.duration)
-        assert ranges == {}
+        viz._current_display_ranges = ranges
+        assert viz._normalize_envelope_value('density', 50.0) == pytest.approx(0.5)
 
-    def test_draw_applies_zoom_to_curve(self):
-        """Integrazione: _draw_envelopes attiva lo zoom. Con factor 2 il
-        movimento occupa il 50% centrale della lane (margine sopra/sotto),
-        contro il ~10% schiacciato del range fisso (-4..16)."""
+    def test_pan_still_cyclic(self):
+        """pan resta ciclico col wrap modulo: 270 -> -90 -> 0.25; 360 -> 0 -> 0.5."""
+        viz = make_viz([make_stream('s1', onset=0.0, duration=10.0)])
+        assert viz._normalize_envelope_value('pan', 270.0) == pytest.approx(0.25)
+        assert viz._normalize_envelope_value('pan', 360.0) == pytest.approx(0.5)
+
+    def test_pitch_now_data_driven(self):
+        """pitch non è più unit-driven nella normalizzazione: ottiene un range
+        data-driven dai suoi valori, senza clip."""
+        from envelopes.envelope import Envelope
+        s = make_stream('s1', onset=0.0, duration=10.0)
+        envelopes = {'pitch': Envelope([[0, 0.0], [10, 12.0]])}
+        ranges = make_viz([s])._compute_display_ranges(
+            envelopes, s, s.onset, s.onset + s.duration)
+        lo, hi = ranges['pitch']
+        assert (lo, hi) == pytest.approx((-0.6, 12.6))
+
+    def test_draw_applies_data_driven_scaling(self):
+        """Integrazione: _draw_envelopes scala la curva data-driven. La curva
+        occupa ~1/(1+2*pad) = 0.909 della lane (margine pad sopra/sotto)."""
         from envelopes.envelope import Envelope
         s = make_stream('s1', onset=0.0, duration=10.0)
         env = {'pointer_speed': Envelope([[0, 2.0], [10, 6.0]])}
 
-        def span_of(viz):
-            fig, ax = plt.subplots()
-            with patch.object(viz, '_get_stream_envelopes', return_value=env):
-                viz._draw_envelopes(ax, s, y_base=0.0, y_height=1.0,
-                                    page_start=0.0, page_end=10.0)
-            ydata = next(l for l in ax.lines
-                         if l.get_label() == 'pointer_speed').get_ydata()
-            return ydata.max() - ydata.min()
-
-        zoomed = span_of(make_viz([s]))
-        flat = span_of(make_viz([s], config={
-            'envelope_autozoom': {'enabled': False}}))
-        assert zoomed == pytest.approx(0.5)
-        assert zoomed > flat * 2
+        fig, ax = plt.subplots()
+        viz = make_viz([s])
+        with patch.object(viz, '_get_stream_envelopes', return_value=env):
+            viz._draw_envelopes(ax, s, y_base=0.0, y_height=1.0,
+                                page_start=0.0, page_end=10.0)
+        ydata = next(l for l in ax.lines
+                     if l.get_label() == 'pointer_speed').get_ydata()
+        span = ydata.max() - ydata.min()
+        assert span == pytest.approx(1.0 / 1.1)
 
     def test_draw_resets_display_ranges_after(self):
         """Dopo il draw, _current_display_ranges torna vuoto: lane successive

--- a/tests/rendering/test_score_visualizer_per_segment.py
+++ b/tests/rendering/test_score_visualizer_per_segment.py
@@ -77,6 +77,7 @@ class TestPerSegmentDrawing:
         viz.config = {
             'envelope_ranges': {'density': (0, 100)},
             'envelope_colors': {'density': '#000000'},
+            'envelope_display': {'pad_ratio': 0.05, 'samples': 128},
         }
         viz._get_stream_envelopes = lambda s: {'density': s.density}
         viz._normalize_envelope_value = lambda name, v: v / 100.0


### PR DESCRIPTION
…i range fissi

Le curve envelope venivano normalizzate su envelope_ranges fissi e clippate a [0,1]: valori oltre il tetto del range (es. density loop 400-1000 g/s, tetto fisso 200) collassavano tutti a 1.0 rendendo la curva piatta pur essendo corretta.

Ora lo scaling e' data-driven puro: ogni curva scala sull'escursione reale dei suoi valori nella finestra visibile (min/max + padding 5%), senza clamp. Generalizza a tutti i parametri l'auto-zoom prima limitato a una whitelist. pan resta ciclico su (-180,180) con wrap modulo.

- config: envelope_autozoom -> envelope_display (pad_ratio, samples)
- _compute_display_ranges: data-driven puro, niente full_range/floor/no-op
- _normalize_envelope_value: niente clip (tranne pan), pitch ora data-driven
- rimossa _full_range (non piu' referenziata)
- test: TestEnvelopeAutozoom -> TestEnvelopeDisplayRange con nuovi casi di regressione (no clipping sopra il vecchio tetto density, costante centrata, pan ciclico, pitch data-driven)

Nessun impatto su superficie pubblica (YAML/CLI/errori/bounds/formati).

Closes #114