### PR TITLE
Estendi bounds minimo pitch_ratio da 0.125 a 0.001

### DIFF
--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -338,7 +338,7 @@ La famiglia EDO (Equal Division of the Octave) converte in ratio con
 | `eighth_tone` | ottavi di tono | 48 | [-144, 144] |
 | `cents` | cents | 1200 | [-3600, 3600] |
 | `edo` (+ `value`) | EDO arbitrario | N | [-3·N, 3·N] |
-| `ratio` | ratio diretto | — | [0.125, 8] |
+| `ratio` | ratio diretto | — | [0.001, 8] |
 
 Più chiavi-unità nello stesso blocco → errore (`InvalidFieldValueError`):
 niente più priorità implicita. Senza alcuna chiave-unità: default `semitones`
@@ -1585,7 +1585,7 @@ un envelope dal YAML al runtime è:
 | `grain_duration` | 0.001 | 10 | 0.05 | secondi |
 | `volume` | -120 | 12 | 0.0 | dB |
 | `pan` | -3600 | 3600 | 0.0 | gradi |
-| `pitch_ratio` | 0.125 | 8 | 1.0 | 3 ottave ↓/↑ |
+| `pitch_ratio` | 0.001 | 8 | 1.0 | ratio diretto |
 | `pitch_semitones` | -36 | 36 | 0 | ±3 ottave |
 | `pointer_speed_ratio` | -100 | 100 | 1.0 | negativo = indietro |
 | `pointer_deviation` | -1 | 1 | 0.0 | offset per-grano |

--- a/src/parameters/parameter_definitions.py
+++ b/src/parameters/parameter_definitions.py
@@ -112,7 +112,7 @@ GRANULAR_PARAMETERS: Dict[str, ParameterBounds] = {
     # PITCH
     # =========================================================================
     # I bounds del pitch sono unit-driven: derivano da PitchUnit.value_bounds()
-    # (±3 ottave per la famiglia EDO, [0.125, 8] per ratio) e non sono registrati
+    # (±3 ottave per la famiglia EDO, [0.001, 8] per ratio) e non sono registrati
     # qui. Vedi src/parameters/pitch_unit.py.
 
     # =========================================================================

--- a/src/parameters/pitch_unit.py
+++ b/src/parameters/pitch_unit.py
@@ -117,8 +117,8 @@ class EdoUnit(PitchUnit):
 class RatioUnit(PitchUnit):
     """Moltiplicatore diretto: ratio = value.
 
-    Bounds e variazione coincidono con lo storico pitch_ratio
-    ([0.125, 8], variazione additiva continua). Il valore neutro è 1 (×1).
+    Bounds e variazione del ratio diretto
+    ([0.001, 8], variazione additiva continua). Il valore neutro è 1 (×1).
     """
 
     def __init__(self, name: str = 'ratio', symbol: str = 'x'):
@@ -140,7 +140,7 @@ class RatioUnit(PitchUnit):
 
     def value_bounds(self) -> ParameterBounds:
         return ParameterBounds(
-            min_val=0.125,
+            min_val=0.001,
             max_val=8.0,
             min_range=0.0,
             max_range=2.0,

--- a/tests/parameters/test_pitch_unit.py
+++ b/tests/parameters/test_pitch_unit.py
@@ -145,10 +145,10 @@ def test_edo_value_bounds_three_octaves(divisions, expected):
 
 
 def test_ratio_value_bounds_matches_legacy():
-    # deve coincidere con i vecchi bounds statici di pitch_ratio
+    # bounds del ratio diretto: minimo esteso a 0.001
     b = RatioUnit().value_bounds()
     assert isinstance(b, ParameterBounds)
-    assert b.min_val == 0.125
+    assert b.min_val == 0.001
     assert b.max_val == 8.0
     assert b.min_range == 0.0
     assert b.max_range == 2.0

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -55,7 +55,7 @@ PITCH_SEMITONES_BOUNDS = ParameterBounds(
     variation_mode='quantized'
 )
 PITCH_RATIO_BOUNDS = ParameterBounds(
-    min_val=0.125, max_val=8.0,
+    min_val=0.001, max_val=8.0,
     min_range=0.0, max_range=2.0,
     default_jitter=0.01
 )
@@ -1016,10 +1016,10 @@ class TestEdgeCases:
         assert abs(result - 1.0) < 0.001
 
     def test_ratio_at_boundary_min(self):
-        """Ratio al limite inferiore dei bounds (0.125)."""
-        param = _make_param(0.125)
+        """Ratio al limite inferiore dei bounds (0.001)."""
+        param = _make_param(0.001)
         strategy = _ratio_strategy(param)
-        assert strategy.calculate(0.0) == pytest.approx(0.125)
+        assert strategy.calculate(0.0) == pytest.approx(0.001)
 
     def test_ratio_at_boundary_max(self):
         """Ratio al limite superiore dei bounds (8.0)."""


### PR DESCRIPTION
## Riepilogo

Amplia il range minimo del pitch_ratio (RatioUnit) da 0.125 a 0.001, consentendo variazioni di pitch più estreme verso il basso (da ~-36 semitoni a ~-120 semitoni, circa 10 ottave).

## Modifiche principali

- **src/parameters/pitch_unit.py**: aggiorna `RatioUnit.value_bounds()` con `min_val=0.001` e documenta il cambio nei commenti
- **src/parameters/parameter_definitions.py**: aggiorna commento di riferimento per i bounds del pitch_ratio
- **tests/strategies/test_strategies.py**: 
  - Aggiorna `PITCH_RATIO_BOUNDS` con `min_val=0.001`
  - Aggiorna test `test_ratio_at_boundary_min` per validare il nuovo limite
- **tests/parameters/test_pitch_unit.py**: aggiorna assertion e commento in `test_ratio_value_bounds_matches_legacy`
- **docs/reference/yaml.md**: aggiorna documentazione YAML con il nuovo range `[0.001, 8]` e descrizione semplificata

## Dettagli implementativi

Il cambio è coerente su tutti i livelli: definizione dei bounds, test di validazione, documentazione YAML e commenti di spiegazione. Il valore neutro rimane 1.0 (×1), e la variazione additiva continua è preservata.

https://claude.ai/code/session_01NdHqJa6aX5Br3JaRY6Trod