### PR TITLE
Aumenta limite voci da 64 a 256 per texture dense

### DIFF
--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -1651,7 +1651,7 @@ un envelope dal YAML al runtime è:
 | `loop_start` | 0 | sample_dur | — | secondi |
 | `loop_end` | 0 | sample_dur | — | secondi |
 | `loop_dur` | 0.005 | sample_dur | — | secondi |
-| `num_voices` | 1 | 64 | 1 | intero |
+| `num_voices` | 1 | 256 | 1 | intero |
 | `scatter` | 0 | 1 | 0.0 | 0=sync, 1=indip. |
 
 Per la sintassi completa multi-voice, vedere [[multi-voice]].

--- a/src/parameters/parameter_definitions.py
+++ b/src/parameters/parameter_definitions.py
@@ -172,7 +172,7 @@ GRANULAR_PARAMETERS: Dict[str, ParameterBounds] = {
     # =========================================================================
     'num_voices': ParameterBounds(
         min_val=1.0,
-        max_val=64.0, # Aumentato per sicurezza
+        max_val=256.0, # Soglia di sicurezza: consente texture a voci molto dense
         variation_mode='quantized' # Le voci sono intere, ma gestite dal manager
     ),
     

--- a/tests/core/test_stream_voices_yaml.py
+++ b/tests/core/test_stream_voices_yaml.py
@@ -122,6 +122,11 @@ class TestNumVoices:
         s = _build_stream({'num_voices': 1})
         assert s._voice_manager.max_voices == 1
 
+    def test_num_voices_high_count_pre_allocates(self):
+        """Voci elevate (256): pre-allocazione di tutti i VoiceConfig."""
+        s = _build_stream({'num_voices': 256})
+        assert s._voice_manager.max_voices == 256
+
     def test_num_voices_default_when_absent(self):
         s = _build_stream({'pitch': {'strategy': 'step', 'step': 3.0}})
         assert s._voice_manager.max_voices == 1
@@ -526,6 +531,16 @@ class TestVoicesYamlIntegration:
         s2.generate_grains()
 
         assert len(s2.grains) == len(s1.grains) * 2
+
+    def test_high_voice_count_renders(self):
+        """Voci elevate (256): generate_grains rende senza errori, una lista per voce."""
+        s = _build_stream({'num_voices': 256})
+        self._prep_for_generate(s)
+
+        s.generate_grains()
+
+        assert len(s.voices) == 256
+        assert len(s.grains) > 0
 
     def test_chord_dom7_pitch_ratios_in_grains(self):
         """Voce 1 con dom7 ha pitch_ratio base × 2^(4/12)."""

--- a/tests/parameters/test_parameter_definitions.py
+++ b/tests/parameters/test_parameter_definitions.py
@@ -33,6 +33,7 @@ from parameters.parameter_definitions import (
     GRANULAR_PARAMETERS,
     get_parameter_definition,
 )
+from parameters.parameter import Parameter
 
 
 # =============================================================================
@@ -523,7 +524,19 @@ class TestVoicesBounds:
     def test_num_voices_bounds(self):
         b = GRANULAR_PARAMETERS['num_voices']
         assert b.min_val == 1.0
-        assert b.max_val == 64.0
+        assert b.max_val == 256.0
+
+    def test_num_voices_accepts_256(self):
+        """256 è dentro il bound (texture a voci molto dense)."""
+        b = GRANULAR_PARAMETERS['num_voices']
+        param = Parameter('num_voices', 256.0, b)
+        assert param.get_value(time=0.0) == 256.0
+
+    def test_num_voices_clamps_above_256(self):
+        """257 viene clampato silenziosamente a 256 (soglia di sicurezza)."""
+        b = GRANULAR_PARAMETERS['num_voices']
+        param = Parameter('num_voices', 257.0, b)
+        assert param.get_value(time=0.0) == 256.0
 
     def test_num_voices_variation_mode_quantized(self):
         """num_voices usa quantized (voci intere)."""


### PR DESCRIPTION
## Riepilogo

Aumenta il limite massimo di voci simultanee da 64 a 256 per supportare texture granulari a densità molto elevata, con test di validazione e aggiornamento della documentazione.

## Modifiche principali

- **Parameter bounds**: `num_voices.max_val` portato da 64.0 a 256.0 in `parameter_definitions.py`
- **Test di pre-allocazione**: aggiunto `test_num_voices_high_count_pre_allocates()` per verificare che il voice manager gestisca correttamente 256 voci
- **Test di rendering**: aggiunto `test_high_voice_count_renders()` per confermare che `generate_grains()` produce output senza errori con 256 voci
- **Test di bounds**: aggiunto `test_num_voices_accepts_256()` e `test_num_voices_clamps_above_256()` per validare il clamping a 256 come soglia di sicurezza
- **Documentazione**: aggiornato `docs/reference/yaml.md` con il nuovo range (1–256)

## Dettagli implementativi

- Il limite 256 funge da soglia di sicurezza: valori superiori vengono clampati silenziosamente
- La pre-allocazione di tutti i VoiceConfig avviene al momento della costruzione dello Stream
- I test confermano che il voice manager e il grain generator mantengono coerenza anche con conteggi elevati
- Nessuna modifica alla logica di interleaving dei grain: rimane ordinata per onset

https://claude.ai/code/session_01Xgka9AvJk2ewiZf1padbKu