### PR TITLE
Lazy grain generation to optimize cache-clean stream rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,15 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Modificato
 
+- Performance: generazione dei grani resa **lazy** (issue #117). `Stream.voices`
+  e `Stream.grains` sono ora property che materializzano i grani al primo
+  accesso; il `Generator` non chiama piu' `generate_grains()` in fase di
+  creazione. In STEMS+CACHE gli stream cache-clean — che il renderer salta su
+  `is_dirty` prima di leggere `.voices` — non generano piu' i grani, evitando il
+  costo dominante (loop tempo×voci). Il loop `--grain-json` scrive il sidecar
+  solo per gli stream effettivamente renderizzati (`generated=True`): gli stream
+  clean mantengono il JSON precedente, ancora valido. Costruzione `Stream` e
+  registrazione tabelle restano eager. Nessun cambiamento a YAML/CLI/schema.
 - Config showcase `configs/PGE_scatter_experiments.yml`: rimosso lo stream
   duplicato `s01_cluster_equidistant1`, ripuliti i flag `solo`/`mute` residui e
   aggiunto `time_mode: normalized` dove mancante. Solo dati di esempio, nessun

--- a/src/core/stream.py
+++ b/src/core/stream.py
@@ -108,8 +108,13 @@ class Stream:
         self.sample_table_num: Optional[int] = None
         self.envelope_table_num: Optional[int] = None
         # === 9. STATO ===
-        self.voices: List[List[Grain]] = []
-        self.grains: List[Grain] = []  # backward compatibility
+        # Generazione lazy dei grani (issue #117): i backing field restano vuoti
+        # finche' qualcuno non legge le property voices/grains, che innescano
+        # generate_grains() al primo accesso. Cosi' il Generator non genera i
+        # grani per gli stream cache-clean (il renderer short-circuita su
+        # is_dirty prima di leggere .voices), risparmiando il costo dominante.
+        self._voices: List[List[Grain]] = []
+        self._grains: List[Grain] = []  # backward compatibility (flat)
         self.generated = False
 
     def _check_required_context_fields(self, params, stream_id):
@@ -444,14 +449,16 @@ class Stream:
         clip_strategy = getattr(self, '_clip_strategy', None)
         if clip_strategy is None:
             clip_strategy = OverflowMarginClipStrategy(margin=0.0)
-        self.voices = clip_strategy.apply(all_voice_grains, self)
+        # Assegna ai backing field, non alle property: il getter di .voices
+        # innescherebbe ricorsivamente generate_grains (generated ancora False).
+        self._voices = clip_strategy.apply(all_voice_grains, self)
         # Flatten e sort per onset (backward compatibility)
-        all_grains = [g for voice in self.voices for g in voice]
+        all_grains = [g for voice in self._voices for g in voice]
         all_grains.sort(key=lambda g: g.onset)
-        self.grains = all_grains
+        self._grains = all_grains
         self.generated = True
 
-        return self.voices
+        return self._voices
     
     def _create_grain(self,
                       elapsed_time: float,
@@ -626,10 +633,46 @@ class Stream:
         return self._scatter
 
     # =========================================================================
+    # GRANI LAZY (issue #117)
+    # =========================================================================
+
+    @property
+    def voices(self) -> List[List[Grain]]:
+        """Grani organizzati per voce. Lazy: genera al primo accesso."""
+        if not self.generated:
+            self.generate_grains()
+        return self._voices
+
+    @voices.setter
+    def voices(self, value: List[List[Grain]]) -> None:
+        """Iniezione esplicita dei grani (test/consumer): materializza lo stato.
+
+        Assegnare voices significa "i grani sono questi": marca generated=True
+        cosi' una lettura successiva non rigenera sovrascrivendo il valore.
+        """
+        self._voices = value
+        self.generated = True
+
+    @property
+    def grains(self) -> List[Grain]:
+        """Vista flat dei grani (backward compat). Lazy: genera al primo accesso."""
+        if not self.generated:
+            self.generate_grains()
+        return self._grains
+
+    @grains.setter
+    def grains(self, value: List[Grain]) -> None:
+        self._grains = value
+        self.generated = True
+
+    # =========================================================================
     # REPR
     # =========================================================================
-    
+
     def __repr__(self) -> str:
         mode = "fill_factor" if self.fill_factor is not None else "density"
+        # NON innescare la generazione lazy: _create_streams stampa {stream} per
+        # ogni stream; leggere la property .grains rigenererebbe tutto.
+        grain_count = len(self._grains) if self.generated else 'lazy'
         return (f"Stream(id={self.stream_id}, onset={self.onset}, "
-                f"dur={self.duration}, mode={mode}, grains={len(self.grains)})")
+                f"dur={self.duration}, mode={mode}, grains={grain_count})")

--- a/src/engine/generator.py
+++ b/src/engine/generator.py
@@ -223,10 +223,13 @@ class Generator:
             # 3. Pre-registra tutte le finestre possibili
             # CHIAMATA QUI ↓
             stream.window_table_map = self._register_stream_windows(stream_data)
-            
-            # 4. Genera grani
-            stream.generate_grains()
-            
+
+            # 4. Generazione grani LAZY (issue #117): NON si chiama qui
+            # generate_grains(). I grani si materializzano al primo accesso a
+            # stream.voices/.grains (renderer dirty, visualizer, export). Gli
+            # stream cache-clean, che il renderer salta su is_dirty prima di
+            # leggere .voices, non generano mai i grani. Tabelle e costruzione
+            # Stream restano invece eager (numerazione FtableManager).
             self.streams.append(stream)
             print(f"  → Stream '{stream.stream_id}': {stream}")
     

--- a/src/main.py
+++ b/src/main.py
@@ -369,6 +369,15 @@ def main():
                 grain_json_dir = os.path.dirname(os.path.abspath(output_file))
                 writer = GrainJsonWriter()
                 for stream in generator.streams:
+                    # Generazione lazy (issue #117): scrivi il grain JSON solo
+                    # per gli stream i cui grani sono stati davvero materializzati
+                    # dal render. Gli stream cache-clean restano generated=False
+                    # (renderer short-circuita su is_dirty) e mantengono il loro
+                    # grain JSON precedente, ancora valido. Senza cache tutti gli
+                    # stream vengono renderizzati → tutti generated=True → tutti
+                    # i JSON scritti come prima.
+                    if not stream.generated:
+                        continue
                     json_path = writer.write(stream, grain_json_dir, yaml_basename)
                     print(f"Grain JSON: {json_path}")
 

--- a/tests/core/test_stream.py
+++ b/tests/core/test_stream.py
@@ -544,8 +544,11 @@ class TestStreamInit:
 
             assert s.stream_id == 'test_stream'
             assert s.duration == 2.0
-            assert s.voices == []
-            assert s.grains == []
+            # Contratto lazy: la costruzione NON genera i grani. Si ispezionano i
+            # backing field grezzi, non le property voices/grains, che innescano
+            # generate_grains() al primo accesso.
+            assert s._voices == []
+            assert s._grains == []
             assert s.generated is False
             assert s.sample_table_num is None
             assert s.envelope_table_num is None
@@ -556,6 +559,89 @@ class TestStreamInit:
         del params['sample']
         with pytest.raises(ValueError, match="sample"):
             Stream(params)
+
+
+# =============================================================================
+# 5b. TEST GENERAZIONE LAZY DEI GRANI (issue #117)
+# =============================================================================
+
+class TestLazyGrainGeneration:
+    """
+    Contratto lazy: i grani si materializzano alla PRIMA lettura di
+    .voices/.grains, non alla costruzione. Questo permette al Generator di
+    non generare i grani per gli stream cache-clean (il renderer short-circuita
+    su is_dirty prima di leggere .voices), realizzando il risparmio di #117.
+    """
+
+    def test_accessing_voices_triggers_generation(self, stream_factory):
+        """Leggere .voices su uno stream non generato innesca generate_grains."""
+        s = stream_factory(duration=1.0, inter_onset=0.1)
+        assert s.generated is False
+
+        voices = s.voices
+
+        assert s.generated is True
+        assert len(voices) == 1            # max_voices=1
+        assert len(voices[0]) > 0
+
+    def test_accessing_grains_triggers_generation(self, stream_factory):
+        """Leggere .grains su uno stream non generato innesca generate_grains."""
+        s = stream_factory(duration=0.5, inter_onset=0.1)
+        assert s.generated is False
+
+        grains = s.grains
+
+        assert s.generated is True
+        assert len(grains) > 0
+
+    def test_voices_memoized_single_generation(self, stream_factory):
+        """Accessi multipli a .voices generano i grani una sola volta."""
+        s = stream_factory(duration=0.5, inter_onset=0.1)
+
+        calls = []
+        original = s.generate_grains
+
+        def counting():
+            calls.append(1)
+            return original()
+
+        s.generate_grains = counting
+
+        first = s.voices
+        second = s.voices
+
+        assert len(calls) == 1
+        assert first is second
+
+    def test_repr_does_not_trigger_generation(self, stream_factory):
+        """__repr__ NON deve materializzare i grani.
+
+        _create_streams stampa {stream} per ogni stream: se __repr__ leggesse la
+        property .grains, rigenererebbe tutti gli stream annullando il risparmio.
+        """
+        s = stream_factory(duration=0.5, inter_onset=0.1)
+
+        r = repr(s)
+
+        assert s.generated is False
+        assert 'test_stream' in r
+
+    def test_explicit_generate_then_access_no_regeneration(self, stream_factory):
+        """Dopo generate_grains() esplicita, leggere .voices non rigenera."""
+        s = stream_factory(duration=0.5, inter_onset=0.1)
+        s.generate_grains()
+
+        calls = []
+        original = s.generate_grains
+
+        def counting():
+            calls.append(1)
+            return original()
+
+        s.generate_grains = counting
+        _ = s.voices
+
+        assert len(calls) == 0
 
     def test_null_sample_raises_value_error(self):
         """Stream con sample: null -> ValueError leggibile."""

--- a/tests/engine/test_generator.py
+++ b/tests/engine/test_generator.py
@@ -677,8 +677,14 @@ class TestCreateStreams:
 
         assert mock_stream.window_table_map == window_map
 
-    def test_calls_generate_grains(self, gen):
-        """_create_streams chiama generate_grains() su ogni stream."""
+    def test_does_not_call_generate_grains(self, gen):
+        """_create_streams NON chiama generate_grains() (issue #117).
+
+        La generazione dei grani e' lazy: avviene al primo accesso a
+        .voices/.grains, non in fase di creazione. Cosi' gli stream cache-clean
+        (che il renderer short-circuita su is_dirty) non generano mai i grani.
+        Tabelle e costruzione Stream restano invece eager.
+        """
         mock_stream = make_mock_stream_for_generator()
         stream_data = [{'stream_id': 's1', 'sample': 'a.wav', 'grain': {}}]
 
@@ -686,7 +692,7 @@ class TestCreateStreams:
              patch.object(gen, '_register_stream_windows', return_value={}):
             gen._create_streams(stream_data)
 
-        mock_stream.generate_grains.assert_called_once()
+        mock_stream.generate_grains.assert_not_called()
 
     def test_creates_multiple_streams(self, gen):
         """_create_streams crea piu' stream in sequenza."""

--- a/tests/rendering/test_numpy_audio_renderer.py
+++ b/tests/rendering/test_numpy_audio_renderer.py
@@ -581,6 +581,42 @@ class TestNumpyAudioRendererCache:
 
         assert mtime_second > mtime_first
 
+    def test_clean_stream_does_not_access_voices(self, sample_registry, window_registry, table_map, tmp_path):
+        """Guard #117: su cache-hit il renderer ritorna PRIMA di leggere .voices.
+
+        E' l'invariante che rende reale il risparmio della generazione lazy: se
+        lo stream e' clean i grani non vengono mai materializzati, perche' il
+        renderer short-circuita su is_dirty prima di toccare .voices.
+        """
+        cache_path = tmp_path / 'cache.json'
+        r = self._make_renderer_with_cache(cache_path, sample_registry, window_registry, table_map)
+        output_path = str(tmp_path / 's1.aif')
+
+        class _AccessSpyStream:
+            def __init__(self, voices):
+                self.stream_id = 's1'
+                self.onset = 0.0
+                self.duration = 0.2
+                self.sample = 'piano.wav'
+                self._voices = voices
+                self.voices_access_count = 0
+
+            @property
+            def voices(self):
+                self.voices_access_count += 1
+                return self._voices
+
+        stream = _AccessSpyStream([[make_grain(onset=0.0, duration=0.05)]])
+
+        # Prima build: dirty → renderizza, accede a .voices
+        r.render_single_stream(stream, output_path)
+        assert stream.voices_access_count >= 1
+
+        # Seconda build: clean → NON deve accedere a .voices
+        stream.voices_access_count = 0
+        r.render_single_stream(stream, output_path)
+        assert stream.voices_access_count == 0
+
 
 # =============================================================================
 # 8. TEST PASSTHROUGH BUFFER (Plan 002)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1456,3 +1456,60 @@ class TestFormatFlag:
         naming = engine_call_kwargs.get('naming_strategy')
         assert naming is not None
         assert naming.ext == '.wav'
+
+# =============================================================================
+# TEST GRAIN JSON: solo per stream con grani materializzati (issue #117)
+# =============================================================================
+
+class TestGrainJsonOnlyGeneratedStreams:
+    """
+    Con generazione lazy, il loop grain JSON deve scrivere il sidecar SOLO per
+    gli stream i cui grani sono stati davvero materializzati dal render
+    (stream.generated True). Gli stream cache-clean non vengono renderizzati
+    (renderer short-circuita su is_dirty), restano generated False e il loro
+    grain JSON precedente non va riscritto.
+    """
+
+    def _make_stream(self, stream_id, generated):
+        s = MagicMock()
+        s.stream_id = stream_id
+        s.generated = generated
+        return s
+
+    def test_grain_json_written_only_for_generated_streams(self, mocks):
+        s_gen = self._make_stream('s1', generated=True)
+        s_clean = self._make_stream('s2', generated=False)
+        mocks['generator_instance'].streams = [s_gen, s_clean]
+
+        writer_instance = MagicMock()
+        writer_instance.write.return_value = '/out/x__s1__grains.json'
+        gjw_cls = MagicMock(return_value=writer_instance)
+        gjw_mod = types.ModuleType('export.grain_json_writer')
+        gjw_mod.GrainJsonWriter = gjw_cls
+
+        with patch.dict(sys.modules, {'export.grain_json_writer': gjw_mod}):
+            run_main(mocks, ['main.py', 'in.yml', '/out/test.aif',
+                             '--per-stream', '--grain-json'])
+
+        written_streams = [c.args[0] for c in writer_instance.write.call_args_list]
+        assert s_gen in written_streams
+        assert s_clean not in written_streams
+
+    def test_grain_json_written_for_all_when_all_generated(self, mocks):
+        s1 = self._make_stream('s1', generated=True)
+        s2 = self._make_stream('s2', generated=True)
+        mocks['generator_instance'].streams = [s1, s2]
+
+        writer_instance = MagicMock()
+        writer_instance.write.return_value = '/out/x__grains.json'
+        gjw_cls = MagicMock(return_value=writer_instance)
+        gjw_mod = types.ModuleType('export.grain_json_writer')
+        gjw_mod.GrainJsonWriter = gjw_cls
+
+        with patch.dict(sys.modules, {'export.grain_json_writer': gjw_mod}):
+            run_main(mocks, ['main.py', 'in.yml', '/out/test.aif',
+                             '--per-stream', '--grain-json'])
+
+        written_streams = [c.args[0] for c in writer_instance.write.call_args_list]
+        assert s1 in written_streams
+        assert s2 in written_streams


### PR DESCRIPTION
## Summary

Implements lazy grain generation (issue #117) to avoid materializing grains for cache-clean streams that the renderer skips. Grains are now generated on first access to `Stream.voices` or `Stream.grains` properties rather than during stream construction, enabling the renderer to short-circuit on `is_dirty` before touching grain data.

## Key Changes

**Core Implementation (`src/core/stream.py`)**
- Renamed `voices` and `grains` from direct attributes to backing fields `_voices` and `_grains`
- Converted `voices` and `grains` to properties with lazy generation: accessing either property triggers `generate_grains()` if `generated=False`
- Added setters for both properties to support explicit injection and mark `generated=True`
- Updated `generate_grains()` to assign to backing fields instead of properties (prevents recursive triggering)
- Modified `__repr__()` to avoid triggering lazy generation by checking `self.generated` and using `len(self._grains)` directly

**Generator (`src/engine/generator.py`)**
- Removed `stream.generate_grains()` call from `_create_streams()` — grain generation is now purely lazy
- Stream construction and window table registration remain eager

**Renderer (`tests/rendering/test_numpy_audio_renderer.py`)**
- Added guard test verifying that clean (cached) streams do not access `.voices` property, confirming the short-circuit optimization works

**Main Export Loop (`src/main.py`)**
- Updated grain JSON export to only write sidecar files for streams with `generated=True`
- Cache-clean streams retain their previous JSON (still valid); only rendered streams get updated

**Tests**
- Updated existing test to inspect `_voices` and `_grains` backing fields directly instead of properties
- Added comprehensive `TestLazyGrainGeneration` suite covering:
  - Accessing `.voices` / `.grains` triggers generation
  - Multiple accesses are memoized (single generation)
  - `__repr__()` does not trigger generation
  - Explicit `generate_grains()` followed by property access does not regenerate
- Added `TestGrainJsonOnlyGeneratedStreams` to verify JSON export respects `generated` flag
- Updated `test_generator.py` to expect `generate_grains()` is NOT called during stream creation

**Documentation (`CHANGELOG.md`)**
- Documented performance improvement and lazy generation contract
- Clarified that construction and table registration remain eager
- Noted that grain JSON behavior changes only for cache scenarios

## Implementation Details

- **Backward Compatibility:** The flat `grains` list is still populated and sorted by onset; only the timing of generation changes
- **Memoization:** Once `generated=True`, subsequent property accesses return cached `_voices`/`_grains` without regeneration
- **Invariant:** The renderer's `is_dirty` check must occur before any access to `.voices` to realize the optimization benefit
- **No Schema Changes:** YAML, CLI, and error handling remain unchanged; this is a pure internal optimization

## Performance Impact

In STEMS+CACHE scenarios with many cache-clean streams, grain generation cost (dominant in the loop over time × voices) is completely avoided for streams the renderer skips, resulting in significant speedup on incremental builds.

https://claude.ai/code/session_01VUmvbSqqSPdt3BXiSPA67E