### PR TITLE
feat(rendering): blackman_harris nel NumpyWindowRegistry (parità con Csound)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Aggiunto
 
+- Renderer NumPy: supporto alla finestra grano `blackman_harris` (GEN20 opt 5),
+  campana a 4 termini con massima soppressione dei lobi laterali. Colma il gap
+  col registry Csound (`WindowRegistry`), che già la definiva: i due renderer ora
+  espongono lo stesso insieme di 16 finestre e l'espansione `envelope: all` (che
+  enumera le finestre Csound) non fallisce più sotto NumPy. Nessuna modifica a
+  YAML/CLI: `blackman_harris` era già un nome valido a livello di engine.
 - Score visualizer: auto-zoom del range colore pitch per-subplot
   (`pitch_color_autozoom`, default attivo). Il colore dei grani normalizza
   `1200*log2(pitch_ratio)` sul min/max in cents dei grani visibili nel

--- a/src/rendering/numpy_window_registry.py
+++ b/src/rendering/numpy_window_registry.py
@@ -95,6 +95,7 @@ class NumpyWindowRegistry:
         names = list(self._NUMPY_WINDOWS.keys())
         names.append('kaiser')
         names.append('gaussian')
+        names.append('blackman_harris')
         names.extend(self._GEN16_WINDOWS.keys())
         names.append('half_sine')
         names.append('rectangle')
@@ -131,15 +132,21 @@ class NumpyWindowRegistry:
         if name == 'gaussian':
             return self._gaussian(n)
 
-        # 5. Half-sine (GEN09 equivalente)
+        # 5. Blackman-Harris a 4 termini (GEN20 opt 5) — campana stretta con
+        # massima soppressione dei lobi laterali. NumPy non ha un built-in
+        # (np.blackman e' la variante a 3 termini): formula esplicita.
+        if name == 'blackman_harris':
+            return self._blackman_harris(n)
+
+        # 6. Half-sine (GEN09 equivalente)
         if name == 'half_sine':
             return self._half_sine(n)
 
-        # 6. Rectangle (GEN20 opt 8) — finestra piatta
+        # 7. Rectangle (GEN20 opt 8) — finestra piatta
         if name == 'rectangle':
             return np.ones(n, dtype=np.float64)
 
-        # 7. Sinc (GEN20 opt 9) — lobo centrale sin(πx)/(πx)
+        # 8. Sinc (GEN20 opt 9) — lobo centrale sin(πx)/(πx)
         if name == 'sinc':
             return self._sinc(n)
 
@@ -187,6 +194,27 @@ class NumpyWindowRegistry:
         """
         x = np.linspace(-1.0, 1.0, n)
         return np.exp(-0.5 * (x / sigma) ** 2)
+
+    @staticmethod
+    def _blackman_harris(n: int) -> np.ndarray:
+        """
+        Finestra Blackman-Harris a 4 termini (equivalente GEN20 opt 5 Csound).
+
+        w(x) = a0 - a1*cos(2*pi*x) + a2*cos(4*pi*x) - a3*cos(6*pi*x)
+        con x in [0, 1] (= k/(N-1)) e coefficienti
+        a0=0.35875, a1=0.48829, a2=0.14128, a3=0.01168.
+
+        Campana simmetrica molto stretta: ~0 ai bordi, picco 1.0 al centro,
+        lobi laterali soppressi (~ -92 dB). np.blackman e' la variante a 3
+        termini, quindi la calcoliamo esplicitamente come gaussian/sinc.
+        """
+        x = np.linspace(0.0, 1.0, n)
+        return (
+            0.35875
+            - 0.48829 * np.cos(2.0 * np.pi * x)
+            + 0.14128 * np.cos(4.0 * np.pi * x)
+            - 0.01168 * np.cos(6.0 * np.pi * x)
+        )
 
     @staticmethod
     def _half_sine(n: int) -> np.ndarray:

--- a/tests/rendering/test_numpy_window_registry.py
+++ b/tests/rendering/test_numpy_window_registry.py
@@ -421,3 +421,80 @@ class TestSincWindow:
         """Tutti i valori sono >= 0 (solo lobo centrale, x in [-1,1])."""
         w = registry.get('sinc', 1024)
         assert np.all(w >= -1e-15)
+
+
+# =============================================================================
+# 10. TEST BLACKMAN-HARRIS WINDOW
+# =============================================================================
+
+class TestBlackmanHarrisWindow:
+    """Test per la finestra blackman_harris (GEN20 opt 5 — campana a 4 termini).
+
+    Parita' col registry Csound (WindowRegistry): blackman_harris era definita
+    solo lato Csound, qui colmiamo il gap nel renderer NumPy.
+    """
+
+    def test_blackman_harris_available(self, registry):
+        """blackman_harris e' nella lista delle finestre disponibili."""
+        assert 'blackman_harris' in registry.available_windows()
+
+    def test_blackman_harris_returns_array(self, registry):
+        """get() ritorna un array NumPy della lunghezza richiesta."""
+        w = registry.get('blackman_harris', 1024)
+        assert isinstance(w, np.ndarray)
+        assert len(w) == 1024
+
+    def test_blackman_harris_dtype_float64(self, registry):
+        """Array in float64."""
+        w = registry.get('blackman_harris', 512)
+        assert w.dtype == np.float64
+
+    def test_blackman_harris_starts_near_zero(self, registry):
+        """Inizia vicino a zero (bordo)."""
+        w = registry.get('blackman_harris', 1024)
+        assert w[0] < 0.01
+
+    def test_blackman_harris_ends_near_zero(self, registry):
+        """Finisce vicino a zero (bordo)."""
+        w = registry.get('blackman_harris', 1024)
+        assert w[-1] < 0.01
+
+    def test_blackman_harris_peak_near_one(self, registry):
+        """Picco ~1.0 al centro."""
+        w = registry.get('blackman_harris', 1024)
+        assert np.max(w) > 0.99
+
+    def test_blackman_harris_peak_at_center(self, registry):
+        """Il picco e' vicino al campione centrale."""
+        w = registry.get('blackman_harris', 1024)
+        center = len(w) // 2
+        assert abs(np.argmax(w) - center) <= 1
+
+    def test_blackman_harris_is_symmetric(self, registry):
+        """La finestra e' simmetrica."""
+        w = registry.get('blackman_harris', 1024)
+        np.testing.assert_array_almost_equal(w, w[::-1])
+
+    def test_blackman_harris_all_non_negative(self, registry):
+        """Tutti i valori sono >= 0 (tolleranza floating point)."""
+        w = registry.get('blackman_harris', 1024)
+        assert np.all(w >= -1e-12)
+
+    def test_blackman_harris_all_at_most_one(self, registry):
+        """Tutti i valori sono <= 1.0."""
+        w = registry.get('blackman_harris', 1024)
+        assert np.all(w <= 1.0 + 1e-10)
+
+    def test_blackman_harris_narrower_than_blackman(self, registry):
+        """blackman_harris e' piu' stretta di blackman: a un quarto della
+        finestra ha valore piu' basso (lobi laterali piu' soppressi)."""
+        bh = registry.get('blackman_harris', 1024)
+        bk = registry.get('blackman', 1024)
+        quarter = 256
+        assert bh[quarter] < bk[quarter]
+
+    def test_blackman_harris_cached(self, registry):
+        """Stessa (name, N) ritorna l'oggetto cachato."""
+        w1 = registry.get('blackman_harris', 1024)
+        w2 = registry.get('blackman_harris', 1024)
+        assert w1 is w2


