### PR TITLE
fix(score_visualizer): separa la corsia _range dal valore base (issue #141)

### DIFF
--- a/src/rendering/score_visualizer.py
+++ b/src/rendering/score_visualizer.py
@@ -51,12 +51,15 @@ ENVELOPE_COLORS = {
     # === OUTPUT ===
     'volume': '#e41a1c',          # rosso
     'volume_prob': '#fb9a99',     # rosso chiaro
+    'volume_range': '#99000d',    # rosso scuro (deviazione per-grano)
     'pan': '#4daf4a',             # verde
     'pan_prob': '#b2df8a',        # verde chiaro
+    'pan_range': '#006d2c',       # verde scuro (deviazione per-grano)
 
     # === GRAIN ===
     'grain_duration': '#377eb8',  # blu
     'grain_duration_prob': '#a6cee3',  # blu chiaro
+    'grain_duration_range': '#08519c',  # blu scuro (deviazione per-grano)
     'reverse': '#999999',         # grigio
     'reverse_prob': '#cccccc',    # grigio chiarissimo
 
@@ -1393,24 +1396,28 @@ class ScoreVisualizer:
             # =====================================================================
             # PARTE 3: ESTRAZIONE RANGE (_mod_range) PER SPEC CON range_path
             # =====================================================================
-            # Per parametri come pointer_deviation il valore base e' un dummy 0
-            # costante (yaml_path='_dummy_fixed_zero_'); la deviazione reale vive
-            # in param._mod_range (issue #96). Chiave = spec.name: sovrascrive il
-            # dummy-0 eventualmente emesso da PARTE 1.
+            # I parametri che arrivano qui (pan, volume, grain_duration) hanno un
+            # valore base REALE gia' emesso da PARTE 1: la deviazione per-grano
+            # vive in param._mod_range (issue #96) e va su una chiave distinta
+            # `spec.name + '_range'` per non sovrascrivere il valore base (issue
+            # #141, es. il loop di pan + pan_range). Stesso pattern del suffisso
+            # '_prob' di PARTE 2. NB: pointer_deviation (base dummy-0) non passa
+            # di qui (hasattr e' False): e' gestito nel blocco dedicato sotto.
             if spec.range_path and isinstance(param, Parameter):
                 mod_range = getattr(param, '_mod_range', None)
+                range_key = f"{spec.name}_range"
 
                 if isinstance(mod_range, Envelope):
                     bp_values = [bp[1] for bp in mod_range.breakpoints]
                     is_static = len(set(bp_values)) == 1
                     if len(mod_range.breakpoints) > 1 and not is_static:
-                        envelopes[spec.name] = mod_range
+                        envelopes[range_key] = mod_range
                     elif show_static:
                         val = bp_values[0]
-                        envelopes[spec.name] = Envelope([[0, val], [stream.duration, val]])
+                        envelopes[range_key] = Envelope([[0, val], [stream.duration, val]])
 
                 elif isinstance(mod_range, (int, float)) and show_static:
-                    envelopes[spec.name] = Envelope([[0, mod_range], [stream.duration, mod_range]])
+                    envelopes[range_key] = Envelope([[0, mod_range], [stream.duration, mod_range]])
 
         # =====================================================================
         # PITCH: unit-driven, non più in PITCH_PARAMETER_SCHEMA. Raccolto da
@@ -2078,14 +2085,23 @@ class ScoreVisualizer:
         'effective_density': 'eff density',
         'distribution': 'distrib',
         'fill_factor': 'fill',
+        # Override compatto: 'grain dur rng' (13) sforerebbe la colonna (issue #141)
+        'grain_duration_range': 'gr dur rng',
     }
 
     def _legend_display_name(self, param_name):
-        """Nome corto per la legenda. Suffisso '_prob' → ' %' (probabilita')."""
+        """Nome corto per la legenda. Un override esplicito in _ENV_LEGEND_SHORT
+        ha precedenza; altrimenti suffisso '_prob' → ' %' (probabilita') e
+        '_range' → ' rng' (deviazione per-grano, issue #141)."""
+        if param_name in self._ENV_LEGEND_SHORT:
+            return self._ENV_LEGEND_SHORT[param_name]
         if param_name.endswith('_prob'):
             base = param_name[:-len('_prob')]
             return f"{self._legend_display_name(base)} %"
-        return self._ENV_LEGEND_SHORT.get(param_name, param_name.replace('_', ' '))
+        if param_name.endswith('_range'):
+            base = param_name[:-len('_range')]
+            return f"{self._legend_display_name(base)} rng"
+        return param_name.replace('_', ' ')
 
     def _draw_envelope_legend(self, ax, legend_entries):
         """

--- a/tests/rendering/test_score_visualizer.py
+++ b/tests/rendering/test_score_visualizer.py
@@ -873,7 +873,8 @@ class TestModRangeEnvelopeCollection:
     """issue #96 - i parametri con range_path (volume_range, pan_range,
     grain.duration_range, offset_range) tengono il range stocastico in
     Parameter._mod_range, mai estratto dal visualizer. Va raccolto sotto la
