### PR TITLE
DC blocker FIR a fase lineare nel renderer NumPy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Aggiunto
 
+- Renderer NumPy: DC blocker FIR a fase lineare sempre attivo a valle
+  dell'overlap-add (`rendering/dc_blocker.py`). Rimuove l'offset DC che si
+  accumula sommando grani (slice finestrate a media non nulla) sottraendo la
+  media mobile centrata del buffer (`y = x - media_mobile(x)`): null esatto a
+  0 Hz, lunghezza invariata, costo O(n) via somma cumulativa. Cutoff sub-audio
+  di default 20 Hz, applicato sia in STEMS (`render_single_stream`) sia in MIX
+  (`render_merged_streams`). Nessuna modifica a YAML/CLI: l'output audio del
+  renderer NumPy ora è centrato sullo zero.
 - Renderer NumPy: supporto alla finestra grano `blackman_harris` (GEN20 opt 5),
   campana a 4 termini con massima soppressione dei lobi laterali. Colma il gap
   col registry Csound (`WindowRegistry`), che già la definiva: i due renderer ora

--- a/src/rendering/dc_blocker.py
+++ b/src/rendering/dc_blocker.py
@@ -1,0 +1,89 @@
+# src/rendering/dc_blocker.py
+"""
+DC blocker FIR a fase lineare.
+
+Problema: l'overlap-add dei grani somma slice finestrate del materiale
+registrato. Ogni slice ha in generale media non nulla (DC), e la somma di
+molti grani accumula un offset DC lentamente variabile nel mix. Risultato:
+forma d'onda non centrata sullo zero, headroom ridotto, asimmetria.
+
+Soluzione (la piu' diretta): sottrarre la media mobile centrata del segnale,
+
+    y[n] = x[n] - media_mobile(x)[n]
+
+E' un FIR con kernel  h = delta - (1/N) * ones(N): null esatto a 0 Hz
+(H(0) = 1 - 1 = 0), fase lineare (kernel simmetrico, ritardo di gruppo
+intero compensato dalla centratura), lunghezza dell'output invariata.
+
+La media mobile e' calcolata in O(n) via somma cumulativa, non per
+convoluzione: nessun costo proporzionale alla lunghezza del kernel.
+
+La lunghezza N della finestra fissa il cutoff: il low-pass media-mobile ha
+il primo null a fs/N, quindi N ~ fs/cutoff_hz. Trade-off dichiarato: un
+cutoff aggressivo rimuove anche le modulazioni d'ampiezza piu' lente del
+cutoff (inviluppi di grani molto lunghi); il default sub-audio (20 Hz)
+tocca solo il DC e il subsonico, lasciando intatta la banda udibile.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+
+# Cutoff di default (Hz): corner sub-audio, kill di DC e subsonico.
+DEFAULT_CUTOFF_HZ = 20.0
+
+
+def dc_block(signal: np.ndarray, sample_rate: int,
+             cutoff_hz: float = DEFAULT_CUTOFF_HZ) -> np.ndarray:
+    """
+    Rimuove il DC offset da un segnale (mono 1D o multicanale 2D).
+
+    Args:
+        signal: array (n,) mono oppure (n, channels) multicanale
+        sample_rate: frequenza di campionamento in Hz
+        cutoff_hz: cutoff sub-audio del filtro (default 20 Hz)
+
+    Returns:
+        Array float64 stessa shape dell'input, con il DC rimosso.
+    """
+    x = np.asarray(signal, dtype=np.float64)
+    if x.ndim == 1:
+        return _dc_block_1d(x, sample_rate, cutoff_hz)
+
+    out = np.empty_like(x)
+    for ch in range(x.shape[1]):
+        out[:, ch] = _dc_block_1d(x[:, ch], sample_rate, cutoff_hz)
+    return out
+
+
+def _dc_block_1d(x: np.ndarray, sample_rate: int, cutoff_hz: float) -> np.ndarray:
+    """DC blocker su segnale mono 1D."""
+    n = x.shape[0]
+    if n == 0:
+        return x.copy()
+
+    # N dispari -> kernel simmetrico, ritardo di gruppo intero (fase lineare).
+    n_taps = int(round(sample_rate / max(cutoff_hz, 1e-9)))
+    if n_taps % 2 == 0:
+        n_taps += 1
+
+    # Finestra troppo corta o piu' lunga del segnale: fallback brutale alla
+    # sottrazione della media globale (il limite della media mobile che copre
+    # tutto il segnale). Rimuove comunque il DC.
+    if n_taps < 3 or n_taps > n:
+        return x - x.mean()
+
+    return x - _centered_moving_average(x, n_taps)
+
+
+def _centered_moving_average(x: np.ndarray, n_taps: int) -> np.ndarray:
+    """
+    Media mobile centrata di finestra n_taps (dispari), via somma cumulativa.
+
+    Bordi gestiti per replica del campione estremo: riduce il transiente di
+    bordo rispetto allo zero-padding. Output di lunghezza pari all'input.
+    """
+    pad = (n_taps - 1) // 2
+    xp = np.concatenate([np.full(pad, x[0]), x, np.full(pad, x[-1])])
+    cs = np.concatenate([[0.0], np.cumsum(xp)])
+    return (cs[n_taps:] - cs[:-n_taps]) / n_taps

--- a/src/rendering/numpy_audio_renderer.py
+++ b/src/rendering/numpy_audio_renderer.py
@@ -26,6 +26,7 @@ from rendering.audio_renderer import AudioRenderer
 from rendering.grain_renderer import GrainRenderer
 from rendering.sample_registry import SampleRegistry
 from rendering.numpy_window_registry import NumpyWindowRegistry
+from rendering.dc_blocker import dc_block
 
 
 class NumpyAudioRenderer(AudioRenderer):
@@ -118,7 +119,10 @@ class NumpyAudioRenderer(AudioRenderer):
             for grain in voice_grains:
                 self._add_grain_relative(buffer, grain, stream.onset)
 
-        # 3. Clamp + scrivi
+        # 3. DC blocker FIR: rimuove l'offset DC accumulato dall'overlap-add
+        buffer = dc_block(buffer, self.output_sr)
+
+        # 4. Clamp + scrivi
         np.clip(buffer, -1.0, 1.0, out=buffer)
         sf.write(output_path, buffer, self.output_sr,
                  format=self.audio_format.sf_format,
@@ -167,7 +171,10 @@ class NumpyAudioRenderer(AudioRenderer):
                 for grain in voice_grains:
                     self._add_grain_absolute(buffer, grain)
 
-        # 3. Clamp + scrivi
+        # 3. DC blocker FIR: rimuove l'offset DC accumulato dall'overlap-add
+        buffer = dc_block(buffer, self.output_sr)
+
+        # 4. Clamp + scrivi
         np.clip(buffer, -1.0, 1.0, out=buffer)
         sf.write(output_path, buffer, self.output_sr,
                  format=self.audio_format.sf_format,

--- a/tests/rendering/test_dc_blocker.py
+++ b/tests/rendering/test_dc_blocker.py
@@ -1,0 +1,144 @@
+# tests/rendering/test_dc_blocker.py
+"""
+TDD suite per dc_blocker.
+
+dc_block() e' un DC blocker FIR a fase lineare: sottrae la media mobile
+centrata del segnale (y[n] = x[n] - media_mobile(x)). Ha un null esatto a
+0 Hz, preserva la banda audio sopra il cutoff e non altera la lunghezza del
+segnale ('same'-length).
+
+Viene applicato a valle dell'overlap-add NumPy per rimuovere il DC offset
+che si accumula sommando grani (slice finestrate a media non nulla).
+
+Coverage:
+1. TestDcRemoval        - rimozione offset costante e DC puro
+2. TestBandPreserved    - la banda audio sopra il cutoff sopravvive
+3. TestShapeAndDtype    - lunghezza e canali invariati
+4. TestStereo           - canali processati indipendentemente
+5. TestEdgeCases        - segnali vuoti, corti, silenzio
+"""
+
+import numpy as np
+import pytest
+
+from rendering.dc_blocker import dc_block, DEFAULT_CUTOFF_HZ
+
+
+SR = 48000
+
+
+def _sine(freq, dur, sr=SR, dc=0.0, amp=1.0):
+    t = np.arange(int(dur * sr)) / sr
+    return amp * np.sin(2 * np.pi * freq * t) + dc
+
+
+# =============================================================================
+# 1. RIMOZIONE DC
+# =============================================================================
+
+class TestDcRemoval:
+    def test_removes_constant_offset(self):
+        """Un seno con offset +0.5: la media dell'output e' ~0."""
+        x = _sine(440, 1.0, dc=0.5)
+        y = dc_block(x, SR)
+        # interno, lontano dai bordi (pad ~ sr/cutoff/2)
+        interior = y[SR // 4: -SR // 4]
+        assert abs(interior.mean()) < 1e-3
+
+    def test_pure_dc_becomes_zero(self):
+        """Segnale costante (DC puro) -> ~0."""
+        x = np.full(SR, 0.7)
+        y = dc_block(x, SR)
+        interior = y[SR // 4: -SR // 4]
+        assert np.max(np.abs(interior)) < 1e-6
+
+    def test_negative_offset_removed(self):
+        """Offset negativo rimosso allo stesso modo."""
+        x = _sine(300, 1.0, dc=-0.3)
+        y = dc_block(x, SR)
+        interior = y[SR // 4: -SR // 4]
+        assert abs(interior.mean()) < 1e-3
+
+
+# =============================================================================
+# 2. BANDA AUDIO PRESERVATA
+# =============================================================================
+
+class TestBandPreserved:
+    def test_audio_tone_survives(self):
+        """Un tono a 440 Hz (senza DC) passa quasi inalterato."""
+        x = _sine(440, 1.0, dc=0.0)
+        y = dc_block(x, SR)
+        interior_x = x[SR // 4: -SR // 4]
+        interior_y = y[SR // 4: -SR // 4]
+        ratio = np.sum(interior_y ** 2) / np.sum(interior_x ** 2)
+        assert 0.9 < ratio < 1.1
+
+    def test_does_not_amplify(self):
+        """L'output non amplifica il picco del segnale."""
+        x = _sine(1000, 1.0, dc=0.2)
+        y = dc_block(x, SR)
+        assert np.max(np.abs(y)) <= np.max(np.abs(x)) + 1e-9
+
+
+# =============================================================================
+# 3. SHAPE E DTYPE
+# =============================================================================
+
+class TestShapeAndDtype:
+    def test_length_preserved_1d(self):
+        x = _sine(440, 0.5, dc=0.5)
+        y = dc_block(x, SR)
+        assert y.shape == x.shape
+
+    def test_length_preserved_2d(self):
+        x = np.stack([_sine(440, 0.5, dc=0.5), _sine(660, 0.5, dc=-0.4)], axis=1)
+        y = dc_block(x, SR)
+        assert y.shape == x.shape
+
+    def test_returns_float(self):
+        x = _sine(440, 0.2, dc=0.5)
+        y = dc_block(x, SR)
+        assert np.issubdtype(y.dtype, np.floating)
+
+
+# =============================================================================
+# 4. STEREO
+# =============================================================================
+
+class TestStereo:
+    def test_channels_independent(self):
+        """Canali con DC diverso: entrambi azzerati indipendentemente."""
+        left = _sine(440, 1.0, dc=0.5)
+        right = _sine(440, 1.0, dc=-0.6)
+        x = np.stack([left, right], axis=1)
+        y = dc_block(x, SR)
+        interior = y[SR // 4: -SR // 4]
+        assert abs(interior[:, 0].mean()) < 1e-3
+        assert abs(interior[:, 1].mean()) < 1e-3
+
+
+# =============================================================================
+# 5. EDGE CASES
+# =============================================================================
+
+class TestEdgeCases:
+    def test_empty_signal(self):
+        x = np.zeros(0)
+        y = dc_block(x, SR)
+        assert y.shape == (0,)
+
+    def test_silence_stays_silence(self):
+        x = np.zeros(SR)
+        y = dc_block(x, SR)
+        assert np.max(np.abs(y)) < 1e-12
+
+    def test_short_signal_falls_back_to_mean(self):
+        """Segnale piu' corto della finestra: fallback a sottrazione media."""
+        x = np.full(10, 0.5)
+        y = dc_block(x, SR)
+        assert np.max(np.abs(y)) < 1e-9
+
+    def test_default_cutoff_is_subsonic(self):
+        """Il cutoff di default e' nel range sub-audio."""
+        assert 1.0 <= DEFAULT_CUTOFF_HZ <= 30.0

--- a/tests/rendering/test_numpy_audio_renderer.py
+++ b/tests/rendering/test_numpy_audio_renderer.py
@@ -61,6 +61,20 @@ def make_sample_registry():
     return reg
 
 
+def make_dc_sample_registry():
+    """SampleRegistry con un sample a DC offset forte (+0.5) + tono 300 Hz."""
+    reg = SampleRegistry.__new__(SampleRegistry)
+    reg.base_path = './refs/'
+    reg._cache = {}
+
+    sr = OUTPUT_SR
+    n = sr * 2
+    t = np.arange(n) / sr
+    audio = (0.5 + 0.3 * np.sin(2 * np.pi * 300 * t)).astype(np.float32)
+    reg._cache['piano.wav'] = (audio, sr)
+    return reg
+
+
 def make_table_map():
     """Mapping table_num -> (type, name) come FtableManager.tables."""
     return {
@@ -736,6 +750,68 @@ class TestPassthroughBufferSizing:
 
         actual_duration = len(data) / sr
         assert abs(actual_duration - 0.4) < 1e-3
+
+
+class TestDcBlockerAlwaysOn:
+    """
+    Il DC blocker FIR e' sempre attivo a valle dell'overlap-add: l'offset DC
+    accumulato sommando grani a media non nulla viene rimosso. Si applica sia
+    a render_single_stream (STEMS) sia a render_merged_streams (MIX).
+    """
+
+    def _dc_renderer(self, window_registry, table_map):
+        return NumpyAudioRenderer(
+            sample_registry=make_dc_sample_registry(),
+            window_registry=window_registry,
+            table_map=table_map,
+            output_sr=OUTPUT_SR,
+        )
+
+    def _dense_grains(self):
+        # Grani corti densi (hop 10ms, durata 20ms) che coprono ~0-0.5s:
+        # l'overlap-add di slice a media positiva crea un DC sostenuto.
+        return [
+            make_grain(onset=i * 0.01, duration=0.02, pointer_pos=0.5)
+            for i in range(50)
+        ]
+
+    def test_single_stream_dc_removed(self, window_registry, table_map, tmp_path):
+        import soundfile as sf
+        r = self._dc_renderer(window_registry, table_map)
+        stream = make_mock_stream(duration=0.6, grains=self._dense_grains())
+        output_path = str(tmp_path / 'dc_single.aif')
+        r.render_single_stream(stream, output_path)
+
+        data, sr = sf.read(output_path)
+        interior = data[int(0.15 * sr):int(0.4 * sr)]
+        peak = np.max(np.abs(interior))
+        assert peak > 0.05, "il segnale deve avere contenuto (tono 300 Hz)"
+        # media interna ~0 -> DC rimosso (senza filtro sarebbe ~ +0.5*gain)
+        assert abs(interior.mean()) < peak * 0.1
+
+    def test_merged_streams_dc_removed(self, window_registry, table_map, tmp_path):
+        import soundfile as sf
+        r = self._dc_renderer(window_registry, table_map)
+        stream = make_mock_stream(onset=0.0, duration=0.6, grains=self._dense_grains())
+        output_path = str(tmp_path / 'dc_merged.aif')
+        r.render_merged_streams([stream], output_path)
+
+        data, sr = sf.read(output_path)
+        interior = data[int(0.15 * sr):int(0.4 * sr)]
+        peak = np.max(np.abs(interior))
+        assert peak > 0.05
+        assert abs(interior.mean()) < peak * 0.1
+
+    def test_dc_block_invoked_on_buffer(self, renderer, tmp_path):
+        """Wiring: il renderer chiama dc_block sul buffer prima di scrivere."""
+        stream = make_mock_stream(duration=0.3)
+        output_path = str(tmp_path / 'wired.aif')
+        with patch('rendering.numpy_audio_renderer.dc_block',
+                   side_effect=lambda buf, sr: buf) as mock_dc:
+            renderer.render_single_stream(stream, output_path)
+            assert mock_dc.called
+            buf_arg = mock_dc.call_args.args[0]
+            assert buf_arg.shape[1] == 2
 
 
 class TestAddGrainAtPositionSignature:


### PR DESCRIPTION
## Sommario

Aggiunge un DC blocker FIR a fase lineare sempre attivo a valle dell'overlap-add nel renderer NumPy. Rimuove l'offset DC che si accumula sommando grani (slice finestrate a media non nulla) sottraendo la media mobile centrata del buffer.

## Modifiche principali

- **Nuovo modulo `rendering/dc_blocker.py`**: implementa `dc_block()` che sottrae la media mobile centrata (`y = x - media_mobile(x)`) con kernel FIR simmetrico. Null esatto a 0 Hz, lunghezza invariata, costo O(n) via somma cumulativa. Cutoff sub-audio di default 20 Hz (configurabile).

- **Integrazione in `rendering/numpy_audio_renderer.py`**: applica `dc_block()` a valle dell'overlap-add in entrambi i metodi di rendering:
  - `render_single_stream()` (STEMS)
  - `render_merged_streams()` (MIX)
  
  Posizionato prima del clipping finale, dopo l'accumulo dei grani.

- **Suite TDD completa in `tests/rendering/test_dc_blocker.py`**: 144 righe di test che coprono:
  - Rimozione di offset costante e DC puro
  - Preservazione della banda audio sopra il cutoff
  - Invarianza di lunghezza e canali
  - Elaborazione indipendente dei canali stereo
  - Edge case (segnali vuoti, corti, silenzio)

- **Test di integrazione in `tests/rendering/test_numpy_audio_renderer.py`**: verifica che il DC blocker sia effettivamente invocato e che l'output sia centrato sullo zero anche con grani densi a media positiva.

- **CHANGELOG.md**: documentazione della feature.

## Dettagli implementativi

- **Fase lineare**: kernel simmetrico (dispari) garantisce ritardo di gruppo intero, nessuna distorsione di fase.
- **Gestione bordi**: replica del campione estremo per ridurre il transiente rispetto allo zero-padding.
- **Fallback**: se la finestra è troppo corta o più lunga del segnale, sottrae la media globale (limite della media mobile).
- **Multicanale**: elabora ogni canale indipendentemente, preservando la shape dell'input.
- **Nessuna modifica YAML/CLI**: l'output audio del renderer NumPy è ora centrato sullo zero senza configurazione aggiuntiva.

https://claude.ai/code/session_01RuCsEa5ftv3yNKoX57Qk11