### PR TITLE
feat(export): plotStyle SV dal tipo di interpolazione dell'envelope

### DIFF
--- a/docs/how-to/sonic-visualiser.md
+++ b/docs/how-to/sonic-visualiser.md
@@ -7,7 +7,7 @@ sources:
   - src/export/sv_exporter.py
   - src/rendering/envelope_extractor.py
   - src/main.py
-last_synced_commit: 1de1947
+last_synced_commit: 2518eab
 entry_for: [export-sonic-visualiser]
 ---
 
@@ -104,7 +104,23 @@ la waveform e ogni curva envelope devono essere allineate sul tempo dell'audio.
   hardcoded.
 - **Colori** dei layer da `ENVELOPE_COLORS` (palette dell'engine, condivisa con
   la partitura). Con piu' stream il nome del layer e' `<stream_id>/<chiave>`.
-- **`plotStyle="3"`** (Lines): segmenti retti tra breakpoint.
+- **`plotStyle` dal tipo di interpolazione** dell'envelope (per-layer, dal
+  `type` globale dell'`Envelope`):
+
+  | `type` envelope | plotStyle SV | Stile |
+  |-----------------|--------------|-------|
+  | `linear` | `3` | PlotLines (segmenti retti tra breakpoint) |
+  | `cubic` | `7` | PlotCubicHermite (curva cubica monotona, Fritsch-Carlson) |
+  | `step` | `3` | fallback PlotLines (vedi nota) |
+
+  Nota: SV non ha uno stile nativo che tenga il valore fino al breakpoint
+  successivo (gradini), quindi `step` ripiega su Lines. Aggiunta di una
+  visualizzazione a gradini a `TimeValueLayer` tracciata in
+  [sonic-visualiser#3](https://github.com/DMGiulioRomano/sonic-visualiser/issues/3).
+  SV applica il
+  `plotStyle` per-layer: il `type` globale dell'envelope e' la granularita'
+  giusta; eventuali override per-segmento (`[t, v, type]`) non sono
+  rappresentabili e seguono il tipo globale.
 - **Solo curve dinamiche**: gli envelope statici non vengono esportati (come la
   partitura di default).
 

--- a/src/export/sv_exporter.py
+++ b/src/export/sv_exporter.py
@@ -39,9 +39,27 @@ from rendering.envelope_extractor import (
     get_stream_envelopes,
 )
 
-# plotStyle SV: "3" = Lines (segmenti retti tra breakpoint, corretto per
-# envelope lineari).
-_PLOT_STYLE = "3"
+# plotStyle SV per tipo di interpolazione dell'Envelope. I valori sono gli
+# interi dell'enum PlotStyle di TimeValueLayer (svgui), serializzati come stringa
+# nell'attributo plotStyle del layer:
+#   "3" = PlotLines        -> spezzata di segmenti retti tra i breakpoint
+#   "7" = PlotCubicHermite -> curva cubica monotona (Fritsch-Carlson)
+# 'step' non ha uno stile nativo in SV (nessun hold del valore fino al
+# breakpoint successivo): fallback su Lines finche' la visualizzazione a gradini
+# non viene aggiunta a TimeValueLayer.
+_PLOT_STYLE_BY_TYPE = {"linear": "3", "cubic": "7", "step": "3"}
+_PLOT_STYLE_DEFAULT = "3"
+
+
+def _envelope_plot_style(envelope) -> str:
+    """plotStyle SV dal tipo di interpolazione dell'Envelope.
+
+    Legge `envelope.type` (sempre presente, default 'linear'). SV ha un
+    plotStyle per-layer, quindi il tipo globale dell'envelope e' la giusta
+    granularita'; eventuali override per-segmento non sono rappresentabili.
+    """
+    return _PLOT_STYLE_BY_TYPE.get(getattr(envelope, "type", "linear"),
+                                   _PLOT_STYLE_DEFAULT)
 
 # Colore di fallback per chiavi senza voce in ENVELOPE_COLORS (non dovrebbe
 # accadere: l'universo dei nomi e' PLOT_ENVELOPE_KEYS).
@@ -147,7 +165,7 @@ class SVExporter:
         # --- Un modello + dataset + layer per ogni envelope ---
         layer_records: List[Tuple[str, str, str]] = []  # (layer_id, model_id, name)
         next_id = 3
-        for name, key, points in layers:
+        for name, key, points, plot_style in layers:
             model_id = str(next_id); next_id += 1
             dataset_id = str(next_id); next_id += 1
             layer_id = str(next_id); next_id += 1
@@ -169,7 +187,7 @@ class SVExporter:
             colour = ENVELOPE_COLORS.get(base_param_name(key), _FALLBACK_COLOUR)
             ET.SubElement(data, "layer", {
                 "id": layer_id, "type": "timevalues", "name": name,
-                "model": model_id, "plotStyle": _PLOT_STYLE, "verticalScale": "0",
+                "model": model_id, "plotStyle": plot_style, "verticalScale": "0",
                 "colourName": name, "colour": colour, "darkBackground": "true",
             })
             layer_records.append((layer_id, model_id, name))
@@ -191,17 +209,18 @@ class SVExporter:
         return info.samplerate, info.frames / float(info.samplerate)
 
     def _collect_layers(self, streams: List, sample_rate: int
-                        ) -> List[Tuple[str, str, List[Tuple[int, float]]]]:
+                        ) -> List[Tuple[str, str, List[Tuple[int, float]], str]]:
         """
         Per ogni stream estrae gli envelope dinamici e converte i breakpoint in
         frame assoluti: frame = round((stream.onset + t_rel) * sample_rate).
 
-        Ritorna tuple (name, key, points): `key` e' la chiave engine (es.
-        'density', per il colore); `name` e' il nome del layer, disambiguato col
-        prefisso '<stream_id>/' quando c'e' piu' di uno stream (evita collisioni).
+        Ritorna tuple (name, key, points, plot_style): `key` e' la chiave engine
+        (es. 'density', per il colore); `name` e' il nome del layer, disambiguato
+        col prefisso '<stream_id>/' quando c'e' piu' di uno stream (evita
+        collisioni); `plot_style` e' lo stile SV dal tipo di interpolazione.
         """
         multi_stream = len(streams) > 1
