### PR TITLE
Localize UI strings to English in score visualizer

### DIFF
--- a/src/rendering/score_visualizer.py
+++ b/src/rendering/score_visualizer.py
@@ -598,12 +598,12 @@ class ScoreVisualizer:
         if n_streams == 0:
             # Pagina vuota
             ax = fig.add_subplot(111)
-            ax.text(0.5, 0.5, "Nessuno stream attivo",
+            ax.text(0.5, 0.5, "No active stream",
                     ha='center', va='center',
                     fontsize=self._fs(self.config['empty_fontsize']), color='gray')
             ax.axis('off')
 
-            title = f"Pagina {page_idx + 1}/{self.page_count} — " \
+            title = f"Page {page_idx + 1}/{self.page_count} — " \
                     f"[{page_start:.1f}s - {page_end:.1f}s]"
             fig.suptitle(title, fontsize=self._fs(self.config['title_fontsize']))
             return fig
@@ -714,7 +714,7 @@ class ScoreVisualizer:
             # Configura assi waveform
             ax_wave.set_ylim(-0.02, sample_duration+0.02)
             ax_wave.set_xlim(-1.1, 1.1)
-            ax_wave.set_ylabel(f"Posizione di lettura (s)\n{sample_path}",
+            ax_wave.set_ylabel(f"Read position (s)\n{sample_path}",
                             fontsize=self._fs(self.config['label_fontsize']))
             ax_wave.set_xticks([])
             # Scarta i tick estremi dell'asse buffer: con le righe impilate
@@ -743,7 +743,7 @@ class ScoreVisualizer:
             
             # X label solo sull'ultimo stream (se non ci sono envelope)
             if i == n_streams - 1 and not has_envelopes:
-                ax_grain.set_xlabel("Tempo (s)", fontsize=self._fs(self.config['label_fontsize']))
+                ax_grain.set_xlabel("Time (s)", fontsize=self._fs(self.config['label_fontsize']))
             else:
                 ax_grain.set_xticklabels([])
         
@@ -785,7 +785,7 @@ class ScoreVisualizer:
             # Configura assi envelope
             ax_env.set_xlim(page_start, page_end)
             ax_env.set_ylim(0, 1)
-            ax_env.set_xlabel("Tempo (s)", fontsize=self._fs(self.config['label_fontsize']))
+            ax_env.set_xlabel("Time (s)", fontsize=self._fs(self.config['label_fontsize']))
             ax_env.set_ylabel("", fontsize=self._fs(self.config['label_fontsize']))
             ax_env.set_yticklabels([])
             ax_env.tick_params(axis='y', length=0)
@@ -810,7 +810,7 @@ class ScoreVisualizer:
         # =========================================================================
         # TITOLO
         # =========================================================================
-        title = f"Pagina {page_idx + 1}/{self.page_count} — " \
+        title = f"Page {page_idx + 1}/{self.page_count} — " \
                 f"[{page_start:.1f}s - {page_end:.1f}s]"
         # Titolo centrato nella striscia riservata in alto, appena sopra il plot:
         # bordo inferiore del testo a title_gap dal plot (stacco quasi nullo).
@@ -1917,7 +1917,7 @@ class ScoreVisualizer:
             'pointer_speed': 'x',
             'fill_factor': '',
             'distribution': '',
-            'num_voices': ' voci',
+            'num_voices': ' voices',
             'scatter': '',  # normalizzato 0-1, adimensionale
             'scatter': '',  # normalizzato 0-1, adimensionale
             'pc_rand_reverse': '%',

--- a/tests/rendering/test_score_visualizer.py
+++ b/tests/rendering/test_score_visualizer.py
@@ -511,8 +511,8 @@ class TestPerStreamLayout:
 
     @staticmethod
     def _wave_axes(fig):
-        """Assi waveform: uno per subplot/stream (ylabel 'Posizione di lettura (s)\\n<path>')."""
-        return [ax for ax in fig.axes if ax.get_ylabel().startswith('Posizione di lettura (s)')]
+        """Assi waveform: uno per subplot/stream (ylabel 'Read position (s)\\n<path>')."""
+        return [ax for ax in fig.axes if ax.get_ylabel().startswith('Read position (s)')]
 
     def test_two_different_samples_produce_at_least_two_axes(self):
         viz = make_viz(two_sample_scene(), config={'page_duration': 30.0})
@@ -1641,7 +1641,7 @@ class TestSingleBufferTimeAxis:
     @staticmethod
     def _wave_axes(fig):
         return [ax for ax in fig.axes
-                if ax.get_ylabel().startswith('Posizione di lettura (s)')]
+                if ax.get_ylabel().startswith('Read position (s)')]
 
     @staticmethod
     def _grain_axes(fig, page_start=0.0, page_end=30.0):
@@ -1694,7 +1694,7 @@ class TestFontScale:
     @staticmethod
     def _wave_ax(fig):
         return next(ax for ax in fig.axes
-                    if ax.get_ylabel().startswith('Posizione di lettura (s)'))
+                    if ax.get_ylabel().startswith('Read position (s)'))
 
     def test_default_config_exposes_font_keys(self):
         """Le nuove chiavi esistono nei default con valori retrocompatibili."""
@@ -1726,7 +1726,7 @@ class TestFontScale:
             viz.analyze()
             fig = viz.render_page(0)
         texts = [t for ax in fig.axes for t in ax.texts
-                 if 'Nessuno stream attivo' in t.get_text()]
+                 if 'No active stream' in t.get_text()]
         assert texts
         assert texts[0].get_fontsize() == 28        # empty_fontsize 14 * 2.0
 
@@ -1751,7 +1751,7 @@ class TestFontScaleLayout:
     @staticmethod
     def _width_ratios(fig):
         ax = next(ax for ax in fig.axes
-                  if ax.get_ylabel().startswith('Posizione di lettura (s)'))
+                  if ax.get_ylabel().startswith('Read position (s)'))
         return list(ax.get_subplotspec().get_gridspec().get_width_ratios())
 
     def test_font_scale_1_preserves_default_columns(self):


### PR DESCRIPTION
## Summary

Translate user-facing strings in the score visualizer from Italian to English, including page titles, axis labels, empty state messages, and parameter annotations.

## Changes

- **Page titles and empty state**: Changed "Pagina" → "Page" and "Nessuno stream attivo" → "No active stream"
- **Axis labels**: Updated "Posizione di lettura (s)" → "Read position (s)" and "Tempo (s)" → "Time (s)"
- **Parameter annotations**: Changed "voci" → "voices" in the `num_voices` parameter label
- **Test updates**: Updated test helper methods and assertions to match the new English strings in `_wave_axes()` and empty page text checks

## Implementation Details

All changes are string literals in the rendering layer (`src/rendering/score_visualizer.py`) and corresponding test assertions. No logic or functionality is altered—this is purely a localization pass to align the UI with English conventions.

The changes maintain backward compatibility with the configuration system and do not affect the YAML interface or any public APIs.

https://claude.ai/code/session_016VZoK7X21jYKpQ2eppBwVJ