### PR TITLE
Score visualizer: per-target corner override for magnify lenses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Aggiunto
 
+- Score visualizer (magnify): `corner` ora è override per-target in
+  `magnify_targets` (`top-right` | `top-left` | `bottom-right` | `bottom-left`),
+  come già `zoom`/`out`/`src`. Consente più lenti d'ingrandimento sullo stesso
+  stream/subplot senza sovrapporle, ancorandole ad angoli diversi (fino a 4 per
+  subplot). Assente la chiave, si usa il `corner` di `magnify_defaults`
+  (`top-right`): comportamento retrocompatibile, nessun cambiamento a
+  YAML/CLI/output.
 - Score visualizer: moltiplicatore globale `font_scale` (config, default `1.0`)
   applicato a tutte le dimensioni del testo della partitura — etichette assi,
   titolo, legenda envelope, annotazioni dei breakpoint, testo della pagina

--- a/src/rendering/score_visualizer.py
+++ b/src/rendering/score_visualizer.py
@@ -234,7 +234,9 @@ class ScoreVisualizer:
             # Default disattivata: a flag spenti render_page è identico a prima.
             'magnify_auto': False,        # lente automatica sul cluster più denso
             'magnify_targets': [],        # target espliciti: list[dict]
-                                          # (t obbligatorio; y/zoom/out/src/stream opz.)
+                                          # (t obbligatorio; y/zoom/out/src/stream/corner opz.)
+                                          # corner per-target -> piu' lenti non
+                                          # sovrapposte sullo stesso subplot
             'magnify_defaults': {
                 'zoom': 8.0,              # fattore di ingrandimento del contenuto
                 'out': 0.12,              # raggio cerchio di USCITA (frazione min figura)
@@ -903,7 +905,8 @@ class ScoreVisualizer:
         _, entry, tc, yc = best
         d = self.config['magnify_defaults']
         return {'entry': entry, 't': tc, 'y': yc,
-                'zoom': d['zoom'], 'out': d['out'], 'src': d['src']}
+                'zoom': d['zoom'], 'out': d['out'], 'src': d['src'],
+                'corner': d.get('corner', 'top-right')}
 
     def _resolve_explicit_target(self, target, page_start, page_end,
                                  stream_entries):
@@ -934,7 +937,8 @@ class ScoreVisualizer:
         return {'entry': entry, 't': float(t), 'y': float(y),
                 'zoom': target.get('zoom', d['zoom']),
                 'out': target.get('out', d['out']),
-                'src': target.get('src', d['src'])}
+                'src': target.get('src', d['src']),
+                'corner': target.get('corner', d.get('corner', 'top-right'))}
 
     def _densest_stream_entry(self, page_start, page_end, stream_entries):
         """Entry dello stream con più grani visibili in pagina (fallback: primo)."""
@@ -1002,7 +1006,8 @@ class ScoreVisualizer:
         # Posizione del cerchio di uscita: angolo del subplot (frazione figura).
         pos = ax_grain.get_position()
         r_fx, r_fy = out_r_px / W, out_r_px / H
-        corner = self.config['magnify_defaults'].get('corner', 'top-right')
+        corner = resolved.get('corner') or \
+            self.config['magnify_defaults'].get('corner', 'top-right')
         pad = 0.012
         cy = (pos.y1 - r_fy - pad) if 'top' in corner else (pos.y0 + r_fy + pad)
         cx = (pos.x1 - r_fx - pad) if 'right' in corner else (pos.x0 + r_fx + pad)

--- a/tests/rendering/test_score_visualizer.py
+++ b/tests/rendering/test_score_visualizer.py
@@ -1928,3 +1928,33 @@ class TestMagnifier:
         # ... e diverso dal valore fedele out/zoom (cerchio di partenza = knob a se')
         faithful = 0.012 * min(W, H)
         assert abs(src_ring.radius - faithful) > 0.1 * faithful
+
+    # --- corner per-target: piu' lenti sullo stesso stream senza sovrapporsi ---
+    def test_two_targets_same_stream_distinct_corners(self):
+        # Stessa regione (t, y) ma proiettata in due angoli opposti: i due inset
+        # NON devono cadere nello stesso punto. Prima della fix entrambi leggono
+        # il corner globale -> stessa posizione (rosso).
+        targets = [
+            {'t': 6.0, 'y': 1.5, 'corner': 'top-right'},
+            {'t': 6.0, 'y': 1.5, 'corner': 'bottom-left'},
+        ]
+        fig = self._render(single_stream_scene(),
+                           {'magnify_targets': targets})
+        lenses = self._magnifier_axes(fig)
+        assert len(lenses) == 2
+        pos = [ax.get_position() for ax in lenses]
+        # top sopra bottom, right a destra di left
+        assert pos[0].y0 > pos[1].y0
+        assert pos[0].x0 > pos[1].x0
+
+    def test_target_corner_default_top_right(self):
+        # Senza 'corner' esplicito la lente resta ancorata top-right (back-compat).
+        fig = self._render(single_stream_scene(),
+                           {'magnify_targets': [{'t': 6.0, 'y': 1.5}]})
+        grain_ax = self._grain_ax(fig)
+        gp = grain_ax.get_position()
+        lp = self._magnifier_axes(fig)[0].get_position()
+        # centro dell'inset nella meta' alta-destra del subplot dei grani
+        cx, cy = (lp.x0 + lp.x1) / 2, (lp.y0 + lp.y1) / 2
+        assert cx > (gp.x0 + gp.x1) / 2
+        assert cy > (gp.y0 + gp.y1) / 2


### PR DESCRIPTION
## Sommario

Aggiunge supporto per override per-target del parametro `corner` nei magnifier del score visualizer, consentendo di ancorare più lenti d'ingrandimento ad angoli diversi dello stesso subplot senza sovrapposizioni.

## Modifiche principali

- **Config schema**: aggiunto `corner` come parametro opzionale in `magnify_targets` (accanto a `zoom`, `out`, `src`), con fallback a `magnify_defaults['corner']` e default globale `'top-right'` per retrocompatibilità
- **Risoluzione target**: `_auto_magnify_target()` e `_resolve_explicit_target()` ora propagano il `corner` nel dict risotto, con cascata di fallback (per-target → defaults → hardcoded)
- **Posizionamento lente**: `_draw_one_magnifier()` legge `corner` da `resolved` anziché solo da config globale, permettendo posizionamenti indipendenti per ogni lente
- **Test**: due nuovi test verificano che lenti sullo stesso stream con corner diversi si posizionino in angoli distinti e che l'assenza di `corner` esplicito mantenga il comportamento `'top-right'`
- **Changelog**: documentato il nuovo parametro e il comportamento retrocompatibile

## Dettagli implementativi

- La cascata di fallback (`resolved.get('corner') or defaults.get('corner', 'top-right')`) garantisce che un `corner` esplicito per-target prevalga, altrimenti si usi il default globale
- Il calcolo di `cy` e `cx` in `_draw_one_magnifier()` rimane invariato; il `corner` string controlla solo quale angolo del subplot viene usato come ancoraggio
- Nessun cambio alla superficie YAML/CLI/output — il parametro è completamente opzionale e trasparente se non usato

https://claude.ai/code/session_013QKtfFFV1CTAVf1f68CP7e