### PR TITLE
Rimuovi bordi dai poligoni dei grain nella visualizzazione

### DIFF
--- a/src/rendering/score_visualizer.py
+++ b/src/rendering/score_visualizer.py
@@ -799,8 +799,7 @@ class ScoreVisualizer:
         collection = PatchCollection(
             polygons,
             facecolors=colors,
-            edgecolors='black',
-            linewidths=0.02,
+            edgecolors='none',
             clip_on=True,
             zorder=2
         )


### PR DESCRIPTION
## Riepilogo

Semplifica la resa visiva dei grain nella visualizzazione dello score rimuovendo i bordi neri dai poligoni e disabilitando il rendering degli edge.

## Modifiche principali

- Cambia `edgecolors` da `'black'` a `'none'` nella `PatchCollection` dei grain
- Rimuove il parametro `linewidths=0.02` che definiva lo spessore dei bordi

## Dettagli implementativi

La modifica interessa il metodo `_draw_grains_full()` in `src/rendering/score_visualizer.py`. Disabilitando completamente i bordi (`edgecolors='none'`), si ottiene una visualizzazione più pulita dei grain senza la distrazione visiva dei contorni neri. Questo migliora la leggibilità della rappresentazione grafica, soprattutto quando i grain sono densamente impacchettati.

Il parametro `linewidths` diventa irrilevante una volta che `edgecolors='none'`, quindi viene rimosso per mantenere il codice pulito.

https://claude.ai/code/session_01Y8khVneuV5CPG8HMvsirpM