### PR TITLE
Fix colorbar width alignment between grain and envelope subplots

### DIFF
--- a/src/rendering/score_visualizer.py
+++ b/src/rendering/score_visualizer.py
@@ -125,6 +125,12 @@ class ScoreVisualizer:
             'waveform_color': 'steelblue',
             'waveform_width_ratio': 0.06,    # 3% della larghezza pagina
             'waveform_downsample': 200,      # 1 punto ogni N campioni
+            # Larghezza (frazione della pagina) della colonna dedicata alla
+            # colorbar del pitch. Vive in una colonna propria del GridSpec cosi'
+            # i subplot dei grani e quello degli envelope condividono la colonna
+            # centrale -> stesso bordo destro, niente piu' disallineamento (la
+            # colorbar non ruba larghezza ai soli stream).
+            'colorbar_width_ratio': 0.02,
             # Loop mask
             'loop_mask_color': '#f4a261',    # arancio caldo
             'loop_mask_alpha': 0.18,
@@ -413,14 +419,18 @@ class ScoreVisualizer:
         half = span / 2.0 + az['pad_ratio'] * span
         return (center - half, center + half)
 
-    def _add_pitch_colorbar(self, fig, ax, cents_range, streams,
+    def _add_pitch_colorbar(self, fig, cax_spec, cents_range, streams,
                             page_start, page_end):
         """
-        Colorbar compatta con la scala colore pitch del subplot.
+        Colorbar compatta con la scala colore pitch del subplot, disegnata in una
+        cella dedicata del GridSpec (cax_spec). Con un asse colorbar esplicito
+        (cax=) invece di ax=, non viene rubata larghezza al subplot dei grani:
+        grani ed envelope restano allineati sullo stesso bordo destro.
 
         Con cents_range (auto-zoom attivo): scala in cents zoomata.
         Senza: scala fissa pitch_range in ratio, solo se il subplot ha grani
-        visibili (cents_range None copre anche il caso zero grani).
+        visibili (cents_range None copre anche il caso zero grani). Se non c'e'
+        nulla da disegnare la cella resta vuota (nessun asse creato).
         """
         if cents_range is not None:
             norm = Normalize(cents_range[0], cents_range[1])
@@ -438,12 +448,16 @@ class ScoreVisualizer:
             norm = Normalize(p_min, p_max)
             label = 'pitch (ratio)'
 
+        cax = fig.add_subplot(cax_spec)
         cbar = fig.colorbar(
-            ScalarMappable(norm=norm, cmap=self.cmap),
-            ax=ax, fraction=0.03, pad=0.01
+            ScalarMappable(norm=norm, cmap=self.cmap), cax=cax
         )
         cbar.set_label(label, fontsize=self.config['label_fontsize'] - 1)
         cbar.ax.tick_params(labelsize=self.config['label_fontsize'] - 2)
+        # '<colorbar>' e' la convenzione matplotlib per gli assi colorbar (la
+        # imposta make_axes con ax=...). Con cax= esplicito va messa a mano, cosi'
+        # chi filtra gli assi colorbar (test, consumatori) continua a trovarli.
+        cax.set_label('<colorbar>')
 
     def _pitch_to_color(self, pitch_ratio, cents_range=None):
         """
@@ -526,8 +540,9 @@ class ScoreVisualizer:
         # SETUP GRIDSPEC
         # =========================================================================
         waveform_ratio = self.config['waveform_width_ratio']
+        colorbar_ratio = self.config['colorbar_width_ratio']
         envelope_ratio = self.config['envelope_panel_ratio'] if has_envelopes else 0.0
-        
+
         # Altezza per stream (divisa equamente)
         stream_total_ratio = 1.0 - envelope_ratio
         stream_row_height = stream_total_ratio / n_streams
@@ -539,11 +554,16 @@ class ScoreVisualizer:
         else:
             height_ratios = [stream_row_height] * n_streams
             n_rows = n_streams
-        
-        # GridSpec: n_rows righe × 2 colonne
+
+        # GridSpec: n_rows righe × 3 colonne [waveform, contenuto, colorbar].
+        # La colorbar del pitch ha una colonna propria: i subplot dei grani e
+        # quello degli envelope condividono la colonna centrale (stesso bordo
+        # destro). Prima, fig.colorbar(ax=...) rubava larghezza ai soli grani e
+        # il pannello envelope restava piu' largo, disallineato a destra.
+        main_ratio = 1 - waveform_ratio - colorbar_ratio
         gs = fig.add_gridspec(
-            n_rows, 2,
-            width_ratios=[waveform_ratio, 1 - waveform_ratio],
+            n_rows, 3,
+            width_ratios=[waveform_ratio, main_ratio, colorbar_ratio],
             height_ratios=height_ratios,
             wspace=0.02,
             hspace=0.0  # gap verticale tra stream
@@ -584,8 +604,9 @@ class ScoreVisualizer:
                                    page_start, page_end, cents_range)
             self._draw_stream_label_full(ax_grain, stream, page_start, sample_duration)
 
-            # Legenda della scala colore pitch (auto-zoomata o fissa)
-            self._add_pitch_colorbar(fig, ax_grain, cents_range,
+            # Legenda della scala colore pitch (auto-zoomata o fissa) nella
+            # colonna dedicata gs[i, 2]: non ruba larghezza al subplot dei grani.
+            self._add_pitch_colorbar(fig, gs[i, 2], cents_range,
                                      [stream], page_start, page_end)
             # Configura assi waveform
             ax_wave.set_ylim(-0.02, sample_duration+0.02)

--- a/tests/rendering/test_score_visualizer.py
+++ b/tests/rendering/test_score_visualizer.py
@@ -1528,3 +1528,77 @@ class TestPitchColorAutozoom:
         with patch('soundfile.read', return_value=(FAKE_AUDIO, SR)):
             figs = viz.render_all()
         assert len(self._colorbar_axes(figs[0])) == 0
+
+
+# =============================================================================
+# GROUP - Allineamento larghezza envelope/stream (colonna colorbar dedicata)
+# =============================================================================
+
+class TestEnvelopeStreamWidthAlignment:
+    """La colorbar del pitch occupa una colonna dedicata del GridSpec: i subplot
+    dei grani (colonna centrale) e il subplot envelope (stessa colonna) condividono
+    lo stesso bordo destro. Pre-fix la colorbar (fig.colorbar(ax=...)) restringeva
+    solo i grani mentre l'envelope restava a piena larghezza -> bordi destri
+    disallineati (la striscia colore del pitch rubava spazio ai soli stream)."""
+
+    @staticmethod
+    def _scene():
+        """Due stream con grani (-> colorbar) e un envelope dinamico
+        (pointer_speed) -> esiste il pannello envelope sotto agli stream."""
+        from envelopes.envelope import Envelope
+        streams = []
+        for sid in ('s1', 's2'):
+            s = make_stream(sid, onset=0.0, duration=10.0, sample='piano.wav')
+            s.pointer_speed = Envelope([[0, -2.0], [10, 4.0]])
+            streams.append(s)
+        return streams
+
+    @staticmethod
+    def _data_axes(fig, page_start, page_end):
+        """Assi-dato (grani + envelope): xlim == (page_start, page_end).
+        Esclude waveform (xlim +-1.1), legenda (xlim 0..1) e colorbar."""
+        out = []
+        for ax in fig.axes:
+            lo, hi = ax.get_xlim()
+            if abs(lo - page_start) < 1e-9 and abs(hi - page_end) < 1e-9:
+                out.append(ax)
+        return out
+
+    def _render(self):
+        viz = make_viz(self._scene(), config={'page_duration': 30.0})
+        with patch('soundfile.read', return_value=(FAKE_AUDIO, SR)):
+            viz.analyze()
+            fig = viz.render_page(0)
+        fig.canvas.draw()  # finalizza le posizioni dei subplot
+        return fig
+
+    def test_default_config_has_colorbar_width_ratio(self):
+        viz = make_viz([make_stream()])
+        assert viz.config['colorbar_width_ratio'] > 0
+
+    def test_envelope_right_edge_aligns_with_grain_subplots(self):
+        """Cuore del bug: il bordo destro dell'envelope deve combaciare con
+        quello dei subplot dei grani."""
+        fig = self._render()
+        data_axes = self._data_axes(fig, 0.0, 30.0)
+        assert len(data_axes) >= 3  # 2 grani + 1 envelope
+        x1s = [ax.get_position().x1 for ax in data_axes]
+        assert max(x1s) - min(x1s) < 1e-6
+
+    def test_envelope_left_edge_aligns_with_grain_subplots(self):
+        """Invariante: stessa colonna -> stesso bordo sinistro (x0)."""
+        fig = self._render()
+        data_axes = self._data_axes(fig, 0.0, 30.0)
+        x0s = [ax.get_position().x0 for ax in data_axes]
+        assert max(x0s) - min(x0s) < 1e-6
+
+    def test_colorbar_in_dedicated_column_right_of_content(self):
+        """Le colorbar restano presenti e a destra dell'area dati (colonna
+        dedicata), non sovrapposte ai grani."""
+        fig = self._render()
+        data_axes = self._data_axes(fig, 0.0, 30.0)
+        content_x1 = min(ax.get_position().x1 for ax in data_axes)
+        cbar_axes = [ax for ax in fig.axes if ax.get_label() == '<colorbar>']
+        assert cbar_axes  # almeno una colorbar disegnata
+        for cax in cbar_axes:
+            assert cax.get_position().x0 >= content_x1 - 1e-6


### PR DESCRIPTION
## Summary

Fixes a layout bug where the pitch colorbar was stealing horizontal space only from grain subplots, causing the envelope panel to extend further right and misalign with the grain subplots' right edge.

## Changes

- **GridSpec restructuring**: Changed from 2-column to 3-column layout
  - Column 0: waveform (fixed width via `waveform_width_ratio`)
  - Column 1: grain and envelope subplots (shared, main content area)
  - Column 2: pitch colorbar (dedicated column via new `colorbar_width_ratio` config)

- **Colorbar rendering**: Modified `_add_pitch_colorbar()` to accept a GridSpec cell (`cax_spec`) instead of an axis reference
  - Creates an explicit colorbar axis via `fig.add_subplot(cax_spec)` and passes it to `fig.colorbar(cax=...)`
  - This prevents the colorbar from reducing the width of grain subplots
  - Manually sets the `<colorbar>` label for test/consumer filtering

- **Configuration**: Added `colorbar_width_ratio` (default 0.02) to control the dedicated colorbar column width

- **Test suite**: Added `TestEnvelopeStreamWidthAlignment` class with four tests
  - Verifies default config includes the new ratio
  - Confirms grain and envelope subplots share the same left and right edges
  - Ensures colorbar occupies a dedicated column to the right of content

## Implementation Details

The root cause was using `fig.colorbar(ax=ax_grain, fraction=0.03, pad=0.01)`, which internally shrinks only the target axis. With grain and envelope subplots in the same GridSpec column but the colorbar only shrinking the grain axis, their right edges diverged.

By moving the colorbar to its own GridSpec column and using an explicit `cax=` parameter, both grain and envelope subplots maintain their full width within the main content column, and the colorbar lives in a separate, dedicated space.

https://claude.ai/code/session_014Qrp4jAcM5HHA8C1PG1ShK