### PR TITLE
Cubic envelope with 2 points: force zero tangents for smoothstep

### DIFF
--- a/configs/PGE_cubic_smoothstep_demo.yml
+++ b/configs/PGE_cubic_smoothstep_demo.yml
@@ -1,0 +1,53 @@
+# Demo: cubic a 2 punti -> smoothstep visibile (non piu' retta).
+# Due stream identici tranne il type dell'envelope density:
+#   - stream_cubic:  type cubic  -> S simmetrica ease-in-out
+#   - stream_linear: type linear -> retta (confronto)
+# La differenza e' leggibile nella curva density della partitura grafica.
+
+title: cubic smoothstep demo
+duration: 20
+bpm: 120
+streams:
+  - stream_id: stream_cubic
+    onset: 0
+    duration: 10
+    sample: demo.wav
+    time_mode: normalized
+    distribution_mode: gaussian
+    density:
+      type: cubic
+      points: [[0, 5], [1, 80]]
+    distribution: [[0, 0], [0.5, 1], [1, 0]]
+    grain:
+      duration: [[0, 0.05], [1, 0.05]]
+      duration_range: 0.01
+      envelope: hanning
+    pointer:
+      start: 0
+      speed_ratio: [[0, 0], [1, 1]]
+    pitch:
+      semitones: 0
+    pan: 0
+    volume: -6
+
+  - stream_id: stream_linear
+    onset: 0
+    duration: 10
+    sample: demo.wav
+    time_mode: normalized
+    distribution_mode: gaussian
+    density:
+      type: linear
+      points: [[0, 5], [1, 80]]
+    distribution: [[0, 0], [0.5, 1], [1, 0]]
+    grain:
+      duration: [[0, 0.05], [1, 0.05]]
+      duration_range: 0.01
+      envelope: hanning
+    pointer:
+      start: 0
+      speed_ratio: [[0, 0], [1, 1]]
+    pitch:
+      semitones: 0
+    pan: 0
+    volume: -6

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -9,7 +9,7 @@ sources:
   - src/strategies/
   - src/envelopes/
   - src/shared/seeding.py
-last_synced_commit: 2caa8a7
+last_synced_commit: 79c1a86
 entry_for: [yaml-syntax, envelope-syntax]
 ---
 
@@ -832,6 +832,16 @@ Internamente l'envelope è composto da:
 
 Per cubic, il sistema pre-calcola le tangenti con l'algoritmo Fritsch-Carlson,
 che garantisce monotonia e previene overshoot tra breakpoint adiacenti.
+
+**Caso a 2 soli punti:** con due breakpoint l'unica informazione disponibile è
+la pendenza del segmento; assegnarla a entrambe le tangenti degenererebbe in una
+retta (indistinguibile da `linear`). Per questo le tangenti agli estremi vengono
+forzate a zero e l'Hermite diventa lo smoothstep simmetrico
+`v(s) = v0 + (v1 - v0)(3s² - 2s³)`: una S con ease-in-out visibile, monotòna e
+senza overshoot. Quindi `type: cubic` su due punti produce sempre una curva, non
+una retta — per la retta usare `type: linear`. Con tre o più punti il
+comportamento Fritsch-Carlson agli estremi (tangente = pendenza del segmento
+adiacente) resta invariato.
 
 ---
 

--- a/src/envelopes/envelope.py
+++ b/src/envelopes/envelope.py
@@ -192,7 +192,15 @@ class Envelope:
         n = len(points)
         if n < 2:
             return [0.0] * n
-        
+
+        # Caso 2 punti: l'unica informazione è la slope del segmento, e
+        # assegnarla a entrambe le tangenti degenererebbe in una retta.
+        # Forzando le tangenti a zero l'Hermite diventa lo smoothstep
+        # simmetrico v0+(v1-v0)(3s^2-2s^3): ease-in-out visibile, monotòno,
+        # senza overshoot. Per la retta resta disponibile type: linear.
+        if n == 2:
+            return [0.0, 0.0]
+
         tangents = [0.0] * n
         
         # Pendenze dei segmenti

--- a/tests/envelopes/test_envelope.py
+++ b/tests/envelopes/test_envelope.py
@@ -484,10 +484,70 @@ class TestFritschCarlsonTangents:
     def test_tangents_single_point(self):
         """Tangenti con singolo punto."""
         env = Envelope({'type': 'cubic', 'points': [[0, 5]]})
