### PR TITLE
Partitura: colormap pitch divergente, contorno grani, label asse Y

### DIFF
--- a/src/rendering/score_visualizer.py
+++ b/src/rendering/score_visualizer.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 from matplotlib.cm import ScalarMappable
 from matplotlib.collections import PatchCollection
-from matplotlib.colors import Normalize
+from matplotlib.colors import Normalize, Colormap, LinearSegmentedColormap
 from matplotlib.backends.backend_pdf import PdfPages
 import numpy as np
 import soundfile as sf
@@ -17,6 +17,32 @@ from math import ceil
 
 # Path samples (stesso del progetto)
 PATHSAMPLES = './refs/'
+
+# Colormap divergente per il pitch dei grani. Il pitch in cents e' una grandezza
+# con segno centrata sullo zero (nessun detune = 0 cents): serve una mappa
+# divergente con punto neutro al centro, non una sequenziale come turbo.
+#   - centro (0 cents): grigio medio #777777 — NON bianco, perche' lo sfondo del
+#     plot e' bianco e un grano neutro col centro bianco sparirebbe;
+#   - braccio freddo (detune negativo): indaco -> blu;
+#   - braccio caldo (detune positivo): arancio -> giallo.
+# Bracci a due tinte (non un solo blu/rosso secco) per dare piu' gradazione
+# cromatica all'escursione, mantenendo la lettura intuitiva freddo=cala /
+# caldo=sale. L'autozoom (pitch_color_autozoom) riscala questa mappa
+# sull'escursione reale dei cents: la normalizzazione resta invariata, cambia
+# solo la mappa di colore.
+PITCH_DIVERGING = LinearSegmentedColormap.from_list(
+    'pitch_div', ['#3b1f8b', '#3a8fd6', '#777777', '#f08c00', '#f2d024']
+)
+
+# Registrazione con guardia: idempotente anche su re-import del modulo.
+try:
+    plt.get_cmap('pitch_div')
+except (ValueError, KeyError):
+    try:
+        import matplotlib as mpl
+        mpl.colormaps.register(PITCH_DIVERGING)
+    except (AttributeError, ImportError):
+        plt.register_cmap(cmap=PITCH_DIVERGING)
 
 # Colori di default degli envelope. A livello modulo perche' le sue chiavi
 # sono l'universo dei nomi plottabili: main.py le usa per validare
@@ -104,7 +130,7 @@ class ScoreVisualizer:
             'margins_mm': 20,
             
             # Grani
-            'grain_colormap': 'turbo',       # pitch_ratio → colore
+            'grain_colormap': 'pitch_div',   # pitch_ratio → colore (divergente)
             'grain_alpha_range': (0.3, 1.0), # volume → alpha
             'pitch_range': (0.5, 2.0),       # range fisso (fallback senza autozoom)
             # Auto-zoom del range colore pitch: normalizza sul min/max in cents
@@ -206,8 +232,10 @@ class ScoreVisualizer:
         self.page_count = None
         self.page_layouts = []
         
-        # Colormap
-        self.cmap = plt.get_cmap(self.config['grain_colormap'])
+        # Colormap. grain_colormap accetta sia una stringa (nome registrato,
+        # incluso 'pitch_div') sia un oggetto Colormap gia' costruito.
+        cmap_cfg = self.config['grain_colormap']
+        self.cmap = cmap_cfg if isinstance(cmap_cfg, Colormap) else plt.get_cmap(cmap_cfg)
     
     # =========================================================================
     # ANALISI STRUTTURA
@@ -613,7 +641,7 @@ class ScoreVisualizer:
             # Configura assi waveform
             ax_wave.set_ylim(-0.02, sample_duration+0.02)
             ax_wave.set_xlim(-1.1, 1.1)