### PR DESCRIPTION
## Problema

Selezionando la window `blackman_harris` (offerta dalla UI di PGE-ui, che usa solo il renderer NumPy) il render fallisce:

```
[ERRORE] Window non trovata: 'blackman_harris'
  Disponibili:  bartlett, blackman, expodec, expodec_strong, exporise,
                exporise_strong, gaussian, half_sine, hamming, hanning,
                kaiser, rectangle, rexpodec, rexporise, sinc
```

## Causa radice

`blackman_harris` era definita **solo** nel registry Csound
(`controllers/window_registry.py`, GEN20 opt 5) ma **non** nel
`rendering/numpy_window_registry.py`. La validazione passa
(`WindowController.parse_window_list` controlla il registry Csound, dove il nome
esiste, e registra la ftable), ma a render-time `NumpyWindowRegistry.get` non la
trova e solleva `InvalidWindowError` con la lista delle 15 finestre NumPy. Lo
stesso gap faceva fallire l'espansione `envelope: all` (che enumera le finestre
Csound) sotto NumPy.

## Fix

Aggiunge la campana **Blackman-Harris a 4 termini** al `NumpyWindowRegistry`,
con formula esplicita (NumPy non ha un built-in: `np.blackman` è la variante a 3
termini), coerente con `_gaussian`/`_sinc`:

```
w(x) = 0.35875 - 0.48829·cos(2πx) + 0.14128·cos(4πx) - 0.01168·cos(6πx),  x ∈ [0,1]
```

- nuova static `_blackman_harris(n)`, branch in `_generate`, nome in `available_windows()`;
- i due renderer ora espongono lo **stesso** insieme di 16 finestre; `envelope: all` non fallisce più sotto NumPy.

## TDD

Ciclo rosso→verde. 12 nuovi test in `TestBlackmanHarrisWindow`
(`tests/rendering/test_numpy_window_registry.py`): disponibilità, dtype/lunghezza,
bordi ~0, picco 1.0 al centro, simmetria, non-negatività, `<= 1.0`, più stretta
di `blackman`, caching. Fase RED riproduce esattamente l'errore segnalato.

**Test gate:** `make tests` → **4465 passed, 2 skipped, 69 deselected**.

## Impatto cross-repo

- **PGE-ui**: già offre `blackman_harris` nel selettore; con questo fix funziona sotto NumPy. Nessuna modifica necessaria (la PR di rimozione provvisoria #88 viene chiusa).
- **PGE-ls**: `blackman_harris` era già un nome valido a livello di engine (registry Csound + `docs/reference/yaml.md`); nessun cambiamento al vocabolario YAML pubblico. Nessuna modifica necessaria.

Nessuna modifica a YAML/CLI/formati/errori.

https://claude.ai/code/session_01A4eqfjJpx6QHBBwaWPDXzF

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4eqfjJpx6QHBBwaWPDXzF)_