-        layers: List[Tuple[str, str, List[Tuple[int, float]]]] = []
+        layers: List[Tuple[str, str, List[Tuple[int, float]], str]] = []
         for stream in streams:
             onset = float(getattr(stream, "onset", 0.0) or 0.0)
             envelopes = get_stream_envelopes(stream)
@@ -211,7 +230,7 @@ class SVExporter:
                     (round((onset + t_rel) * sample_rate), value)
                     for t_rel, value in envelope.breakpoints
                 ]
-                layers.append((name, key, points))
+                layers.append((name, key, points, _envelope_plot_style(envelope)))
         return layers
 
     def _build_display(self, root: ET.Element,

--- a/tests/export/test_sv_exporter.py
+++ b/tests/export/test_sv_exporter.py
@@ -90,6 +90,12 @@ def _points(root, layer_name=None):
     return ds.findall('point')
 
 
+def _timevalues_layer(root, name):
+    """Il layer timevalues con quel name (es. 'density')."""
+    return next(l for l in root.findall('.//data/layer')
+                if l.get('type') == 'timevalues' and l.get('name') == name)
+
+
 def _load_ref(name):
     txt = open(os.path.join(FIX_DIR, name)).read()
     body = txt.split('sonic-visualiser>', 1)[1]
@@ -144,12 +150,39 @@ class TestEnvelopeLayers:
                          if l.get('name') == name)
             assert layer.get('colour') == ENVELOPE_COLORS[name]
 