-    chiave spec.name. Qui via `volume` (stream-level, raggiungibile dal loop)."""
+    chiave `spec.name + '_range'` (issue #141: chiave distinta dal valore base).
+    Qui via `volume` (stream-level, raggiungibile dal loop)."""
 
     def _stream_with_volume_range(self, base, mod_range):
         from parameters.parameter import Parameter
@@ -887,22 +888,63 @@ class TestModRangeEnvelopeCollection:
     def test_dynamic_range_envelope_collected(self):
         from envelopes.envelope import Envelope
         s = self._stream_with_volume_range(-6.0, Envelope([[0, 0.0], [10, 12.0]]))
-        assert 'volume' in make_viz([s])._get_stream_envelopes(s)
+        assert 'volume_range' in make_viz([s])._get_stream_envelopes(s)
 
     def test_dynamic_range_envelope_is_the_mod_range(self):
         from envelopes.envelope import Envelope
         env = Envelope([[0, 0.0], [10, 12.0]])
         s = self._stream_with_volume_range(-6.0, env)
-        assert make_viz([s])._get_stream_envelopes(s)['volume'] is env
+        assert make_viz([s])._get_stream_envelopes(s)['volume_range'] is env
 
     def test_static_range_skipped_without_show_static(self):
         s = self._stream_with_volume_range(-6.0, 3.0)
-        assert 'volume' not in make_viz([s])._get_stream_envelopes(s)
+        assert 'volume_range' not in make_viz([s])._get_stream_envelopes(s)
 
     def test_static_range_collected_with_show_static(self):
         s = self._stream_with_volume_range(-6.0, 3.0)
         viz = make_viz([s], config={'show_static_params': True})
-        assert 'volume' in viz._get_stream_envelopes(s)
+        assert 'volume_range' in viz._get_stream_envelopes(s)
+
+
+class TestValueAndRangeCoexist:
+    """issue #141 - uno stream con valore base reale E range (_mod_range) deve
+    mostrare ENTRAMBE le curve: il valore sotto `spec.name`, il range sotto
+    `spec.name + '_range'`. Prima del fix la PARTE 3 sovrascriveva la chiave del
+    valore base (es. il loop di `pan` perso a favore di `pan_range`)."""
+
+    def _stream_with_pan(self, base, mod_range):
+        from parameters.parameter import Parameter
+        from parameters.parameter_definitions import GRANULAR_PARAMETERS
+        s = make_stream('s1', onset=0.0, duration=10.0)
+        s.pan = Parameter('pan', base, GRANULAR_PARAMETERS['pan'],
+                          mod_range=mod_range)
+        return s
+
+    def test_pan_loop_preserved_when_pan_range_present(self):
+        from envelopes.envelope import Envelope
+        base = Envelope([[0, 0.0], [10, 360.0]])      # loop rotativo
+        rng = Envelope([[0, 20.0], [10, 170.0]])      # deviazione per-grano
+        s = self._stream_with_pan(base, rng)
+        env = make_viz([s])._get_stream_envelopes(s)
+        assert 'pan' in env
+        assert env['pan'] is base
+
+    def test_pan_range_collected_under_suffixed_key(self):
+        from envelopes.envelope import Envelope
+        base = Envelope([[0, 0.0], [10, 360.0]])
+        rng = Envelope([[0, 20.0], [10, 170.0]])
+        s = self._stream_with_pan(base, rng)
+        env = make_viz([s])._get_stream_envelopes(s)
+        assert 'pan_range' in env
+        assert env['pan_range'] is rng
+
+    def test_pan_value_without_range_unchanged(self):
+        from envelopes.envelope import Envelope
+        base = Envelope([[0, 0.0], [10, 360.0]])
+        s = self._stream_with_pan(base, None)
+        env = make_viz([s])._get_stream_envelopes(s)
+        assert env.get('pan') is base
+        assert 'pan_range' not in env
 
 
 class TestDephaseGateEnvelopeCollection:
@@ -1039,6 +1081,17 @@ class TestLegendDisplayName:
 
     def test_grain_duration_prob_abbreviated(self):
         assert self._viz()._legend_display_name('grain_duration_prob') == 'grain dur %'
+
+    def test_range_suffix_becomes_rng(self):
+        # issue #141: la corsia della deviazione per-grano (_range)
+        assert self._viz()._legend_display_name('pan_range') == 'pan rng'
+
+    def test_volume_range_abbreviated(self):
+        assert self._viz()._legend_display_name('volume_range') == 'volume rng'
+
+    def test_grain_duration_range_override(self):
+        # override compatto per non sforare la colonna (13 char -> 10)
+        assert self._viz()._legend_display_name('grain_duration_range') == 'gr dur rng'
 
     def test_unmapped_underscore_becomes_space(self):
         assert self._viz()._legend_display_name('scatter') == 'scatter'


### PR DESCRIPTION
## Problema

Nella partitura grafica, uno stream che definisce **sia** `pan` (valore, anche un loop rotativo) **sia** `pan_range` (deviazione per-grano) mostrava nella corsia "pan" **solo** la curva di `pan_range`: il valore base spariva.

Causa, in `src/rendering/score_visualizer.py` → `_get_stream_envelopes`:

- **PARTE 1** registra il valore base sotto `envelopes[spec.name]` (es. `envelopes['pan']` = loop);
- **PARTE 3** estrae `param._mod_range` e faceva `envelopes[spec.name] = mod_range`, riscrivendo la **stessa chiave** e cancellando il valore base.

Riguarda i parametri con valore base reale e attributo di Stream: `pan`, `volume`, `grain_duration`.

## Fix

Il range va su una chiave distinta `{spec.name}_range`, replicando il pattern già usato per le probabilità (`_prob`). Così valore e deviazione vivono in corsie separate.

- **PARTE 3**: `envelopes[spec.name]` → `envelopes[f"{spec.name}_range"]` (rami dinamico + statici); commento aggiornato.
- `pointer_deviation` (base dummy-0, `yaml_path='_dummy_fixed_zero_'`, gestito nel blocco dedicato) **resta invariato** sulla chiave `pointer_deviation`.
- `ENVELOPE_COLORS`: colori dedicati `volume_range` / `pan_range` / `grain_duration_range` (terza tinta della famiglia del base, distinta da base e `_prob`).
- `_legend_display_name`: suffisso ` rng`; override compatto per `grain_duration_range` (evita lo sforo della colonna legenda stretta).
- Normalizzazione data-driven (#114) già corretta per le nuove chiavi: `pan_range` non è ciclico (non entra nel ramo ±180), scala sulla propria escursione.

## Test (TDD red→green)

- Nuova `TestValueAndRangeCoexist`: con `pan` loop + `pan_range`, ora coesistono le chiavi `pan` (valore) e `pan_range` (deviazione) — rosso prima del fix.
- `TestModRangeEnvelopeCollection` aggiornata alla chiave `volume_range`.
- Nuovi test legenda per `_range`; `TestPointerDeviationEnvelopeCollection` invariato (non-regressione).
- `make tests`: 4551 passati, 2 skip (sample mancanti, non correlati).

## Impatto cross-repo

- **PGE-ls / PGE-ui: nessun impatto.** `pan_range`/`volume_range`/`grain.duration_range` sono sintassi YAML già esistente; il fix è rendering interno del PDF di partitura. PGE-ui consuma audio/stem e grain JSON, non il PDF (cfr. #113); PGE-ls non coinvolto.
- **Paper CIM 2026:** osservabile dagli esempi (`complete_example.yml` combina `pan` + `pan_range`: la corsia pan passa da una a due curve). Dopo il merge va bumpato il submodule PGE nel repo del paper e rigenerati gli esempi (`make link-refs` + `make examples`).

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YEDRVGNoiVcxcyRmA3FxkP

---
_Generated by [Claude Code](https://claude.ai/code/session_01YEDRVGNoiVcxcyRmA3FxkP)_