### PR TITLE
Aggiungi lente di ingrandimento (magnify) alla partitura

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -53,6 +53,7 @@ Senza argomenti: stampa usage ed esce con codice 1.
 | `--visualize` | `-v` | off | `AUTOVISUAL` | esporta partitura grafica PDF accanto all'output |
 | `--show-static` | `-s` | off | `SHOWSTATIC` | include i parametri statici nella partitura |
 | `--show-voice-offsets` | — | off | `SHOWVOICEOFFSETS` | disegna gli offset per-voce nella partitura: una curva per voce per `voice_pitch_offset` e `voice_pointer_offset`, piu' la curva singola di `voice_pointer_range` (vedi [[yaml]] blocco `voices`) |
+| `--magnify` | — | off | `MAGNIFY` | lente di ingrandimento automatica nella partitura: proietta un cerchio zoomato sul cluster di grani piu' denso di ogni pagina (vedi `--magnify-at` per il targeting esplicito) |
 | `--per-stream` | `-p` | off | `STEMS` | un file audio per stream (stems) invece del mix singolo |
 | `--cache` | — | off | `CACHE` | build incrementale per stream (richiede `--per-stream`, vedi [[caching]]) |
 | `--reaper` | — | off | `REAPER` | esporta progetto Reaper `.rpp` (vedi [[reaper]]) |
@@ -75,6 +76,7 @@ Senza argomenti: stampa usage ed esce con codice 1.
 | `--sco-dir DIR` | `generated` | — | destinazione `.sco` (attivo solo con `--keep-sco`) |
 | `--reaper-path FILE` | `{yaml_basename}.rpp` | `REAPER_PATH` | percorso del progetto Reaper |
 | `--plot-envelopes nomi` | tutti | `PLOT_ENVELOPES` | filtro selettivo degli envelope nella partitura: nomi comma-separated (es. `pitch,density,volume_prob`); nome non valido: messaggio con elenco dei validi + exit 1 |
+| `--magnify-at SPEC` | — | `MAGNIFY_AT` | lente/i di ingrandimento esplicite nella partitura. `SPEC` = target separati da `;`, ciascuno coppie `chiave=valore` separate da `,`. Chiave `t` (tempo s) obbligatoria; opzionali `y` (posizione di lettura), `zoom` (fattore), `out` (raggio cerchio di uscita, frazione figura), `src` (raggio cerchio di partenza, frazione figura; default `out/zoom`), `stream` (stream_id). SPEC malformato (`t` mancante, valore non numerico, chiave ignota): messaggio + exit 1 |
 
 ## Bounds
 
@@ -105,6 +107,16 @@ Vincoli tra flag e comportamento nelle combinazioni non valide:
   statico elencato nel filtro appare solo se c'è anche `--show-static`.
   Nomi validi = chiavi di `ENVELOPE_COLORS`
   (`src/rendering/score_visualizer.py`, costante `PLOT_ENVELOPE_KEYS`).