-    def test_plotstyle_lines_and_vertical_scale(self):
+    def test_plotstyle_linear_and_vertical_scale(self):
+        # _e3_stream usa envelope lineari: plotStyle = "3" (PlotLines).
         root = _build([_e3_stream()])
         for l in root.findall('.//data/layer'):
             if l.get('type') == 'timevalues':
                 assert l.get('plotStyle') == '3'      # Lines
                 assert l.get('verticalScale') == '0'
+
+    def test_plotstyle_cubic_maps_to_cubic_hermite(self):
+        # type: cubic -> plotStyle "7" (PlotCubicHermite).
+        s = _stream(density=_param('density', Envelope(
+            {'type': 'cubic', 'points': [[0, 5.0], [DUR, 1000.0]]})))
+        layer = _timevalues_layer(_build([s]), 'density')
+        assert layer.get('plotStyle') == '7'
+
+    def test_plotstyle_step_falls_back_to_lines(self):
+        # type: step -> nessuno stile SV nativo di hold -> fallback "3" (Lines).
+        s = _stream(density=_param('density', Envelope(
+            {'type': 'step', 'points': [[0, 5.0], [DUR, 1000.0]]})))
+        layer = _timevalues_layer(_build([s]), 'density')
+        assert layer.get('plotStyle') == '3'
+
+    def test_plotstyle_per_layer_follows_each_envelope_type(self):
+        # Tipi diversi nello stesso stream -> plotStyle indipendenti per layer.
+        s = _stream(
+            density=_param('density', Envelope(
+                {'type': 'cubic', 'points': [[0, 5.0], [DUR, 1000.0]]})),
+            grain_duration=_param('grain_duration', Envelope(
+                [[0, 0.01], [DUR, 0.05]])),  # linear (default)
+        )
+        root = _build([s])
+        assert _timevalues_layer(root, 'density').get('plotStyle') == '7'
+        assert _timevalues_layer(root, 'grain_duration').get('plotStyle') == '3'
 
     def test_layer_names_are_engine_keys(self):
         root = _build([_e3_stream()])


### PR DESCRIPTION
## Cosa cambia

L'`SVExporter` usava `plotStyle="3"` (Lines) fisso per ogni layer, perdendo
l'interpolazione cubica della IR. Ora il `plotStyle` segue `Envelope.type`
per-layer, così Sonic Visualiser disegna le curve come nella partitura:

| `type` envelope | plotStyle SV | Stile |
|-----------------|--------------|-------|
| `linear` | `3` | PlotLines (segmenti retti) |
| `cubic` | `7` | PlotCubicHermite (curva cubica monotona) |
| `step` | `3` | fallback PlotLines (vedi nota) |

`step` ripiega su Lines: SV non ha uno stile nativo a gradini
([sonic-visualiser#3](https://github.com/DMGiulioRomano/sonic-visualiser/issues/3)).
Il `plotStyle` è per-layer dal `type` globale dell'envelope; eventuali override
per-segmento non sono rappresentabili e seguono il tipo globale.

## Implementazione

- `_PLOT_STYLE_BY_TYPE` + `_envelope_plot_style()`: mapping tipo → plotStyle
- `_collect_layers` propaga `plot_style` per-layer a `build()`

## Test

- `tests/export/test_sv_exporter.py`: cubic→7, step→3, plotStyle indipendenti
  per layer; golden invariati
- `make tests`: 4634 passed

## Verifica manuale

Render di `configs/PGE_cubic_smoothstep_demo.yml` (stream cubic + linear a
confronto) con `--export-sv`: nel `.sv` `stream_cubic/density` → plotStyle 7,
`stream_linear/density` → 3.

## Docs

`docs/how-to/sonic-visualiser.md`: tabella tipo→plotStyle e nota sul fallback step.

## Impatto cross-repo

- **PGE-ls**: nessun impatto — non cambia sintassi/schema YAML né errori.
- **PGE-ui**: nessun impatto — superficie YAML e CLI invariate.

Closes parte di #150 (rendering SV).
