### PR TITLE
Hide redundant y-axis labels on grain subplots

### DIFF
--- a/src/rendering/score_visualizer.py
+++ b/src/rendering/score_visualizer.py
@@ -624,7 +624,11 @@ class ScoreVisualizer:
             ax_grain.set_xlim(page_start, page_end)
             ax_grain.set_ylim(-0.02, sample_duration+0.02)
             ax_grain.set_ylabel("")  # label già nella waveform
-            ax_grain.tick_params(axis='y', labelsize=self.config['label_fontsize'] - 1)
+            # L'asse del tempo del buffer e' descritto una sola volta, sulla
+            # waveform a sinistra. Il subplot dei grani condivide lo stesso ylim
+            # ma non ripete le etichette y (ridondanti): restano solo le tacche
+            # di griglia, niente testo.
+            ax_grain.tick_params(axis='y', labelleft=False, length=0)
             ax_grain.grid(True, alpha=0.3, linestyle='--')
             
             # X label solo sull'ultimo stream (se non ci sono envelope)

--- a/tests/rendering/test_score_visualizer.py
+++ b/tests/rendering/test_score_visualizer.py
@@ -1602,3 +1602,58 @@ class TestEnvelopeStreamWidthAlignment:
         assert cbar_axes  # almeno una colorbar disegnata
         for cax in cbar_axes:
             assert cax.get_position().x0 >= content_x1 - 1e-6
+
+
+# =============================================================================
+# GROUP - Asse tempo del buffer mostrato una sola volta (a sinistra del buffer)
+# =============================================================================
+
+class TestSingleBufferTimeAxis:
+    """L'asse temporale del buffer (ordinata in secondi del sample) deve
+    comparire una sola volta, sull'asse waveform a sinistra del buffer. Il
+    subplot dei grani condivide lo stesso ylim ma NON deve ripetere le
+    etichette y: pre-fix le stampava una seconda volta, ridondante e visivamente
+    confusa."""
+
+    def _render(self):
+        viz = make_viz(single_stream_scene(), config={'page_duration': 30.0})
+        with patch('soundfile.read', return_value=(FAKE_AUDIO, SR)):
+            viz.analyze()
+            fig = viz.render_page(0)
+        fig.canvas.draw()  # finalizza tick e visibilita' delle etichette
+        return fig
+
+    @staticmethod
+    def _wave_axes(fig):
+        return [ax for ax in fig.axes
+                if ax.get_ylabel().startswith('Sample (s)')]
+
+    @staticmethod
+    def _grain_axes(fig, page_start=0.0, page_end=30.0):
+        """Subplot grani: xlim == pagina e ylim != (0,1) (esclude l'envelope)."""
+        out = []
+        for ax in fig.axes:
+            lo, hi = ax.get_xlim()
+            ylo, yhi = ax.get_ylim()
+            same_page = abs(lo - page_start) < 1e-9 and abs(hi - page_end) < 1e-9
+            is_envelope = abs(ylo - 0.0) < 1e-9 and abs(yhi - 1.0) < 1e-9
+            if same_page and not is_envelope:
+                out.append(ax)
+        return out
+
+    def test_waveform_keeps_y_tick_labels(self):
+        """L'asse del buffer resta visibile sulla waveform (l'unica descrizione)."""
+        fig = self._render()
+        wave_axes = self._wave_axes(fig)
+        assert wave_axes
+        for ax in wave_axes:
+            assert any(t.get_visible() and t.get_text()
+                       for t in ax.get_yticklabels())
+
+    def test_grain_subplot_hides_y_tick_labels(self):
+        """Il subplot dei grani non ripete le etichette dell'asse del buffer."""
+        fig = self._render()
+        grain_axes = self._grain_axes(fig)
+        assert grain_axes
+        for ax in grain_axes:
+            assert all(not t.get_visible() for t in ax.get_yticklabels())


### PR DESCRIPTION
## Summary

Removes redundant y-axis tick labels from grain subplots while preserving them on the waveform axis. The buffer time axis (sample duration in seconds) now appears only once, on the left waveform subplot, eliminating visual confusion from duplicate labels.

## Changes

- **src/rendering/score_visualizer.py**: Modified grain subplot tick parameters to hide y-axis labels (`labelleft=False`) and remove tick marks (`length=0`). The subplot retains the same y-limits as the waveform for alignment but no longer repeats the time axis description. Grid lines remain visible for reference.

- **tests/rendering/test_score_visualizer.py**: Added `TestSingleBufferTimeAxis` test class with two test methods:
  - `test_waveform_keeps_y_tick_labels`: Verifies that waveform axes retain visible y-axis labels
  - `test_grain_subplot_hides_y_tick_labels`: Verifies that grain subplots hide all y-axis tick labels

## Implementation Details

The change preserves the shared y-limits between waveform and grain subplots (necessary for visual alignment) while using matplotlib's `tick_params` to suppress label rendering on grain axes only. This maintains grid alignment without redundant text, improving readability of the visualization.

https://claude.ai/code/session_01W2o1GSzjg9NKV9fzEkvbdo