### PR TITLE
Implement seed-based reproducibility for stochastic grain generation

### DIFF
--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -8,6 +8,7 @@ sources:
   - src/parameters/
   - src/strategies/
   - src/envelopes/
+  - src/shared/seeding.py
 last_synced_commit: 836a236
 entry_for: [yaml-syntax, envelope-syntax]
 ---
@@ -31,6 +32,7 @@ Reference completa del formato YAML consumato da `main.py`: sintassi per stream,
 Sezioni rilevanti in questo doc:
 
 - [Minimal Stream](#minimal-stream) — schema minimo
+- [Seed (Riproducibilità)](#seed-riproducibilità) — render NumPy riproducibili
 - [Parameter Syntax](#parameter-syntax) — scalari, tuple, dict, envelope
 - [Campi Obbligatori di Stream](#campi-obbligatori-di-stream)
 - [Configurazione Processo (StreamConfig)](#configurazione-processo-streamconfig)
@@ -66,6 +68,42 @@ streams:
     grain:
       duration: 0.05
 ```
+
+---
+
+## Seed (Riproducibilità)
+
+Chiave **top-level** opzionale (sibling di `streams`) per render riproducibili
+con il renderer NumPy.
+
+```yaml
+seed: 42        # opzionale; assente → comportamento attuale (non riproducibile)
+streams:
+  - stream_id: "s1"
+    onset: 0.0
+    duration: 30
+    sample: "sample.wav"
+```
+
+- **Assente** (default): comportamento storico. I meccanismi stocastici (IOT
+  async di `distribution`, variazione `_range`, gate di probabilità, selezione
+  finestra, offset stocastici delle voci) cambiano a ogni processo.
+- **Presente**: lo stesso YAML produce lo stesso render NumPy fra processi
+  diversi. Copre due meccanismi:
+  - **random globale dei grani** — `random.seed(seed)` chiamato una volta a
+    inizio `create_elements`, prima della generazione (lazy) dei grani.
+  - **RNG locale delle voci stocastiche** (`voices.{pitch,onset,pointer}` con
+    `strategy: stochastic`, `voices.pan` con `strategy: random`) — seed derivato
+    via `hashlib.sha256(f"{seed}:{stream_id}:{voice_index}")`, deterministico e
+    indipendente da `PYTHONHASHSEED`.
+
+`seed: 0` è un valore valido e distinto da assente. Sono accettati interi (anche
+negativi) e stringhe.
+
+**Limite (Csound):** `seed` semina solo il `random` di Python (renderer NumPy).
+Csound ha un RNG proprio: con `--renderer csound` i due renderer NON sono
+bit-identici nemmeno col seed. Le tendency mask restano stocastiche per natura —
+l'obiettivo è riprodurre *lo stesso run*, non l'identità bit-a-bit.
 
 ---
 

--- a/src/core/stream.py
+++ b/src/core/stream.py
@@ -68,13 +68,19 @@ class Stream:
         grains: List[Grain] - lista flattened (backward compatibility)
     """
     
-    def __init__(self, params: dict):
+    def __init__(self, params: dict, seed=None):
         """
         Inizializza lo stream dai parametri YAML.
-        
+
         Args:
             params: dizionario parametri dallo YAML
+            seed: seed YAML top-level (issue #81), propagato alle voice strategy
+                  stocastiche per la riproducibilità fra processi. None (default)
+                  → comportamento legacy (hash() per-voce).
         """
+        # Seed di riproducibilità: iniettato nelle strategy stocastiche in
+        # _init_voice_manager. None → fallback hash() (retrocompat).
+        self.seed = seed
         # === 3. CONFIGURATION ===
         sample = params.get('sample')
         stream_id = params.get('stream_id', 'unknown')
@@ -284,6 +290,7 @@ class Stream:
             pitch_unit = make_pitch_unit(unit_spec)
             if name == 'stochastic':
                 kw['stream_id'] = self.stream_id
+                kw['seed'] = self.seed
             kw = {k: _parse_strategy_kwarg(val, self.duration) for k, val in kw.items()}
             pitch_strategy = VoicePitchStrategyFactory.create(name, **kw)
 
@@ -294,6 +301,7 @@ class Stream:
             name = kw.pop('strategy')
             if name == 'stochastic':
                 kw['stream_id'] = self.stream_id
+                kw['seed'] = self.seed
             kw = {k: _parse_strategy_kwarg(val, self.duration) for k, val in kw.items()}
             onset_strategy = VoiceOnsetStrategyFactory.create(name, **kw)
 
@@ -317,6 +325,7 @@ class Stream:
             self._voice_pointer_normalized = raw_normalized
             if name == 'stochastic':
                 kw['stream_id'] = self.stream_id
+                kw['seed'] = self.seed
             kw = {k: _parse_strategy_kwarg(val, self.duration) for k, val in kw.items()}
             pointer_strategy = VoicePointerStrategyFactory.create(name, **kw)
 
@@ -329,6 +338,7 @@ class Stream:
             pan_spread = _parse_strategy_kwarg(kw.pop('spread', 0.0), self.duration)
             if name == 'random':
                 kw['stream_id'] = self.stream_id
+                kw['seed'] = self.seed
             pan_strategy = VoicePanStrategyFactory.create(name, **kw)
 
         self._voice_manager = VoiceManager(

--- a/src/engine/generator.py
+++ b/src/engine/generator.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import yaml
 import re
 import math
+import random
 from typing import List, Dict, Any
 
 from core.stream import Stream
@@ -55,6 +56,9 @@ class Generator:
         self.yaml_path = yaml_path
         self.data: Dict[str, Any] = None
         self.streams: List[Stream] = []
+        # Seed di riproducibilità (issue #81): popolato da load_yaml dalla chiave
+        # top-level `seed`. None → comportamento attuale (non riproducibile).
+        self.seed = None
 
         # Delegati specializzati
         self.ftable_manager = FtableManager(start_num=1)
@@ -79,8 +83,10 @@ class Generator:
         """
         with open(self.yaml_path, 'r') as f:
             raw_data = yaml.safe_load(f)
-        
+
         self.data = self._eval_math_expressions(raw_data)
+        # Seed top-level opzionale (issue #81): None se assente.
+        self.seed = self.data.get('seed') if isinstance(self.data, dict) else None
         return self.data
     
     def create_elements(self) -> List[Stream]:
@@ -97,6 +103,14 @@ class Generator:
         """
         if self.data is None:
             raise ValueError("Devi prima caricare il YAML con load_yaml()")
+
+        # Seed del random globale (issue #81, meccanismo 2): semina UNA volta
+        # qui, prima della generazione (lazy) dei grani. Copre tutti i siti
+        # `random.*` consumati durante generate_grains (density async, variazione
+        # _range, probability gate, window selection, ...). Assente → nessun
+        # seeding, comportamento attuale (non riproducibile fra processi).
+        if self.seed is not None:
+            random.seed(self.seed)
 
         # Estrai e filtra stream
         stream_data_list = self.data.get('streams', [])
@@ -216,7 +230,7 @@ class Generator:
             #import json
             #print(f"[DEBUG] PRIMA Stream({stream_data.get('stream_id')}): {json.dumps(stream_data, default=str)[:200]}", flush=True)
 
-            stream = Stream(stream_data)
+            stream = Stream(stream_data, seed=self.seed)
             #print(f"[DEBUG] DOPO  Stream({stream_data.get('stream_id')}): {json.dumps(stream_data, default=str)[:200]}", flush=True)
             self.stream_data_map[stream_data['stream_id']] = stream_data
             # 2. Registra ftable sample

--- a/src/shared/seeding.py
+++ b/src/shared/seeding.py
@@ -1,0 +1,43 @@
+# src/shared/seeding.py
+"""
+seeding.py — derivazione deterministica del RNG per-voce (issue #81).
+
+Singola fonte di verità per il seed locale delle voice strategy stocastiche
+(`StochasticPitchStrategy`, `StochasticOnsetStrategy`, `StochasticPointerStrategy`,
+`RandomPanStrategy`). Mantenere allineate le quattro strategy: tutte delegano qui.
+
+Due regimi:
+
+- `seed is None` → comportamento legacy: `hash(stream_id + str(voice_index))`.
+  Stabile ENTRO un run, NON riproducibile fra processi: `hash()` su stringa è
+  randomizzato per-processo (PYTHONHASHSEED non è fissato nel repo).
+- `seed` valorizzato (int/str) → derivazione `hashlib.sha256` su
+  `f"{seed}:{stream_id}:{voice_index}"`. `hashlib` è deterministico per
+  costruzione: il valore non dipende da PYTHONHASHSEED, quindi è riproducibile
+  fra processi diversi. Copre `seed: 0` e seed negativi/stringa senza casi speciali.
+"""
+from __future__ import annotations
+
+import hashlib
+import random
+
+
+def voice_rng(seed, stream_id: str, voice_index: int) -> random.Random:
+    """Restituisce un `random.Random` deterministico per (seed, stream_id, voice_index).
+
+    Args:
+        seed: seed YAML top-level (int/str) oppure None per il fallback legacy.
+        stream_id: id dello stream proprietario della voce.
+        voice_index: indice della voce (0-based).
+
+    Returns:
+        Istanza `random.Random` già seminata.
+    """
+    if seed is None:
+        derived = hash(stream_id + str(voice_index))
+    else:
+        digest = hashlib.sha256(
+            f"{seed}:{stream_id}:{voice_index}".encode()
+        ).hexdigest()
+        derived = int(digest, 16)
+    return random.Random(derived)

--- a/src/strategies/voice_onset_strategy.py
+++ b/src/strategies/voice_onset_strategy.py
@@ -24,12 +24,12 @@ Coerente con: voice_pitch_strategy.py, voice_pan_strategy.py
 """
 from __future__ import annotations
 
-import random
 from abc import ABC, abstractmethod
 from typing import Dict, Type
 
 from parameters.parameter import resolve_param, StrategyParam
 from shared.exceptions import StrategyNotFoundError
+from shared.seeding import voice_rng
 
 
 # =============================================================================
@@ -110,18 +110,20 @@ class StochasticOnsetStrategy(VoiceOnsetStrategy):
     Offset fisso per voce entro un singolo run; la magnitudine può variare nel
     tempo se max_offset è un Envelope.
 
-    Seed = hash(stream_id + str(voice_index)): stabile ENTRO un run, NON
-    riproducibile fra processi diversi. hash() su stringa è randomizzato
-    per-processo (PYTHONHASHSEED non è fissato in questo repo), quindi l'offset
-    cambia a ogni avvio. Ciò che si conserva fra run è l'andamento, non il valore.
+    Seed (issue #81): se `seed` è None il RNG per-voce usa hash(stream_id+vi) —
+    stabile ENTRO un run, NON riproducibile fra processi (hash() randomizzato
+    per-processo, PYTHONHASHSEED non fissato). Se `seed` è valorizzato la
+    derivazione è hashlib (vedi shared.seeding.voice_rng): l'offset diventa
+    riproducibile fra processi diversi.
     _cache[voice_index] memorizza il fattore normalizzato in [0, 1].
     Offset = _cache[vi] * max_offset(t).
     Voce 0 → sempre 0.0.
     """
 
-    def __init__(self, max_offset: StrategyParam, stream_id: str):
+    def __init__(self, max_offset: StrategyParam, stream_id: str, seed=None):
         self.max_offset = max_offset
         self.stream_id = stream_id
+        self.seed = seed
         self._cache: Dict[int, float] = {}
 
     def get_onset_offset(self, voice_index: int, num_voices: int, time: float) -> float:
@@ -129,8 +131,7 @@ class StochasticOnsetStrategy(VoiceOnsetStrategy):
         if voice_index == 0 or resolved == 0.0:
             return 0.0
         if voice_index not in self._cache:
-            seed = hash(self.stream_id + str(voice_index))
-            rng = random.Random(seed)
+            rng = voice_rng(self.seed, self.stream_id, voice_index)
             self._cache[voice_index] = rng.uniform(0.0, 1.0)
         return self._cache[voice_index] * resolved
 

--- a/src/strategies/voice_pan_strategy.py
+++ b/src/strategies/voice_pan_strategy.py
@@ -25,7 +25,6 @@ Coerente con: variation_strategy.py, variation_registry.py,
 """
 from __future__ import annotations
 
-import random
 from abc import ABC, abstractmethod
 from typing import Dict, Type
 
@@ -33,6 +32,7 @@ from shared.exceptions import (
     InvalidStrategyConfigError,
     StrategyNotFoundError,
 )
+from shared.seeding import voice_rng
 
 
 # =============================================================================
@@ -128,18 +128,20 @@ class RandomPanStrategy(VoicePanStrategy):
 
     _cache[voice_index] memorizza il fattore normalizzato in [-1, 1].
     Offset = _cache[vi] * spread / 2.
-    Seed = hash(stream_id + str(voice_index)): stabile ENTRO un run, NON
-    riproducibile fra processi diversi. hash() su stringa è randomizzato
-    per-processo (PYTHONHASHSEED non è fissato in questo repo), quindi l'offset
-    cambia a ogni avvio. Ciò che si conserva fra run è l'andamento, non il valore.
+    Seed (issue #81): se `seed` è None il RNG per-voce usa hash(stream_id+vi) —
+    stabile ENTRO un run, NON riproducibile fra processi (hash() randomizzato
+    per-processo, PYTHONHASHSEED non fissato). Se `seed` è valorizzato la
+    derivazione è hashlib (vedi shared.seeding.voice_rng): l'offset diventa
+    riproducibile fra processi diversi.
     Voce 0 → sempre 0.0.
 
     Uso tipico: posizionamento "random but bounded" delle voci, texture
     dove la distribuzione spaziale deve essere imprevedibile ma contenuta.
     """
 
-    def __init__(self, stream_id: str):
+    def __init__(self, stream_id: str, seed=None):
         self.stream_id = stream_id
+        self.seed = seed
         self._cache: Dict[int, float] = {}
 
     def get_pan_offset(
@@ -165,8 +167,7 @@ class RandomPanStrategy(VoicePanStrategy):
             return 0.0
 
         if voice_index not in self._cache:
-            seed = hash(self.stream_id + str(voice_index))
-            rng = random.Random(seed)
+            rng = voice_rng(self.seed, self.stream_id, voice_index)
             self._cache[voice_index] = rng.uniform(-1.0, 1.0)
 
         return self._cache[voice_index] * spread / 2.0

--- a/src/strategies/voice_pitch_strategy.py
+++ b/src/strategies/voice_pitch_strategy.py
@@ -30,7 +30,6 @@ Coerente con: voice_pan_strategy.py, variation_strategy.py
 from __future__ import annotations
 
 import math
-import random
 from abc import ABC, abstractmethod
 from typing import Dict, List, Type
 
@@ -38,6 +37,7 @@ from shared.exceptions import (
     InvalidStrategyConfigError,
     StrategyNotFoundError,
 )
+from shared.seeding import voice_rng
 
 from parameters.parameter import resolve_param, StrategyParam
 
@@ -218,19 +218,21 @@ class StochasticPitchStrategy(VoicePitchStrategy):
     Offset fisso per voce entro un singolo run; la direzione è fissa, la magnitudine
     può variare nel tempo se pitch_range è un Envelope.
 
-    Seed = hash(stream_id + str(voice_index)): stabile ENTRO un run, NON
-    riproducibile fra processi diversi. hash() su stringa è randomizzato
-    per-processo (PYTHONHASHSEED non è fissato in questo repo), quindi l'offset
-    cambia a ogni avvio. Ciò che si conserva fra run è l'andamento, non il valore.
+    Seed (issue #81): se `seed` è None il RNG per-voce usa hash(stream_id+vi) —
+    stabile ENTRO un run, NON riproducibile fra processi (hash() randomizzato
+    per-processo, PYTHONHASHSEED non fissato). Se `seed` è valorizzato la
+    derivazione è hashlib (vedi shared.seeding.voice_rng): l'offset diventa
+    riproducibile fra processi diversi.
     _cache[voice_index] memorizza la posizione normalizzata in [-1, 1].
     Fattore = unit.materialize(position, pitch_range(t)): EDO → ± attorno a 0
     in semitoni; ratio → simmetrico geometrico (es. range=2 → [0.5, 2]).
     Voce 0 (e range 0) → sempre 1.0 (identità).
     """
 
-    def __init__(self, pitch_range: StrategyParam, stream_id: str):
+    def __init__(self, pitch_range: StrategyParam, stream_id: str, seed=None):
         self.pitch_range = pitch_range
         self.stream_id = stream_id
+        self.seed = seed
         self._cache: Dict[int, float] = {}
 
     def get_pitch_factor(self, voice_index, num_voices, time, unit):
@@ -238,8 +240,7 @@ class StochasticPitchStrategy(VoicePitchStrategy):
         if voice_index == 0 or resolved == 0.0:
             return 1.0
         if voice_index not in self._cache:
-            seed = hash(self.stream_id + str(voice_index))
-            rng = random.Random(seed)
+            rng = voice_rng(self.seed, self.stream_id, voice_index)
             self._cache[voice_index] = rng.uniform(-1.0, 1.0)
         return unit.materialize(self._cache[voice_index], resolved)
 

--- a/src/strategies/voice_pointer_strategy.py
+++ b/src/strategies/voice_pointer_strategy.py
@@ -35,12 +35,12 @@ Coerente con: voice_pitch_strategy.py, voice_onset_strategy.py
 """
 from __future__ import annotations
 
-import random
 from abc import ABC, abstractmethod
 from typing import Dict, Type
 
 from parameters.parameter import resolve_param, StrategyParam
 from shared.exceptions import StrategyNotFoundError
+from shared.seeding import voice_rng
 
 
 # =============================================================================
@@ -102,10 +102,11 @@ class StochasticPointerStrategy(VoicePointerStrategy):
     Offset fisso per voce entro un singolo run; la magnitudine può variare nel
     tempo se pointer_range è un Envelope.
 
-    Seed = hash(stream_id + str(voice_index)): stabile ENTRO un run, NON
-    riproducibile fra processi diversi. hash() su stringa è randomizzato
-    per-processo (PYTHONHASHSEED non è fissato in questo repo), quindi l'offset
-    cambia a ogni avvio. Ciò che si conserva fra run è l'andamento, non il valore.
+    Seed (issue #81): se `seed` è None il RNG per-voce usa hash(stream_id+vi) —
+    stabile ENTRO un run, NON riproducibile fra processi (hash() randomizzato
+    per-processo, PYTHONHASHSEED non fissato). Se `seed` è valorizzato la
+    derivazione è hashlib (vedi shared.seeding.voice_rng): l'offset diventa
+    riproducibile fra processi diversi.
     _cache[voice_index] memorizza il fattore normalizzato in [-1, 1].
     Offset = _cache[vi] * pointer_range(t).
     Voce 0 → sempre 0.0.
@@ -114,9 +115,10 @@ class StochasticPointerStrategy(VoicePointerStrategy):
     diversa nel sample, creando variazione timbrica senza pattern regolari.
     """
 
-    def __init__(self, pointer_range: StrategyParam, stream_id: str):
+    def __init__(self, pointer_range: StrategyParam, stream_id: str, seed=None):
         self.pointer_range = pointer_range
         self.stream_id = stream_id
+        self.seed = seed
         self._cache: Dict[int, float] = {}
 
     def get_pointer_offset(self, voice_index: int, num_voices: int, time: float) -> float:
@@ -124,8 +126,7 @@ class StochasticPointerStrategy(VoicePointerStrategy):
         if voice_index == 0 or resolved == 0.0:
             return 0.0
         if voice_index not in self._cache:
-            seed = hash(self.stream_id + str(voice_index))
-            rng = random.Random(seed)
+            rng = voice_rng(self.seed, self.stream_id, voice_index)
             self._cache[voice_index] = rng.uniform(-1.0, 1.0)
         return self._cache[voice_index] * resolved
 

--- a/tests/core/test_stream_voices_yaml.py
+++ b/tests/core/test_stream_voices_yaml.py
@@ -71,7 +71,7 @@ from shared.exceptions import InvalidStrategyConfigError
 
 SAMPLE_DUR = 5.0
 
-def _build_stream(voices_params=None, stream_id='s1'):
+def _build_stream(voices_params=None, stream_id='s1', seed=None):
     """Costruisce uno Stream reale con params YAML minimi + voices block."""
     params = {
         'stream_id': stream_id,
@@ -83,7 +83,9 @@ def _build_stream(voices_params=None, stream_id='s1'):
         params['voices'] = voices_params
 
     with patch('core.stream.get_sample_duration', return_value=SAMPLE_DUR):
-        return Stream(params)
+        if seed is None:
+            return Stream(params)
+        return Stream(params, seed=seed)
 
 
 # =============================================================================
@@ -338,6 +340,68 @@ class TestStochasticStreamIdInjection:
         for i in range(1, 3):
             offset = s._voice_manager.get_voice_config(i, 0.0).pan_offset
             assert -30.0 <= offset <= 30.0
+
+
+# =============================================================================
+# 7b. Seed propagato alle strategy stocastiche (issue #81)
+# =============================================================================
+
+import hashlib
+import random as _random
+
+
+def _seeded_pos(seed, stream_id, vi, lo=-1.0, hi=1.0):
+    h = hashlib.sha256(f"{seed}:{stream_id}:{vi}".encode()).hexdigest()
+    return _random.Random(int(h, 16)).uniform(lo, hi)
+
+
+class TestSeedPropagation:
+
+    def test_seed_injected_into_stochastic_pitch(self):
+        s = _build_stream({
+            'num_voices': 3,
+            'pitch': {'strategy': 'stochastic', 'pitch_range': 3.0},
+        }, stream_id='s1', seed=42)
+        assert s._voice_manager._pitch_strategy.seed == 42
+
+    def test_seed_injected_into_stochastic_onset(self):
+        s = _build_stream({
+            'num_voices': 3,
+            'onset_offset': {'strategy': 'stochastic', 'max_offset': 0.2},
+        }, stream_id='s1', seed=42)
+        assert s._voice_manager._onset_strategy.seed == 42
+
+    def test_seed_injected_into_stochastic_pointer(self):
+        s = _build_stream({
+            'num_voices': 3,
+            'pointer': {'strategy': 'stochastic', 'pointer_range': 0.1},
+        }, stream_id='s1', seed=42)
+        assert s._voice_manager._pointer_strategy.seed == 42
+
+    def test_seed_injected_into_random_pan(self):
+        s = _build_stream({
+            'num_voices': 3,
+            'pan': {'strategy': 'random', 'spread': 60.0},
+        }, stream_id='s1', seed=42)
+        assert s._voice_manager._pan_strategy.seed == 42
+
+    def test_default_seed_is_none_backward_compatible(self):
+        """Senza seed: strategy.seed è None → fallback hash() (comportamento attuale)."""
+        s = _build_stream({
+            'num_voices': 3,
+            'pitch': {'strategy': 'stochastic', 'pitch_range': 3.0},
+        }, stream_id='s1')
+        assert s._voice_manager._pitch_strategy.seed is None
+
+    def test_seed_produces_hashlib_offset(self):
+        """Col seed l'offset è il valore derivato via hashlib (riproducibile)."""
+        s = _build_stream({
+            'num_voices': 3,
+            'pitch': {'strategy': 'stochastic', 'pitch_range': 2.0},
+        }, stream_id='s1', seed=42)
+        expected = EdoUnit(12).materialize(_seeded_pos(42, 's1', 1), 2.0)
+        got = s._voice_manager.get_voice_config(1, 0.0).pitch_factor
+        assert got == pytest.approx(expected)
 
 
 # =============================================================================

--- a/tests/engine/test_generator.py
+++ b/tests/engine/test_generator.py
@@ -110,6 +110,14 @@ class TestGeneratorInit:
             g = Generator('config.yml')
         assert g.streams == []
 
+    def test_init_seed_is_none(self):
+        """seed e' None prima di load_yaml() (issue #81)."""
+        Generator = _get_generator_class()
+        with patch('engine.generator.FtableManager'), \
+             patch('engine.generator.ScoreWriter'):
+            g = Generator('config.yml')
+        assert g.seed is None
+
     def test_init_creates_ftable_manager(self):
         """Il costruttore crea un FtableManager."""
         Generator = _get_generator_class()
@@ -190,6 +198,27 @@ class TestLoadYaml:
             result = gen.load_yaml()
 
         assert result['value'] == 15
+
+    def test_load_yaml_extracts_seed(self, gen):
+        """load_yaml estrae self.seed dalla chiave top-level (issue #81)."""
+        m = mock_open(read_data=yaml.dump({'seed': 42, 'streams': []}))
+        with patch('builtins.open', m):
+            gen.load_yaml()
+        assert gen.seed == 42
+
+    def test_load_yaml_seed_absent_is_none(self, gen):
+        """seed assente → self.seed None (comportamento attuale invariato)."""
+        m = mock_open(read_data=yaml.dump({'streams': []}))
+        with patch('builtins.open', m):
+            gen.load_yaml()
+        assert gen.seed is None
+
+    def test_load_yaml_seed_zero_preserved(self, gen):
+        """seed: 0 è valido e distinto da assente."""
+        m = mock_open(read_data=yaml.dump({'seed': 0, 'streams': []}))
+        with patch('builtins.open', m):
+            gen.load_yaml()
+        assert gen.seed == 0
 
     def test_load_yaml_file_not_found(self, gen):
         """load_yaml solleva FileNotFoundError se file non esiste."""
@@ -610,6 +639,28 @@ class TestCreateElements:
 
         mock_filter.assert_called_once_with([])
 
+    def test_create_elements_seeds_global_random_when_seed_present(self, gen):
+        """Col seed, create_elements semina il random globale (meccanismo 2, issue #81)."""
+        m = mock_open(read_data=yaml.dump({'seed': 42, 'streams': []}))
+        with patch('builtins.open', m):
+            gen.load_yaml()
+        with patch.object(gen, '_filter_solo_mute', return_value=[]), \
+             patch.object(gen, '_create_streams'), \
+             patch('engine.generator.random.seed') as mock_seed:
+            gen.create_elements()
+        mock_seed.assert_called_once_with(42)
+
+    def test_create_elements_no_seed_skips_global_random(self, gen):
+        """Senza seed, create_elements NON semina il random globale (retrocompat)."""
+        m = mock_open(read_data=yaml.dump({'streams': []}))
+        with patch('builtins.open', m):
+            gen.load_yaml()
+        with patch.object(gen, '_filter_solo_mute', return_value=[]), \
+             patch.object(gen, '_create_streams'), \
+             patch('engine.generator.random.seed') as mock_seed:
+            gen.create_elements()
+        mock_seed.assert_not_called()
+
 # =============================================================================
 # 6. TEST _create_streams()
 # =============================================================================
@@ -626,8 +677,20 @@ class TestCreateStreams:
              patch.object(gen, '_register_stream_windows', return_value={}):
             gen._create_streams(stream_data)
 
-        MockStream.assert_called_once_with(stream_data[0])
+        MockStream.assert_called_once_with(stream_data[0], seed=None)
         assert len(gen.streams) == 1
+
+    def test_create_streams_passes_seed_to_stream(self, gen):
+        """_create_streams propaga self.seed al costruttore Stream (issue #81)."""
+        gen.seed = 42
+        stream_data = [{'stream_id': 's1', 'sample': 'a.wav', 'grain': {}}]
+        mock_stream = make_mock_stream_for_generator()
+
+        with patch('engine.generator.Stream', return_value=mock_stream) as MockStream, \
+             patch.object(gen, '_register_stream_windows', return_value={}):
+            gen._create_streams(stream_data)
+
+        MockStream.assert_called_once_with(stream_data[0], seed=42)
 
     def test_registers_sample(self, gen):
         """_create_streams registra il sample nel FtableManager."""
@@ -698,7 +761,7 @@ class TestCreateStreams:
         """_create_streams crea piu' stream in sequenza."""
         streams_created = []
 
-        def make_s(data):
+        def make_s(data, seed=None):
             s = make_mock_stream_for_generator(stream_id=data['stream_id'])
             streams_created.append(s)
             return s
@@ -1280,7 +1343,7 @@ class TestStreamDataMap:
         ]
         with patch('engine.generator.Stream') as MockStream, \
              patch('engine.generator.WindowController'):
-            def make_stream(d):
+            def make_stream(d, seed=None):
                 m = Mock()
                 m.stream_id = d['stream_id']
                 m.sample = d['sample']

--- a/tests/engine/test_seed_reproducibility.py
+++ b/tests/engine/test_seed_reproducibility.py
@@ -1,0 +1,152 @@
+# tests/engine/test_seed_reproducibility.py
+"""
+test_seed_reproducibility.py
+
+Test di riproducibilità della chiave YAML `seed` (issue #81).
+
+Due meccanismi stocastici, due livelli di verifica:
+
+- Meccanismo 2 (random globale dei grani): con `distribution: 1.0` l'inter-onset
+  per-grano usa `random.uniform` globale. Due render con `seed: 42` devono
+  produrre la stessa sequenza di onset; senza seed le due materializzazioni
+  divergono (il random globale non viene mai re-seminato). Verificato in-process:
+  `random.seed()` è deterministico per costruzione, l'unico difetto era che non
+  veniva mai chiamato.
+
+- Meccanismo 1 (RNG locale delle voci): l'offset stocastico delle voci deve
+  essere identico fra PROCESSI diversi quando il seed è fissato. Verificato via
+  subprocess con `PYTHONHASHSEED` differenti: con seed → identico (derivazione
+  hashlib), senza seed → diverso (hash() randomizzato per-processo).
+
+Non richiede csound/sox né sample reali: il sample è mockato (`get_sample_duration`)
+e i grani si confrontano simbolicamente (onset/pointer/pitch), senza rendering audio.
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+import yaml
+from unittest.mock import patch
+
+from engine.generator import Generator
+
+
+PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', '..')
+)
+
+
+# =============================================================================
+# MECCANISMO 2 — random globale dei grani (in-process)
+# =============================================================================
+
+def _yaml_async_stream(seed=None):
+    """YAML con un singolo stream async (distribution: 1.0 → IOT stocastico)."""
+    data = {
+        'streams': [{
+            'stream_id': 's1',
+            'onset': 0.0,
+            'duration': 8.0,
+            'sample': 'test.wav',
+            'density': 20,
+            'distribution': 1.0,
+            'grain': {'duration': 0.05},
+        }],
+    }
+    if seed is not None:
+        data['seed'] = seed
+    return data
+
+
+def _materialize_onsets(tmp_path, yaml_data):
+    """Crea il Generator, semina (se seed presente) e materializza i grani.
+
+    Ritorna la lista di onset dei grani (lo stocastico del meccanismo 2 vive
+    nell'inter-onset async).
+    """
+    cfg = tmp_path / "seed_repro.yml"
+    cfg.write_text(yaml.safe_dump(yaml_data))
+    gen = Generator(str(cfg))
+    gen.load_yaml()
+    with patch('core.stream.get_sample_duration', return_value=10.0):
+        gen.create_elements()
+        onsets = [round(g.onset, 9) for s in gen.streams for g in s.grains]
+    return onsets
+
+
+class TestGlobalRandomReproducibility:
+
+    def test_same_seed_reproducible(self, tmp_path):
+        """Due render con lo stesso seed → stessa sequenza di onset."""
+        run1 = _materialize_onsets(tmp_path, _yaml_async_stream(seed=42))
+        run2 = _materialize_onsets(tmp_path, _yaml_async_stream(seed=42))
+        assert run1 == run2
+        assert len(run1) > 10  # lo stream ha davvero generato grani stocastici
+
+    def test_without_seed_not_reproducible(self, tmp_path):
+        """Senza seed le due materializzazioni divergono (random globale mai re-seminato)."""
+        run1 = _materialize_onsets(tmp_path, _yaml_async_stream(seed=None))
+        run2 = _materialize_onsets(tmp_path, _yaml_async_stream(seed=None))
+        assert run1 != run2
+
+    def test_different_seeds_diverge(self, tmp_path):
+        """Seed diversi → sequenze diverse."""
+        run1 = _materialize_onsets(tmp_path, _yaml_async_stream(seed=1))
+        run2 = _materialize_onsets(tmp_path, _yaml_async_stream(seed=2))
+        assert run1 != run2
+
+    def test_seed_zero_reproducible(self, tmp_path):
+        """seed: 0 è valido e riproducibile (non confuso con assente)."""
+        run1 = _materialize_onsets(tmp_path, _yaml_async_stream(seed=0))
+        run2 = _materialize_onsets(tmp_path, _yaml_async_stream(seed=0))
+        assert run1 == run2
+
+
+# =============================================================================
+# MECCANISMO 1 — RNG locale voci (cross-process via PYTHONHASHSEED)
+# =============================================================================
+
+_SNIPPET = textwrap.dedent("""
+    import sys
+    from strategies.voice_pitch_strategy import StochasticPitchStrategy
+    from parameters.pitch_unit import EdoUnit
+    seed = None if sys.argv[1] == 'none' else int(sys.argv[1])
+    s = StochasticPitchStrategy(pitch_range=2.0, stream_id='s1', seed=seed)
+    u = EdoUnit(12)
+    vals = [s.get_pitch_factor(i, 6, 0.0, u) for i in range(1, 6)]
+    print(','.join(f'{v:.12f}' for v in vals))
+""")
+
+
+def _run_with_hashseed(hashseed: str, seed_arg: str) -> str:
+    """Esegue lo snippet in un processo separato con PYTHONHASHSEED fissato."""
+    env = dict(os.environ)
+    env['PYTHONHASHSEED'] = hashseed
+    env['PYTHONPATH'] = 'src' + os.pathsep + env.get('PYTHONPATH', '')
+    result = subprocess.run(
+        [sys.executable, '-c', _SNIPPET, seed_arg],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+class TestVoiceRngCrossProcess:
+
+    def test_seed_reproducible_across_processes(self):
+        """Con seed fissato l'offset è identico fra PYTHONHASHSEED diversi."""
+        out1 = _run_with_hashseed('1', '42')
+        out2 = _run_with_hashseed('2', '42')
+        assert out1 == out2
+
+    def test_without_seed_differs_across_processes(self):
+        """Senza seed l'offset dipende da PYTHONHASHSEED (bug pre-#81)."""
+        out1 = _run_with_hashseed('1', 'none')
+        out2 = _run_with_hashseed('2', 'none')
+        assert out1 != out2

--- a/tests/strategies/test_voice_onset_strategy.py
+++ b/tests/strategies/test_voice_onset_strategy.py
@@ -414,3 +414,54 @@ class TestDynamicOnsetParams:
         assert v0 >= 0.0
         assert v1 >= 0.0
         assert v1 > v0
+
+
+# =============================================================================
+# StochasticOnsetStrategy — seed riproducibile (issue #81)
+# =============================================================================
+
+import hashlib
+import random as _random
+
+
+def _seeded_pos(seed, stream_id, vi, lo, hi):
+    """Posizione attesa col seed fissato (hashlib + Mersenne, cross-process)."""
+    h = hashlib.sha256(f"{seed}:{stream_id}:{vi}".encode()).hexdigest()
+    return _random.Random(int(h, 16)).uniform(lo, hi)
+
+
+class TestStochasticOnsetSeed:
+
+    def test_seed_produces_deterministic_value(self):
+        _, _, _, StochasticOnsetStrategy, *_ = _get_module()
+        s = StochasticOnsetStrategy(max_offset=0.1, stream_id="s1", seed=42)
+        expected = _seeded_pos(42, "s1", 1, 0.0, 1.0) * 0.1
+        assert s.get_onset_offset(1, 4, 0.0) == pytest.approx(expected)
+
+    def test_different_seeds_different_offsets(self):
+        _, _, _, StochasticOnsetStrategy, *_ = _get_module()
+        s1 = StochasticOnsetStrategy(max_offset=0.5, stream_id="s1", seed=1)
+        s2 = StochasticOnsetStrategy(max_offset=0.5, stream_id="s1", seed=2)
+        o1 = [s1.get_onset_offset(i, 4, 0.0) for i in range(1, 4)]
+        o2 = [s2.get_onset_offset(i, 4, 0.0) for i in range(1, 4)]
+        assert o1 != o2
+
+    def test_seed_none_backward_compatible(self):
+        _, _, _, StochasticOnsetStrategy, *_ = _get_module()
+        s = StochasticOnsetStrategy(max_offset=0.3, stream_id="s1", seed=None)
+        for i in range(1, 5):
+            assert 0.0 <= s.get_onset_offset(i, 5, 0.0) <= 0.3
+
+    def test_seed_zero_accepted(self):
+        _, _, _, StochasticOnsetStrategy, *_ = _get_module()
+        s = StochasticOnsetStrategy(max_offset=0.1, stream_id="s1", seed=0)
+        expected = _seeded_pos(0, "s1", 1, 0.0, 1.0) * 0.1
+        assert s.get_onset_offset(1, 4, 0.0) == pytest.approx(expected)
+
+    def test_factory_propagates_seed(self):
+        *_, VoiceOnsetStrategyFactory = _get_module()
+        s = VoiceOnsetStrategyFactory.create(
+            'stochastic', max_offset=0.1, stream_id='s1', seed=42
+        )
+        expected = _seeded_pos(42, "s1", 1, 0.0, 1.0) * 0.1
+        assert s.get_onset_offset(1, 4, 0.0) == pytest.approx(expected)

--- a/tests/strategies/test_voice_pan_strategy.py
+++ b/tests/strategies/test_voice_pan_strategy.py
@@ -692,3 +692,52 @@ class TestFactoryRegistryIntegration:
         assert strategy.get_pan_offset(1, 4, 100.0, 0.0) == pytest.approx(-50.0)
         assert strategy.get_pan_offset(2, 4, 100.0, 0.0) == pytest.approx(50.0)
         assert strategy.get_pan_offset(3, 4, 100.0, 0.0) == pytest.approx(-50.0)
+
+
+# =============================================================================
+# RandomPanStrategy — seed riproducibile (issue #81)
+# =============================================================================
+
+import hashlib
+import random as _random
+
+
+def _seeded_pos(seed, stream_id, vi, lo=-1.0, hi=1.0):
+    """Posizione attesa col seed fissato (hashlib + Mersenne, cross-process)."""
+    h = hashlib.sha256(f"{seed}:{stream_id}:{vi}".encode()).hexdigest()
+    return _random.Random(int(h, 16)).uniform(lo, hi)
+
+
+class TestRandomPanSeed:
+
+    def test_seed_produces_deterministic_value(self):
+        _, _, RandomPanStrategy, *_ = _get_module()
+        s = RandomPanStrategy(stream_id="s1", seed=42)
+        expected = _seeded_pos(42, "s1", 1) * 180.0 / 2.0
+        assert s.get_pan_offset(1, 4, 180.0, 0.0) == pytest.approx(expected)
+
+    def test_different_seeds_different_offsets(self):
+        _, _, RandomPanStrategy, *_ = _get_module()
+        s1 = RandomPanStrategy(stream_id="s1", seed=1)
+        s2 = RandomPanStrategy(stream_id="s1", seed=2)
+        o1 = [s1.get_pan_offset(i, 4, 180.0, 0.0) for i in range(1, 4)]
+        o2 = [s2.get_pan_offset(i, 4, 180.0, 0.0) for i in range(1, 4)]
+        assert o1 != o2
+
+    def test_seed_none_backward_compatible(self):
+        _, _, RandomPanStrategy, *_ = _get_module()
+        s = RandomPanStrategy(stream_id="s1", seed=None)
+        for i in range(1, 5):
+            assert -90.0 <= s.get_pan_offset(i, 5, 180.0, 0.0) <= 90.0
+
+    def test_seed_zero_accepted(self):
+        _, _, RandomPanStrategy, *_ = _get_module()
+        s = RandomPanStrategy(stream_id="s1", seed=0)
+        expected = _seeded_pos(0, "s1", 1) * 180.0 / 2.0
+        assert s.get_pan_offset(1, 4, 180.0, 0.0) == pytest.approx(expected)
+
+    def test_factory_propagates_seed(self):
+        *_, VoicePanStrategyFactory = _get_module()
+        s = VoicePanStrategyFactory.create('random', stream_id='s1', seed=42)
+        expected = _seeded_pos(42, "s1", 1) * 180.0 / 2.0
+        assert s.get_pan_offset(1, 4, 180.0, 0.0) == pytest.approx(expected)

--- a/tests/strategies/test_voice_pitch_strategy.py
+++ b/tests/strategies/test_voice_pitch_strategy.py
@@ -393,6 +393,72 @@ class TestStochasticPitchStrategy:
 
 
 # =============================================================================
+# 6b. StochasticPitchStrategy — seed riproducibile (issue #81)
+# =============================================================================
+
+import hashlib
+import random as _random
+
+
+def _seeded_pos(seed, stream_id, vi, lo=-1.0, hi=1.0):
+    """Posizione attesa quando il seed è fissato: derivazione hashlib + Mersenne.
+
+    Indipendente da PYTHONHASHSEED (a differenza di hash()), quindi
+    riproducibile fra processi. Replica il contratto documentato.
+    """
+    h = hashlib.sha256(f"{seed}:{stream_id}:{vi}".encode()).hexdigest()
+    return _random.Random(int(h, 16)).uniform(lo, hi)
+
+
+class TestStochasticPitchSeed:
+
+    def test_seed_produces_deterministic_value(self):
+        """Con seed fissato il fattore è il valore derivato via hashlib (cross-process)."""
+        _, _, _, _, StochasticPitchStrategy, *_ = _get_module()
+        s = StochasticPitchStrategy(pitch_range=2.0, stream_id="s1", seed=42)
+        expected = ST.materialize(_seeded_pos(42, "s1", 1), 2.0)
+        assert _factor(s, 1, 4, 0.0) == pytest.approx(expected)
+
+    def test_seed_value_independent_of_hash_randomization(self):
+        """Stesso (seed, stream_id, vi) → stesso valore noto a priori, non hash-dipendente."""
+        _, _, _, _, StochasticPitchStrategy, *_ = _get_module()
+        s = StochasticPitchStrategy(pitch_range=2.0, stream_id="s1", seed=7)
+        for vi in range(1, 5):
+            expected = ST.materialize(_seeded_pos(7, "s1", vi), 2.0)
+            assert _factor(s, vi, 5, 0.0) == pytest.approx(expected)
+
+    def test_different_seeds_different_offsets(self):
+        _, _, _, _, StochasticPitchStrategy, *_ = _get_module()
+        s1 = StochasticPitchStrategy(pitch_range=5.0, stream_id="s1", seed=1)
+        s2 = StochasticPitchStrategy(pitch_range=5.0, stream_id="s1", seed=2)
+        o1 = [_factor(s1, i, 4, 0.0) for i in range(1, 4)]
+        o2 = [_factor(s2, i, 4, 0.0) for i in range(1, 4)]
+        assert o1 != o2
+
+    def test_seed_none_is_backward_compatible(self):
+        """seed=None (default) → fallback hash(): stabile entro il run, entro range."""
+        _, _, _, _, StochasticPitchStrategy, *_ = _get_module()
+        s = StochasticPitchStrategy(pitch_range=3.0, stream_id="s1", seed=None)
+        for i in range(1, 6):
+            assert -3.0 <= _st(s, i, 6, 0.0) <= 3.0
+
+    def test_seed_zero_accepted(self):
+        """seed: 0 è un valore valido (non confuso con assente)."""
+        _, _, _, _, StochasticPitchStrategy, *_ = _get_module()
+        s = StochasticPitchStrategy(pitch_range=2.0, stream_id="s1", seed=0)
+        expected = ST.materialize(_seeded_pos(0, "s1", 1), 2.0)
+        assert _factor(s, 1, 4, 0.0) == pytest.approx(expected)
+
+    def test_factory_propagates_seed(self):
+        _, _, _, _, _, _, _, VoicePitchStrategyFactory, _ = _get_module()
+        s = VoicePitchStrategyFactory.create(
+            'stochastic', pitch_range=2.0, stream_id='s1', seed=42
+        )
+        expected = ST.materialize(_seeded_pos(42, "s1", 1), 2.0)
+        assert s.get_pitch_factor(1, 4, 0.0, ST) == pytest.approx(expected)
+
+
+# =============================================================================
 # 7. Invariante voce 0 — tutte le strategy
 # =============================================================================
 

--- a/tests/strategies/test_voice_pointer_strategy.py
+++ b/tests/strategies/test_voice_pointer_strategy.py
@@ -347,3 +347,54 @@ class TestDynamicPointerParams:
         v0 = abs(s.get_pointer_offset(1, 4, 0.0))
         v1 = abs(s.get_pointer_offset(1, 4, 1.0))
         assert v1 > v0
+
+
+# =============================================================================
+# StochasticPointerStrategy — seed riproducibile (issue #81)
+# =============================================================================
+
+import hashlib
+import random as _random
+
+
+def _seeded_pos(seed, stream_id, vi, lo=-1.0, hi=1.0):
+    """Posizione attesa col seed fissato (hashlib + Mersenne, cross-process)."""
+    h = hashlib.sha256(f"{seed}:{stream_id}:{vi}".encode()).hexdigest()
+    return _random.Random(int(h, 16)).uniform(lo, hi)
+
+
+class TestStochasticPointerSeed:
+
+    def test_seed_produces_deterministic_value(self):
+        _, _, StochasticPointerStrategy, *_ = _get_module()
+        s = StochasticPointerStrategy(pointer_range=0.2, stream_id="s1", seed=42)
+        expected = _seeded_pos(42, "s1", 1) * 0.2
+        assert s.get_pointer_offset(1, 4, 0.0) == pytest.approx(expected)
+
+    def test_different_seeds_different_offsets(self):
+        _, _, StochasticPointerStrategy, *_ = _get_module()
+        s1 = StochasticPointerStrategy(pointer_range=0.5, stream_id="s1", seed=1)
+        s2 = StochasticPointerStrategy(pointer_range=0.5, stream_id="s1", seed=2)
+        o1 = [s1.get_pointer_offset(i, 4, 0.0) for i in range(1, 4)]
+        o2 = [s2.get_pointer_offset(i, 4, 0.0) for i in range(1, 4)]
+        assert o1 != o2
+
+    def test_seed_none_backward_compatible(self):
+        _, _, StochasticPointerStrategy, *_ = _get_module()
+        s = StochasticPointerStrategy(pointer_range=0.3, stream_id="s1", seed=None)
+        for i in range(1, 5):
+            assert -0.3 <= s.get_pointer_offset(i, 5, 0.0) <= 0.3
+
+    def test_seed_zero_accepted(self):
+        _, _, StochasticPointerStrategy, *_ = _get_module()
+        s = StochasticPointerStrategy(pointer_range=0.2, stream_id="s1", seed=0)
+        expected = _seeded_pos(0, "s1", 1) * 0.2
+        assert s.get_pointer_offset(1, 4, 0.0) == pytest.approx(expected)
+
+    def test_factory_propagates_seed(self):
+        *_, VoicePointerStrategyFactory = _get_module()
+        s = VoicePointerStrategyFactory.create(
+            'stochastic', pointer_range=0.2, stream_id='s1', seed=42
+        )
+        expected = _seeded_pos(42, "s1", 1) * 0.2
+        assert s.get_pointer_offset(1, 4, 0.0) == pytest.approx(expected)


### PR DESCRIPTION
## Summary

Implements reproducible grain generation across processes via an optional top-level `seed` YAML key (issue #81). Two stochastic mechanisms are now controllable:

1. **Global random (Mechanism 2):** `random.seed()` called once at `create_elements()` start, controlling inter-onset timing for async streams (`distribution: 1.0`)
2. **Per-voice RNG (Mechanism 1):** Stochastic offsets in pitch, onset, pointer, and pan strategies now derive from `hashlib.sha256(f"{seed}:{stream_id}:{voice_index}")` instead of `hash()`, making them deterministic across processes with different `PYTHONHASHSEED`

## Key Changes

- **New module `src/shared/seeding.py`:** Single source of truth for per-voice RNG derivation. Provides `voice_rng(seed, stream_id, voice_index)` returning a seeded `random.Random` instance. Handles both legacy mode (`seed=None` → `hash()` fallback) and deterministic mode (hashlib-based).

- **Generator (`src/engine/generator.py`):**
  - Added `self.seed` attribute (initialized to `None`, populated by `load_yaml()` from top-level YAML key)
  - `load_yaml()` extracts optional `seed` key from YAML data
  - `create_elements()` calls `random.seed(self.seed)` if seed is present
  - `_create_streams()` passes `seed` to Stream constructor

- **Stream (`src/core/stream.py`):**
  - Constructor now accepts optional `seed` parameter
  - Stores `self.seed` and propagates it to voice manager initialization

- **Voice strategies** (`src/strategies/voice_*_strategy.py`):
  - All stochastic strategies (`StochasticPitchStrategy`, `StochasticOnsetStrategy`, `StochasticPointerStrategy`, `RandomPanStrategy`) now accept optional `seed` parameter
  - Replaced direct `random.uniform()` calls with `voice_rng(seed, stream_id, voice_index).uniform()`
  - Factory methods updated to propagate seed through strategy creation chain

- **Comprehensive test suite** (`tests/engine/test_seed_reproducibility.py`):
  - In-process tests verify same seed produces identical onset sequences
  - Cross-process tests (via subprocess with different `PYTHONHASHSEED`) verify deterministic per-voice offsets
  - Tests confirm `seed: 0` is valid and distinct from absent seed

- **Existing test updates:**
  - Generator tests verify seed extraction and global random seeding
  - Stream/voice tests verify seed propagation through initialization chain
  - Strategy tests verify deterministic output with fixed seed and backward compatibility with `seed=None`

- **Documentation (`docs/reference/yaml.md`):**
  - Added "Seed (Riproducibilità)" section explaining optional top-level `seed` key
  - Documents two mechanisms (global random + per-voice RNG)
  - Notes limitation: Csound renderer has its own RNG, not affected by Python seed

## Implementation Details

- **Backward compatible:** `seed=None` (default) preserves existing behavior using `hash()` for per-voice offsets
- **Cross-process determinism:** `hashlib.sha256` is platform-independent and not affected by `PYTHONHASHSEED`, unlike `hash()`
- **Covers edge cases:** `seed: 0` and negative integers are valid and handled correctly
- **No external dependencies:** Uses only Python stdlib (`hashlib`, `random`)
- **Lazy grain generation:** Global `random.seed()` is called before lazy grain creation, ensuring deterministic inter-onset timing

https://claude.ai/code/session_01NSTb5b4TJGQmr1xoNW14kf