### PR TITLE
fix: voice strategy envelopes inherit stream time_mode (issue #144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,17 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Corretto
 
+- fix(stream): gli envelope dei parametri delle strategy voce
+  (`voices.{pitch,onset_offset,pointer,pan}.{step,spread,…}`) ora ereditano il
+  `time_mode: normalized` dichiarato a livello di stream, come già gli envelope
+  diretti (`density`, `pan_range`, …). Prima la forma compatta (lista di
+  breakpoint) restava sempre in secondi assoluti anche su stream `normalized`:
+  lo stesso `time_mode` aveva due semantiche diverse a seconda che l'envelope
+  fosse diretto o dentro `voices.*` (incoerenza silenziosa). `Stream._parse_strategy_kwarg`
+  riceve ora il `time_mode` dello stream; la forma dict con `time_mode`/`time_unit`
+  locale continua a sovrascriverlo. **Breaking change semantico**: chi usava la
+  forma compatta dentro `voices.*` su uno stream `normalized` vedrà i tempi
+  scalati sulla `duration` invece che interpretati in secondi. (issue #144)
 - fix(score-visualizer): curve envelope data-driven, rimosso il clipping ai
   range fissi (pan resta ciclico). Le curve envelope venivano normalizzate su
   `envelope_ranges` fissi e clippate a `[0,1]`: quando i valori reali superavano

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -1034,6 +1034,45 @@ density: [[[0, 0], [100, 50]], 0.5, 4]
 # 4 ripetizioni distribuite tra 0 e 15s
 ```
 
+#### 3.4 Strategy envelope dei `voices.*`
+
+Gli envelope dei parametri delle strategy voce
+(`voices.{pitch,onset_offset,pointer,pan}.{step,spread,...}`) **ereditano** il
+`time_mode` dello stream esattamente come gli envelope diretti (`density`,
+`pan_range`, …). Una lista compatta di breakpoint su uno stream `normalized`
+viene quindi scalata sulla `duration`:
+
+```yaml
+streams:
+  - stream_id: s1
+    duration: 40.0
+    time_mode: normalized
+    voices:
+      num_voices: 5
+      pan:
+        strategy: step
+        step: [[.6, 0], [.7, 60.0]]   # 0.6 → 24s, 0.7 → 28s (scalati su duration)
+```
+
+Come per gli envelope diretti, la forma dict con `time_mode` (o l'alias
+`time_unit`) locale **sovrascrive** quello dello stream:
+
+```yaml
+    time_mode: normalized
+    voices:
+      pan:
+        strategy: step
+        step:                          # locale absolute → tempi in secondi
+          points: [[.6, 0], [.7, 60.0]]
+          time_mode: absolute
+```
+
+> Nota storica: fino all'issue #144 le strategy envelope in forma compatta
+> restavano sempre in secondi assoluti anche su stream `normalized` (incoerenza
+> silenziosa con gli envelope diretti). Dopo il fix il `time_mode` di stream è
+> onorato — breaking change semantico per chi usava la forma compatta dentro
+> `voices.*` su stream `normalized`.
+
 ---
 
 ### 4. Tipi di interpolazione

--- a/src/core/stream.py
+++ b/src/core/stream.py
@@ -43,14 +43,22 @@ from strategies.grain_clip_strategy import GrainClipStrategyFactory, OverflowMar
 from dataclasses import fields
 
 
-def _parse_strategy_kwarg(value, duration: float):
-    """Converte kwarg YAML strategy: str/int passthrough, envelope-like → Envelope."""
-    if isinstance(value, str):
-        return value
-    if isinstance(value, (int, float)):
+def _parse_strategy_kwarg(value, duration: float, stream_time_mode: str = 'absolute'):
+    """Converte kwarg YAML strategy: str/int passthrough, envelope-like → Envelope.
+
+    Gli envelope-like ereditano il `time_mode` dello stream (issue #144),
+    esattamente come gli envelope diretti via GranularParser. In forma dict il
+    `time_mode` locale sovrascrive quello dello stream; in forma compatta (lista)
+    si applica il time_mode dello stream.
+    """
+    if isinstance(value, (str, int, float)):
         return value
     if Envelope.is_envelope_like(value):
-        if isinstance(value, dict) and value.get('time_mode') == 'normalized':
+        if isinstance(value, dict):
+            tm = value.get('time_mode', stream_time_mode)
+        else:
+            tm = stream_time_mode
+        if tm == 'normalized':
             return create_scaled_envelope(value, duration, 'normalized')
         return Envelope(value)
     return value
@@ -291,7 +299,7 @@ class Stream:
             if name == 'stochastic':
                 kw['stream_id'] = self.stream_id
                 kw['seed'] = self.seed
-            kw = {k: _parse_strategy_kwarg(val, self.duration) for k, val in kw.items()}
+            kw = {k: _parse_strategy_kwarg(val, self.duration, config.time_mode) for k, val in kw.items()}
             pitch_strategy = VoicePitchStrategyFactory.create(name, **kw)
 
         # --- ONSET ---
@@ -302,7 +310,7 @@ class Stream:
             if name == 'stochastic':
                 kw['stream_id'] = self.stream_id
                 kw['seed'] = self.seed
-            kw = {k: _parse_strategy_kwarg(val, self.duration) for k, val in kw.items()}
+            kw = {k: _parse_strategy_kwarg(val, self.duration, config.time_mode) for k, val in kw.items()}
             onset_strategy = VoiceOnsetStrategyFactory.create(name, **kw)
 
         # --- POINTER ---
@@ -326,7 +334,7 @@ class Stream:
             if name == 'stochastic':
                 kw['stream_id'] = self.stream_id
                 kw['seed'] = self.seed
-            kw = {k: _parse_strategy_kwarg(val, self.duration) for k, val in kw.items()}
+            kw = {k: _parse_strategy_kwarg(val, self.duration, config.time_mode) for k, val in kw.items()}
             pointer_strategy = VoicePointerStrategyFactory.create(name, **kw)
 
         # --- PAN ---
@@ -337,7 +345,7 @@ class Stream:
             if name == 'stochastic':
                 kw['stream_id'] = self.stream_id
                 kw['seed'] = self.seed
-            kw = {k: _parse_strategy_kwarg(val, self.duration) for k, val in kw.items()}
+            kw = {k: _parse_strategy_kwarg(val, self.duration, config.time_mode) for k, val in kw.items()}
             pan_strategy = VoicePanStrategyFactory.create(name, **kw)
 
         self._voice_manager = VoiceManager(

--- a/tests/core/test_stream_voices_yaml.py
+++ b/tests/core/test_stream_voices_yaml.py
@@ -57,6 +57,8 @@ from strategies.voice_pointer_strategy import (
 )
 from strategies.voice_pan_strategy import RangePanStrategy, StochasticPanStrategy, StepPanStrategy
 from parameters.pitch_unit import EdoUnit, RatioUnit
+from parameters.parameter import resolve_param
+from envelopes.envelope import Envelope
 
 
 def _f(semitones: float) -> float:
@@ -896,3 +898,95 @@ class TestVoicesPitchUnitSemitoneLocked:
             'pitch': {'strategy': 'chord', 'chord': 'dom7', 'unit': 'semitones'},
         })
         assert s._voice_manager.pitch_unit.divisions == 12
+
+
+# =============================================================================
+# 11. time_mode di stream ereditato dagli envelope delle strategy voce (issue #144)
+# =============================================================================
+
+def _build_stream_tm(voices_params, time_mode=None, duration=10.0, stream_id='s1'):
+    """Come _build_stream ma con controllo su time_mode e duration dello stream.
+
+    Serve a verificare che gli envelope delle strategy voce (voices.*) ereditino
+    il time_mode dello stream, come gli envelope diretti (issue #144).
+    """
+    params = {
+        'stream_id': stream_id,
+        'onset': 0.0,
+        'duration': duration,
+        'sample': 'test.wav',
+        'voices': voices_params,
+    }
+    if time_mode is not None:
+        params['time_mode'] = time_mode
+    with patch('core.stream.get_sample_duration', return_value=SAMPLE_DUR):
+        return Stream(params)
+
+
+class TestVoiceStrategyTimeModeInheritance:
+    """Issue #144: gli envelope dei parametri delle strategy voce ereditano il
+    `time_mode: normalized` dichiarato a livello di stream, esattamente come gli
+    envelope diretti (density, pan_range, ...). Il time_mode locale (forma dict)
+    sovrascrive quello dello stream."""
+
+    def test_compact_list_inherits_normalized_pan(self):
+        """Lista compatta + stream normalized → tempi scalati su duration.
+
+        step: [[.6, 0], [.7, 60]] con duration=10 normalized → rampa 6s..7s.
+        Pre-fix: rampa entro 0.6..0.7s assoluti (fallisce)."""
+        s = _build_stream_tm(
+            {'num_voices': 2, 'pan': {'strategy': 'step', 'step': [[.6, 0], [.7, 60.0]]}},
+            time_mode='normalized', duration=10.0,
+        )
+        step_env = s._voice_manager._pan_strategy.step
+        assert isinstance(step_env, Envelope)
+        assert resolve_param(step_env, 6.0) == pytest.approx(0.0)
+        assert resolve_param(step_env, 6.5) == pytest.approx(30.0)
+        assert resolve_param(step_env, 7.0) == pytest.approx(60.0)
+
+    def test_compact_list_absolute_unchanged_pan(self):
+        """Stream absolute (time_mode assente): tempi restano assoluti in secondi."""
+        s = _build_stream_tm(
+            {'num_voices': 2, 'pan': {'strategy': 'step', 'step': [[.6, 0], [.7, 60.0]]}},
+            time_mode=None, duration=10.0,
+        )
+        step_env = s._voice_manager._pan_strategy.step
+        assert resolve_param(step_env, 0.6) == pytest.approx(0.0)
+        assert resolve_param(step_env, 0.7) == pytest.approx(60.0)
+        # ben oltre 0.7s la rampa è già finita (assoluto)
+        assert resolve_param(step_env, 6.0) == pytest.approx(60.0)
+
+    def test_dict_local_absolute_overrides_stream_normalized(self):
+        """Forma dict con time_mode locale `absolute` su stream normalized → assoluto."""
+        s = _build_stream_tm(
+            {'num_voices': 2, 'pan': {'strategy': 'step',
+             'step': {'points': [[.6, 0], [.7, 60.0]], 'time_mode': 'absolute'}}},
+            time_mode='normalized', duration=10.0,
+        )
+        step_env = s._voice_manager._pan_strategy.step
+        assert resolve_param(step_env, 0.6) == pytest.approx(0.0)
+        assert resolve_param(step_env, 0.7) == pytest.approx(60.0)
+        assert resolve_param(step_env, 6.0) == pytest.approx(60.0)
+
+    def test_dict_local_normalized_unchanged(self):
+        """Forma dict con time_mode locale normalized → scalato su duration (invariato)."""
+        s = _build_stream_tm(
+            {'num_voices': 2, 'pan': {'strategy': 'step',
+             'step': {'points': [[.6, 0], [.7, 60.0]], 'time_mode': 'normalized'}}},
+            time_mode=None, duration=10.0,
+        )
+        step_env = s._voice_manager._pan_strategy.step
+        assert resolve_param(step_env, 6.0) == pytest.approx(0.0)
+        assert resolve_param(step_env, 7.0) == pytest.approx(60.0)
+
+    def test_compact_list_inherits_normalized_onset(self):
+        """La correzione vale per tutti i blocchi voce, non solo pan: qui onset_offset."""
+        s = _build_stream_tm(
+            {'num_voices': 2, 'onset_offset': {'strategy': 'linear',
+             'step': [[.2, 0.0], [.8, 1.0]]}},
+            time_mode='normalized', duration=10.0,
+        )
+        step_env = s._voice_manager._onset_strategy.step
+        assert isinstance(step_env, Envelope)
+        assert resolve_param(step_env, 2.0) == pytest.approx(0.0)
+        assert resolve_param(step_env, 8.0) == pytest.approx(1.0)


### PR DESCRIPTION
## Sommario

Corregge un'incoerenza silenziosa dove gli envelope dei parametri delle strategy voce (`voices.{pitch,onset_offset,pointer,pan}.{step,spread,…}`) non ereditavano il `time_mode: normalized` dichiarato a livello di stream, a differenza degli envelope diretti (`density`, `pan_range`, …). La forma compatta (lista di breakpoint) restava sempre in secondi assoluti anche su stream `normalized`.

## Modifiche principali

- **src/core/stream.py**: 
  - `_parse_strategy_kwarg()` riceve ora il parametro `stream_time_mode` (default `'absolute'`)
  - Logica aggiornata: se l'envelope è in forma dict, il `time_mode` locale sovrascrive quello dello stream; se è in forma compatta (lista), si applica il `time_mode` dello stream
  - Tutti e quattro i factory di strategy voce (pitch, onset, pointer, pan) passano `config.time_mode` a `_parse_strategy_kwarg()`

- **tests/core/test_stream_voices_yaml.py**:
  - Nuova suite `TestVoiceStrategyTimeModeInheritance` con 5 test che verificano:
    - Forma compatta su stream `normalized` → tempi scalati sulla `duration`
    - Forma compatta su stream `absolute` → tempi restano in secondi
    - Forma dict con `time_mode: absolute` locale → sovrascrive stream `normalized`
    - Forma dict con `time_mode: normalized` locale → mantiene scaling
    - Correzione vale per tutti i blocchi voce (pan, onset_offset, etc.)
  - Helper `_build_stream_tm()` per costruire stream con controllo su `time_mode` e `duration`

- **docs/reference/yaml.md**:
  - Nuova sezione 3.4 "Strategy envelope dei `voices.*`" che documenta:
    - Ereditarietà del `time_mode` dello stream
    - Comportamento della forma compatta vs dict
    - Sovrascrittura locale con `time_mode`/`time_unit`
    - Nota storica su breaking change semantico (issue #144)

- **CHANGELOG.md**:
  - Entry in sezione "Corretto" che descrive il fix, l'impatto semantico e il breaking change per chi usava forma compatta su stream `normalized`

## Dettagli implementativi

- La correzione applica lo stesso pattern già usato per gli envelope diretti via `GranularParser`
- Il `time_mode` locale (forma dict) continua a sovrascrivere quello dello stream, mantenendo coerenza con il comportamento degli envelope diretti
- **Breaking change semantico**: chi usava forma compatta dentro `voices.*` su stream `normalized` vedrà i tempi scalati sulla `duration` invece che interpretati in secondi assoluti

https://claude.ai/code/session_01BZWURSs19qBoU2VcbS795f