### PR TITLE
Revert: ripristina il bordo nero dei grani nel PDF

### DIFF
--- a/src/rendering/score_visualizer.py
+++ b/src/rendering/score_visualizer.py
@@ -799,7 +799,8 @@ class ScoreVisualizer:
         collection = PatchCollection(
             polygons,
             facecolors=colors,
-            edgecolors='none',
+            edgecolors='black',
+            linewidths=0.02,
             clip_on=True,
             zorder=2
         )


### PR DESCRIPTION
Revert della PR #128.

Ripristina `edgecolors='black'` e `linewidths=0.02` nel `PatchCollection` dei grani in `src/rendering/score_visualizer.py`, riportando il rendering del PDF allo stato precedente alla #128 su richiesta dell'utente.

`make tests` verde (4468 passed, 2 skipped).

https://claude.ai/code/session_01Y8khVneuV5CPG8HMvsirpM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y8khVneuV5CPG8HMvsirpM)_