### PR TITLE
feat(dephase): per-param tratta le chiavi assenti/null come range-only

### DIFF
--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -9,7 +9,7 @@ sources:
   - src/strategies/
   - src/envelopes/
   - src/shared/seeding.py
-last_synced_commit: 836a236
+last_synced_commit: 2caa8a7
 entry_for: [yaml-syntax, envelope-syntax]
 ---
 
@@ -407,6 +407,25 @@ dephase:
 dephase:
   volume: [[0, 0], [30, 80]]
   pan: 50
+```
+
+> **Default in modalità per-parametro.** Una chiave **assente** dal dict — o
+> impostata esplicitamente a **`null`** — non viene dephased: si comporta come
+> `dephase: false` per quel parametro (*range-only*). Il suo `_range` esplicito,
+> se presente, resta **sempre attivo** (100% dei grani); senza `_range` non c'è
+> nessuna variazione (niente jitter implicito). Quindi nel dict per-parametro
+> dichiari **solo** i parametri di cui vuoi *ridurre* la probabilità: gli altri
+> applicano il loro range a piena ampiezza. Per ottenere l'1% implicito su un
+> singolo parametro, scrivilo esplicito (es. `pan: 1`).
+>
+> Differisce dalla modalità **globale** (`dephase: 50`), dove un'unica
+> probabilità vale per tutti i parametri indistintamente.
+
+```yaml
+# Solo 'volume' ridotto al 30%. pan/duration/pitch/pointer/reverse/envelope:
+# se hanno un _range dichiarato lo applicano al 100%, altrimenti restano fermi.
+dephase:
+  volume: 30
 ```
 
 ### Detune implicito del pitch (senza `range`)

--- a/src/parameters/gate_factory.py
+++ b/src/parameters/gate_factory.py
@@ -71,7 +71,7 @@ class GateFactory:
         mode = GateFactory._classify_dephase(dephase)
         # Logica basata sullo stato
         if mode == DephaseMode.DISABLED:
-            return AlwaysGate() if has_explicit_range else NeverGate()
+            return GateFactory._range_only_gate(has_explicit_range)
         elif mode == DephaseMode.IMPLICIT:
             return GateFactory._create_probability_gate(default_prob)
         elif mode == DephaseMode.GLOBAL:
@@ -81,10 +81,16 @@ class GateFactory:
             envelope = create_scaled_envelope(dephase, duration, time_mode)
             return EnvelopeGate(envelope)
         elif mode == DephaseMode.SPECIFIC:
+            # Chiave assente o null: il parametro non è dephased esplicitamente e
+            # segue la semantica range-only (come dephase:false). Il range
+            # esplicito, se presente, resta sempre attivo; senza range nessuna
+            # variazione. Così in per-param si riduce la probabilità solo sui
+            # parametri dichiarati, gli altri mantengono il range a piena
+            # applicazione senza jitter implicito a sorpresa.
             if param_key in dephase:
                 raw_value = dephase[param_key]
                 if raw_value is None:
-                    return GateFactory._create_probability_gate(default_prob)
+                    return GateFactory._range_only_gate(has_explicit_range)
                 elif GateFactory._is_envelope_like(raw_value):
                     # Valore envelope per questo parametro specifico
                     envelope = create_scaled_envelope(raw_value, duration, time_mode)
@@ -92,8 +98,20 @@ class GateFactory:
                 else:
                     return GateFactory._parse_raw_value(raw_value, duration, time_mode)
             else:
-                return GateFactory._create_probability_gate(default_prob)        
+                return GateFactory._range_only_gate(has_explicit_range)
         return NeverGate()
+
+    @staticmethod
+    def _range_only_gate(has_explicit_range: bool) -> ProbabilityGate:
+        """Semantica 'range-only' (come dephase:false / DephaseMode.DISABLED).
+
+        Il parametro non viene dephased: se ha un range esplicito lo applica
+        sempre (AlwaysGate), altrimenti nessuna variazione (NeverGate). Riusata
+        in modalità SPECIFIC per le chiavi assenti o null, così i parametri non
+        dichiarati nel dict per-param mantengono il loro range a piena
+        applicazione senza introdurre jitter implicito.
+        """
+        return AlwaysGate() if has_explicit_range else NeverGate()
 
     @staticmethod
     def _create_probability_gate(probability: float) -> ProbabilityGate:

--- a/tests/controllers/test_window_controller.py
+++ b/tests/controllers/test_window_controller.py
@@ -389,14 +389,16 @@ class TestWindowControllerGateCreation:
         assert isinstance(ctrl._gate, RandomGate)
         assert ctrl._gate.get_probability_value(0.0) == 80.0
 
-    def test_dephase_specific_key_missing_uses_default_prob(self):
+    def test_dephase_specific_key_missing_is_range_only(self):
+        """Chiave 'pc_rand_envelope' assente dal dict per-param: il gate finestra
+        segue la semantica range-only (come dephase:false). Con più finestre
+        (has_explicit_range=True) → AlwaysGate, non più il default 1%."""
         config = make_config(dephase={'altro_parametro': 80.0})
         ctrl = WindowController(
             {'envelope': ['hanning', 'expodec']},
             config=config
         )
-        assert isinstance(ctrl._gate, RandomGate)
-        assert ctrl._gate.get_probability_value(0.0) == DEFAULT_PROB
+        assert isinstance(ctrl._gate, AlwaysGate)
 
     def test_single_element_list_behaves_like_string(self, config_dephase_disabled):
         ctrl = WindowController({'envelope': ['hanning']}, config=config_dephase_disabled)

--- a/tests/parameters/test_gate_factory.py
+++ b/tests/parameters/test_gate_factory.py
@@ -494,40 +494,65 @@ class TestCreateGateSpecific:
         )
         assert isinstance(gate, AlwaysGate)
 
-    def test_specific_key_found_none_uses_default(self):
-        """Chiave trovata con valore None → usa default_prob."""
+    def test_specific_key_none_with_range_returns_always(self):
+        """Chiave presente con valore None: trattata come assente → semantica
+        range-only (come dephase:false). Con range esplicito → AlwaysGate."""
         gate = GateFactory.create_gate(
             dephase={"freq": None},
             param_key="freq",
-            default_prob=60.0,
-            has_explicit_range=False,
+            default_prob=60.0,        # ignorato in SPECIFIC
+            has_explicit_range=True,
             range_always_active=False
         )
-        assert isinstance(gate, RandomGate)
-        assert gate.get_probability_value(0.0) == 60.0
+        assert isinstance(gate, AlwaysGate)
 
-    def test_specific_key_not_found_uses_default(self):
-        """Chiave non trovata → usa default_prob."""
+    def test_specific_key_none_without_range_returns_never(self):
+        """Chiave None senza range esplicito → NeverGate (nessun jitter implicito)."""
         gate = GateFactory.create_gate(
-            dephase={"dur": 50},
-            param_key="freq",     # "freq" non è nel dict
-            default_prob=75.0,
-            has_explicit_range=False,
-            range_always_active=False
-        )
-        assert isinstance(gate, RandomGate)
-        assert gate.get_probability_value(0.0) == 75.0
-
-    def test_specific_key_not_found_default_zero(self):
-        """Chiave non trovata + default_prob=0 → NeverGate."""
-        gate = GateFactory.create_gate(
-            dephase={"dur": 50},
+            dephase={"freq": None},
             param_key="freq",
-            default_prob=0.0,
+            default_prob=60.0,        # ignorato in SPECIFIC
             has_explicit_range=False,
             range_always_active=False
         )
         assert isinstance(gate, NeverGate)
+
+    def test_specific_key_not_found_with_range_returns_always(self):
+        """Chiave non elencata + range esplicito → AlwaysGate (range pieno).
+        I parametri non dichiarati nel dict per-param si comportano come
+        dephase:false: riduci la probabilità solo dove la dichiari."""
+        gate = GateFactory.create_gate(
+            dephase={"dur": 50},
+            param_key="freq",     # "freq" non è nel dict
+            default_prob=75.0,    # ignorato in SPECIFIC
+            has_explicit_range=True,
+            range_always_active=False
+        )
+        assert isinstance(gate, AlwaysGate)
+
+    def test_specific_key_not_found_without_range_returns_never(self):
+        """Chiave non elencata senza range → NeverGate: nessun jitter a sorpresa
+        sui parametri mai dichiarati."""
+        gate = GateFactory.create_gate(
+            dephase={"dur": 50},
+            param_key="freq",
+            default_prob=75.0,    # ignorato in SPECIFIC
+            has_explicit_range=False,
+            range_always_active=False
+        )
+        assert isinstance(gate, NeverGate)
+
+    def test_specific_default_prob_ignored_for_missing_keys(self):
+        """In SPECIFIC il default_prob non viene più usato per le chiavi assenti:
+        conta solo has_explicit_range (semantica range-only)."""
+        common = dict(dephase={"dur": 50}, param_key="freq",
+                      range_always_active=False)
+        with_range = GateFactory.create_gate(default_prob=99.0,
+                                              has_explicit_range=True, **common)
+        without_range = GateFactory.create_gate(default_prob=99.0,
+                                                 has_explicit_range=False, **common)
+        assert isinstance(with_range, AlwaysGate)
+        assert isinstance(without_range, NeverGate)
 
     def test_specific_key_envelope_value(self):
         """Chiave con valore envelope → EnvelopeGate (con Envelope reale)."""
@@ -547,17 +572,27 @@ class TestCreateGateSpecific:
         assert gate.get_probability_value(0.0) == pytest.approx(0.0)
         assert gate.get_probability_value(1.0) == pytest.approx(100.0)
 
-    def test_specific_empty_dict_uses_default(self):
-        """Dict vuoto → chiave non trovata → usa default_prob."""
+    def test_specific_empty_dict_with_range_returns_always(self):
+        """Dict vuoto → tutte le chiavi assenti. Con range esplicito → AlwaysGate."""
         gate = GateFactory.create_gate(
             dephase={},
             param_key="freq",
-            default_prob=50.0,
+            default_prob=50.0,        # ignorato in SPECIFIC
+            has_explicit_range=True,
+            range_always_active=False
+        )
+        assert isinstance(gate, AlwaysGate)
+
+    def test_specific_empty_dict_without_range_returns_never(self):
+        """Dict vuoto senza range → NeverGate (equivale a dephase:false)."""
+        gate = GateFactory.create_gate(
+            dephase={},
+            param_key="freq",
+            default_prob=50.0,        # ignorato in SPECIFIC
             has_explicit_range=False,
             range_always_active=False
         )
-        assert isinstance(gate, RandomGate)
-        assert gate.get_probability_value(0.0) == 50.0
+        assert isinstance(gate, NeverGate)
 
 
 # =============================================================================
@@ -887,14 +922,17 @@ class TestGateFactoryIntegration:
             assert gate.get_probability_value(0.0) == 50.0
 
     def test_workflow_specific_dephase_per_param(self):
-        """Scenario: dephase specifico per ogni parametro."""
+        """Scenario: dephase specifico per ogni parametro.
+        Le chiavi elencate usano il loro valore; quelle assenti o null seguono
+        la semantica range-only (come dephase:false): qui has_explicit_range=True
+        per tutte → AlwaysGate, niente jitter implicito."""
         dephase_config = {
             "freq": 90,
             "dur": 30,
-            "amp": None,    # Usa default
-            # "pan" non definito → usa default
+            "amp": None,    # null → range-only (range esplicito → Always)
+            # "pan" non definito → range-only (range esplicito → Always)
         }
-        
+
         gate_freq = GateFactory.create_gate(
             dephase=dephase_config, param_key="freq",
             default_prob=50.0, has_explicit_range=True,
@@ -916,10 +954,12 @@ class TestGateFactoryIntegration:
             range_always_active=False, duration=10.0, time_mode='absolute'
         )
         
+        assert isinstance(gate_freq, RandomGate)
         assert gate_freq.get_probability_value(0.0) == 90.0
+        assert isinstance(gate_dur, RandomGate)
         assert gate_dur.get_probability_value(0.0) == 30.0
-        assert gate_amp.get_probability_value(0.0) == 50.0   # default
-        assert gate_pan.get_probability_value(0.0) == 50.0   # default (chiave mancante)
+        assert isinstance(gate_amp, AlwaysGate)   # null + range esplicito → range pieno
+        assert isinstance(gate_pan, AlwaysGate)   # chiave assente + range esplicito → range pieno
 
     def test_workflow_range_always_active_overrides(self):
         """Scenario: range_always_active=None bypassa tutta la logica dephase."""


### PR DESCRIPTION
## Sommario

In modalità dephase **per-parametro**, un parametro **non elencato** nel dict (o con valore `null`) non viene più dephased all'1% implicito: ora segue la semantica di `dephase: false` (*range-only*). Il suo `_range` esplicito, se presente, resta **sempre attivo** (100% dei grani); senza `_range` nessuna variazione (niente jitter implicito).

Così nel dict per-parametro si dichiarano **solo** i parametri di cui ridurre la probabilità; gli altri applicano il loro range a piena ampiezza.

Modalità `implicit` (`dephase: null`) e `global` (numero/envelope) **invariate**.

## Modifiche

- `GateFactory`: nuovo helper `_range_only_gate(has_explicit_range)`, riusato dal ramo `DISABLED` e dalle chiavi assenti/`null` nel ramo `SPECIFIC`.
- Test `test_gate_factory.py` e `test_window_controller.py` aggiornati (TDD rosso→verde).
- Doc `docs/reference/yaml.md`, sezione Dephase.

## Verifica

- `make tests`: 4468 passed, 2 skipped, nessuna regressione.
- `make docs-lint`: OK.

## ⚠️ Breaking change

I config per-param che si affidavano al default 1% sui parametri non elencati cambiano resa. Per l'1% esplicito su un parametro, scrivere il valore (es. `pan: 1`). Inoltre uno stream con più finestre (`grain.envelope` lista) e per-param senza chiave `envelope` ora cambia finestra al 100% dei grani (prima 1%), coerente con ciò che `dephase: false` già fa per multi-finestra.

## Impatto cross-repo

- **PGE-ui**: la classificazione e il round-trip non cambiano; aggiornamento UX separato per indicare che i parametri non elencati sono "range pieni".
- **PGE-ls**: impatto su hover/validazione della semantica per-param (fuori dallo scope di accesso di questa sessione).

https://claude.ai/code/session_013GShkr9waV3vYUVtGsHCJT

---
_Generated by [Claude Code](https://claude.ai/code/session_013GShkr9waV3vYUVtGsHCJT)_