-        
+
         tangents = env.segments[0].context['tangents']
         assert len(tangents) == 1
         assert tangents[0] == pytest.approx(0.0)
+
+
+class TestCubicTwoPointSmoothstep:
+    """
+    Cubic a 2 punti: smoothstep visibile (tangenti 0,0) invece della retta.
+
+    Con 2 soli punti l'unica informazione è la slope del segmento; assegnarla
+    a entrambe le tangenti degenera in retta. Forzando le tangenti agli estremi
+    a zero l'Hermite diventa lo smoothstep simmetrico v0+(v1-v0)(3s^2-2s^3):
+    ease-in-out monotòno e senza overshoot.
+    """
+
+    def test_two_point_cubic_tangents_are_zero(self):
+        env = Envelope({'type': 'cubic', 'points': [[0, 0], [1, 10]]})
+        tangents = env.segments[0].context['tangents']
+        assert tangents == pytest.approx([0.0, 0.0])
+
+    def test_two_point_cubic_quarter_point_is_smoothstep_not_linear(self):
+        env = Envelope({'type': 'cubic', 'points': [[0, 0], [1, 10]]})
+        # smoothstep a s=0.25: 3*0.0625 - 2*0.015625 = 0.15625 -> 1.5625
+        assert env.evaluate(0.25) == pytest.approx(1.5625)
+        # ease-in: sotto la retta (che darebbe 2.5)
+        assert env.evaluate(0.25) < 2.5
+
+    def test_two_point_cubic_three_quarter_point_eases_out(self):
+        env = Envelope({'type': 'cubic', 'points': [[0, 0], [1, 10]]})
+        # smoothstep a s=0.75: 3*0.5625 - 2*0.421875 = 0.84375 -> 8.4375
+        assert env.evaluate(0.75) == pytest.approx(8.4375)
+        # ease-out: sopra la retta (che darebbe 7.5)
+        assert env.evaluate(0.75) > 7.5
+
+    def test_two_point_cubic_midpoint_unchanged(self):
+        # A s=0.5 smoothstep e retta coincidono: il punto medio resta 5.0
+        env = Envelope({'type': 'cubic', 'points': [[0, 0], [1, 10]]})
+        assert env.evaluate(0.5) == pytest.approx(5.0)
+
+    def test_two_point_cubic_symmetry(self):
+        # Simmetria centrale: f(0.25)+f(0.75) = v0+v1
+        env = Envelope({'type': 'cubic', 'points': [[0, 0], [1, 10]]})
+        assert env.evaluate(0.25) + env.evaluate(0.75) == pytest.approx(10.0)
+
+    def test_two_point_cubic_stays_within_bounds(self):
+        # Nessun overshoot: valori sempre in [v0, v1]
+        env = Envelope({'type': 'cubic', 'points': [[0, 0], [1, 10]]})
+        for i in range(11):
+            t = i / 10.0
+            assert 0.0 <= env.evaluate(t) <= 10.0
+
+    def test_two_point_cubic_endpoints_exact(self):
+        env = Envelope({'type': 'cubic', 'points': [[0, 0], [1, 10]]})
+        assert env.evaluate(0.0) == pytest.approx(0.0)
+        assert env.evaluate(1.0) == pytest.approx(10.0)
+
+    def test_multipoint_cubic_extrema_tangents_unchanged(self):
+        # Regression: con 3+ punti le tangenti agli estremi restano la slope
+        # Fritsch-Carlson (delta), NON zero.
+        env = Envelope({'type': 'cubic', 'points': [[0, 0], [1, 5], [2, 10]]})
+        tangents = env.segments[0].context['tangents']
+        assert tangents[0] == pytest.approx(5.0)
+        assert tangents[-1] == pytest.approx(5.0)
 
 
 # =============================================================================

--- a/tests/envelopes/test_envelope_plus.py
+++ b/tests/envelopes/test_envelope_plus.py
@@ -406,13 +406,14 @@ class TestFritschCarlsonTangents:
         tangents = env._compute_fritsch_carlson_tangents([])
         assert tangents == []
 
