### PR TITLE
Add grain_shape='window' mode to visualize envelope curves

### DIFF
--- a/configs/PGE_grain_shape_window_demo.yml
+++ b/configs/PGE_grain_shape_window_demo.yml
@@ -1,0 +1,62 @@
+# PGE_grain_shape_window_demo.yml
+# Demo del flag grain_shape='window' dello score visualizer: il bordo
+# superiore ("testa") del grano traccia la curva della finestra/envelope.
+# Cinque stream, una finestra ciascuno (hanning, expodec, exporise, gaussian,
+# bartlett); grani radi e lunghi cosi' la silhouette e' ben leggibile nella
+# partitura.
+streams:
+
+  - stream_id: "s1_hanning"
+    onset: 0.0
+    duration: 6.0
+    sample: "sinus.wav"
+    density: 1.0
+    grain:
+      duration: 0.6
+      envelope: hanning
+    pointer:
+      speed_ratio: {points: [[0.0, 0.3], [6.0, 0.0]]}
+
+  - stream_id: "s2_expodec"
+    onset: 0.0
+    duration: 6.0
+    sample: "sinus.wav"
+    density: 1.0
+    grain:
+      duration: 0.6
+      envelope: expodec
+    pointer:
+      speed_ratio: {points: [[0.0, 0.3], [6.0, 0.0]]}
+
+  - stream_id: "s3_exporise"
+    onset: 0.0
+    duration: 6.0
+    sample: "sinus.wav"
+    density: 1.0
+    grain:
+      duration: 0.6
+      envelope: exporise
+    pointer:
+      speed_ratio: {points: [[0.0, 0.3], [6.0, 0.0]]}
+
+  - stream_id: "s4_gaussian"
+    onset: 0.0
+    duration: 6.0
+    sample: "sinus.wav"
+    density: 1.0
+    grain:
+      duration: 0.6
+      envelope: gaussian
+    pointer:
+      speed_ratio: {points: [[0.0, 0.3], [6.0, 0.0]]}
+
+  - stream_id: "s5_bartlett"
+    onset: 0.0
+    duration: 6.0
+    sample: "sinus.wav"
+    density: 1.0
+    grain:
+      duration: 0.6
+      envelope: bartlett
+    pointer:
+      speed_ratio: {points: [[0.0, 0.3], [6.0, 0.0]]}

--- a/src/rendering/score_visualizer.py
+++ b/src/rendering/score_visualizer.py
@@ -147,6 +147,23 @@ class ScoreVisualizer:
             },
             'volume_range': (-60, 0),        # dB range per normalizzare alpha
             'min_grain_width_pts': 1,        # larghezza minima visibile
+            # Forma del grano nella partitura:
+            #   'arrow'  -> freccia direzionale (default, comportamento storico);
+            #   'window' -> il bordo superiore ("testa") traccia la curva della
+            #               finestra/envelope del grano, base piatta sul pointer.
+            # La finestra e' altrimenti invisibile nella partitura: due grani con
+            # envelope diversi (hanning vs expodec) hanno la stessa freccia.
+            'grain_shape': 'arrow',
+            # Numero di punti con cui campionare la curva della finestra per la
+            # silhouette (solo grain_shape='window'). La silhouette normalizzata
+            # e' precalcolata e cachata per (nome, risoluzione): il costo per
+            # grano e' solo una trasformazione affine dei vertici.
+            'window_shape_resolution': 32,
+            # Soglia adattiva: se la larghezza del grano sulla pagina e' sotto
+            # questo numero di pixel, la finestra non sarebbe leggibile e il
+            # grano ripiega sulla freccia a 5 vertici (cap al costo vettoriale
+            # sugli score densi).
+            'window_shape_min_px': 3,
             
             # Waveform
             'waveform_alpha': 0.3,
@@ -253,6 +270,12 @@ class ScoreVisualizer:
         
         # Cache waveform
         self.waveform_cache = {}
+
+        # Cache silhouette finestra normalizzata, chiave (nome, risoluzione).
+        # Popolata lazy da _window_silhouette; il registry NumPy e' creato al
+        # primo uso (solo con grain_shape='window').
+        self._window_silhouette_cache = {}
+        self._window_registry = None
         
         # Dati calcolati
         self.total_duration = None
@@ -1080,6 +1103,112 @@ class ScoreVisualizer:
         )
 
 