+- **`--magnify` / `--magnify-at`** hanno effetto solo insieme a
+  `--visualize` (come `--show-static`); la validazione di `--magnify-at`
+  avviene comunque (SPEC malformato → exit 1 anche senza `--visualize`). Le
+  due si combinano: `--magnify` aggiunge la lente automatica (cluster più
+  denso) e `--magnify-at` i target espliciti, che compaiono solo sulla
+  pagina che contiene il loro `t`. I quattro controlli per target sono
+  indipendenti: coordinate (`t`,`y`), `zoom`, cerchio di uscita (`out`),
+  cerchio di partenza (`src`); con più lenti sulla stessa pagina la
+  proiezione usa l'angolo configurato in `magnify_defaults['corner']` e può
+  sovrapporsi (limite noto dell'MVP).
 - Le flag con valore leggono il token successivo in `sys.argv`; se manca,
   la flag viene ignorata senza errore.
 
@@ -129,6 +141,16 @@ python src/main.py configs/brano.yml --visualize --plot-envelopes pitch,density
 
 # Equivalente via Make
 make all FILE=brano AUTOVISUAL=true PLOT_ENVELOPES=pitch,density
+
+# Partitura con lente automatica sul cluster piu' denso di ogni pagina
+python src/main.py configs/brano.yml --visualize --magnify
+
+# Lente esplicita (auto + un target a t=14s, posizione 2.7, zoom 10)
+python src/main.py configs/brano.yml --visualize --magnify \
+  --magnify-at "t=14,y=2.7,zoom=10,out=0.12,src=0.04"
+
+# Due lenti esplicite via Make (target separati da ';')
+make all FILE=brano AUTOVISUAL=true MAGNIFY_AT="t=5;t=14,zoom=12"
 ```
 
 ## Versionato da

--- a/make/build.mk
+++ b/make/build.mk
@@ -53,6 +53,17 @@ ifneq ($(strip $(PAGE_DURATION)),)
 PYFLAGS += --page-duration $(PAGE_DURATION)
 endif
 
+# 2d. Se MAGNIFY e' true, aggiungi --magnify (lente automatica sul cluster denso)
+ifeq ($(MAGNIFY), true)
+PYFLAGS += --magnify
+endif
+
+# 2e. Se MAGNIFY_AT e' non-vuoto, aggiungi --magnify-at (target espliciti).
+# Le virgolette proteggono il ';' fra target dalla shell.
+ifneq ($(strip $(MAGNIFY_AT)),)
+PYFLAGS += --magnify-at "$(MAGNIFY_AT)"
+endif
+
 # 3. Se REAPER e' true, aggiungi --reaper (esporta .rpp Reaper)
 ifeq ($(REAPER), true)
 PYFLAGS += --reaper

--- a/src/main.py
+++ b/src/main.py
@@ -117,6 +117,60 @@ def _build_renderer(renderer_type: str, generator, **kwargs):
     )
 
 
+# Chiavi ammesse in un target di --magnify-at. Numeriche (float) e stringa.
+_MAGNIFY_NUMERIC_KEYS = frozenset({'t', 'y', 'zoom', 'out', 'src'})
+_MAGNIFY_STR_KEYS = frozenset({'stream'})
+_MAGNIFY_KEYS = _MAGNIFY_NUMERIC_KEYS | _MAGNIFY_STR_KEYS
+
+
+def _parse_magnify_spec(spec):
+    """Parsa lo SPEC di --magnify-at in una lista di target dict.
+
+    SPEC = target separati da ';'; ogni target = coppie chiave=valore separate
+    da ','. La chiave 't' (tempo in secondi) e' obbligatoria; opzionali y, zoom,
+    out, src (float) e stream (stringa). Come --plot-envelopes, la validazione
+    e' sempre attiva: token malformato, chiave ignota, valore non numerico o 't'
+    mancante stampano un messaggio su stdout ed escono con codice 1.
+    """
+    import sys
+    targets = []
+    for raw in spec.split(';'):
+        raw = raw.strip()
+        if not raw:
+            continue
+        target = {}
+        for pair in raw.split(','):
+            pair = pair.strip()
+            if not pair:
+                continue
+            if '=' not in pair:
+                print(f"--magnify-at: token non valido '{pair}'. "
+                      f"Usa chiave=valore (es. t=14,zoom=10).")
+                sys.exit(1)
+            key, _, value = pair.partition('=')
+            key, value = key.strip(), value.strip()
+            if key not in _MAGNIFY_KEYS:
+                print(f"--magnify-at: chiave ignota '{key}'. "
+                      f"Valide: {', '.join(sorted(_MAGNIFY_KEYS))}.")
+                sys.exit(1)
+            if key in _MAGNIFY_NUMERIC_KEYS:
+                try:
+                    target[key] = float(value)
+                except ValueError:
+                    print(f"--magnify-at: valore non numerico per '{key}': '{value}'.")
+                    sys.exit(1)
+            else:
+                target[key] = value
+        if 't' not in target:
+            print("--magnify-at: ogni target richiede la chiave 't' (tempo in secondi).")
+            sys.exit(1)
+        targets.append(target)
+    if not targets:
+        print("--magnify-at: nessun target valido nello SPEC.")
+        sys.exit(1)
+    return targets
+
+
 def main():
     import sys
     import os
@@ -126,6 +180,7 @@ def main():
             "Uso: python main.py <file.yml> [output.aif] "
             "[--visualize] [--show-static] [--show-voice-offsets] "
             "[--plot-envelopes nomi,csv] "
+            "[--magnify] [--magnify-at SPEC] "
             "[--page-duration SECONDI] "
             "[--per-stream] "
             "[--renderer csound|numpy] "
@@ -185,6 +240,19 @@ def main():
                     f"Validi: {', '.join(sorted(PLOT_ENVELOPE_KEYS))}"
                 )
                 sys.exit(1)
+    # --magnify: lente automatica sul cluster piu' denso (una per pagina).
+    # Effetto solo con --visualize, come --show-static. Token esatto: '--magnify'
+    # non collide con '--magnify-at' (sono elementi distinti di sys.argv).
+    magnify_auto = '--magnify' in sys.argv
+
+    # --magnify-at "SPEC": target espliciti della lente (vedi _parse_magnify_spec).
+    # Validazione sempre attiva; effetto sul rendering solo con --visualize.
+    magnify_targets = []
+    if '--magnify-at' in sys.argv:
+        idx = sys.argv.index('--magnify-at')
+        if idx + 1 < len(sys.argv):
+            magnify_targets = _parse_magnify_spec(sys.argv[idx + 1])
+
     per_stream = '--per-stream' in sys.argv or '-p' in sys.argv
     use_cache = '--cache' in sys.argv
     reaper_export = '--reaper' in sys.argv
@@ -391,6 +459,8 @@ def main():
                 'show_static_params': show_static,
                 'show_voice_offsets': show_voice_offsets,
                 'envelope_filter': plot_envelopes,
+                'magnify_auto': magnify_auto,
+                'magnify_targets': magnify_targets,
             })
             viz.export_pdf(pdf_file)
 

--- a/src/rendering/score_visualizer.py
+++ b/src/rendering/score_visualizer.py
@@ -227,8 +227,24 @@ class ScoreVisualizer:
                 'pad_ratio': 0.05,      # margine sopra/sotto: 5% dell'escursione
                 'samples': 128,         # densità campionamento (cattura overshoot cubic)
             },
+
+            # === LENTE DI INGRANDIMENTO (magnify) ===
+            # Proietta un cerchio che ingrandisce una regione del piano
+            # tempo×posizione di lettura, con connettori verso la sorgente.
+            # Default disattivata: a flag spenti render_page è identico a prima.
+            'magnify_auto': False,        # lente automatica sul cluster più denso
+            'magnify_targets': [],        # target espliciti: list[dict]
+                                          # (t obbligatorio; y/zoom/out/src/stream opz.)
+            'magnify_defaults': {
+                'zoom': 8.0,              # fattore di ingrandimento del contenuto
+                'out': 0.12,              # raggio cerchio di USCITA (frazione min figura)
+                'src': None,              # raggio cerchio di PARTENZA; None = out/zoom
+                'corner': 'top-right',    # angolo del subplot dove proiettare la lente
+            },
+            'magnify_hist_bins': (40, 16),  # bin (tempo, posizione) per auto-densest
+            'magnify_color': '#c1121f',   # colore marker sorgente + connettori
         }
-        
+
         self.config = default_config
         if config:
             self.config.update(config)
@@ -656,6 +672,11 @@ class ScoreVisualizer:
         # =========================================================================
         # DISEGNA UN SUBPLOT PER OGNI STREAM
         # =========================================================================
+        # Entry per stream raccolte per la lente di ingrandimento (magnify):
+        # l'asse dei grani, la durata del sample e il range colore servono a
+        # ridisegnare il contenuto zoomato nell'inset. Vuoto/inutilizzato quando
+        # magnify è spenta.
+        stream_entries = []
         for i, stream in enumerate(active_streams):
             # Crea subplot per questo stream
             ax_wave = fig.add_subplot(gs[i, 0])
@@ -678,6 +699,13 @@ class ScoreVisualizer:
             self._draw_grains_full(ax_grain, stream, sample_duration,
                                    page_start, page_end, cents_range)
             self._draw_stream_label_full(ax_grain, stream, page_start, sample_duration)
+
+            stream_entries.append({
+                'stream': stream,
+                'ax': ax_grain,
+                'sample_duration': sample_duration,
+                'cents_range': cents_range,
+            })
 
             # Legenda della scala colore pitch (auto-zoomata o fissa) nella
             # colonna dedicata gs[i, 2]: non ruba larghezza al subplot dei grani.
@@ -772,6 +800,14 @@ class ScoreVisualizer:
                 ax_legend = fig.add_subplot(gs[n_streams, 0])
                 self._draw_envelope_legend(ax_legend, legend_entries)
         # =========================================================================
+        # LENTE DI INGRANDIMENTO (magnify)
+        # =========================================================================
+        # Disegnata per ultima, sopra i subplot: l'overlay e gli inset non
+        # alterano il GridSpec. Se magnify è spenta o non ci sono target per la
+        # pagina, non viene creato alcun asse (back-compat).
+        self._render_magnifiers(fig, page_start, page_end, stream_entries)
+
+        # =========================================================================
         # TITOLO
         # =========================================================================
         title = f"Pagina {page_idx + 1}/{self.page_count} — " \
@@ -783,6 +819,234 @@ class ScoreVisualizer:
                      fontsize=self._fs(self.config['title_fontsize']))
 
         return fig
+
+    # =========================================================================
+    # LENTE DI INGRANDIMENTO (magnify)
+    # =========================================================================
+
+    def _render_magnifiers(self, fig, page_start, page_end, stream_entries):
+        """Disegna le lenti attive per questa pagina.
+
+        Risolve i target (auto sul cluster più denso + espliciti che cadono nella
+        finestra di pagina), poi proietta per ciascuno un cerchio zoomato con
+        marker sorgente e connettori. Nessun asse creato se magnify è spenta o
+        non ci sono target (invariante back-compat)."""
+        if not stream_entries:
+            return
+        targets = self._resolve_magnify_targets(
+            page_start, page_end, stream_entries)
+        if not targets:
+            return
+        overlay = self._make_magnify_overlay(fig)
+        for resolved in targets:
+            self._draw_one_magnifier(fig, overlay, resolved)
+
+    def _resolve_magnify_targets(self, page_start, page_end, stream_entries):
+        """Target risolti (concreti) per la pagina: {entry, t, y, zoom, out, src}.
+
+        L'auto (se abilitato) aggiunge la lente sul cluster più denso; gli
+        espliciti la cui 't' cade in [page_start, page_end) vengono risolti su
+        stream e y concreti."""
+        resolved = []
+        if self.config.get('magnify_auto'):
+            auto = self._auto_magnify_target(
+                page_start, page_end, stream_entries)
+            if auto is not None:
+                resolved.append(auto)
+        for target in (self.config.get('magnify_targets') or []):
+            r = self._resolve_explicit_target(
+                target, page_start, page_end, stream_entries)
+            if r is not None:
+                resolved.append(r)
+        return resolved
+
+    def _page_grain_points(self, stream, page_start, page_end):
+        """(onset, pointer_pos) dei grani dello stream visibili nella pagina."""
+        return [
+            (g.onset, g.pointer_pos)
+            for voice_grains in stream.voices
+            for g in voice_grains
+            if g.onset < page_end and (g.onset + g.duration) > page_start
+        ]
+
+    def _auto_magnify_target(self, page_start, page_end, stream_entries):
+        """Target automatico: centroide del bin più denso (tempo×posizione) fra
+        gli stream attivi. None se nessuno stream ha grani in pagina."""
+        nt, ny = self.config['magnify_hist_bins']
+        best = None  # (count, entry, tc, yc)
+        for entry in stream_entries:
+            pts = self._page_grain_points(entry['stream'], page_start, page_end)
+            if not pts:
+                continue
+            ts = np.array([p[0] for p in pts])
+            ys = np.array([p[1] for p in pts])
+            y_hi = max(entry['sample_duration'], 1e-6)
+            H, te, ye = np.histogram2d(
+                ts, ys, bins=[nt, ny],
+                range=[[page_start, page_end], [0.0, y_hi]])
+            i, j = np.unravel_index(int(np.argmax(H)), H.shape)
+            count = H[i, j]
+            if count <= 0:
+                continue
+            # Centro sul centroide dei grani del bin: cade su grani reali, così
+            # la finestra (stretta per via dello zoom) li contiene davvero.
+            in_bin = [(t, y) for t, y in pts
+                      if te[i] <= t <= te[i + 1] and ye[j] <= y <= ye[j + 1]]
+            if not in_bin:
+                continue
+            tc = float(np.mean([t for t, _ in in_bin]))
+            yc = float(np.mean([y for _, y in in_bin]))
+            if best is None or count > best[0]:
+                best = (count, entry, tc, yc)
+        if best is None:
+            return None
+        _, entry, tc, yc = best
+        d = self.config['magnify_defaults']
+        return {'entry': entry, 't': tc, 'y': yc,
+                'zoom': d['zoom'], 'out': d['out'], 'src': d['src']}
+
+    def _resolve_explicit_target(self, target, page_start, page_end,
+                                 stream_entries):
+        """Risolve un target esplicito {t, y?, zoom?, out?, src?, stream?}.
+
+        None se 't' non cade nella pagina. Stream: la chiave 'stream' (per
+        stream_id) o, in mancanza, lo stream più denso in pagina. y: la chiave
+        'y' o il centroide dei pointer_pos vicino a 't' (o metà sample)."""
+        t = target.get('t')
+        if t is None or not (page_start <= t < page_end):
+            return None
+        entry = None
+        sid = target.get('stream')
+        if sid is not None:
+            entry = next((e for e in stream_entries
+                          if e['stream'].stream_id == sid), None)
+        if entry is None:
+            entry = self._densest_stream_entry(
+                page_start, page_end, stream_entries)
+        if entry is None:
+            return None
+        d = self.config['magnify_defaults']
+        y = target.get('y')
+        if y is None:
+            y = self._auto_y_at(entry['stream'], t, page_start, page_end)
+            if y is None:
+                y = entry['sample_duration'] * 0.5
+        return {'entry': entry, 't': float(t), 'y': float(y),
+                'zoom': target.get('zoom', d['zoom']),
+                'out': target.get('out', d['out']),
+                'src': target.get('src', d['src'])}
+
+    def _densest_stream_entry(self, page_start, page_end, stream_entries):
+        """Entry dello stream con più grani visibili in pagina (fallback: primo)."""
+        best, best_n = None, 0
+        for entry in stream_entries:
+            n = len(self._page_grain_points(
+                entry['stream'], page_start, page_end))
+            if n > best_n:
+                best, best_n = entry, n
+        return best or (stream_entries[0] if stream_entries else None)
+
+    def _auto_y_at(self, stream, t, page_start, page_end):
+        """Centroide dei pointer_pos dei grani vicini a 't' (None se nessuno)."""
+        pts = self._page_grain_points(stream, page_start, page_end)
+        if not pts:
+            return None
+        w = 0.05 * (page_end - page_start)  # finestra locale ±5% pagina
+        near = [y for (gt, y) in pts if abs(gt - t) <= w] or [y for _, y in pts]
+        return float(np.mean(near))
+
+    def _make_magnify_overlay(self, fig):
+        """Asse a tutta figura in coordinate pixel: cerchi tondi e linee dritte
+        nonostante l'asse-dato sia anisotropo (X tempo, Y posizione). Etichettato
+        '<magnifier-overlay>' come '<colorbar>', così i consumatori lo filtrano."""
+        W, H = fig.get_size_inches() * fig.dpi
+        ov = fig.add_axes([0, 0, 1, 1], zorder=10)
+        ov.set_label('<magnifier-overlay>')
+        ov.set_xlim(0, W)
+        ov.set_ylim(0, H)
+        ov.set_aspect('equal')
+        ov.axis('off')
+        return ov
+
+    def _draw_one_magnifier(self, fig, overlay, resolved):
+        """Proietta una lente: inset circolare zoomato + marker sorgente +
+        connettori. I quattro controlli (center, zoom, out, src) sono
+        indipendenti; src=None usa il valore fedele out/zoom."""
+        entry = resolved['entry']
+        ax_grain = entry['ax']
+        stream = entry['stream']
+        sample_dur = entry['sample_duration']
+        cents_range = entry['cents_range']
+        tc, yc = float(resolved['t']), float(resolved['y'])
+        zoom = max(float(resolved['zoom']), 1e-6)
+
+        W, H = fig.get_size_inches() * fig.dpi
+        min_dim = min(W, H)
+        out_r_px = float(resolved['out']) * min_dim
+        src = resolved.get('src')
+        src_r_px = (float(src) * min_dim) if src is not None else out_r_px / zoom
+
+        # Scala px/dato dell'asse principale al centro (asse lineare).
+        base = ax_grain.transData.transform((tc, yc))
+        px_per_t = ax_grain.transData.transform((tc + 1.0, yc))[0] - base[0]
+        px_per_y = ax_grain.transData.transform((tc, yc + 1.0))[1] - base[1]
+        px_per_t = px_per_t if abs(px_per_t) > 1e-9 else 1.0
+        px_per_y = px_per_y if abs(px_per_y) > 1e-9 else 1.0
+
+        # Finestra dati mostrata: derivata da (zoom, out) → contenuto × zoom.
+        hwx = out_r_px / (zoom * abs(px_per_t))
+        hwy = out_r_px / (zoom * abs(px_per_y))
+        t0, t1 = tc - hwx, tc + hwx
+        y0, y1 = yc - hwy, yc + hwy
+
+        # Posizione del cerchio di uscita: angolo del subplot (frazione figura).
+        pos = ax_grain.get_position()
+        r_fx, r_fy = out_r_px / W, out_r_px / H
+        corner = self.config['magnify_defaults'].get('corner', 'top-right')
+        pad = 0.012
+        cy = (pos.y1 - r_fy - pad) if 'top' in corner else (pos.y0 + r_fy + pad)
+        cx = (pos.x1 - r_fx - pad) if 'right' in corner else (pos.x0 + r_fx + pad)
+
+        # Inset lente: quadrato in pixel (cerchio tondo), clip a cerchio.
+        lens_ax = fig.add_axes([cx - r_fx, cy - r_fy, 2 * r_fx, 2 * r_fy])
+        lens_ax.set_label('<magnifier>')
+        lens_ax.add_patch(mpatches.Circle(
+            (0.5, 0.5), 0.5, transform=lens_ax.transAxes,
+            facecolor='white', edgecolor='none', zorder=0))
+        self._draw_loop_mask(lens_ax, stream, t0, t1, sample_dur)
+        self._draw_grains_full(lens_ax, stream, sample_dur, t0, t1, cents_range)
+        lens_ax.set_xlim(t0, t1)
+        lens_ax.set_ylim(y0, y1)
+        lens_ax.set_xticks([])
+        lens_ax.set_yticks([])
+        clip = mpatches.Circle((0.5, 0.5), 0.5, transform=lens_ax.transAxes)
+        for art in (list(lens_ax.collections) + list(lens_ax.patches)
+                    + list(lens_ax.lines)):
+            art.set_clip_path(clip)
+        lens_ax.patch.set_visible(False)
+        for sp in lens_ax.spines.values():
+            sp.set_visible(False)
+
+        # Marker sorgente, connettori e anello lente sull'overlay (pixel).
+        lpx, lpy = cx * W, cy * H
+        accent = self.config['magnify_color']
+        direction = np.array([lpx - base[0], lpy - base[1]], float)
+        direction /= (np.hypot(*direction) + 1e-9)
+        perp = np.array([-direction[1], direction[0]])
+        for s in (+1.0, -1.0):
+            a = np.array(base) + s * src_r_px * perp
+            b = np.array([lpx, lpy]) + s * out_r_px * perp
+            line, = overlay.plot([a[0], b[0]], [a[1], b[1]],
+                                 color=accent, lw=1.2, alpha=0.55, zorder=4)
+            line.set_gid('magnify-connector')
+        src_ring = mpatches.Circle((base[0], base[1]), src_r_px, fill=False,
+                                   ec=accent, lw=1.4, zorder=5)
+        src_ring.set_gid('magnify-source')
+        overlay.add_patch(src_ring)
+        lens_ring = mpatches.Circle((lpx, lpy), out_r_px, fill=False,
+                                    ec='#222222', lw=2.2, zorder=6)
+        lens_ring.set_gid('magnify-lens')
+        overlay.add_patch(lens_ring)
 
     def _draw_waveform_full(self, ax, stream, sample_duration):
         """Disegna waveform usando tutto lo spazio verticale dello subplot."""

--- a/tests/rendering/test_score_visualizer.py
+++ b/tests/rendering/test_score_visualizer.py
@@ -1806,3 +1806,125 @@ class TestFontScaleLayout:
              patch('rendering.score_visualizer.PdfPages', return_value=ctx):
             viz.export_pdf('/tmp/tight_test.pdf')
         assert inst.savefig.call_args.kwargs.get('bbox_inches') == 'tight'
+
+
+# =============================================================================
+# GROUP - Lente di ingrandimento proiettata (magnify)
+# =============================================================================
+
+class TestMagnifier:
+    """La partitura puo' proiettare una lente circolare che ingrandisce una
+    regione (tempo x posizione di lettura), col cerchio zoomato affiancato e
+    connettori verso la regione sorgente. Due modalita': auto (cluster piu'
+    denso) ed esplicita (target con center/zoom/out/src indipendenti).
+    Default: disattivata (back-compat con la partitura esistente)."""
+
+    PAGE = 30.0
+
+    @staticmethod
+    def _magnifier_axes(fig):
+        return [ax for ax in fig.axes if ax.get_label() == '<magnifier>']
+
+    @staticmethod
+    def _overlay_axes(fig):
+        return [ax for ax in fig.axes if ax.get_label() == '<magnifier-overlay>']
+
+    @classmethod
+    def _grain_ax(cls, fig, page_start=0.0, page_end=None):
+        """Asse dei grani: xlim == (page_start, page_end), non lente ne' overlay."""
+        page_end = cls.PAGE if page_end is None else page_end
+        for ax in fig.axes:
+            lo, hi = ax.get_xlim()
+            if (abs(lo - page_start) < 1e-9 and abs(hi - page_end) < 1e-9
+                    and ax.get_label() not in ('<magnifier>', '<magnifier-overlay>')):
+                return ax
+        return None
+
+    def _render(self, streams, config):
+        cfg = {'page_duration': self.PAGE}
+        cfg.update(config)
+        viz = make_viz(streams, config=cfg)
+        with patch('soundfile.read', return_value=(FAKE_AUDIO, SR)):
+            viz.analyze()
+            fig = viz.render_page(0)
+        fig.canvas.draw()  # finalizza transform/posizioni
+        return fig
+
+    # --- back-compat: default OFF ---
+    def test_no_magnifier_by_default(self):
+        fig = self._render(single_stream_scene(), {})
+        assert self._magnifier_axes(fig) == []
+        assert self._overlay_axes(fig) == []
+
+    # --- modalita' auto ---
+    def test_auto_creates_one_magnifier(self):
+        fig = self._render(single_stream_scene(), {'magnify_auto': True})
+        assert len(self._magnifier_axes(fig)) == 1
+        assert len(self._overlay_axes(fig)) == 1
+
+    def test_auto_magnifier_contains_grains(self):
+        from matplotlib.collections import PatchCollection
+        fig = self._render(single_stream_scene(), {'magnify_auto': True})
+        lens = self._magnifier_axes(fig)[0]
+        grain_colls = [c for c in lens.collections
+                       if isinstance(c, PatchCollection) and c.get_zorder() == 2]
+        assert len(grain_colls) == 1
+
+    def test_overlay_has_two_rings_and_two_connectors(self):
+        fig = self._render(single_stream_scene(), {'magnify_auto': True})
+        ov = self._overlay_axes(fig)[0]
+        src = [p for p in ov.patches if p.get_gid() == 'magnify-source']
+        lens = [p for p in ov.patches if p.get_gid() == 'magnify-lens']
+        conn = [ln for ln in ov.lines if ln.get_gid() == 'magnify-connector']
+        assert len(src) == 1 and len(lens) == 1
+        assert len(conn) == 2
+
+    def test_no_magnifier_when_no_grains(self):
+        s = make_stream('s1', onset=0.0, duration=20.0,
+                        sample='piano.wav', n_grains=0)
+        fig = self._render([s], {'magnify_auto': True})
+        assert self._magnifier_axes(fig) == []
+
+    # --- modalita' esplicita: i 4 controlli indipendenti ---
+    def test_explicit_center_positions_window(self):
+        target = {'t': 6.0, 'y': 1.5, 'zoom': 8.0, 'out': 0.12}
+        fig = self._render(single_stream_scene(), {'magnify_targets': [target]})
+        lens = self._magnifier_axes(fig)[0]
+        x0, x1 = lens.get_xlim()
+        y0, y1 = lens.get_ylim()
+        assert (x0 + x1) / 2 == pytest.approx(6.0, abs=1e-6)
+        assert (y0 + y1) / 2 == pytest.approx(1.5, abs=1e-6)
+
+    def test_zoom_factor_respected(self):
+        zoom = 8.0
+        target = {'t': 6.0, 'y': 1.5, 'zoom': zoom, 'out': 0.12}
+        fig = self._render(single_stream_scene(), {'magnify_targets': [target]})
+        lens = self._magnifier_axes(fig)[0]
+        grain_ax = self._grain_ax(fig)
+
+        def px_per_data_x(ax):
+            p0 = ax.transData.transform((0.0, 0.0))
+            p1 = ax.transData.transform((1.0, 0.0))
+            return abs(p1[0] - p0[0])
+
+        magnif = px_per_data_x(lens) / px_per_data_x(grain_ax)
+        assert magnif == pytest.approx(zoom, rel=0.12)
+
+    def test_explicit_target_outside_page_no_lens(self):
+        # multi_page_scene: pagina 0 = [0,30); target a t=45 cade in pagina 1.
+        target = {'t': 45.0, 'y': 1.0, 'zoom': 8.0}
+        fig = self._render(multi_page_scene(), {'magnify_targets': [target]})
+        assert self._magnifier_axes(fig) == []
+
+    def test_src_radius_independent_of_zoom(self):
+        # out=0.12, zoom=10 -> src "fedele" = 0.012; passo src=0.03 esplicito.
+        target = {'t': 6.0, 'y': 1.5, 'zoom': 10.0, 'out': 0.12, 'src': 0.03}
+        fig = self._render(single_stream_scene(), {'magnify_targets': [target]})
+        ov = self._overlay_axes(fig)[0]
+        src_ring = [p for p in ov.patches if p.get_gid() == 'magnify-source'][0]
+        W, H = fig.get_size_inches() * fig.dpi
+        expected = 0.03 * min(W, H)
+        assert src_ring.radius == pytest.approx(expected, rel=0.05)
+        # ... e diverso dal valore fedele out/zoom (cerchio di partenza = knob a se')
+        faithful = 0.012 * min(W, H)
+        assert abs(src_ring.radius - faithful) > 0.1 * faithful

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1513,3 +1513,124 @@ class TestGrainJsonOnlyGeneratedStreams:
         written_streams = [c.args[0] for c in writer_instance.write.call_args_list]
         assert s1 in written_streams
         assert s2 in written_streams
+
+
+# =============================================================================
+# TEST FLAG --magnify / --magnify-at (lente di ingrandimento della partitura)
+# =============================================================================
+
+class TestMagnifyFlags:
+    """
+    --magnify (booleano) abilita la lente automatica sul cluster piu' denso:
+    config['magnify_auto'] = True. Effetto solo con --visualize.
+    --magnify-at "SPEC" aggiunge target espliciti: config['magnify_targets'] e'
+    una lista di dict (chiave 't' obbligatoria; opz. y, zoom, out, src, stream).
+    SPEC = target separati da ';', ciascuno chiave=valore separati da ','.
+    Malformato (t mancante / valore non numerico / chiave ignota): exit 1.
+    """
+
+    def _get_viz_config(self, mocks, argv):
+        with patch.object(sys, 'argv', argv):
+            mocks['main'].main()
+        _, kwargs = mocks['ScoreVisualizer'].call_args
+        return kwargs['config']
+
+    # --- default ---
+    def test_default_magnify_auto_false(self, mocks):
+        config = self._get_viz_config(
+            mocks, ['main.py', 'test.yml', 'out.aif', '--visualize'])
+        assert config.get('magnify_auto') is False
+
+    def test_default_magnify_targets_empty(self, mocks):
+        config = self._get_viz_config(
+            mocks, ['main.py', 'test.yml', 'out.aif', '--visualize'])
+        assert config.get('magnify_targets') == []
+
+    # --- --magnify (auto) ---
+    def test_magnify_flag_sets_auto_true(self, mocks):
+        config = self._get_viz_config(
+            mocks, ['main.py', 'test.yml', 'out.aif', '--visualize', '--magnify'])
+        assert config.get('magnify_auto') is True
+
+    def test_magnify_without_visualize_does_not_create_visualizer(self, mocks):
+        with patch.object(sys, 'argv',
+                          ['main.py', 'test.yml', 'out.aif', '--magnify']):
+            mocks['main'].main()
+        mocks['ScoreVisualizer'].assert_not_called()
+
+    # --- --magnify-at (esplicito) ---
+    def test_magnify_at_single_target_t(self, mocks):
+        config = self._get_viz_config(
+            mocks, ['main.py', 'test.yml', 'out.aif', '--visualize',
+                    '--magnify-at', 't=5'])
+        targets = config.get('magnify_targets')
+        assert len(targets) == 1
+        assert targets[0]['t'] == 5.0
+
+    def test_magnify_at_full_spec_parsed(self, mocks):
+        config = self._get_viz_config(
+            mocks, ['main.py', 'test.yml', 'out.aif', '--visualize',
+                    '--magnify-at', 't=14,y=2.7,zoom=10,out=0.12,src=0.04'])
+        tgt = config['magnify_targets'][0]
+        assert tgt['t'] == 14.0
+        assert tgt['y'] == 2.7
+        assert tgt['zoom'] == 10.0
+        assert tgt['out'] == 0.12
+        assert tgt['src'] == 0.04
+
+    def test_magnify_at_stream_key_is_string(self, mocks):
+        config = self._get_viz_config(
+            mocks, ['main.py', 'test.yml', 'out.aif', '--visualize',
+                    '--magnify-at', 't=5,stream=texture2'])
+        assert config['magnify_targets'][0]['stream'] == 'texture2'
+
+    def test_magnify_at_multiple_targets(self, mocks):
+        config = self._get_viz_config(
+            mocks, ['main.py', 'test.yml', 'out.aif', '--visualize',
+                    '--magnify-at', 't=5;t=12,zoom=6'])
+        targets = config['magnify_targets']
+        assert len(targets) == 2
+        assert targets[0]['t'] == 5.0
+        assert targets[1]['t'] == 12.0
+        assert targets[1]['zoom'] == 6.0
+
+    def test_magnify_and_magnify_at_combine(self, mocks):
+        """Entrambi: --magnify (auto) + --magnify-at (esplicito)."""
+        config = self._get_viz_config(
+            mocks, ['main.py', 'test.yml', 'out.aif', '--visualize',
+                    '--magnify', '--magnify-at', 't=5'])
+        assert config['magnify_auto'] is True
+        assert config['magnify_targets'][0]['t'] == 5.0
+
+    def test_magnify_at_alone_populates_targets(self, mocks):
+        """--magnify-at da solo (senza --magnify) popola comunque i target."""
+        config = self._get_viz_config(
+            mocks, ['main.py', 'test.yml', 'out.aif', '--visualize',
+                    '--magnify-at', 't=5'])
+        assert config['magnify_auto'] is False
+        assert config['magnify_targets'][0]['t'] == 5.0
+
+    # --- validazione ---
+    def test_magnify_at_missing_t_exits_1(self, mocks):
+        with patch.object(sys, 'argv',
+                          ['main.py', 'test.yml', 'out.aif', '--visualize',
+                           '--magnify-at', 'zoom=10']):
+            with pytest.raises(SystemExit) as exc:
+                mocks['main'].main()
+        assert exc.value.code == 1
+
+    def test_magnify_at_non_numeric_exits_1(self, mocks):
+        with patch.object(sys, 'argv',
+                          ['main.py', 'test.yml', 'out.aif', '--visualize',
+                           '--magnify-at', 't=abc']):
+            with pytest.raises(SystemExit) as exc:
+                mocks['main'].main()
+        assert exc.value.code == 1
+
+    def test_magnify_at_unknown_key_exits_1(self, mocks):
+        with patch.object(sys, 'argv',
+                          ['main.py', 'test.yml', 'out.aif', '--visualize',
+                           '--magnify-at', 't=5,foo=1']):
+            with pytest.raises(SystemExit) as exc:
+                mocks['main'].main()
+        assert exc.value.code == 1


### PR DESCRIPTION
## Sommario

Implementa un sistema di lente di ingrandimento circolare per la partitura grafica che proietta una regione zoomata del piano tempo×posizione di lettura. La feature è disattivata per default (back-compat) e supporta due modalità: automatica (sul cluster più denso) ed esplicita (target con controlli indipendenti).

## Cambiamenti principali

**Score Visualizer (`src/rendering/score_visualizer.py`)**
- Aggiunge configurazione `magnify_*` (auto, targets, defaults, hist_bins, color) al config di default
- Implementa `_render_magnifiers()` come entry point per disegnare le lenti attive in una pagina
- Risolve target (auto + espliciti) con `_resolve_magnify_targets()`, che:
  - Calcola il cluster più denso via istogramma 2D (tempo×posizione) per l'auto
  - Filtra target espliciti che cadono nella finestra di pagina
  - Risolve stream e y mancanti con fallback intelligenti
- Disegna ogni lente con `_draw_one_magnifier()`:
  - Inset circolare zoomato (clippato a cerchio) con contenuto ridisegnato
  - Marker sorgente e connettori sull'overlay in pixel
  - Quattro controlli indipendenti: center (t, y), zoom, out (raggio uscita), src (raggio partenza)
- Aggiunge helper per calcoli geometrici: scala px/dato, finestra dati, posizionamento angolo

**CLI (`src/main.py`)**
- Aggiunge `--magnify` (booleano): abilita lente automatica sul cluster più denso
- Aggiunge `--magnify-at SPEC`: target espliciti con parsing robusto
  - SPEC = target separati da `;`, ciascuno coppie `chiave=valore` separate da `,`
  - Chiave `t` (tempo) obbligatoria; opzionali `y`, `zoom`, `out`, `src` (float), `stream` (stringa)
  - Validazione sempre attiva: token malformato, chiave ignota, valore non numerico → exit 1
- Passa `magnify_auto` e `magnify_targets` al config del visualizer

**Build (`make/build.mk`)**
- Aggiunge supporto per variabili `MAGNIFY` (booleano) e `MAGNIFY_AT` (stringa SPEC)
- Traduce in flag CLI `--magnify` e `--magnify-at`

**Documentazione (`docs/reference/cli.md`)**
- Documenta `--magnify` e `--magnify-at` con esempi di SPEC

**Test**
- `tests/rendering/test_score_visualizer.py`: suite `TestMagnifier` con 13 test
  - Back-compat: default OFF, nessun asse creato
  - Auto: crea una lente sul cluster più denso, contiene grani, overlay ha anelli e connettori
  - Esplicito: center posiziona la finestra, zoom rispettato, target fuori pagina ignorato
  - Indipendenza: src radius indipendente da zoom
- `tests/test_main.py`: suite `TestMagnifyFlags` con 13 test
  - Default: `magnify_auto=False`, `magnify_targets=[]`
  - Parsing: singolo/multiplo target, chiavi numeriche e stringa
  - Combinazione: `--magnify` + `--magnify-at` insieme
  - Validazione: t mancante, valore non numerico, chiave ignota → exit 1

## Dettagli implementativi

- **Overlay in pixel**: asse a tutta figura con `zorder=10` per disegnare anelli e connettori dritti

https://claude.ai/code/session_01X4PzvpCVq1qfSxEn59Njce