-            ax_wave.set_ylabel(f"Sample (s)\n{sample_path}", 
+            ax_wave.set_ylabel(f"Posizione di lettura (s)\n{sample_path}",
                             fontsize=self.config['label_fontsize'])
             ax_wave.set_xticks([])
             ax_wave.tick_params(axis='y', labelsize=self.config['label_fontsize'] - 1)
@@ -800,11 +828,15 @@ class ScoreVisualizer:
             colors.append(color)
         
         # Collection
+        # Contorno sottile per ogni grano: i grani prossimi al neutro (grigio
+        # chiaro della mappa divergente) restano leggibili come forme sul fondo
+        # bianco. Solo il bordo cambia: facecolor e alpha (guidato dal volume)
+        # restano invariati.
         collection = PatchCollection(
             polygons,
             facecolors=colors,
-            edgecolors='black',
-            linewidths=0.02,
+            edgecolors='#555555',
+            linewidths=0.3,
             clip_on=True,
             zorder=2
         )

--- a/tests/rendering/test_score_visualizer.py
+++ b/tests/rendering/test_score_visualizer.py
@@ -469,6 +469,15 @@ class TestConfigPropagation:
                        config={'grain_colormap': 'viridis'})
         assert viz.config['grain_colormap'] == 'viridis'
 
+    def test_grain_colormap_accepts_colormap_object(self):
+        """grain_colormap robusto: accetta sia una stringa sia un oggetto
+        Colormap gia' costruito (risoluzione in __init__)."""
+        from matplotlib.colors import LinearSegmentedColormap
+        cmap = LinearSegmentedColormap.from_list('custom', ['#000000', '#ffffff'])
+        viz = make_viz(single_stream_scene(),
+                       config={'grain_colormap': cmap})
+        assert viz.cmap is cmap
+
     def test_custom_pitch_range_accepted(self):
         viz = make_viz(single_stream_scene(),
                        config={'pitch_range': (0.25, 4.0)})
@@ -502,8 +511,8 @@ class TestPerStreamLayout:
 
     @staticmethod
     def _wave_axes(fig):
-        """Assi waveform: uno per subplot/stream (ylabel 'Sample (s)\\n<path>')."""
-        return [ax for ax in fig.axes if ax.get_ylabel().startswith('Sample (s)')]
+        """Assi waveform: uno per subplot/stream (ylabel 'Posizione di lettura (s)\\n<path>')."""
+        return [ax for ax in fig.axes if ax.get_ylabel().startswith('Posizione di lettura (s)')]
 
     def test_two_different_samples_produce_at_least_two_axes(self):
         viz = make_viz(two_sample_scene(), config={'page_duration': 30.0})
@@ -1327,7 +1336,7 @@ class TestEnvelopeFilter:
 
 
 # =============================================================================
-# GROUP - Pitch color auto-zoom (colormap turbo + range dinamico per-subplot)
+# GROUP - Pitch color auto-zoom (colormap divergente pitch_div + range dinamico per-subplot)
 # =============================================================================
 
 class TestPitchColorAutozoom:
@@ -1335,9 +1344,11 @@ class TestPitchColorAutozoom:
     cents dei pitch_ratio visibili nel subplot invece del range fisso
     pitch_range (0.5, 2.0) — rende visibile il micro-detune ±6 cents."""
 
-    def test_default_colormap_is_turbo(self):
+    def test_default_colormap_is_pitch_div(self):
         viz = make_viz([make_stream()])
-        assert viz.config['grain_colormap'] == 'turbo'
+        assert viz.config['grain_colormap'] == 'pitch_div'
+        # 'pitch_div' deve risolversi a una Colormap (registrata a livello modulo)
+        assert viz.cmap.name == 'pitch_div'
 
     def test_default_config_has_pitch_color_autozoom(self):
         viz = make_viz([make_stream()])
@@ -1491,14 +1502,18 @@ class TestPitchColorAutozoom:
         assert np.abs(colors[0][:3] - colors[1][:3]).max() < 0.7
 
     def test_render_page_above_semitone_detune_still_distinct(self):
-        """Uno scarto reale >= 1 semitono (qui 120 cents) supera il floor:
-        i colori restano chiaramente distinti, come prima della modifica."""
+        """Uno scarto reale >= 1 semitono (qui 120 cents) supera il floor: i
+        grani cadono ai due estremi della mappa divergente (braccio freddo
+        indaco/blu vs braccio caldo arancio/giallo) e restano cromaticamente
+        ben distinti. Soglia 0.4: pitch_div ha estremi meno saturi su un singolo
+        canale rispetto alla vecchia turbo, ma la separazione freddo/caldo resta
+        netta e ampiamente sopra il caso micro-detune."""
         viz = make_viz(self._semitone_detuned_scene(), config={'page_duration': 30.0})
         with patch('soundfile.read', return_value=(FAKE_AUDIO, SR)):
             figs = viz.render_all()
         colors = self._grain_facecolors(figs[0])
         assert colors is not None and len(colors) == 2
-        assert np.abs(colors[0][:3] - colors[1][:3]).max() > 0.5
+        assert np.abs(colors[0][:3] - colors[1][:3]).max() > 0.4
 
     def test_render_page_fixed_colors_when_disabled(self):
         """Autozoom off: i due grani a ±6c restano indistinguibili."""
@@ -1626,7 +1641,7 @@ class TestSingleBufferTimeAxis:
     @staticmethod
     def _wave_axes(fig):
         return [ax for ax in fig.axes
-                if ax.get_ylabel().startswith('Sample (s)')]
+                if ax.get_ylabel().startswith('Posizione di lettura (s)')]
 
     @staticmethod
     def _grain_axes(fig, page_start=0.0, page_end=30.0):


### PR DESCRIPTION
Tre modifiche alla mappa/partitura grafica in `src/rendering/score_visualizer.py`.

## 1. Colormap del pitch divergente con centro grigio neutro
Il pitch in cents è una grandezza con segno centrata sullo zero: `turbo` (sequenziale, senza punto neutro) era inadatto. Introdotta a livello di modulo `PITCH_DIVERGING` (registrata con guardia idempotente) e default di `grain_colormap` portato a `'pitch_div'`:

```python
PITCH_DIVERGING = LinearSegmentedColormap.from_list(
    'pitch_div', ['#3b1f8b', '#3a8fd6', '#777777', '#f08c00', '#f2d024']
)
```

- braccio freddo (detune negativo): indaco → blu;
- centro (0 cents, nessun detune): grigio medio `#777777` — **non** bianco, così il grano neutro non sparisce sul fondo bianco del plot;
- braccio caldo (detune positivo): arancio → giallo.

La risoluzione del colormap è resa robusta: `self.cmap` accetta sia una stringa (nome registrato) sia un oggetto `Colormap`. La logica di `pitch_color_autozoom` resta **invariata** — riscala la nuova mappa sull'escursione reale dei cents.

## 2. Contorno dei grani
Aggiunto un contorno sottile alla `PatchCollection` dei grani (`edgecolor='#555555'`, `linewidth=0.3`): i grani prossimi al neutro (grigio) restano leggibili come forme sul fondo bianco. `facecolor` e `alpha` (guidato dal volume) invariati.

## 3. Etichetta asse Y
Da `"Sample (s)"` a `"Posizione di lettura (s)"`, mantenendo il nome del file come seconda riga.

## Test
`tests/rendering/test_score_visualizer.py`:
- `test_default_colormap_is_pitch_div` (ex `_is_turbo`) + verifica `viz.cmap.name`;
- helper `_wave_axes` aggiornati sulla nuova label;
- nuovo `test_grain_colormap_accepts_colormap_object`;
- soglia del caso macro-detune ricalibrata (`0.5 → 0.4`) sulla dinamica della mappa divergente (estremi meno saturi su singolo canale rispetto a turbo, separazione freddo/caldo comunque netta).

`make tests`: 4487 passed, 2 skipped.

## Impatto cross-repo
`pitch_div` è interno al renderer della partitura: nessun cambiamento a schema YAML, bounds, errori, CLI o formati di output. Contorno e label sono puramente visivi. Nessun impatto su PGE-ls / PGE-ui → nessuna issue aperta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013sc23BsqPofHtsrqoaWNU6

---
_Generated by [Claude Code](https://claude.ai/code/session_013sc23BsqPofHtsrqoaWNU6)_