+    def _grain_arrow_vertices(self, grain):
+        """Vertici della freccia direzionale (forma storica del grano).
+
+        5 vertici: rettangolo [onset, onset+duration] x [pointer, pointer+dur]
+        con punta triangolare verso l'alto (forward) o il basso (reverse)."""
+        x = grain.onset
+        width = grain.duration
+        pointer_y = grain.pointer_pos
+        height = grain.duration
+        arrow_head_width = width * 0.5
+
+        if grain.pitch_ratio < 0:
+            y_top = pointer_y
+            y_bottom = pointer_y - height
+            return [
+                (x, y_top),                               # alto sinistra
+                (x + width, y_top),                       # alto destra
+                (x + width, y_bottom + arrow_head_width), # prima della punta destra
+                (x + width / 2, y_bottom),                # punta centrale (GIU')
+                (x, y_bottom + arrow_head_width),         # prima della punta sinistra
+            ]
+        y_bottom = pointer_y
+        y_top = pointer_y + height
+        return [
+            (x, y_bottom),                                # basso sinistra
+            (x + width, y_bottom),                        # basso destra
+            (x + width, y_top - arrow_head_width),        # prima della punta destra
+            (x + width / 2, y_top),                       # punta centrale (SU)
+            (x, y_top - arrow_head_width),                # prima della punta sinistra
+        ]
+
+    def _grain_window_vertices(self, grain, xs, w):
+        """Vertici della silhouette "testa/bordo": base piatta sul pointer, il
+        bordo superiore segue la curva della finestra w (normalizzata su [0,1]).
+
+        xs, w: arrays normalizzati su [0,1] (vedi _window_silhouette). La
+        direzione (sopra/sotto il pointer) segue il segno di pitch_ratio come
+        per la freccia."""
+        x = grain.onset
+        width = grain.duration
+        pointer_y = grain.pointer_pos
+        height = grain.duration
+
+        xs_abs = x + xs * width
+        if grain.pitch_ratio < 0:
+            edge = pointer_y - height * w
+        else:
+            edge = pointer_y + height * w
+
+        vertices = [(x, pointer_y)]
+        vertices.extend((float(xi), float(yi)) for xi, yi in zip(xs_abs, edge))
+        vertices.append((x + width, pointer_y))
+        return vertices
+
+    def _window_registry_lazy(self):
+        """Istanzia il NumpyWindowRegistry al primo uso (solo grain_shape='window')."""
+        if self._window_registry is None:
+            from rendering.numpy_window_registry import NumpyWindowRegistry
+            self._window_registry = NumpyWindowRegistry()
+        return self._window_registry
+
+    def _window_silhouette(self, name, resolution):
+        """Curva finestra normalizzata su [0,1] in ampiezza e dominio.
+
+        Ritorna (xs, w) con xs = linspace(0,1,resolution) e w la finestra
+        riscalata a picco unitario. Cachata per (name, resolution): la forma di
+        una finestra dato il nome e' sempre la stessa, cambia solo la scala
+        applicata per grano."""
+        key = (name, resolution)
+        cached = self._window_silhouette_cache.get(key)
+        if cached is not None:
+            return cached
+
+        w = self._window_registry_lazy().get(name, resolution)
+        w = np.clip(np.asarray(w, dtype=float), 0.0, None)
+        peak = float(w.max())
+        if peak > 0:
+            w = w / peak
+        xs = np.linspace(0.0, 1.0, resolution)
+        result = (xs, w)
+        self._window_silhouette_cache[key] = result
+        return result
+
+    def _window_name_map(self, stream):
+        """Mappa table_num -> nome finestra invertendo stream.window_table_map.
+
+        Ritorna {} se la mappa non e' disponibile (fallback alla freccia)."""
+        wtm = getattr(stream, 'window_table_map', None)
+        if not wtm:
+            return {}
+        return {num: name for name, num in wtm.items()}
+
+    def _grain_page_width_px(self, ax, grain):
+        """Larghezza del grano sulla pagina in pixel display.
+
+        Usata per il fallback adattivo: grani sub-pixel non mostrano la finestra
+        in modo leggibile. Se la trasformazione non e' disponibile (axes non
+        ancora disegnato) ritorna +inf -> nessun fallback."""
+        try:
+            t = ax.transData
+            x0 = t.transform((grain.onset, 0.0))[0]
+            x1 = t.transform((grain.onset + grain.duration, 0.0))[0]
+            return abs(x1 - x0)
+        except Exception:
+            return float('inf')
+
     def _draw_grains_full(self, ax, stream, sample_duration, page_start,
                           page_end, cents_range=None):
         """Disegna grani con coordinate Y assolute nel sample.
@@ -1097,57 +1226,44 @@ class ScoreVisualizer:
         
         if not visible_grains:
             return
-        
+
         polygons = []
         #rectangles = []
         colors = []
-        
+
+        # Modalita' forma del grano. In 'window' il bordo superiore traccia la
+        # curva della finestra; serve la mappa table_num -> nome finestra (una
+        # volta per stream) e la risoluzione di campionamento.
+        grain_shape = self.config.get('grain_shape', 'arrow')
+        window_mode = grain_shape == 'window'
+        if window_mode:
+            name_map = self._window_name_map(stream)
+            resolution = self.config['window_shape_resolution']
+            min_px = self.config['window_shape_min_px']
+            # name_map vuota (window_table_map assente) -> niente nomi da
+            # risolvere: si ripiega interamente sulla freccia.
+            if not name_map:
+                window_mode = False
+
         for grain in visible_grains:
-            # X: tempo partitura
-            x = grain.onset
-            width = grain.duration
-            
-            # Y: posizione assoluta nel sample (in secondi)
-            pointer_y = grain.pointer_pos
-            
-            # Altezza: sample consumato (in secondi)
-            # Considerando durata
-            height = grain.duration # * abs(grain.pitch_ratio)
-
-            # Dimensione punta freccia (% della larghezza)
-            arrow_head_width = width * 0.5  # 30% della larghezza del grano
-
-            # Direzione
-            if grain.pitch_ratio < 0:
-                y_top = pointer_y
-                y_bottom = pointer_y - height
-
-                # 7 punti: rettangolo con punta triangolare in basso
-                vertices = [
-                    (x, y_top),                           # alto sinistra
-                    (x + width, y_top),                   # alto destra
-                    (x + width, y_bottom + arrow_head_width),  # prima della punta destra
-                    (x + width/2, y_bottom),              # punta centrale (GIÙ)
-                    (x, y_bottom + arrow_head_width),     # prima della punta sinistra
-                ]
+            # window_mode con grano abbastanza largo sulla pagina e finestra
+            # risolvibile -> silhouette della finestra; altrimenti freccia.
+            use_window = (
+                window_mode
+                and self._grain_page_width_px(ax, grain) >= min_px
+                and grain.envelope_table in name_map
+            )
+            if use_window:
+                xs, w = self._window_silhouette(
+                    name_map[grain.envelope_table], resolution)
+                vertices = self._grain_window_vertices(grain, xs, w)
             else:
-                # FRECCIA SU (forward)
-                y_bottom = pointer_y
-                y_top = pointer_y + height
-                
-                # 7 punti: rettangolo con punta triangolare in alto
-                vertices = [
-                    (x, y_bottom),                        # basso sinistra
-                    (x + width, y_bottom),                # basso destra
-                    (x + width, y_top - arrow_head_width),  # prima della punta destra
-                    (x + width/2, y_top),                 # punta centrale (SU)
-                    (x, y_top - arrow_head_width),        # prima della punta sinistra
-                ]
-            
+                vertices = self._grain_arrow_vertices(grain)
+
             # Crea poligono
             poly = mpatches.Polygon(vertices, closed=True)
             polygons.append(poly)
-            
+
             # Colore
             color = list(self._pitch_to_color(abs(grain.pitch_ratio),
                                               cents_range))

--- a/tests/rendering/test_score_visualizer_window_shape.py
+++ b/tests/rendering/test_score_visualizer_window_shape.py
@@ -1,0 +1,260 @@
+# tests/rendering/test_score_visualizer_window_shape.py
+"""
+Suite per la rappresentazione della finestratura nella forma del grano
+(variante "testa/bordo sagomato", flag opt-in grain_shape).
+
+La finestra del grano (hanning, expodec, exporise, ...) e' oggi invisibile
+nella partitura: tutti i grani sono frecce identiche. Con grain_shape='window'
+il bordo superiore (la "testa") del grano traccia la curva della finestra,
+mentre la base resta piatta sulla traccia del pointer.
+
+Test divisi in:
+- geometria pura (silhouette normalizzata + vertici del poligono), senza
+  dipendere da matplotlib;
+- comportamento del disegno (default invariato, branch window, fallback
+  adattivo per grani troppo piccoli).
+"""
+
+import sys
+import types
+
+import numpy as np
+import pytest
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+from unittest.mock import MagicMock
+
+# Stesso blocco dipendenze pesanti degli altri test del visualizer
+_sf_mod = types.ModuleType('soundfile')
+_sf_mod.read = MagicMock()
+_sf_mod.info = MagicMock()
+sys.modules.setdefault('soundfile', _sf_mod)
+
+from rendering.score_visualizer import ScoreVisualizer  # noqa: E402
+
+
+# =============================================================================
+# FACTORY
+# =============================================================================
+
+def make_grain(onset=0.0, duration=0.5, pointer_pos=0.5,
+               pitch_ratio=1.0, volume=-6.0, envelope_table=10):
+    g = MagicMock()
+    g.onset = onset
+    g.duration = duration
+    g.pointer_pos = pointer_pos
+    g.pitch_ratio = pitch_ratio
+    g.volume = volume
+    g.envelope_table = envelope_table
+    return g
+
+
+def make_stream(grains, window_table_map=None):
+    s = MagicMock()
+    s.voices = [grains]
+    s.stream_id = 's1'
+    s.onset = 0.0
+    s.duration = 6.0
+    if window_table_map is not None:
+        s.window_table_map = window_table_map
+    else:
+        del s.window_table_map
+    return s
+
+
+def make_viz(config=None):
+    gen = MagicMock()
+    gen.streams = []
+    return ScoreVisualizer(gen, config=config)
+
+
+@pytest.fixture(autouse=True)
+def close_figures():
+    yield
+    plt.close('all')
+
+
+# =============================================================================
+# GROUP 1 - Config: opt-in, default invariato
+# =============================================================================
+
+class TestConfigDefault:
+
+    def test_grain_shape_default_is_arrow(self):
+        viz = make_viz()
+        assert viz.config['grain_shape'] == 'arrow'
+
+    def test_grain_shape_override_window(self):
+        viz = make_viz(config={'grain_shape': 'window'})
+        assert viz.config['grain_shape'] == 'window'
+
+
+# =============================================================================
+# GROUP 2 - Silhouette finestra normalizzata
+# =============================================================================
+
+class TestWindowSilhouette:
+
+    def test_returns_arrays_of_requested_resolution(self):
+        viz = make_viz()
+        xs, w = viz._window_silhouette('hanning', 32)
+        assert len(xs) == 32
+        assert len(w) == 32
+
+    def test_normalized_to_unit_peak_and_domain(self):
+        viz = make_viz()
+        xs, w = viz._window_silhouette('hanning', 64)
+        assert xs[0] == pytest.approx(0.0)
+        assert xs[-1] == pytest.approx(1.0)
+        assert w.max() == pytest.approx(1.0)
+        assert w.min() >= 0.0
+
+    def test_hanning_is_symmetric(self):
+        viz = make_viz()
+        _, w = viz._window_silhouette('hanning', 64)
+        assert np.allclose(w, w[::-1], atol=1e-6)
+
+    def test_expodec_decays_left_to_right(self):
+        # expodec: attacco pieno, decadimento -> w[0] > w[-1]
+        viz = make_viz()
+        _, w = viz._window_silhouette('expodec', 64)
+        assert w[0] > w[-1]
+
+    def test_exporise_rises_left_to_right(self):
+        viz = make_viz()
+        _, w = viz._window_silhouette('exporise', 64)
+        assert w[0] < w[-1]
+
+    def test_silhouette_cached_by_name_and_resolution(self):
+        viz = make_viz()
+        a = viz._window_silhouette('hanning', 32)
+        b = viz._window_silhouette('hanning', 32)
+        assert a is b
+
+
+# =============================================================================
+# GROUP 3 - Vertici del poligono (variante testa/bordo)
+# =============================================================================
+
+class TestWindowVertices:
+
+    def test_vertex_count_is_resolution_plus_two(self):
+        viz = make_viz()
+        xs, w = viz._window_silhouette('hanning', 32)
+        grain = make_grain(onset=1.0, duration=0.5, pointer_pos=0.4)
+        verts = viz._grain_window_vertices(grain, xs, w)
+        assert len(verts) == 34  # base sx + 32 punti bordo + base dx
+
+    def test_base_flat_on_pointer_forward(self):
+        viz = make_viz()
+        xs, w = viz._window_silhouette('hanning', 32)
+        grain = make_grain(onset=1.0, duration=0.5, pointer_pos=0.4,
+                           pitch_ratio=1.0)
+        verts = viz._grain_window_vertices(grain, xs, w)
+        # primo e ultimo vertice = base piatta sul pointer
+        assert verts[0][1] == pytest.approx(0.4)
+        assert verts[-1][1] == pytest.approx(0.4)
+
+    def test_edge_follows_window_above_pointer_forward(self):
+        viz = make_viz()
+        xs, w = viz._window_silhouette('hanning', 32)
+        grain = make_grain(onset=1.0, duration=0.5, pointer_pos=0.4,
+                           pitch_ratio=1.0)
+        verts = viz._grain_window_vertices(grain, xs, w)
+        edge_ys = [y for (_, y) in verts[1:-1]]
+        # tutti sopra (o uguali) il pointer; picco = pointer + height
+        assert min(edge_ys) >= 0.4 - 1e-9
+        assert max(edge_ys) == pytest.approx(0.4 + 0.5)
+
+    def test_edge_below_pointer_when_reverse(self):
+        viz = make_viz()
+        xs, w = viz._window_silhouette('hanning', 32)
+        grain = make_grain(onset=1.0, duration=0.5, pointer_pos=0.4,
+                           pitch_ratio=-1.0)
+        verts = viz._grain_window_vertices(grain, xs, w)
+        edge_ys = [y for (_, y) in verts[1:-1]]
+        assert max(edge_ys) <= 0.4 + 1e-9
+        assert min(edge_ys) == pytest.approx(0.4 - 0.5)
+
+    def test_x_span_matches_grain_extent(self):
+        viz = make_viz()
+        xs, w = viz._window_silhouette('hanning', 32)
+        grain = make_grain(onset=1.0, duration=0.5, pointer_pos=0.4)
+        verts = viz._grain_window_vertices(grain, xs, w)
+        xsv = [x for (x, _) in verts]
+        assert min(xsv) == pytest.approx(1.0)
+        assert max(xsv) == pytest.approx(1.5)
+
+
+# =============================================================================
+# GROUP 4 - Vertici freccia (comportamento legacy invariato)
+# =============================================================================
+
+class TestArrowVertices:
+
+    def test_arrow_has_five_vertices(self):
+        viz = make_viz()
+        grain = make_grain(onset=1.0, duration=0.5, pointer_pos=0.4,
+                           pitch_ratio=1.0)
+        verts = viz._grain_arrow_vertices(grain)
+        assert len(verts) == 5
+
+
+# =============================================================================
+# GROUP 5 - Disegno: branch su grain_shape
+# =============================================================================
+
+class TestDrawGrainsFullBranch:
+
+    def _draw(self, config):
+        viz = make_viz(config=config)
+        fig, ax = plt.subplots()
+        # axes con range realistico cosi' la trasformazione px e' sensata
+        ax.set_xlim(0, 6)
+        ax.set_ylim(0, 2)
+        fig.canvas.draw()
+        wtm = {'expodec': 10}
+        grain = make_grain(onset=1.0, duration=0.5, pointer_pos=0.4,
+                           pitch_ratio=1.0, envelope_table=10)
+        stream = make_stream([grain], window_table_map=wtm)
+        viz._draw_grains_full(ax, stream, sample_duration=2.0,
+                              page_start=0.0, page_end=6.0)
+        return ax
+
+    def test_arrow_mode_polygon_has_five_vertices(self):
+        ax = self._draw({'grain_shape': 'arrow'})
+        assert len(ax.collections) == 1
+        paths = ax.collections[0].get_paths()
+        # 5 vertici + eventuale chiusura -> <= 6 punti nel path
+        assert len(paths[0].vertices) <= 6
+
+    def test_window_mode_polygon_has_many_vertices(self):
+        ax = self._draw({'grain_shape': 'window',
+                         'window_shape_resolution': 32})
+        assert len(ax.collections) == 1
+        paths = ax.collections[0].get_paths()
+        assert len(paths[0].vertices) > 6
+
+
+# =============================================================================
+# GROUP 6 - Fallback adattivo per grani sotto soglia
+# =============================================================================
+
+class TestAdaptiveFallback:
+
+    def test_tiny_grain_falls_back_to_arrow(self):
+        viz = make_viz(config={'grain_shape': 'window',
+                               'window_shape_resolution': 32,
+                               'window_shape_min_px': 50})
+        fig, ax = plt.subplots()
+        ax.set_xlim(0, 600)   # 600s su pochi pollici -> grano 0.5s e' sub-pixel
+        ax.set_ylim(0, 2)
+        fig.canvas.draw()
+        grain = make_grain(onset=1.0, duration=0.5, pointer_pos=0.4,
+                           envelope_table=10)
+        stream = make_stream([grain], window_table_map={'hanning': 10})
+        viz._draw_grains_full(ax, stream, sample_duration=2.0,
+                              page_start=0.0, page_end=600.0)
+        paths = ax.collections[0].get_paths()
+        assert len(paths[0].vertices) <= 6  # ripiego a freccia


### PR DESCRIPTION
## Summary

Implements optional visualization of grain envelope curves in the score visualizer. When `grain_shape='window'` is enabled, the top edge ("head") of each grain polygon traces the normalized window/envelope curve, while the base remains flat on the pointer position. This makes envelope differences (hanning vs expodec vs exporise, etc.) visible in the score, whereas previously all grains appeared as identical directional arrows.

## Key Changes

- **New config options** in `ScoreVisualizer.__init__`:
  - `grain_shape`: 'arrow' (default, backward-compatible) or 'window'
  - `window_shape_resolution`: sampling resolution for envelope curve (default 32)
  - `window_shape_min_px`: adaptive fallback threshold in pixels (default 3)

- **New methods in `ScoreVisualizer`**:
  - `_grain_arrow_vertices()`: extracted legacy 5-vertex arrow logic
  - `_grain_window_vertices()`: generates polygon vertices following envelope curve
  - `_window_silhouette()`: normalizes and caches window curves by (name, resolution)
  - `_window_registry_lazy()`: lazy instantiation of NumpyWindowRegistry
  - `_window_name_map()`: inverts stream.window_table_map for table_num → name lookup
  - `_grain_page_width_px()`: computes grain width in display pixels for adaptive fallback

- **Refactored `_draw_grains_full()`**:
  - Branching logic on `grain_shape` config
  - Adaptive fallback: if grain width < `window_shape_min_px` or envelope table not in map, uses arrow
  - Requires `stream.window_table_map` to resolve envelope names; gracefully falls back to arrow if absent

- **Caching**:
  - `_window_silhouette_cache`: memoizes normalized curves by (name, resolution)
  - `_window_registry`: lazy-loaded NumpyWindowRegistry instance

- **Comprehensive test suite** (`tests/rendering/test_score_visualizer_window_shape.py`):
  - Config opt-in and default invariance (GROUP 1)
  - Window silhouette normalization and symmetry (GROUP 2)
  - Polygon vertex geometry for window mode (GROUP 3)
  - Arrow vertex legacy behavior (GROUP 4)
  - Drawing branch on `grain_shape` config (GROUP 5)
  - Adaptive fallback for sub-pixel grains (GROUP 6)

- **Demo config** (`configs/PGE_grain_shape_window_demo.yml`):
  - Five streams with different envelopes (hanning, expodec, exporise, gaussian, bartlett)
  - Sparse, long grains for clear silhouette visibility

## Implementation Details

- **Direction handling**: Envelope curves scale with `grain.duration` and respect `grain.pitch_ratio` sign (forward/reverse)
- **Fallback strategy**: Grained sub-pixel on page or missing envelope table → automatic arrow fallback (no error)
- **Backward compatible**: Default `grain_shape='arrow'` preserves existing behavior; no breaking changes
- **Lazy registry**: NumpyWindowRegistry only instantiated if `grain_shape='window'` is actually used
- **Coordinate transform**: Uses `ax.transData` to compute pixel width; handles missing transform gracefully (returns ∞ → no fallback)

https://claude.ai/code/session_01MP6Sef6DCknfDkpLRhg7hW