-    def test_two_points_linear(self):
-        """Due punti: tangente iniziale = tangente finale = pendenza."""
+    def test_two_points_smoothstep(self):
+        """Due punti: tangenti zero -> smoothstep visibile, non retta."""
         env = self._make_cubic_env([[0, 0], [10, 100]])
         tangents = env._compute_fritsch_carlson_tangents([[0, 0], [10, 100]])
-        # Pendenza = 100/10 = 10
-        assert tangents[0] == pytest.approx(10.0)
-        assert tangents[1] == pytest.approx(10.0)
+        # Con 2 soli punti le tangenti agli estremi sono forzate a zero:
+        # l'Hermite diventa lo smoothstep simmetrico (ease-in-out).
+        assert tangents[0] == pytest.approx(0.0)
+        assert tangents[1] == pytest.approx(0.0)
 
     def test_three_points_monotone_increasing(self):
         """Tre punti monotoni crescenti: tangenti interne non-zero."""
@@ -485,13 +486,18 @@ class TestFritschCarlsonTangents:
         assert tangents[3] == pytest.approx(-10.0)
 
     def test_negative_slopes(self):
-        """Pendenze negative: tangenti negative."""
-        points = [[0, 100], [10, 0]]
-        env = self._make_cubic_env([[0, 100], [10, 0]])
+        """Pendenze negative (3+ punti): tangenti negative.
+
+        Con 3 punti gli estremi conservano la slope Fritsch-Carlson; il caso
+        2-punti è coperto a parte da test_two_points_smoothstep.
+        """
+        points = [[0, 100], [5, 50], [10, 0]]
+        env = self._make_cubic_env(points)
         tangents = env._compute_fritsch_carlson_tangents(points)
 
         assert tangents[0] == pytest.approx(-10.0)
         assert tangents[1] == pytest.approx(-10.0)
+        assert tangents[2] == pytest.approx(-10.0)
 
     def test_many_points_all_tangents_computed(self):
         """Con molti punti, ogni punto ottiene una tangente."""


### PR DESCRIPTION
## Summary

Implements a special case for cubic envelopes with exactly 2 breakpoints: forces tangents to zero at both endpoints, transforming the Hermite interpolation into a symmetric smoothstep curve (ease-in-out) instead of degenerating into a straight line.

## Changes

- **src/envelopes/envelope.py**: Added early return in `_compute_fritsch_carlson_tangents()` that forces `[0.0, 0.0]` when `n == 2`. With only two points, the segment slope is the only available information; assigning it to both tangents would produce a line indistinguishable from `type: linear`. Zero tangents yield the smoothstep `v(s) = v0 + (v1 - v0)(3s² - 2s³)`, which is monotonic, has no overshoot, and provides visible ease-in-out behavior.

- **tests/envelopes/test_envelope_plus.py**: 
  - Renamed `test_two_points_linear()` → `test_two_points_smoothstep()` and updated assertions to expect `[0.0, 0.0]` instead of slope values
  - Updated `test_negative_slopes()` to use 3 points (to test Fritsch-Carlson behavior on extrema with 3+ points) and added assertion for the third tangent

- **tests/envelopes/test_envelope.py**: 
  - Added comprehensive test class `TestCubicTwoPointSmoothstep` with 8 tests covering:
    - Tangents are zero
    - Quarter-point is below the linear interpolation (ease-in)
    - Three-quarter-point is above the linear interpolation (ease-out)
    - Midpoint unchanged (smoothstep and line coincide at s=0.5)
    - Central symmetry property: `f(0.25) + f(0.75) = v0 + v1`
    - No overshoot within bounds
    - Exact endpoint values
    - Regression test: 3+ points preserve Fritsch-Carlson slope tangents at extrema

- **docs/reference/yaml.md**: Added documentation explaining the 2-point special case, the smoothstep formula, and clarification that `type: linear` should be used for actual straight lines.

- **configs/PGE_cubic_smoothstep_demo.yml**: Added demo configuration file comparing cubic (smoothstep) vs. linear density envelopes on identical streams.

## Implementation Details

The change is minimal and surgical: a 4-line guard clause in the tangent computation. The behavior for 3+ points remains unchanged (Fritsch-Carlson algorithm applies normally). This ensures backward compatibility while providing the expected non-degenerate behavior for the 2-point case.

https://claude.ai/code/session_01EocgxJAL9HqUnD8d136Jia