### PR TITLE
feat: NumPy rendering multi-processo con --jobs / JOBS (overlap-add + STEMS a livello di stream)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Aggiunto
 
+- Rendering NumPy multi-processo **a livello di stream** (STEMS): con
+  `--jobs > 1` e almeno due stream da rendere, ogni stem diventa un task per il
+  pool di processi (overlap-add + `dc_block` + scrittura interamente nel
+  worker), invece del solo overlap-add parallelo dentro un singolo stream. Con
+  molti stem il guadagno passa da ~1.5x a scaling quasi lineare (il lavoro
+  per-stream, prima seriale nel parent, gira ora nei worker). Contratto di
+  determinismo **rafforzato**: ogni stem prodotto è byte-identico a `--jobs 1`
+  (le somme float64 nel worker sono nell'ordine storico), non più solo < 1 LSB
+  a 24 bit. Invarianti preservate: la generazione dei grani resta nel parent in
+  ordine di stream (RNG deterministico), il check cache (`is_dirty`) precede
+  l'accesso ai grani (gli stream *clean* non generano né vengono dispatchati),
+  la cache si aggiorna solo per gli stem completati con successo. Nessun
+  cambiamento a YAML/CLI (`--jobs`/`JOBS` invariati) né ai formati di output.
+  Sotto le soglie (jobs=1, un solo stream dirty, pochi grani) il comportamento
+  resta il path per-stream con overlap-add parallelo intra-stream.
 - Rendering NumPy multi-processo: flag CLI `--jobs N|auto` (variabile Make
   `JOBS`) parallelizza l'overlap-add del renderer NumPy su più core. `auto`
   (default) = core disponibili − 1; `--jobs 1` mantiene il path sequenziale

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Aggiunto
 
+- Rendering NumPy multi-processo: flag CLI `--jobs N|auto` (variabile Make
+  `JOBS`) parallelizza l'overlap-add del renderer NumPy su più core. `auto`
+  (default) = core disponibili − 1; `--jobs 1` mantiene il path sequenziale
+  con campioni bit-identici allo storico. La generazione dei grani resta nel
+  parent (riproducibilità del RNG globale). Ignorato con `--renderer csound`;
+  valori non validi → messaggio + exit 1. Nuovo log `Rendering completato in
+  Ns (jobs=N)` a fine render. Determinismo: a parità di `jobs` i campioni
+  sono bit-identici tra run (il file AIFF float no: PEAK chunk con timestamp
+  wall-clock); tra `jobs` diversi la differenza è < 1 LSB a 24 bit.
 - Voci (`num_voices`): fade frazionario della voce di confine. Quando
   `num_voices` interpola tra due conteggi interi (es. `[[0, 6], [1, 5]]`), la
   parte frazionaria del valore diventa uno scaler di volume sulla voce che si
@@ -111,6 +120,12 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Corretto
 
+- Rendering parallelo: il test di determinismo `--jobs` confrontava i byte
+  grezzi del file AIFF (flaky su macOS: il PEAK chunk float porta un timestamp
+  wall-clock con granularità 1s, quindi due run in secondi diversi
+  divergevano). Ora confronta i campioni via `soundfile.read`. Documentazione
+  (`cli.md`, `architecture.md`) allineata: il contratto di determinismo vale
+  sui campioni, non sul file byte-a-byte.
 - fix(stream): gli envelope dei parametri delle strategy voce
   (`voices.{pitch,onset_offset,pointer,pan}.{step,spread,…}`) ora ereditano il
   `time_mode: normalized` dichiarato a livello di stream, come già gli envelope

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,10 @@ STEMS ?= true
 GRAIN_JSON ?= false   # esporta JSON sidecar dei grani (richiede STEMS=true, issue #99)
 RENDERER ?= numpy
 FORMAT ?= aiff
+# Worker per il rendering NumPy multi-processo (--jobs): vuoto = auto
+# (core disponibili - 1), N = numero esplicito, 1 = sequenziale
+# byte-identico allo storico. Ignorato con RENDERER=csound.
+JOBS ?=
 REAPER ?= true
 # Default: nome .rpp = nome YAML in $(SFDIR), accanto agli .aif. Multi-tab per YAML (vedi issue #17)
 REAPER_PATH ?= $(SFDIR)/$(FILE).rpp

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -6,7 +6,7 @@ tags: [architecture, rendering, ocp]
 sources:
   - src/rendering/
   - src/main.py
-last_synced_commit: 9de1079
+last_synced_commit: d750ba6
 ---
 
 # Architettura Renderer
@@ -112,6 +112,45 @@ Proprietà:
 - Il check cache (`is_dirty` prima di toccare `.voices`) e la generazione
   lazy dei grani (issue #117) sono invariati.
 
+#### Parallelismo a livello di stream (STEMS)
+
+Il chunk path sopra parallelizza l'overlap-add **dentro** un singolo stream.
+In STEMS però il resto del lavoro per-stream (generazione a parte, somma dei
+buffer, `dc_block` sull'intero extent, scrittura) resta seriale nel parent e
+si paga una volta per stream: per Amdahl il guadagno reale sul wall totale si
+ferma a ~1.5x anche quando il render puro scala ~3x.
+
+`NumpyAudioRenderer.render_streams` (override del default concreto dell'ABC
+`AudioRenderer`) sposta il parallelismo **a livello di stream**: quando
+conviene, ogni stem diventa **un task per il pool** (`render_stream_to_file`
+in `numpy_parallel.py`) che esegue overlap-add + `dc_block` + scrittura
+interamente nel worker. Così ~il 100% del lavoro per-stream va in parallelo e
+lo scaling è quasi lineare con molti stem. `StemsRenderMode` delega il loop a
+`renderer.render_streams(pairs)`: il mode decide **cosa** (stems), il renderer
+decide **come** (seriale o parallelo) — `CsoundRenderer` eredita il default
+(loop su `render_single_stream`) senza modifiche.
+
+Sequenza e invarianti:
+
+- **Triage cache prima di `.voices`** (#117): gli stream *clean* ritornano il
+  proprio path senza generare grani né essere dispatchati.
+- **Generazione nel parent, in ordine di stream**: i grani degli stem *dirty*
+  si materializzano nel parent nell'ordine dei pair, identico al loop storico
+  → il consumo del `random` (e quindi la riproducibilità) è invariato. Solo
+  overlap-add/`dc_block`/scrittura vanno nel worker.
+- **IPC di ritorno ~zero**: il worker ritorna la sola stringa `output_path`
+  (scrive lui il file), contro i buffer audio del chunk path.
+- **Determinismo rafforzato**: dentro il worker le somme float64 sono
+  nell'ordine storico → ogni stem è **byte-identico a `jobs=1`** (contratto
+  più forte del chunk path, che garantiva solo < 1 LSB a 24 bit).
+- **Cache aggiornata solo per gli stem completati**: un'eccezione nel worker
+  si propaga da `future.result()` e la cache dello stream non completato non
+  viene toccata.
+- **Policy conservativa**: si parallelizza tra stream solo con `jobs > 1`,
+  almeno due stem *dirty* e grani totali sopra soglia; altrimenti si ricade
+  sul path per-stream (che sotto ha ancora il chunk path per lo stem denso
+  singolo).
+
 ## Trade-off
 
 | Aspetto | Alternativa | Perché questa |
@@ -133,11 +172,11 @@ Proprietà:
 | Layer | Strumento | Conteggio |
 |-------|-----------|-----------|
 | Unit (mock) | `pytest` / `make tests` | 4149 test |
-| E2E | `pytest -m e2e` / `make e2e-tests` | 21 test |
+| E2E | `pytest -m e2e` / `make e2e-tests` | 24 test |
 
 **E2E Csound** (`tests/e2e/test_cache_e2e.py`, 15 test): pipeline `make → Python → Csound → filesystem` in `STEMS=true CACHE=true`. Copre first build, incremental, partial rebuild, garbage collection.
 
-**E2E NumPy** (`tests/e2e/test_numpy_renderer_e2e.py`, 6 test): pipeline `make → Python → NumPy → filesystem`, no Csound. Copre stems e mix.
+**E2E NumPy** (`tests/e2e/test_numpy_renderer_e2e.py`, 9 test): pipeline `make → Python → NumPy → filesystem`, no Csound. Copre stems, mix, rendering multi-processo (`JOBS`) intra-stream e a livello di stream (stem byte-identici a `JOBS=1`, cache clean).
 
 **Note semantica onset:**
 - Csound/NumPy STEMS: onset relativi allo stream (onset=0 nel file)

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -6,7 +6,7 @@ tags: [architecture, rendering, ocp]
 sources:
   - src/rendering/
   - src/main.py
-last_synced_commit: 4c4fee4
+last_synced_commit: 9de1079
 ---
 
 # Architettura Renderer
@@ -79,6 +79,35 @@ generated = engine.render(streams=generator.streams, output_path=output_file, mo
 ```
 
 Caching incrementale è componente separato, vedi [[caching]].
+
+### Rendering NumPy multi-processo (`--jobs`)
+
+L'overlap-add del renderer NumPy è parallelizzabile perché il rendering del
+singolo grano è puro (nessun `random`, nessuno stato condiviso:
+`GrainRenderer`). La **generazione** dei grani invece consuma il `random`
+globale seminato una volta in `Generator.create_elements()` e resta nel
+processo parent: l'ordine di consumo è la riproducibilità delle composizioni.
+
+Il parallelismo vive interamente dentro `NumpyAudioRenderer`
+(`RenderMode`/`RenderingEngine`/ABC invariati): le coppie
+`(grain, onset_sample)` vengono ordinate per onset, divise in chunk contigui
+(`src/rendering/numpy_parallel.py`) e affidate a un pool `spawn` di
+`jobs` worker; ogni worker rende il proprio chunk in un buffer locale
+all'extent del chunk e il parent somma i risultati in ordine di chunk fisso,
+poi applica `dc_block`, clamp e scrittura come nel path sequenziale.
+
+Proprietà:
+
+- `jobs=1` (default dell'API; il default `auto` = core-1 è policy del solo
+  entry point CLI/Make) → path sequenziale **bit-identico allo storico**.
+- Sotto `PARALLEL_MIN_GRAINS` grani il render resta sequenziale anche con
+  `jobs > 1`: niente pool per render piccoli e per i test.
+- A parità di `jobs` l'output è byte-identico tra run; tra valori diversi di
+  `jobs` cambia solo l'ordine delle somme float64 (< 1 LSB a 24 bit).
+- Il pool è lazy, riusato per tutti gli stream della run (STEMS) e spento
+  con `close()`; i worker ricostruiscono i registry da disco (`init_worker`).
+- Il check cache (`is_dirty` prima di toccare `.voices`) e la generazione
+  lazy dei grani (issue #117) sono invariati.
 
 ## Trade-off
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -102,8 +102,11 @@ Proprietà:
   entry point CLI/Make) → path sequenziale **bit-identico allo storico**.
 - Sotto `PARALLEL_MIN_GRAINS` grani il render resta sequenziale anche con
   `jobs > 1`: niente pool per render piccoli e per i test.
-- A parità di `jobs` l'output è byte-identico tra run; tra valori diversi di
-  `jobs` cambia solo l'ordine delle somme float64 (< 1 LSB a 24 bit).
+- A parità di `jobs` i **campioni** sono bit-identici tra run; tra valori
+  diversi di `jobs` cambia solo l'ordine delle somme float64 (< 1 LSB a 24
+  bit). Il file AIFF float non è byte-identico tra run: libsndfile scrive un
+  timestamp wall-clock nel PEAK chunk dell'header (confronta i campioni, non
+  i byte).
 - Il pool è lazy, riusato per tutti gli stream della run (STEMS) e spento
   con `close()`; i worker ricostruiscono i registry da disco (`init_worker`).
 - Il check cache (`is_dirty` prima di toccare `.voices`) e la generazione

--- a/docs/plans/2026-07-02-001-feat-numpy-parallel-rendering-plan.md
+++ b/docs/plans/2026-07-02-001-feat-numpy-parallel-rendering-plan.md
@@ -1,0 +1,117 @@
+---
+slug: 2026-07-02-001-feat-numpy-parallel-rendering
+type: plan
+status: done
+tags: [rendering, numpy, performance, multiprocessing, cli]
+sources:
+  - src/rendering/numpy_parallel.py
+  - src/rendering/numpy_audio_renderer.py
+  - src/rendering/renderer_factory.py
+  - src/core/grain.py
+  - src/main.py
+  - make/build.mk
+last_synced_commit: 9de1079
+---
+
+# Plan: feat — rendering NumPy multi-core (`--jobs` / `JOBS`)
+
+## Contesto
+
+Il renderer NumPy (default del Makefile: `RENDERER=numpy`) era mono-core.
+Profiling empirico (stream 30s, density 200, ~6000 grani):
+
+- `generate_grains()`: 61 ms (7.5%) — Python puro, **stateful**: consuma il
+  `random` globale seminato una volta in `Generator.create_elements()`;
+  l'ordine di consumo determina la riproducibilità → NON parallelizzabile
+  senza cambiare l'output di YAML esistenti.
+- rendering NumPy (overlap-add + dc_block + write): 752 ms (92.5%) — **puro**
+  (zero `random` in `src/rendering/`) → parallelizzabile.
+
+Composizioni reali: `PGE_12min.yml` = 132 stream, `PGE_cim.yml` = density
+fino a ~3000. Amdahl con 92.5% parallelo → ~4-5x su macchine consumer.
+Requisito: deve girare su tutti i computer senza saturarli (default
+prudente core-1, fallback sequenziale sotto soglia).
+
+Vincoli verificati empiricamente prima del design:
+
+1. `Grain` (frozen + `__slots__` manuale) non era picklable: l'unpickle
+   ripristina gli slot via `setattr`, rifiutato dal `__setattr__` frozen.
+   Fix: `__reduce__` che ricostruisce via `__init__`.
+2. `ProcessPoolExecutor` con contesto `spawn` (~130ms startup per 2 worker):
+   i worker re-importano i moduli → il codice worker vive in un modulo
+   importabile senza side effect a import-time.
+3. I thread non aiutano (GIL: loop Python per-grano su array ~2400 campioni);
+   nessun BLAS nel path caldo → niente oversubscription con i processi.
+
+## Analisi d'impatto (procedura `.claude/commands/impact-analysis.md`)
+
+- **Moduli modificati:** `core/grain.py` (additivo: `__reduce__`),
+  `rendering/numpy_audio_renderer.py` (kwarg `jobs`, path parallelo),
+  `rendering/renderer_factory.py` (propagazione), `main.py` (flag),
+  `Makefile`/`make/build.mk` (variabile `JOBS`).
+- **Dipendenti diretti di `numpy_audio_renderer`:** `renderer_factory`,
+  `main`. `RenderMode`, `RenderingEngine`, ABC `AudioRenderer`,
+  `CsoundRenderer`, cache manager: invariati.
+- **Test coinvolti:** `tests/core/test_grain.py`,
+  `tests/rendering/test_numpy_audio_renderer.py` (regressioni: rounding
+  onset, cache clean/dirty, guard `.voices` issue #117, passthrough Plan
+  002), `tests/rendering/test_numpy_parallel.py` (nuovo),
+  `tests/test_main_jobs_flag.py` (nuovo), `tests/e2e/test_numpy_renderer_e2e.py`.
+- **Rischio principale:** riproducibilità bit-level dell'output con il
+  default parallelo → gestito dal contratto di determinismo (sotto) e da
+  `--jobs 1`.
+
+## Design
+
+Tutto il parallelismo vive dentro `NumpyAudioRenderer` (OCP: RenderMode ed
+engine invariati). Primitiva worker unica:
+`render_grain_chunk(chunk) -> (offset_samples, buffer_locale)`.
+
+- Parent: coppie `(grain, onset_sample)` (relativo per STEMS, assoluto per
+  MIX) ordinate per onset → chunk contigui (`chunk_grains`) → pool `spawn`.
+- Worker (`init_worker`): registries propri caricati da disco una volta;
+  rende ogni grano con `GrainRenderer` + CLAMP 1 e fa overlap-add in un
+  buffer locale all'extent del chunk (~1/N della timeline → IPC minimo).
+- Parent: somma i buffer locali in ordine di chunk fisso → `dc_block` →
+  clamp → `sf.write` (invariati).
+- Generazione grani: nel parent, prima del dispatch → seed identico a oggi.
+  Check cache `is_dirty` prima di `.voices` (issue #117): invariato.
+
+Policy jobs: `resolve_jobs('auto')` = `max(1, core-1)` via
+`sched_getaffinity` (quote container) con fallback `cpu_count`; sotto
+`PARALLEL_MIN_GRAINS` (1024) per chiamata si resta sequenziali. Pool lazy,
+riusato tra stream (STEMS), `close()` esplicito.
+
+Contratto di determinismo:
+
+- `jobs=1` → bit-identico al rendering sequenziale storico;
+- a parità di `jobs` → output byte-identico tra run;
+- tra `jobs` diversi → cambia solo l'ordine delle somme float64
+  dell'overlap-add: differenza < 1 LSB a 24 bit (verificata dai test).
+
+Default: CLI/Make = `auto`; API libreria `NumpyAudioRenderer(jobs=1)` resta
+conservativa.
+
+## Test (TDD, rossi → verdi)
+
+1. `test_grain.py::TestGrainPickle` — roundtrip pickle.
+2. `test_numpy_parallel.py` — `resolve_jobs`, `chunk_grains`,
+   `resolve_table_name`, `render_grain_chunk` in-process (equivalenza
+   bit-exact col riferimento sequenziale, CLAMP 1, chunk vuoto).
+3. `test_numpy_audio_renderer.py::TestParallelRendering` — jobs=2 vs jobs=1
+   `< 2^-24` (single e merged, pool reale), determinismo byte-identico tra
+   run, soglia → nessun pool, `close()`, riuso pool tra stream.
+4. `test_main_jobs_flag.py` — `_parse_jobs` (default auto, interi, invalidi
+   → exit 1) e wiring `_build_renderer` → renderer.
+5. e2e: `TestNumpyStemsParallel` — build `JOBS=2` via make + equivalenza
+   `JOBS=1` vs `JOBS=2` sotto 1 LSB 24-bit.
+
+## Cross-repo
+
+- **PGE-ls:** nessun impatto (superficie YAML invariata).
+- **PGE-ui:** nuovo flag CLI opzionale `--jobs`; nessun aggiornamento
+  obbligatorio (default retro-compatibile a livello di semantica; da
+  valutare se esporre il controllo jobs nell'UI).
+- **Paper CIM 2026:** il default `auto` cambia l'output a livello di bit
+  (non udibile, < 1 LSB 24-bit): alla PR va valutato il bump del submodule
+  (regola `submodule-sync-cim.md`).

--- a/docs/plans/2026-07-04-001-feat-parallel-stems-plan.md
+++ b/docs/plans/2026-07-04-001-feat-parallel-stems-plan.md
@@ -1,7 +1,7 @@
 ---
 slug: 2026-07-04-001-feat-parallel-stems
 type: plan
-status: draft
+status: done
 tags: [rendering, numpy, performance, multiprocessing, stems]
 sources:
   - src/rendering/audio_renderer.py
@@ -9,7 +9,7 @@ sources:
   - src/rendering/numpy_audio_renderer.py
   - src/rendering/numpy_parallel.py
   - src/rendering/stream_cache_manager.py
-last_synced_commit: 12228ce
+last_synced_commit: d750ba6
 ---
 
 # Plan: feat — STEMS multi-processo (parallelismo a livello di stream)

--- a/docs/plans/2026-07-04-001-feat-parallel-stems-plan.md
+++ b/docs/plans/2026-07-04-001-feat-parallel-stems-plan.md
@@ -1,0 +1,176 @@
+---
+slug: 2026-07-04-001-feat-parallel-stems
+type: plan
+status: draft
+tags: [rendering, numpy, performance, multiprocessing, stems]
+sources:
+  - src/rendering/audio_renderer.py
+  - src/rendering/render_mode.py
+  - src/rendering/numpy_audio_renderer.py
+  - src/rendering/numpy_parallel.py
+  - src/rendering/stream_cache_manager.py
+last_synced_commit: 12228ce
+---
+
+# Plan: feat — STEMS multi-processo (parallelismo a livello di stream)
+
+## Contesto
+
+Il plan 2026-07-02-001 ha parallelizzato l'overlap-add DENTRO un singolo
+stream (chunk di grani ai worker). Verifica end-to-end: il render puro scala
+~3x su 3 worker, ma il wall totale solo ~1.5x. Il collo di bottiglia si e'
+spostato sulle fasi rimaste sequenziali nel parent, che in STEMS si pagano
+UNA VOLTA PER STREAM, in serie:
+
+1. `StemsRenderMode.execute` itera gli stream uno alla volta
+   (`render_mode.py:91`): lo stream i+1 non parte finche' i non ha finito
+   dc_block + write.
+2. Per ogni stream, in `render_single_stream`: generazione grani (stateful,
+   `random` globale), somma dei buffer locali di ritorno dal pool,
+   `dc_block` (FIR sull'intero extent), clamp, `sf.write` — tutto nel parent.
+3. L'IPC di ritorno trasporta buffer audio (~1/N dell'extent per chunk).
+
+Composizioni reali: `PGE_12min.yml` = 132 stream. Con il chunk path attuale
+ogni stream sotto i 1024 grani non parallelizza affatto; sopra soglia
+parallelizza solo l'overlap-add. Amdahl per-stream limita il guadagno a
+~1.5x. Parallelizzare GLI STREAM TRA LORO copre invece ~il 100% del lavoro
+per-stream (overlap-add + dc_block + write dentro il worker) → scaling
+quasi lineare con molti stream.
+
+Vincoli invarianti (dal plan precedente, tutti confermati nel codice):
+
+- Generazione grani stateful: consuma il `random` globale; l'ordine di
+  consumo tra stream determina la riproducibilita' → la generazione resta
+  nel parent, in ordine di stream (`stream.voices` lazy,
+  `stream.py:688-692`).
+- Cache STEMS: `is_dirty` va chiamato PRIMA di toccare `.voices`
+  (issue #117) — gli stream clean non devono generare.
+- Pool `spawn` gia' esistente, riusato tra stream, con registries per
+  worker (`init_worker`). `Grain` picklable via `__reduce__`.
+
+## Analisi d'impatto
+
+- **Moduli modificati:**
+  - `rendering/audio_renderer.py` — nuovo metodo NON astratto
+    `render_streams(pairs)` con default = loop su `render_single_stream`
+    (retro-compatibile: `CsoundRenderer` eredita il default, zero modifiche).
+  - `rendering/render_mode.py` — `StemsRenderMode.execute` sostituisce il
+    loop con una chiamata a `renderer.render_streams(paths_map)`.
+  - `rendering/numpy_parallel.py` — nuova primitiva worker
+    `render_stream_to_file(task)`.
+  - `rendering/numpy_audio_renderer.py` — override `render_streams` con
+    dispatch per-stream; refactor del corpo di `render_single_stream` in
+    helper riusabili (cache check, costruzione pairs, finalizzazione).
+- **Invarianti:** `RenderingEngine`, `MixRenderMode`, `NamingStrategy`,
+  `CsoundRenderer`, `StreamCacheManager`, CLI (`--jobs` invariato),
+  Makefile. Nessuna nuova superficie pubblica.
+- **Test coinvolti:** `test_render_mode.py` (il mock renderer deve
+  supportare/ereditare `render_streams`), `test_numpy_audio_renderer.py`,
+  `test_numpy_parallel.py`, e2e STEMS.
+- **Rischio principale:** interazione cache/parallelismo (update del
+  manifest per stream falliti) e doppio livello di parallelismo
+  (oversubscription) → gestiti dalla policy sotto.
+
+## Design
+
+### Interfaccia (OCP)
+
+`AudioRenderer.render_streams(pairs: List[Tuple[stream, path]]) -> List[str]`
+metodo concreto sull'ABC, default:
+
+```python
+def render_streams(self, pairs):
+    return [self.render_single_stream(s, p) for s, p in pairs]
+```
+
+`StemsRenderMode.execute` diventa una delega:
+`generated = renderer.render_streams(paths_map)`. Il RenderMode continua a
+decidere COSA (stems), il renderer decide COME (seriale o parallelo) —
+coerente con l'atomic interface: il loop era gia' meccanico, la strategia
+resta nel mode.
+
+### NumpyAudioRenderer.render_streams (override)
+
+Parent, in ordine di stream (sequenziale, obbligatorio per il random):
+
+1. Cache check per ogni stream (`is_dirty` prima di `.voices`, print
+   `[CACHE]` nel parent). Stream clean → path in output, nessuna
+   generazione, nessun dispatch.
+2. Per gli stream dirty: materializza i grani (ordine di consumo del
+   `random` identico a oggi — stesso ordine di visita degli stream) e
+   costruisci il task picklable:
+   `(pairs=(grain, onset_sample_relativo), n_total, output_path,
+   sf_format, sf_subtype, output_sr)`.
+3. **Policy di dispatch:**
+   - `jobs > 1` E stream dirty >= 2 E grani totali >= `min_parallel_grains`
+     → un task per stream al pool esistente (`_ensure_executor`), worker
+     round-robin; DENTRO il worker il rendering e' interamente sequenziale
+     (niente chunking annidato: eviterebbe oversubscription e
+     ricomplicherebbe il determinismo).
+   - Altrimenti → fallback al path attuale (`render_single_stream` in
+     loop, che sotto ha ancora il chunk path per il singolo stream denso).
+4. Raccogli i risultati in ordine di submit; per ogni stream riuscito
+   aggiorna la cache (`update_after_build`, nel parent, come oggi).
+   Un'eccezione nel worker si propaga dal `future.result()` → la cache
+   degli stream non completati NON viene aggiornata.
+
+### Worker: render_stream_to_file (numpy_parallel)
+
+Replica ESATTAMENTE il path sequenziale di `render_single_stream` dal punto
+"buffer allocato" in poi:
+
+- buffer `(n_total, 2)` float64;
+- overlap-add di tutte le pairs NELL'ORDINE RICEVUTO (voice-major, come il
+  loop storico) con CLAMP 1;
+- `dc_block` + `np.clip` + `sf.write(output_path, ...)`;
+- ritorna `output_path` (stringa: IPC di ritorno ~zero, contro i buffer
+  audio del chunk path).
+
+Usa `_worker_grain_renderer`/`_worker_table_map` gia' inizializzati da
+`init_worker` (invariato).
+
+### Contratto di determinismo (rafforzato)
+
+- Ogni stem prodotto dal path stream-parallel e' **byte-identico** a
+  `jobs=1`: dentro il worker l'ordine delle somme float64 e' quello
+  storico. (Il chunk path garantiva solo < 1 LSB a 24 bit; per STEMS
+  multi-stream il nuovo contratto e' piu' forte.)
+- A parita' di jobs → byte-identico tra run (gia' vero, resta vero).
+- MIX e STEMS a stream singolo: invariati (chunk path).
+
+### Memoria e I/O
+
+- Ogni worker alloca il buffer dell'INTERO extent del proprio stream:
+  stereo float64, ~23 MB/minuto → accettabile (N worker × 1 stream alla
+  volta).
+- `sf.write` concorrente su file distinti: nessuna contesa oltre la banda
+  disco.
+
+## Test (TDD, rossi → verdi)
+
+1. `test_audio_renderer.py` (o dove vive il test dell'ABC) —
+   `render_streams` default: chiama `render_single_stream` per ogni coppia,
+   nell'ordine, e ritorna i path.
+2. `test_render_mode.py` — `StemsRenderMode.execute` delega a
+   `renderer.render_streams` (mock); output invariato.
+3. `test_numpy_parallel.py::TestRenderStreamToFile` — in-process: file
+   scritto byte-identico al riferimento `render_single_stream` sequenziale
+   (dc_block incluso); CLAMP 1; task senza grani.
+4. `test_numpy_audio_renderer.py::TestStreamParallel` — pool reale, 2+
+   stream, jobs=2: file byte-identici a jobs=1; con cache: stream clean non
+   generano (`generated` resta False) e non vengono dispatchati; manifest
+   aggiornato solo per stream riusciti; eccezione worker → propagata, cache
+   non aggiornata per quello stream; sotto soglia → nessun dispatch
+   stream-level.
+5. e2e (`test_numpy_renderer_e2e.py`) — STEMS 3 stream densi `JOBS=2` vs
+   `JOBS=1`: stem byte-identici (`==`, non < 1 LSB); STEMS+CACHE+JOBS:
+   seconda run tutta clean.
+
+## Cross-repo
+
+- **PGE-ls:** nessun impatto (superficie YAML invariata).
+- **PGE-ui:** nessun impatto (CLI invariata, stesso `--jobs`).
+- **Paper CIM 2026:** per STEMS con jobs>1 l'output diventa byte-identico
+  al sequenziale (oggi differiva < 1 LSB): cambiamento migliorativo del
+  comportamento del rendering → alla PR valutare il bump del submodule
+  (regola `submodule-sync-cim.md`).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -6,7 +6,7 @@ tags: [cli, flags, make, rendering, export]
 sources:
   - src/main.py
   - make/build.mk
-last_synced_commit: 9eb9c14
+last_synced_commit: 9de1079
 entry_for: [cli-flags, build-flags]
 ---
 
@@ -65,6 +65,7 @@ Senza argomenti: stampa usage ed esce con codice 1.
 | Flag | Default | Variabile Make | Descrizione |
 |------|---------|----------------|-------------|
 | `--renderer csound\|numpy` | `csound` | `RENDERER` | motore di rendering; valore non valido solleva `InvalidRendererError` |
+| `--jobs N\|auto` | `auto` | `JOBS` | worker del rendering NumPy multi-processo. `auto` = core disponibili - 1 (min 1, via affinity dove disponibile); `1` = sequenziale byte-identico allo storico; `0`, negativi o non numerici: messaggio + exit 1. Ignorato con `--renderer csound` |
 | `--format aiff\|wav\|flac` | `aiff` | `FORMAT` | formato audio; valore non valido: messaggio + exit 1 |
 | `--cache-dir DIR` | `cache` | `CACHEDIR` | directory dei manifest di fingerprint |
 | `--orc-path PATH` | `csound/main.orc` | — | orchestra Csound |
@@ -96,6 +97,14 @@ Vincoli tra flag e comportamento nelle combinazioni non valide:
   garbage collection degli stream orfani scatta solo con entrambe attive.
 - **`--keep-sco` / `--sco-dir`** hanno effetto solo con `--renderer csound`
   (il renderer numpy non produce `.sco`).
+- **`--jobs`** ha effetto solo con `--renderer numpy`. Sotto una soglia di
+  grani per render (`PARALLEL_MIN_GRAINS`, `src/rendering/numpy_parallel.py`)
+  il path resta sequenziale anche con `--jobs > 1` (l'overhead del pool
+  supererebbe il guadagno). Contratto di determinismo: a parità di valore di
+  `--jobs` l'output è byte-identico tra run; tra valori diversi cambia solo
+  l'ordine delle somme float64 dell'overlap-add (differenza < 1 LSB a 24
+  bit, non udibile); `--jobs 1` riproduce esattamente, bit a bit, l'output
+  del rendering sequenziale storico.
 - **`--show-static`** ha effetto solo insieme a `--visualize`.
 - **`--show-voice-offsets`** ha effetto solo insieme a `--visualize`. Gli
   offset per-voce vengono campionati dalle voice strategy
@@ -132,6 +141,12 @@ python src/main.py configs/brano.yml output/brano.aif \
 
 # Equivalente via Make
 make all FILE=brano STEMS=true CACHE=true GRAIN_JSON=true RENDERER=numpy
+
+# Rendering sequenziale garantito byte-identico (riproducibilita' esatta)
+python src/main.py configs/brano.yml --renderer numpy --jobs 1
+
+# Numero esplicito di worker via Make (vuoto = auto = core-1)
+make all FILE=brano RENDERER=numpy JOBS=4
 
 # Debug csound: conserva gli .sco intermedi
 python src/main.py configs/brano.yml --renderer csound --keep-sco --sco-dir generated

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -65,7 +65,7 @@ Senza argomenti: stampa usage ed esce con codice 1.
 | Flag | Default | Variabile Make | Descrizione |
 |------|---------|----------------|-------------|
 | `--renderer csound\|numpy` | `csound` | `RENDERER` | motore di rendering; valore non valido solleva `InvalidRendererError` |
-| `--jobs N\|auto` | `auto` | `JOBS` | worker del rendering NumPy multi-processo. `auto` = core disponibili - 1 (min 1, via affinity dove disponibile); `1` = sequenziale byte-identico allo storico; `0`, negativi o non numerici: messaggio + exit 1. Ignorato con `--renderer csound` |
+| `--jobs N\|auto` | `auto` | `JOBS` | worker del rendering NumPy multi-processo. `auto` = core disponibili - 1 (min 1, via affinity dove disponibile); `1` = sequenziale, campioni bit-identici allo storico; `0`, negativi o non numerici: messaggio + exit 1. Ignorato con `--renderer csound` |
 | `--format aiff\|wav\|flac` | `aiff` | `FORMAT` | formato audio; valore non valido: messaggio + exit 1 |
 | `--cache-dir DIR` | `cache` | `CACHEDIR` | directory dei manifest di fingerprint |
 | `--orc-path PATH` | `csound/main.orc` | — | orchestra Csound |
@@ -101,10 +101,13 @@ Vincoli tra flag e comportamento nelle combinazioni non valide:
   grani per render (`PARALLEL_MIN_GRAINS`, `src/rendering/numpy_parallel.py`)
   il path resta sequenziale anche con `--jobs > 1` (l'overhead del pool
   supererebbe il guadagno). Contratto di determinismo: a parità di valore di
-  `--jobs` l'output è byte-identico tra run; tra valori diversi cambia solo
-  l'ordine delle somme float64 dell'overlap-add (differenza < 1 LSB a 24
-  bit, non udibile); `--jobs 1` riproduce esattamente, bit a bit, l'output
-  del rendering sequenziale storico.
+  `--jobs` i **campioni** audio sono bit-identici tra run; tra valori diversi
+  cambia solo l'ordine delle somme float64 dell'overlap-add (differenza < 1
+  LSB a 24 bit, non udibile); `--jobs 1` riproduce esattamente, bit a bit, i
+  campioni del rendering sequenziale storico. Nota: il file AIFF float non è
+  byte-identico tra run perché libsndfile scrive un timestamp wall-clock nel
+  PEAK chunk dell'header; confronta i campioni (`soundfile.read`), non i byte
+  grezzi.
 - **`--show-static`** ha effetto solo insieme a `--visualize`.
 - **`--show-voice-offsets`** ha effetto solo insieme a `--visualize`. Gli
   offset per-voce vengono campionati dalle voice strategy
@@ -142,7 +145,7 @@ python src/main.py configs/brano.yml output/brano.aif \
 # Equivalente via Make
 make all FILE=brano STEMS=true CACHE=true GRAIN_JSON=true RENDERER=numpy
 
-# Rendering sequenziale garantito byte-identico (riproducibilita' esatta)
+# Rendering sequenziale: campioni bit-identici allo storico (riproducibilita' esatta)
 python src/main.py configs/brano.yml --renderer numpy --jobs 1
 
 # Numero esplicito di worker via Make (vuoto = auto = core-1)

--- a/make/build.mk
+++ b/make/build.mk
@@ -64,6 +64,12 @@ ifneq ($(strip $(MAGNIFY_AT)),)
 PYFLAGS += --magnify-at "$(MAGNIFY_AT)"
 endif
 
+# 2f. Se JOBS e' non-vuoto, aggiungi --jobs (rendering NumPy multi-processo;
+# main.py lo ignora con --renderer csound). Vuoto = default 'auto' di main.py.
+ifneq ($(strip $(JOBS)),)
+PYFLAGS += --jobs $(JOBS)
+endif
+
 # 3. Se REAPER e' true, aggiungi --reaper (esporta .rpp Reaper)
 ifeq ($(REAPER), true)
 PYFLAGS += --reaper

--- a/src/core/grain.py
+++ b/src/core/grain.py
@@ -45,6 +45,16 @@ class Grain:
                     f"got {type(value).__name__}"
                 )
 
+    def __reduce__(self):
+        """Pickling frozen+slots: lo slot-state di default viene ripristinato
+        via setattr, che il __setattr__ frozen rifiuta. Ricostruire via
+        __init__ preserva immutabilita' e validazione (necessario per il
+        rendering multi-processo, dove i Grain attraversano il pickle)."""
+        return (self.__class__, (
+            self.onset, self.duration, self.pointer_pos, self.pitch_ratio,
+            self.volume, self.pan, self.sample_table, self.envelope_table,
+        ))
+
     def to_score_line(self, onset_offset: float = 0.0) -> str:
         """Genera la linea di score Csound.
 

--- a/src/main.py
+++ b/src/main.py
@@ -463,11 +463,16 @@ def main():
         from rendering.naming_strategy import DefaultNamingStrategy
         engine = RenderingEngine(renderer, naming_strategy=DefaultNamingStrategy(ext=audio_format.extension))
         mode = StemsRenderMode() if per_stream else MixRenderMode()
+        import time
+        _render_t0 = time.perf_counter()
         generated = engine.render(
             streams=generator.streams,
             output_path=output_file,
             mode=mode,
         )
+        _render_dt = time.perf_counter() - _render_t0
+        jobs_note = f" (jobs={renderer.jobs})" if renderer_type == 'numpy' else ""
+        print(f"\n Rendering completato in {_render_dt:.2f}s{jobs_note}")
 
         print(f"\n Generazione completata! {len(generated)} file generati:")
         for path in generated:

--- a/src/main.py
+++ b/src/main.py
@@ -77,6 +77,7 @@ def _build_renderer(renderer_type: str, generator, **kwargs):
             cache_manager=cache_manager,
             stream_data_map=generator.stream_data_map,
             audio_format=kwargs.get('audio_format', DEFAULT_FORMAT),
+            jobs=kwargs.get('jobs', 'auto'),
         )
 
     if renderer_type == 'csound':
@@ -115,6 +116,36 @@ def _build_renderer(renderer_type: str, generator, **kwargs):
         renderer_type=renderer_type,
         available=["csound", "numpy"],
     )
+
+
+def _parse_jobs(argv):
+    """Parsa --jobs per il rendering NumPy multi-processo.
+
+    Ritorna 'auto' (default: core disponibili - 1, min 1) oppure un intero
+    >= 1. La risoluzione di 'auto' avviene nel renderer via
+    numpy_parallel.resolve_jobs. Come gli altri flag di main: valore
+    mancante → default; valore non valido → messaggio + exit(1).
+    Con --jobs 1 l'output resta byte-identico al rendering sequenziale.
+    Ignorato dal renderer csound.
+    """
+    import sys
+    if '--jobs' not in argv:
+        return 'auto'
+    idx = argv.index('--jobs')
+    if idx + 1 >= len(argv):
+        return 'auto'
+    raw = argv[idx + 1]
+    if raw.lower() == 'auto':
+        return 'auto'
+    try:
+        value = int(raw)
+    except ValueError:
+        print(f"--jobs non valido: '{raw}'. Usa un intero >= 1 oppure 'auto'.")
+        sys.exit(1)
+    if value < 1:
+        print(f"--jobs deve essere >= 1, ricevuto: {value}. Usa 1 per il rendering sequenziale.")
+        sys.exit(1)
+    return value
 
 
 # Chiavi ammesse in un target di --magnify-at. Numeriche (float) e stringa.
@@ -184,6 +215,7 @@ def main():
             "[--page-duration SECONDI] "
             "[--per-stream] "
             "[--renderer csound|numpy] "
+            "[--jobs N|auto] "
             "[--format aiff|wav|flac] "
             "[--orc-path PATH] [--incdir DIR] [--ssdir DIR] [--sfdir DIR] "
             "[--log-dir DIR] [--message-level N] "
@@ -294,6 +326,9 @@ def main():
         if idx + 1 < len(sys.argv):
             renderer_type = sys.argv[idx + 1]
 
+    # --jobs N|auto (default: auto = core-1). Solo renderer numpy.
+    jobs = _parse_jobs(sys.argv)
+
     # --cache-dir DIR
     cache_dir = 'cache'
     if '--cache-dir' in sys.argv:
@@ -390,6 +425,7 @@ def main():
             renderer_type,
             generator,
             output_sr=48000,
+            jobs=jobs,
             orc_path=orc_path,
             incdir=incdir,
             ssdir=ssdir,

--- a/src/rendering/audio_renderer.py
+++ b/src/rendering/audio_renderer.py
@@ -16,7 +16,7 @@ Il renderer sa solo renderizzare, non decide la logica di controllo
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import List
+from typing import List, Tuple
 
 
 class AudioRenderer(ABC):
@@ -26,6 +26,8 @@ class AudioRenderer(ABC):
     Contratto (ATOMICO):
     - render_single_stream(): renderizza UN stream in UN file (onset relativi)
     - render_merged_streams(): renderizza PIÙ stream in UN file (onset assoluti)
+    - render_streams(): CONCRETO — renderizza N stream in N file; default =
+      loop su render_single_stream, override possibile per parallelizzare
 
     Il renderer NON decide:
     - Se fare stems o mix (responsabilità di RenderMode)
@@ -89,3 +91,24 @@ class AudioRenderer(ABC):
             # → file di 15 secondi: s1 a 0-5s, silenzio 5-10s, s2 a 10-15s
         """
         ...
+
+    def render_streams(self, pairs: List[Tuple[object, str]]) -> List[str]:
+        """
+        Renderizza N stream in N file (onset relativi), un file per coppia.
+
+        Usato per: STEMS mode (StemsRenderMode delega qui il loop).
+
+        Metodo CONCRETO, non astratto: il default itera le coppie in ordine
+        e delega a render_single_stream — comportamento identico al loop
+        storico di StemsRenderMode. Le sottoclassi possono fare override per
+        cambiare il COME (es. NumpyAudioRenderer: un task per stream a un
+        pool di processi) senza toccare RenderMode, che continua a decidere
+        il COSA (OCP).
+
+        Args:
+            pairs: coppie (stream, output_path), una per stem
+
+        Returns:
+            Lista dei path prodotti, nell'ordine delle coppie
+        """
+        return [self.render_single_stream(stream, path) for stream, path in pairs]

--- a/src/rendering/numpy_audio_renderer.py
+++ b/src/rendering/numpy_audio_renderer.py
@@ -32,9 +32,11 @@ from rendering.numpy_window_registry import NumpyWindowRegistry
 from rendering.dc_blocker import dc_block
 from rendering.numpy_parallel import (
     DEFAULT_MIN_PARALLEL_GRAINS,
+    StreamRenderTask,
     chunk_grains,
     init_worker,
     render_grain_chunk,
+    render_stream_to_file,
     resolve_jobs,
     resolve_table_name,
 )
@@ -119,52 +121,172 @@ class NumpyAudioRenderer(AudioRenderer):
         Returns:
             Path del file prodotto
         """
-        # Cache check: skip se stream e' clean
-        if self.cache_manager:
-            stream_dict = self.stream_data_map.get(stream.stream_id)
-            if stream_dict:
-                dirty = self.cache_manager.is_dirty(stream_dict, output_path)
-                status = "DIRTY" if dirty else "clean"
-                print(f"[CACHE] {stream.stream_id}: {status}", flush=True)
-                if not dirty:
-                    return output_path
+        # Cache check: skip se stream e' clean (is_dirty PRIMA di .voices, #117)
+        if self._cache_skip(stream, output_path):
+            return output_path
 
-        # 1. Alloca buffer su extent reale dei grain (Plan 002 U1).
-        # stream.voices e' la fonte di verita' (Plan 001): il renderer si adatta
-        # al contenuto, senza opinioni proprie sui bounds.
-        all_grains = [g for voice in stream.voices for g in voice]
+        # Overlap-add (chunk path intra-stream sopra soglia) + dc_block + write
+        self._render_single_stream_body(stream, output_path)
+
+        # Aggiorna cache dopo build riuscita
+        self._update_cache(stream)
+
+        return output_path
+
+    def render_streams(self, pairs: List[Tuple[object, str]]) -> List[str]:
+        """
+        Renderizza N stream in N file, un task per stream al pool (STEMS).
+
+        Override del default dell'ABC: invece di un loop sequenziale su
+        render_single_stream (che parallelizza solo l'overlap-add DENTRO uno
+        stream, via chunk path), sposta il parallelismo A LIVELLO DI STREAM.
+        Ogni stem diventa un task per il pool: overlap-add + dc_block + write
+        girano interamente nel worker, coprendo ~il 100% del lavoro per-stream
+        e scalando quasi linearmente con molti stream.
+
+        Ordine e determinismo:
+        - Il cache check (is_dirty) precede l'accesso a .voices (#117): gli
+          stream clean ritornano il loro path senza generare ne' dispatchare.
+        - I grani degli stream dirty si materializzano nel parent IN ORDINE DI
+          STREAM (stesso ordine di consumo del `random` del loop storico):
+          la riproducibilita' e' invariata.
+        - Ogni stem prodotto e' byte-identico a jobs=1 (dentro il worker le
+          somme float64 sono nell'ordine storico).
+
+        Policy di dispatch: parallelizza tra stream solo se conviene
+        (jobs > 1, almeno 2 stream dirty, grani totali >= soglia); altrimenti
+        delega al path per-stream (render_single_stream, col chunk path per lo
+        stream denso singolo).
+        """
+        results: List[Optional[str]] = [None] * len(pairs)
+
+        # Fase 1 — triage cache (is_dirty prima di .voices, #117).
+        dirty: List[Tuple[int, object, str]] = []
+        for idx, (stream, path) in enumerate(pairs):
+            if self._cache_skip(stream, path):
+                results[idx] = path
+            else:
+                dirty.append((idx, stream, path))
+
+        # Fase 2 — policy: sotto le condizioni per il parallelismo stream-level
+        # si delega al path per-stream (che a sua volta usa il chunk path per
+        # lo stream denso singolo). Il cache check e' gia' stato fatto sopra,
+        # quindi si chiama direttamente il corpo + update.
+        def _render_dirty_locally() -> None:
+            for idx, stream, path in dirty:
+                self._render_single_stream_body(stream, path)
+                self._update_cache(stream)
+                results[idx] = path
+
+        if self.jobs <= 1 or len(dirty) < 2:
+            _render_dirty_locally()
+            return [p for p in results]
+
+        # Materializza i task in ordine di stream (random deterministico).
+        tasks = [
+            (idx, stream, path, self._build_stream_task(stream, path))
+            for idx, stream, path in dirty
+        ]
+        total_grains = sum(len(task.pairs) for _, _, _, task in tasks)
+
+        if total_grains < self.min_parallel_grains:
+            _render_dirty_locally()
+            return [p for p in results]
+
+        # Fase 3 — dispatch stream-level: un task per stream al pool.
+        executor = self._ensure_executor()
+        futures = [
+            (idx, stream, path, executor.submit(render_stream_to_file, task))
+            for idx, stream, path, task in tasks
+        ]
+        # Raccolta in ordine di submit. Un'eccezione nel worker si propaga da
+        # future.result(): la cache degli stream non completati NON si aggiorna.
+        for idx, stream, path, future in futures:
+            results[idx] = future.result()
+            self._update_cache(stream)
+
+        return [p for p in results]
+
+    # =========================================================================
+    # INTERNAL - Cache + corpo render (riusati da single-stream e stream-level)
+    # =========================================================================
+
+    def _cache_skip(self, stream, output_path: str) -> bool:
+        """Cache check: logga lo stato e ritorna True se lo stream e' clean
+        (build da saltare). is_dirty va chiamato PRIMA di toccare .voices
+        (#117): gli stream clean non devono generare grani."""
+        if not self.cache_manager:
+            return False
+        stream_dict = self.stream_data_map.get(stream.stream_id)
+        if not stream_dict:
+            return False
+        dirty = self.cache_manager.is_dirty(stream_dict, output_path)
+        status = "DIRTY" if dirty else "clean"
+        print(f"[CACHE] {stream.stream_id}: {status}", flush=True)
+        return not dirty
+
+    def _update_cache(self, stream) -> None:
+        """Aggiorna la cache dopo una build riuscita dello stream."""
+        if not self.cache_manager:
+            return
+        stream_dict = self.stream_data_map.get(stream.stream_id)
+        if stream_dict:
+            self.cache_manager.update_after_build([stream_dict])
+
+    def _relative_n_total(self, all_grains, stream) -> int:
+        """Lunghezza buffer (samples) per uno stream con onset RELATIVI.
+
+        Extent reale dei grain (Plan 002 U1): stream.voices e' la fonte di
+        verita' (Plan 001), il renderer si adatta al contenuto."""
         if all_grains:
             max_end_rel = max(g.onset + g.duration for g in all_grains) - stream.onset
             max_end_rel = max(max_end_rel, stream.duration)
         else:
             max_end_rel = stream.duration
-        n_total = max(1, round(max_end_rel * self.output_sr))
+        return max(1, round(max_end_rel * self.output_sr))
+
+    def _render_single_stream_body(self, stream, output_path: str) -> None:
+        """Corpo di render_single_stream senza cache: alloca, overlap-add
+        (chunk path intra-stream sopra soglia), dc_block, clip, write.
+
+        Bit-identico al path storico: stesso extent, stesse pairs, stesso
+        ordine di somma."""
+        all_grains = [g for voice in stream.voices for g in voice]
+        n_total = self._relative_n_total(all_grains, stream)
         buffer = np.zeros((n_total, 2), dtype=np.float64)
 
-        # 2. Overlap-add con onset RELATIVI (all_grains e' gia' in ordine
-        # voice-major: stesso ordine di somma del loop storico)
+        # all_grains e' gia' in ordine voice-major: stesso ordine del loop storico
         pairs = [
             (grain, self._relative_onset_sample(grain, stream.onset))
             for grain in all_grains
         ]
         self._overlap_add(buffer, pairs)
 
-        # 3. DC blocker FIR: rimuove l'offset DC accumulato dall'overlap-add
         buffer = dc_block(buffer, self.output_sr)
-
-        # 4. Clamp + scrivi
         np.clip(buffer, -1.0, 1.0, out=buffer)
         sf.write(output_path, buffer, self.output_sr,
                  format=self.audio_format.sf_format,
                  subtype=self.audio_format.sf_subtype)
 
-        # Aggiorna cache dopo build riuscita
-        if self.cache_manager:
-            stream_dict = self.stream_data_map.get(stream.stream_id)
-            if stream_dict:
-                self.cache_manager.update_after_build([stream_dict])
+    def _build_stream_task(self, stream, output_path: str) -> StreamRenderTask:
+        """Costruisce il task picklable per il worker stream-level.
 
-        return output_path
+        n_total e pairs sono identici a quelli di _render_single_stream_body
+        → lo stem prodotto dal worker e' byte-identico al path sequenziale."""
+        all_grains = [g for voice in stream.voices for g in voice]
+        n_total = self._relative_n_total(all_grains, stream)
+        pairs = [
+            (grain, self._relative_onset_sample(grain, stream.onset))
+            for grain in all_grains
+        ]
+        return StreamRenderTask(
+            pairs=pairs,
+            n_total=n_total,
+            output_path=output_path,
+            sf_format=self.audio_format.sf_format,
+            sf_subtype=self.audio_format.sf_subtype,
+            output_sr=self.output_sr,
+        )
 
     def render_merged_streams(self, streams: List, output_path: str) -> str:
         """

--- a/src/rendering/numpy_audio_renderer.py
+++ b/src/rendering/numpy_audio_renderer.py
@@ -17,9 +17,12 @@ Template Method interno (comune):
 """
 from __future__ import annotations
 
+import multiprocessing
+from concurrent.futures import ProcessPoolExecutor
+from typing import Dict, Tuple, List, Optional
+
 import numpy as np
 import soundfile as sf
-from typing import Dict, Tuple, List, Optional
 
 from rendering.audio_format import AudioFormat, DEFAULT_FORMAT
 from rendering.audio_renderer import AudioRenderer
@@ -27,6 +30,14 @@ from rendering.grain_renderer import GrainRenderer
 from rendering.sample_registry import SampleRegistry
 from rendering.numpy_window_registry import NumpyWindowRegistry
 from rendering.dc_blocker import dc_block
+from rendering.numpy_parallel import (
+    DEFAULT_MIN_PARALLEL_GRAINS,
+    chunk_grains,
+    init_worker,
+    render_grain_chunk,
+    resolve_jobs,
+    resolve_table_name,
+)
 
 
 class NumpyAudioRenderer(AudioRenderer):
@@ -44,6 +55,12 @@ class NumpyAudioRenderer(AudioRenderer):
         output_sr: sample rate di output (default: 48000)
         cache_manager: StreamCacheManager opzionale per skip stream invariati
         stream_data_map: dict {stream_id: yaml_dict} per fingerprint cache
+        jobs: worker per l'overlap-add multi-processo. 1 (default) =
+              sequenziale, identico bit a bit al comportamento storico;
+              'auto' = core disponibili - 1 (min 1). Vedi numpy_parallel.
+        min_parallel_grains: sotto questa soglia di grani per chiamata il
+              rendering resta sequenziale anche con jobs > 1 (l'overhead
+              del pool supererebbe il guadagno). None = default di modulo.
     """
 
     def __init__(
@@ -55,6 +72,8 @@ class NumpyAudioRenderer(AudioRenderer):
         cache_manager=None,
         stream_data_map: Optional[Dict[str, dict]] = None,
         audio_format: AudioFormat = DEFAULT_FORMAT,
+        jobs=1,
+        min_parallel_grains: Optional[int] = None,
     ):
         self.sample_registry = sample_registry
         self.window_registry = window_registry
@@ -63,6 +82,14 @@ class NumpyAudioRenderer(AudioRenderer):
         self.cache_manager = cache_manager
         self.stream_data_map = dict(stream_data_map) if stream_data_map is not None else {}
         self.audio_format = audio_format
+        self.jobs = resolve_jobs(jobs)
+        self.min_parallel_grains = (
+            DEFAULT_MIN_PARALLEL_GRAINS if min_parallel_grains is None
+            else min_parallel_grains
+        )
+        # Pool multi-processo: lazy al primo render sopra soglia, riusato per
+        # tutti gli stream della run (STEMS), spento da close().
+        self._executor: Optional[ProcessPoolExecutor] = None
 
         self._grain_renderer = GrainRenderer(
             sample_registry=sample_registry,
@@ -114,10 +141,13 @@ class NumpyAudioRenderer(AudioRenderer):
         n_total = max(1, round(max_end_rel * self.output_sr))
         buffer = np.zeros((n_total, 2), dtype=np.float64)
 
-        # 2. Overlap-add con onset RELATIVI
-        for voice_grains in stream.voices:
-            for grain in voice_grains:
-                self._add_grain_relative(buffer, grain, stream.onset)
+        # 2. Overlap-add con onset RELATIVI (all_grains e' gia' in ordine
+        # voice-major: stesso ordine di somma del loop storico)
+        pairs = [
+            (grain, self._relative_onset_sample(grain, stream.onset))
+            for grain in all_grains
+        ]
+        self._overlap_add(buffer, pairs)
 
         # 3. DC blocker FIR: rimuove l'offset DC accumulato dall'overlap-add
         buffer = dc_block(buffer, self.output_sr)
@@ -165,11 +195,13 @@ class NumpyAudioRenderer(AudioRenderer):
         n_total = max(1, round(max_end_time * self.output_sr))
         buffer = np.zeros((n_total, 2), dtype=np.float64)
 
-        # 2. Overlap-add con onset ASSOLUTI
-        for stream in streams:
-            for voice_grains in stream.voices:
-                for grain in voice_grains:
-                    self._add_grain_absolute(buffer, grain)
+        # 2. Overlap-add con onset ASSOLUTI (all_grains e' gia' in ordine
+        # stream-major/voice-major: stesso ordine di somma del loop storico)
+        pairs = [
+            (grain, self._absolute_onset_sample(grain))
+            for grain in all_grains
+        ]
+        self._overlap_add(buffer, pairs)
 
         # 3. DC blocker FIR: rimuove l'offset DC accumulato dall'overlap-add
         buffer = dc_block(buffer, self.output_sr)
@@ -186,6 +218,14 @@ class NumpyAudioRenderer(AudioRenderer):
     # INTERNAL - Overlap-add helpers
     # =========================================================================
 
+    def _relative_onset_sample(self, grain, stream_onset: float) -> int:
+        """onset_sample = round((grain.onset - stream_onset) * sr) — STEMS."""
+        return round((grain.onset - stream_onset) * self.output_sr)
+
+    def _absolute_onset_sample(self, grain) -> int:
+        """onset_sample = round(grain.onset * sr) — MIX."""
+        return round(grain.onset * self.output_sr)
+
     def _add_grain_relative(
         self,
         buffer: np.ndarray,
@@ -200,7 +240,7 @@ class NumpyAudioRenderer(AudioRenderer):
         Onset calculation: onset_sample = (grain.onset - stream_onset) * sr
         → grano posizionato relativamente allo stream (parte da 0)
         """
-        onset_sample = round((grain.onset - stream_onset) * self.output_sr)
+        onset_sample = self._relative_onset_sample(grain, stream_onset)
         self._add_grain_at_position(buffer, grain, onset_sample)
 
     def _add_grain_absolute(
@@ -213,8 +253,80 @@ class NumpyAudioRenderer(AudioRenderer):
 
         Usato da: render_merged_streams() (MIX mode)
         """
-        onset_sample = round(grain.onset * self.output_sr)
+        onset_sample = self._absolute_onset_sample(grain)
         self._add_grain_at_position(buffer, grain, onset_sample)
+
+    def _overlap_add(
+        self,
+        buffer: np.ndarray,
+        pairs: List[Tuple[object, int]],
+    ) -> None:
+        """
+        Somma tutti i grani nel buffer, sequenziale o multi-processo.
+
+        Path sequenziale (jobs=1 o poco lavoro): itera le coppie nell'ordine
+        ricevuto — bit-identico al loop storico. Path parallelo: chunk
+        contigui in ordine di onset ai worker, somma dei buffer locali in
+        ordine di chunk fisso (deterministico a jobs fissato; vs sequenziale
+        cambia solo l'ordine delle somme float64, < 1 LSB a 24 bit).
+        """
+        if self.jobs > 1 and len(pairs) >= self.min_parallel_grains:
+            self._overlap_add_parallel(buffer, pairs)
+        else:
+            for grain, onset_sample in pairs:
+                self._add_grain_at_position(buffer, grain, onset_sample)
+
+    def _overlap_add_parallel(
+        self,
+        buffer: np.ndarray,
+        pairs: List[Tuple[object, int]],
+    ) -> None:
+        """Distribuisce l'overlap-add su un pool di processi."""
+        # Ordina per onset (stabile → deterministico): chunk contigui nel
+        # tempo, buffer locali ~1/N dell'extent.
+        ordered = sorted(pairs, key=lambda pair: pair[1])
+        chunks = chunk_grains(ordered, self.jobs)
+        executor = self._ensure_executor()
+        futures = [executor.submit(render_grain_chunk, chunk) for chunk in chunks]
+        # Somma in ordine di submit, non di completamento: output identico
+        # tra run a parita' di jobs.
+        for future in futures:
+            result = future.result()
+            if result is None:
+                continue
+            offset, local = result
+            buffer[offset:offset + local.shape[0]] += local
+
+    def _ensure_executor(self) -> ProcessPoolExecutor:
+        """Crea il pool alla prima necessita' e lo riusa per tutta la run."""
+        if self._executor is None:
+            sample_names = [
+                name for ftype, name in self.table_map.values()
+                if ftype == 'sample'
+            ]
+            config = {
+                'base_path': self.sample_registry.base_path,
+                'sample_names': sample_names,
+                'table_map': self.table_map,
+                'output_sr': self.output_sr,
+            }
+            # spawn esplicito: uniforme macOS/Linux, nessuna eredita' di
+            # stato dal parent (i worker ricostruiscono i registry da disco).
+            ctx = multiprocessing.get_context('spawn')
+            self._executor = ProcessPoolExecutor(
+                max_workers=self.jobs,
+                mp_context=ctx,
+                initializer=init_worker,
+                initargs=(config,),
+            )
+        return self._executor
+
+    def close(self) -> None:
+        """Spegne il pool multi-processo. Idempotente; il renderer resta
+        utilizzabile (un nuovo render sopra soglia ricrea il pool)."""
+        if self._executor is not None:
+            self._executor.shutdown(wait=True)
+            self._executor = None
 
     def _add_grain_at_position(
         self,
@@ -258,28 +370,8 @@ class NumpyAudioRenderer(AudioRenderer):
 
     def _resolve_sample_name(self, table_num: int) -> str:
         """Risolve table_num -> sample name dal table_map."""
-        if table_num not in self.table_map:
-            raise KeyError(
-                f"Table num {table_num} non trovato nel table_map. "
-                f"Disponibili: {list(self.table_map.keys())}"
-            )
-        ftype, name = self.table_map[table_num]
-        if ftype != 'sample':
-            raise KeyError(
-                f"Table {table_num} e' di tipo '{ftype}', atteso 'sample'"
-            )
-        return name
+        return resolve_table_name(self.table_map, table_num, 'sample')
 
     def _resolve_window_name(self, table_num: int) -> str:
         """Risolve table_num -> window name dal table_map."""
-        if table_num not in self.table_map:
-            raise KeyError(
-                f"Table num {table_num} non trovato nel table_map. "
-                f"Disponibili: {list(self.table_map.keys())}"
-            )
-        ftype, name = self.table_map[table_num]
-        if ftype != 'window':
-            raise KeyError(
-                f"Table {table_num} e' di tipo '{ftype}', atteso 'window'"
-            )
-        return name
+        return resolve_table_name(self.table_map, table_num, 'window')

--- a/src/rendering/numpy_parallel.py
+++ b/src/rendering/numpy_parallel.py
@@ -35,11 +35,13 @@ differenza massima sotto 1 LSB a 24 bit (coperto dai test del renderer).
 from __future__ import annotations
 
 import os
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Dict, List, NamedTuple, Optional, Sequence, Tuple
 
 import numpy as np
+import soundfile as sf
 
 from core.grain import Grain
+from rendering.dc_blocker import dc_block
 from rendering.grain_renderer import GrainRenderer
 from rendering.sample_registry import SampleRegistry
 from rendering.numpy_window_registry import NumpyWindowRegistry
@@ -246,3 +248,82 @@ def render_grain_chunk(
         local[start:start + buf.shape[0]] += buf
 
     return offset, local
+
+
+# =============================================================================
+# LATO WORKER - PARALLELISMO A LIVELLO DI STREAM
+# =============================================================================
+
+class StreamRenderTask(NamedTuple):
+    """
+    Task picklable per il rendering di UNO stream nel worker.
+
+    Contiene tutto il necessario per replicare render_single_stream dal punto
+    "buffer allocato" in poi, senza toccare lo stato del parent:
+
+    - pairs:      coppie (grain, onset_sample RELATIVO allo stream), in ordine
+                  voice-major (stesso ordine di somma del loop storico)
+    - n_total:    lunghezza del buffer in samples (calcolata dal parent)
+    - output_path: file .aif/.wav di destinazione
+    - sf_format:  container soundfile (es. 'AIFF')
+    - sf_subtype: sottotipo soundfile (es. 'PCM_24')
+    - output_sr:  sample rate di output (per dc_block e write)
+    """
+    pairs: List[Tuple[Grain, int]]
+    n_total: int
+    output_path: str
+    sf_format: str
+    sf_subtype: str
+    output_sr: int
+
+
+def render_stream_to_file(task: StreamRenderTask) -> str:
+    """
+    Rende UNO stream in UN file, interamente nel worker.
+
+    Replica ESATTAMENTE il path sequenziale di render_single_stream dal
+    buffer in poi: overlap-add di tutte le pairs NELL'ORDINE RICEVUTO (con
+    CLAMP 1 sull'onset negativo), dc_block FIR, clip a [-1, 1], scrittura.
+    L'ordine delle somme float64 e' quello storico → lo stem e' byte-identico
+    a jobs=1 (contratto piu' forte del chunk path, che garantiva solo < 1 LSB).
+
+    L'IPC di ritorno e' la sola stringa output_path: nessun buffer audio
+    attraversa il confine di processo (contro i buffer locali del chunk path).
+
+    Args:
+        task: StreamRenderTask picklable (pairs relative, n_total, output...)
+
+    Returns:
+        Il percorso del file prodotto (task.output_path).
+    """
+    if _worker_grain_renderer is None or _worker_table_map is None:
+        raise RuntimeError(
+            "Worker non inizializzato: chiamare init_worker(config) prima "
+            "di render_stream_to_file (initializer del pool)."
+        )
+
+    buffer = np.zeros((task.n_total, 2), dtype=np.float64)
+    for grain, onset_sample in task.pairs:
+        sample_name = resolve_table_name(
+            _worker_table_map, grain.sample_table, 'sample')
+        window_name = resolve_table_name(
+            _worker_table_map, grain.envelope_table, 'window')
+
+        grain_buffer = _worker_grain_renderer.render(
+            grain, sample_name, window_name)
+
+        # CLAMP 1 — onset negativo: taglia l'inizio del grano.
+        if onset_sample < 0:
+            grain_buffer = grain_buffer[-onset_sample:]
+            onset_sample = 0
+
+        end_sample = onset_sample + grain_buffer.shape[0]
+        if grain_buffer.shape[0] > 0:
+            buffer[onset_sample:end_sample] += grain_buffer
+
+    buffer = dc_block(buffer, task.output_sr)
+    np.clip(buffer, -1.0, 1.0, out=buffer)
+    sf.write(task.output_path, buffer, task.output_sr,
+             format=task.sf_format, subtype=task.sf_subtype)
+
+    return task.output_path

--- a/src/rendering/numpy_parallel.py
+++ b/src/rendering/numpy_parallel.py
@@ -1,0 +1,248 @@
+# src/rendering/numpy_parallel.py
+"""
+numpy_parallel - Primitive del rendering NumPy multi-processo.
+
+Il rendering dei grani e' puro (nessun random, nessuno stato condiviso:
+vedi GrainRenderer), quindi parallelizzabile per chunk. La generazione dei
+grani invece resta nel processo parent: consuma il `random` globale seminato
+una volta in Generator.create_elements(), e l'ordine di consumo determina la
+riproducibilita' delle composizioni.
+
+Architettura (usata da NumpyAudioRenderer):
+
+    parent                                  worker (xN, spawn)
+    ------                                  ------------------
+    flatten grani in ordine di onset        init_worker(config):
+    con onset_sample precomputato             registries + GrainRenderer
+    → chunk_grains(pairs, jobs)               globali di modulo (una volta)
+    → submit render_grain_chunk(chunk)      render_grain_chunk(chunk):
+    → somma (offset, buffer) nel buffer       rende ogni grano e fa
+      target IN ORDINE DI CHUNK               overlap-add in un buffer
+      (determinismo a jobs fissato)           locale all'extent del chunk
+
+I chunk sono contigui nel tempo (input ordinato per onset), quindi ogni
+buffer locale copre ~1/N della timeline: l'IPC di ritorno resta ~costante
+rispetto al rendering sequenziale dell'intero extent.
+
+Contesto multiprocessing: SEMPRE 'spawn' (uniforme macOS/Linux). I worker
+re-importano i moduli: questo file non deve avere side effect a import-time.
+
+Determinismo: a parita' di (jobs, versione) l'output e' byte-identico tra
+run. Con jobs=1 il renderer non passa di qui (path sequenziale invariato).
+Tra valori di jobs diversi cambia solo l'ordine delle somme float64:
+differenza massima sotto 1 LSB a 24 bit (coperto dai test del renderer).
+"""
+from __future__ import annotations
+
+import os
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+from core.grain import Grain
+from rendering.grain_renderer import GrainRenderer
+from rendering.sample_registry import SampleRegistry
+from rendering.numpy_window_registry import NumpyWindowRegistry
+
+
+# Sotto questa soglia di grani il pool non conviene (startup spawn ~100ms
+# per worker vs ~8k grani/s del path sequenziale): il renderer resta
+# sequenziale. Vale per singola chiamata render_*.
+DEFAULT_MIN_PARALLEL_GRAINS = 1024
+
+
+# =============================================================================
+# POLICY JOBS
+# =============================================================================
+
+def resolve_jobs(spec) -> int:
+    """
+    Risolve la spec del numero di worker in un intero >= 1.
+
+    Args:
+        spec: 'auto' o None → max(1, core disponibili - 1); un core resta
+              libero per il parent e per il resto della macchina.
+              int >= 1 → passthrough (scelta esplicita dell'utente).
+
+    Returns:
+        Numero di worker (>= 1).
+
+    Raises:
+        ValueError: per spec non valida (0, negativi, bool, tipi non int).
+    """
+    if spec is None or spec == 'auto':
+        return max(1, _available_cores() - 1)
+    # bool e' subclass di int: rifiutato esplicitamente (come Grain.__post_init__)
+    if isinstance(spec, int) and not isinstance(spec, bool) and spec >= 1:
+        return spec
+    raise ValueError(
+        f"jobs non valido: {spec!r}. Usa 'auto' oppure un intero >= 1."
+    )
+
+
+def _available_cores() -> int:
+    """Core utilizzabili dal processo: affinity se disponibile (rispetta
+    quote container/CI), altrimenti conteggio fisico."""
+    getaffinity = getattr(os, 'sched_getaffinity', None)
+    if getaffinity is not None:
+        try:
+            return len(getaffinity(0))
+        except OSError:
+            pass
+    return os.cpu_count() or 1
+
+
+# =============================================================================
+# CHUNKING
+# =============================================================================
+
+def chunk_grains(items: Sequence, n_chunks: int) -> List[List]:
+    """
+    Divide una sequenza in al piu' n_chunks chunk contigui e bilanciati.
+
+    Contiguita' + input ordinato per onset → ogni chunk copre una finestra
+    temporale limitata (buffer locale piccolo). Deterministico: stesse
+    dimensioni e stesso contenuto a parita' di input.
+
+    Args:
+        items: sequenza da dividere (tipicamente coppie (grain, onset_sample))
+        n_chunks: numero massimo di chunk (>= 1)
+
+    Returns:
+        Lista di chunk non vuoti; [] se items e' vuota.
+    """
+    n_items = len(items)
+    if n_items == 0:
+        return []
+    n_chunks = max(1, min(n_chunks, n_items))
+    base, extra = divmod(n_items, n_chunks)
+    chunks = []
+    start = 0
+    for i in range(n_chunks):
+        size = base + (1 if i < extra else 0)
+        chunks.append(list(items[start:start + size]))
+        start += size
+    return chunks
+
+
+# =============================================================================
+# RISOLUZIONE TABLE (condivisa parent/worker)
+# =============================================================================
+
+def resolve_table_name(
+    table_map: Dict[int, Tuple[str, str]],
+    table_num: int,
+    expected_type: str,
+) -> str:
+    """
+    Risolve table_num -> nome, verificando il tipo ('sample' | 'window').
+
+    Unica fonte di verita' per parent (NumpyAudioRenderer._resolve_*) e
+    worker: stessi messaggi d'errore da entrambi i lati del pool.
+    """
+    if table_num not in table_map:
+        raise KeyError(
+            f"Table num {table_num} non trovato nel table_map. "
+            f"Disponibili: {list(table_map.keys())}"
+        )
+    ftype, name = table_map[table_num]
+    if ftype != expected_type:
+        raise KeyError(
+            f"Table {table_num} e' di tipo '{ftype}', atteso '{expected_type}'"
+        )
+    return name
+
+
+# =============================================================================
+# LATO WORKER
+# =============================================================================
+
+# Stato del worker, popolato una volta da init_worker (initializer del pool).
+# Nei test viene popolato in-process chiamando init_worker direttamente.
+_worker_grain_renderer: Optional[GrainRenderer] = None
+_worker_table_map: Optional[Dict[int, Tuple[str, str]]] = None
+
+
+def init_worker(config: dict) -> None:
+    """
+    Initializer del pool: costruisce registries e GrainRenderer del worker.
+
+    Ogni worker carica i sample da disco UNA volta e cachea le finestre on
+    demand, come fa il parent nel path sequenziale.
+
+    Args:
+        config: dict picklable con chiavi:
+            base_path:    directory dei sample (SampleRegistry)
+            sample_names: nomi file da precaricare
+            table_map:    {table_num: ('sample'|'window', name)}
+            output_sr:    sample rate di output
+    """
+    global _worker_grain_renderer, _worker_table_map
+
+    sample_registry = SampleRegistry(base_path=config['base_path'])
+    for name in config['sample_names']:
+        sample_registry.load(name)
+
+    _worker_grain_renderer = GrainRenderer(
+        sample_registry=sample_registry,
+        window_registry=NumpyWindowRegistry(),
+        output_sr=config['output_sr'],
+    )
+    _worker_table_map = dict(config['table_map'])
+
+
+def render_grain_chunk(
+    chunk: List[Tuple[Grain, int]],
+) -> Optional[Tuple[int, np.ndarray]]:
+    """
+    Rende un chunk di (grain, onset_sample) in un buffer locale.
+
+    Replica esattamente il path sequenziale del renderer per ogni grano:
+    render via GrainRenderer + CLAMP 1 (onset negativo → trim della testa;
+    unico clamp legittimo, cfr. NumpyAudioRenderer._add_grain_at_position).
+    L'overlap-add avviene in un buffer locale dimensionato sull'extent del
+    chunk; il parent lo somma nel buffer target all'offset ritornato.
+
+    Args:
+        chunk: coppie (grain, onset_sample nel buffer target)
+
+    Returns:
+        (offset_samples, buffer stereo float64) oppure None se il chunk e'
+        vuoto o tutti i grani sono stati scartati (interamente prima di t=0).
+    """
+    if not chunk:
+        return None
+    if _worker_grain_renderer is None or _worker_table_map is None:
+        raise RuntimeError(
+            "Worker non inizializzato: chiamare init_worker(config) prima "
+            "di render_grain_chunk (initializer del pool)."
+        )
+
+    rendered: List[Tuple[int, np.ndarray]] = []
+    for grain, onset_sample in chunk:
+        sample_name = resolve_table_name(
+            _worker_table_map, grain.sample_table, 'sample')
+        window_name = resolve_table_name(
+            _worker_table_map, grain.envelope_table, 'window')
+
+        grain_buffer = _worker_grain_renderer.render(
+            grain, sample_name, window_name)
+
+        # CLAMP 1 — onset negativo: taglia l'inizio del grano.
+        if onset_sample < 0:
+            grain_buffer = grain_buffer[-onset_sample:]
+            onset_sample = 0
+        if grain_buffer.shape[0] > 0:
+            rendered.append((onset_sample, grain_buffer))
+
+    if not rendered:
+        return None
+
+    offset = min(onset for onset, _ in rendered)
+    end = max(onset + buf.shape[0] for onset, buf in rendered)
+    local = np.zeros((end - offset, 2), dtype=np.float64)
+    for onset, buf in rendered:
+        start = onset - offset
+        local[start:start + buf.shape[0]] += buf
+
+    return offset, local

--- a/src/rendering/render_mode.py
+++ b/src/rendering/render_mode.py
@@ -81,18 +81,18 @@ class StemsRenderMode(RenderMode):
 
         Delega a:
         - naming.generate_paths() per ottenere path
-        - renderer.render_single_stream() per ogni stream
+        - renderer.render_streams() per il loop sugli stream
+
+        Il mode decide COSA renderizzare (un file per stream); il renderer
+        decide COME (default dell'ABC: loop sequenziale su
+        render_single_stream; NumpyAudioRenderer: un task per stream a un
+        pool di processi).
         """
         # Genera path per ogni stream
         paths_map = naming.generate_paths(output_path, streams, mode='stems')
 
-        # Renderizza ogni stream separatamente
-        generated = []
-        for stream, path in paths_map:
-            renderer.render_single_stream(stream, path)
-            generated.append(path)
-
-        return generated
+        # Renderizza gli stream (il renderer sceglie seriale o parallelo)
+        return renderer.render_streams(paths_map)
 
 
 class MixRenderMode(RenderMode):

--- a/src/rendering/renderer_factory.py
+++ b/src/rendering/renderer_factory.py
@@ -69,6 +69,7 @@ class RendererFactory:
                 cache_manager=kwargs.get('cache_manager'),
                 stream_data_map=kwargs.get('stream_data_map'),
                 audio_format=kwargs.get('audio_format', DEFAULT_FORMAT),
+                jobs=kwargs.get('jobs', 1),
             )
 
         if renderer_type == 'csound':

--- a/tests/core/test_grain.py
+++ b/tests/core/test_grain.py
@@ -485,3 +485,48 @@ class TestGrainToScoreLineWithOnsetOffset:
         assert result.endswith('\n')
         parts = result.strip().split()
         assert len(parts) == 10
+
+
+# =============================================================================
+# TEST PICKLE (rendering parallelo: i Grain attraversano il confine di processo)
+# =============================================================================
+
+class TestGrainPickle:
+    """Grain deve essere picklable per il rendering multi-processo.
+
+    frozen=True + __slots__ manuale rompe il pickling di default: l'unpickle
+    ripristina lo slot state via setattr, che il __setattr__ frozen rifiuta
+    con FrozenInstanceError. Serve __reduce__ che ricostruisce via __init__.
+    """
+
+    def test_pickle_roundtrip_preserves_equality(self, sample_grain):
+        """dumps → loads restituisce un Grain uguale all'originale."""
+        import pickle
+        restored = pickle.loads(pickle.dumps(sample_grain))
+        assert restored == sample_grain
+
+    def test_pickle_roundtrip_preserves_all_fields(self, sample_grain):
+        """Ogni campo sopravvive al roundtrip con lo stesso valore e tipo."""
+        import pickle
+        restored = pickle.loads(pickle.dumps(sample_grain))
+        for field in sample_grain.__slots__:
+            assert getattr(restored, field) == getattr(sample_grain, field)
+        assert isinstance(restored.sample_table, int)
+        assert isinstance(restored.envelope_table, int)
+
+    def test_pickled_grain_is_still_frozen(self, sample_grain):
+        """Il Grain ricostruito resta immutabile."""
+        import pickle
+        restored = pickle.loads(pickle.dumps(sample_grain))
+        with pytest.raises(FrozenInstanceError):
+            restored.onset = 99.0
+
+    def test_pickle_list_of_grains(self, sample_grain_data):
+        """Una lista di Grain (payload dei worker) fa il roundtrip intera."""
+        import pickle
+        grains = [
+            Grain(**{**sample_grain_data, 'onset': i * 0.01})
+            for i in range(100)
+        ]
+        restored = pickle.loads(pickle.dumps(grains))
+        assert restored == grains

--- a/tests/e2e/test_numpy_renderer_e2e.py
+++ b/tests/e2e/test_numpy_renderer_e2e.py
@@ -88,12 +88,13 @@ def _load_manifest(tmp_path) -> dict:
     return json.loads(manifest_path.read_text())
 
 
-def _make_build_stems(tmp_path, cache=True):
+def _make_build_stems(tmp_path, cache=True, jobs=None):
     """
     Invoca `make all STEMS=true RENDERER=numpy` con directory temporanee.
 
     Args:
         cache: se True passa CACHE=true (abilita manifest incrementale)
+        jobs: se valorizzato passa JOBS=<jobs> (rendering multi-processo)
 
     Returns:
         tuple (CompletedProcess, str) — processo e output combinato
@@ -122,6 +123,8 @@ def _make_build_stems(tmp_path, cache=True):
         f'LOGDIR={logdir}',
         f'YMLDIR={ymldir}',
     ]
+    if jobs is not None:
+        cmd.append(f'JOBS={jobs}')
 
     result = subprocess.run(
         cmd,
@@ -322,3 +325,56 @@ class TestNumpyStemsCache:
 
         assert "[CACHE] s1: DIRTY" in output2
         assert "[CACHE] s2: clean" in output2
+
+
+# =============================================================================
+# 4. STEMS + JOBS (rendering multi-processo)
+# =============================================================================
+
+# Density alta: abbastanza grani da superare la soglia PARALLEL_MIN_GRAINS
+# e coinvolgere davvero il pool di processi.
+_YAML_DENSE_STREAM = """\
+composition:
+  title: "e2e numpy parallel test"
+
+streams:
+  - stream_id: "s1"
+    onset: 0.0
+    duration: 1.0
+    sample: "pino.wav"
+    density: 2000
+    grain:
+      duration: 0.05
+"""
+
+
+@pytest.mark.e2e
+class TestNumpyStemsParallel:
+    """STEMS=true RENDERER=numpy JOBS=2: pipeline multi-processo via make."""
+
+    def test_parallel_build_creates_files(self, tmp_path):
+        """La build con JOBS=2 completa e produce gli stem attesi."""
+        _write_yaml(tmp_path, _YAML_DENSE_STREAM)
+        result, output = _make_build_stems(tmp_path, cache=False, jobs=2)
+
+        assert result.returncode == 0, f"make fallito:\n{output}"
+        assert (tmp_path / "output" / "e2e_numpy_test__s1.aif").exists(), \
+            "stem s1 non trovato con JOBS=2"
+
+    def test_parallel_output_matches_sequential(self, tmp_path):
+        """JOBS=2 vs JOBS=1: stessa durata, diff massima < 1 LSB a 24 bit."""
+        import numpy as np
+        import soundfile as sf
+
+        _write_yaml(tmp_path, _YAML_DENSE_STREAM)
+        r1, out1 = _make_build_stems(tmp_path, cache=False, jobs=1)
+        assert r1.returncode == 0, f"make JOBS=1 fallito:\n{out1}"
+        stem = tmp_path / "output" / "e2e_numpy_test__s1.aif"
+        seq, _ = sf.read(str(stem))
+
+        r2, out2 = _make_build_stems(tmp_path, cache=False, jobs=2)
+        assert r2.returncode == 0, f"make JOBS=2 fallito:\n{out2}"
+        par, _ = sf.read(str(stem))
+
+        assert seq.shape == par.shape
+        assert np.max(np.abs(seq - par)) < 2.0 ** -24

--- a/tests/e2e/test_numpy_renderer_e2e.py
+++ b/tests/e2e/test_numpy_renderer_e2e.py
@@ -444,3 +444,92 @@ class TestNumpyMixParallelAuto:
 
         assert seq.shape == par.shape
         assert np.max(np.abs(seq - par)) < 2.0 ** -24
+
+
+# =============================================================================
+# 6. STEMS PARALLELO A LIVELLO DI STREAM (piu' stream dirty, un task per stream)
+# =============================================================================
+
+# Tre stream densi: >= 2 stream dirty attivano il path stream-level
+# (render_streams override), non solo il chunk path intra-stream.
+_YAML_DENSE_THREE_STREAMS = """\
+composition:
+  title: "e2e numpy stream-parallel test"
+
+streams:
+  - stream_id: "s1"
+    onset: 0.0
+    duration: 1.0
+    sample: "pino.wav"
+    density: 1500
+    grain:
+      duration: 0.05
+  - stream_id: "s2"
+    onset: 1.0
+    duration: 1.0
+    sample: "pino.wav"
+    density: 1500
+    grain:
+      duration: 0.05
+  - stream_id: "s3"
+    onset: 2.0
+    duration: 1.0
+    sample: "pino.wav"
+    density: 1500
+    grain:
+      duration: 0.05
+"""
+
+
+@pytest.mark.e2e
+class TestNumpyStemsStreamParallel:
+    """STEMS=true RENDERER=numpy JOBS=2 con piu' stream densi: il dispatch
+    stream-level produce stem byte-identici a JOBS=1 (contratto rafforzato)."""
+
+    def test_stream_parallel_creates_all_stems(self, tmp_path):
+        """La build con JOBS=2 su 3 stream densi produce tutti gli stem."""
+        _write_yaml(tmp_path, _YAML_DENSE_THREE_STREAMS)
+        result, output = _make_build_stems(tmp_path, cache=False, jobs=2)
+
+        assert result.returncode == 0, f"make fallito:\n{output}"
+        for sid in ('s1', 's2', 's3'):
+            assert (tmp_path / "output" / f"e2e_numpy_test__{sid}.aif").exists(), \
+                f"stem {sid} non trovato con JOBS=2"
+
+    def test_stream_parallel_stems_byte_identical_to_sequential(self, tmp_path):
+        """JOBS=2 vs JOBS=1: ogni stem BYTE-IDENTICO (==), non solo < 1 LSB.
+
+        Nel path stream-level l'ordine delle somme float64 dentro il worker e'
+        quello storico, quindi l'uguaglianza e' esatta sui campioni."""
+        import numpy as np
+        import soundfile as sf
+
+        _write_yaml(tmp_path, _YAML_DENSE_THREE_STREAMS)
+        r1, out1 = _make_build_stems(tmp_path, cache=False, jobs=1)
+        assert r1.returncode == 0, f"make JOBS=1 fallito:\n{out1}"
+        seq = {sid: sf.read(str(tmp_path / "output" / f"e2e_numpy_test__{sid}.aif"))[0]
+               for sid in ('s1', 's2', 's3')}
+
+        r2, out2 = _make_build_stems(tmp_path, cache=False, jobs=2)
+        assert r2.returncode == 0, f"make JOBS=2 fallito:\n{out2}"
+        for sid in ('s1', 's2', 's3'):
+            par, _ = sf.read(str(tmp_path / "output" / f"e2e_numpy_test__{sid}.aif"))
+            assert seq[sid].shape == par.shape
+            assert np.array_equal(seq[sid], par), \
+                f"stem {sid}: JOBS=2 non byte-identico a JOBS=1"
+
+    def test_second_run_all_clean_with_cache_and_jobs(self, tmp_path):
+        """STEMS+CACHE+JOBS: seconda run tutta clean (nessun re-render).
+
+        La cache clean fa ritornare gli stream prima del dispatch: con jobs>1
+        il path stream-level non deve rigenerare nulla alla seconda run."""
+        _write_yaml(tmp_path, _YAML_DENSE_THREE_STREAMS)
+
+        r1, out1 = _make_build_stems(tmp_path, cache=True, jobs=2)
+        assert r1.returncode == 0, f"prima build fallita:\n{out1}"
+        assert out1.count("DIRTY") == 3, f"prima run: attesi 3 DIRTY\n{out1}"
+
+        r2, out2 = _make_build_stems(tmp_path, cache=True, jobs=2)
+        assert r2.returncode == 0, f"seconda build fallita:\n{out2}"
+        assert "DIRTY" not in out2, f"seconda run: nessuno stream doveva essere DIRTY\n{out2}"
+        assert out2.count("clean") == 3, f"seconda run: attesi 3 clean\n{out2}"

--- a/tests/e2e/test_numpy_renderer_e2e.py
+++ b/tests/e2e/test_numpy_renderer_e2e.py
@@ -135,9 +135,13 @@ def _make_build_stems(tmp_path, cache=True, jobs=None):
     return result, result.stdout + result.stderr
 
 
-def _make_build_mix(tmp_path):
+def _make_build_mix(tmp_path, jobs=None):
     """
     Invoca `make all STEMS=false RENDERER=numpy` con directory temporanee.
+
+    Args:
+        jobs: se valorizzato passa JOBS=<jobs>; None lascia JOBS vuoto
+              (build.mk non passa --jobs → default 'auto' di main.py)
 
     Returns:
         tuple (CompletedProcess, str) — processo e output combinato
@@ -163,6 +167,8 @@ def _make_build_mix(tmp_path):
         f'LOGDIR={logdir}',
         f'YMLDIR={ymldir}',
     ]
+    if jobs is not None:
+        cmd.append(f'JOBS={jobs}')
 
     result = subprocess.run(
         cmd,
@@ -375,6 +381,66 @@ class TestNumpyStemsParallel:
         r2, out2 = _make_build_stems(tmp_path, cache=False, jobs=2)
         assert r2.returncode == 0, f"make JOBS=2 fallito:\n{out2}"
         par, _ = sf.read(str(stem))
+
+        assert seq.shape == par.shape
+        assert np.max(np.abs(seq - par)) < 2.0 ** -24
+
+
+# =============================================================================
+# 5. MIX PARALLELO (JOBS default 'auto')
+# =============================================================================
+
+_YAML_DENSE_TWO_STREAMS = """\
+composition:
+  title: "e2e numpy parallel mix test"
+
+streams:
+  - stream_id: "s1"
+    onset: 0.0
+    duration: 1.0
+    sample: "pino.wav"
+    density: 1500
+    grain:
+      duration: 0.05
+  - stream_id: "s2"
+    onset: 0.5
+    duration: 1.0
+    sample: "pino.wav"
+    density: 1500
+    grain:
+      duration: 0.05
+"""
+
+
+@pytest.mark.e2e
+class TestNumpyMixParallelAuto:
+    """STEMS=false RENDERER=numpy, JOBS vuoto (default CLI 'auto'):
+    render_merged_streams multi-processo via make."""
+
+    def test_mix_auto_build_creates_file(self, tmp_path):
+        """La build MIX senza JOBS (auto) completa e produce il mix."""
+        _write_yaml(tmp_path, _YAML_DENSE_TWO_STREAMS)
+        result, output = _make_build_mix(tmp_path)
+
+        assert result.returncode == 0, f"make fallito:\n{output}"
+        assert (tmp_path / "output" / "e2e_numpy_test.aif").exists(), \
+            "file mix non trovato con JOBS=auto"
+
+    def test_mix_auto_matches_sequential(self, tmp_path):
+        """JOBS auto vs JOBS=1 su MIX multi-stream: stessa durata,
+        diff massima < 1 LSB a 24 bit."""
+        import numpy as np
+        import soundfile as sf
+
+        _write_yaml(tmp_path, _YAML_DENSE_TWO_STREAMS)
+        r1, out1 = _make_build_mix(tmp_path, jobs=1)
+        assert r1.returncode == 0, f"make JOBS=1 fallito:\n{out1}"
+        mix = tmp_path / "output" / "e2e_numpy_test.aif"
+        seq, _ = sf.read(str(mix))
+
+        r2, out2 = _make_build_mix(tmp_path)
+        assert r2.returncode == 0, f"make JOBS=auto fallito:\n{out2}"
+        par, _ = sf.read(str(mix))
 
         assert seq.shape == par.shape
         assert np.max(np.abs(seq - par)) < 2.0 ** -24

--- a/tests/e2e/test_numpy_renderer_e2e.py
+++ b/tests/e2e/test_numpy_renderer_e2e.py
@@ -88,6 +88,16 @@ def _load_manifest(tmp_path) -> dict:
     return json.loads(manifest_path.read_text())
 
 
+def _count_cache_status(output: str, status: str) -> int:
+    """Conta le righe di stato cache `[CACHE] <id>: <status>` nell'output.
+
+    Ancorato al prefisso `[CACHE] <id>: ` per non contare la sottostringa
+    altrove (es. il tmp_path di pytest può contenere 'clean' e comparire in
+    ogni path stampato)."""
+    import re
+    return len(re.findall(rf"\[CACHE\] \S+: {re.escape(status)}\b", output))
+
+
 def _make_build_stems(tmp_path, cache=True, jobs=None):
     """
     Invoca `make all STEMS=true RENDERER=numpy` con directory temporanee.
@@ -527,9 +537,12 @@ class TestNumpyStemsStreamParallel:
 
         r1, out1 = _make_build_stems(tmp_path, cache=True, jobs=2)
         assert r1.returncode == 0, f"prima build fallita:\n{out1}"
-        assert out1.count("DIRTY") == 3, f"prima run: attesi 3 DIRTY\n{out1}"
+        assert _count_cache_status(out1, "DIRTY") == 3, \
+            f"prima run: attesi 3 DIRTY\n{out1}"
 
         r2, out2 = _make_build_stems(tmp_path, cache=True, jobs=2)
         assert r2.returncode == 0, f"seconda build fallita:\n{out2}"
-        assert "DIRTY" not in out2, f"seconda run: nessuno stream doveva essere DIRTY\n{out2}"
-        assert out2.count("clean") == 3, f"seconda run: attesi 3 clean\n{out2}"
+        assert _count_cache_status(out2, "DIRTY") == 0, \
+            f"seconda run: nessuno stream doveva essere DIRTY\n{out2}"
+        assert _count_cache_status(out2, "clean") == 3, \
+            f"seconda run: attesi 3 clean\n{out2}"

--- a/tests/rendering/test_audio_renderer.py
+++ b/tests/rendering/test_audio_renderer.py
@@ -7,6 +7,7 @@ Coverage:
 2. TestConcreteRendererContract      - sottoclassi concrete devono implementare tutti i metodi
 3. TestRenderSingleStreamContract    - contratto render_single_stream()
 4. TestRenderMergedStreamsContract   - contratto render_merged_streams()
+5. TestRenderStreamsDefault          - default concreto render_streams()
 """
 
 import pytest
@@ -165,3 +166,61 @@ class TestRenderMergedStreamsContract:
     def test_accepts_streams_and_path(self, renderer, mock_streams):
         """render_merged_streams accetta due argomenti posizionali senza errori."""
         renderer.render_merged_streams(mock_streams, 'out.aif')
+
+
+# =============================================================================
+# 5. TEST RENDER_STREAMS (default concreto sull'ABC)
+# =============================================================================
+
+class RecordingRenderer(AudioRenderer):
+    """Renderer che registra le chiamate a render_single_stream."""
+
+    def __init__(self):
+        self.calls = []
+
+    def render_single_stream(self, stream, output_path: str) -> str:
+        self.calls.append((stream, output_path))
+        return output_path
+
+    def render_merged_streams(self, streams, output_path: str) -> str:
+        return output_path
+
+
+class TestRenderStreamsDefault:
+    """
+    render_streams(pairs) e' un metodo CONCRETO dell'ABC: default = loop su
+    render_single_stream, nell'ordine delle coppie. Le sottoclassi (es.
+    NumpyAudioRenderer) possono fare override per parallelizzare gli stream;
+    CsoundRenderer eredita il default senza modifiche (OCP).
+    """
+
+    @pytest.fixture
+    def pairs(self):
+        streams = []
+        for i in range(3):
+            s = MagicMock()
+            s.stream_id = f'stream_{i}'
+            streams.append(s)
+        return [(s, f'/out/base__{s.stream_id}.aif') for s in streams]
+
+    def test_render_streams_is_not_abstract(self):
+        """render_streams NON e' astratto: le sottoclassi esistenti restano valide."""
+        assert 'render_streams' not in AudioRenderer.__abstractmethods__
+
+    def test_default_calls_render_single_stream_per_pair_in_order(self, pairs):
+        """Il default chiama render_single_stream per ogni coppia, nell'ordine."""
+        renderer = RecordingRenderer()
+        renderer.render_streams(pairs)
+        assert renderer.calls == pairs
+
+    def test_default_returns_paths_in_order(self, pairs):
+        """Il default ritorna i path prodotti da render_single_stream, in ordine."""
+        renderer = RecordingRenderer()
+        result = renderer.render_streams(pairs)
+        assert result == [path for _, path in pairs]
+
+    def test_default_with_empty_pairs_returns_empty_list(self):
+        """Nessuno stream → lista vuota, nessuna chiamata."""
+        renderer = RecordingRenderer()
+        assert renderer.render_streams([]) == []
+        assert renderer.calls == []

--- a/tests/rendering/test_numpy_audio_renderer.py
+++ b/tests/rendering/test_numpy_audio_renderer.py
@@ -980,7 +980,16 @@ class TestParallelRendering:
             r.close()
 
     def test_parallel_is_deterministic_across_runs(self, tmp_path):
-        """Due run con lo stesso jobs → file byte-identici."""
+        """Due run con lo stesso jobs → campioni bit-identici.
+
+        NB: si confrontano i CAMPIONI, non i byte del file. Il container AIFF
+        float scrive nel PEAK chunk un timestamp wall-clock (granularità 1s):
+        due file con audio identico differiscono nell'header se i render
+        cadono in secondi diversi. Il contratto di determinismo vale sui
+        campioni, non sul file grezzo.
+        """
+        import soundfile as sf
+
         r = self._make_renderer(tmp_path, jobs=2)
         try:
             grains = make_dense_grains()
@@ -990,7 +999,9 @@ class TestParallelRendering:
                 make_mock_stream(duration=0.6, grains=list(grains)), p1)
             r.render_single_stream(
                 make_mock_stream(duration=0.6, grains=list(grains)), p2)
-            assert open(p1, 'rb').read() == open(p2, 'rb').read()
+            d1, _ = sf.read(p1)
+            d2, _ = sf.read(p2)
+            assert np.array_equal(d1, d2)
         finally:
             r.close()
 
@@ -1063,4 +1074,35 @@ class TestParallelRendering:
             assert r._executor is first
         finally:
             r.close()
+
+    def test_clean_cache_never_creates_pool(self, tmp_path):
+        """Cache clean → skip prima dell'overlap-add: nessun pool creato.
+
+        Invariante della seconda run STEMS: se lo stream è invariato il
+        renderer ritorna prima del dispatch, quindi con jobs > 1 il
+        ProcessPoolExecutor non deve mai nascere (né re-render).
+        """
+        from unittest.mock import MagicMock
+
+        reg, table_map = make_disk_sample_env(tmp_path)
+        cache = MagicMock()
+        cache.is_dirty.return_value = False
+        r = NumpyAudioRenderer(
+            sample_registry=reg,
+            window_registry=NumpyWindowRegistry(),
+            table_map=table_map,
+            output_sr=OUTPUT_SR,
+            jobs=4,
+            min_parallel_grains=8,
+            cache_manager=cache,
+            stream_data_map={'s1': {'stream_id': 's1'}},
+        )
+        out = str(tmp_path / 's1.aif')
+        result = r.render_single_stream(
+            make_mock_stream('s1', duration=0.6, grains=make_dense_grains()),
+            out)
+        assert result == out
+        assert r._executor is None
+        assert not os.path.exists(out)  # clean → nessun file riscritto
+        cache.update_after_build.assert_not_called()
 

--- a/tests/rendering/test_numpy_audio_renderer.py
+++ b/tests/rendering/test_numpy_audio_renderer.py
@@ -883,3 +883,184 @@ class TestOnsetRounding:
             f"onset_sample atteso {expected} (round), ottenuto {onset_sample}"
         )
 
+
+# =============================================================================
+# 9. TEST RENDERING PARALLELO (multi-processo, jobs > 1)
+# =============================================================================
+
+def make_disk_sample_env(tmp_path):
+    """SampleRegistry su file REALE: i worker del pool caricano da disco."""
+    import soundfile as sf
+    sr = OUTPUT_SR
+    n = sr * 2
+    t = np.linspace(0, 2.0, n, endpoint=False)
+    audio = (0.4 * np.sin(2 * np.pi * 330 * t)).astype(np.float32)
+    sf.write(str(tmp_path / 'tone.wav'), audio, sr)
+
+    reg = SampleRegistry(base_path=str(tmp_path) + '/')
+    reg.load('tone.wav')
+    table_map = {1: ('sample', 'tone.wav'), 2: ('window', 'hanning')}
+    return reg, table_map
+
+
+def make_dense_grains(n=48, hop=0.01, dur=0.03):
+    """Grani fitti e sovrapposti: abbastanza lavoro da superare la soglia."""
+    return [make_grain(onset=i * hop, duration=dur, pointer_pos=0.2 + i * 0.001)
+            for i in range(n)]
+
+
+class TestParallelRendering:
+    """Rendering multi-processo: equivalenza, determinismo, fallback."""
+
+    # Tolleranza: 1 LSB a 24 bit. Il parallelo riordina solo somme float64;
+    # qualunque differenza deve sparire sotto il quanto di un file a 24 bit.
+    TOL = 2.0 ** -24
+
+    def _make_renderer(self, tmp_path, jobs, min_parallel_grains=8):
+        reg, table_map = make_disk_sample_env(tmp_path)
+        return NumpyAudioRenderer(
+            sample_registry=reg,
+            window_registry=NumpyWindowRegistry(),
+            table_map=table_map,
+            output_sr=OUTPUT_SR,
+            jobs=jobs,
+            min_parallel_grains=min_parallel_grains,
+        )
+
+    def test_jobs_default_is_one(self, sample_registry, window_registry, table_map):
+        """API libreria conservativa: senza jobs espliciti, sequenziale."""
+        r = NumpyAudioRenderer(
+            sample_registry=sample_registry,
+            window_registry=window_registry,
+            table_map=table_map,
+        )
+        assert r.jobs == 1
+
+    def test_jobs_accepts_auto(self, sample_registry, window_registry, table_map):
+        """jobs='auto' viene risolto a un intero >= 1 al costruttore."""
+        r = NumpyAudioRenderer(
+            sample_registry=sample_registry,
+            window_registry=window_registry,
+            table_map=table_map,
+            jobs='auto',
+        )
+        assert isinstance(r.jobs, int)
+        assert r.jobs >= 1
+
+    def test_parallel_single_stream_matches_sequential(self, tmp_path):
+        """jobs=2 vs jobs=1 su render_single_stream: diff < 1 LSB 24-bit."""
+        import soundfile as sf
+        grains = make_dense_grains()
+        r_seq = self._make_renderer(tmp_path, jobs=1)
+        r_par = self._make_renderer(tmp_path, jobs=2)
+        try:
+            p_seq = str(tmp_path / 'seq.aif')
+            p_par = str(tmp_path / 'par.aif')
+            r_seq.render_single_stream(
+                make_mock_stream(duration=0.6, grains=list(grains)), p_seq)
+            r_par.render_single_stream(
+                make_mock_stream(duration=0.6, grains=list(grains)), p_par)
+
+            d_seq, _ = sf.read(p_seq)
+            d_par, _ = sf.read(p_par)
+            assert d_seq.shape == d_par.shape
+            assert np.max(np.abs(d_seq - d_par)) < self.TOL
+            assert np.max(np.abs(d_par)) > 1e-4  # non-silente: test significativo
+        finally:
+            r_par.close()
+
+    def test_parallel_render_uses_pool(self, tmp_path):
+        """Sopra soglia con jobs>1 il pool viene creato davvero."""
+        r = self._make_renderer(tmp_path, jobs=2)
+        try:
+            stream = make_mock_stream(duration=0.6, grains=make_dense_grains())
+            r.render_single_stream(stream, str(tmp_path / 'out.aif'))
+            assert r._executor is not None
+        finally:
+            r.close()
+
+    def test_parallel_is_deterministic_across_runs(self, tmp_path):
+        """Due run con lo stesso jobs → file byte-identici."""
+        r = self._make_renderer(tmp_path, jobs=2)
+        try:
+            grains = make_dense_grains()
+            p1 = str(tmp_path / 'run1.aif')
+            p2 = str(tmp_path / 'run2.aif')
+            r.render_single_stream(
+                make_mock_stream(duration=0.6, grains=list(grains)), p1)
+            r.render_single_stream(
+                make_mock_stream(duration=0.6, grains=list(grains)), p2)
+            assert open(p1, 'rb').read() == open(p2, 'rb').read()
+        finally:
+            r.close()
+
+    def test_parallel_merged_streams_matches_sequential(self, tmp_path):
+        """jobs=2 vs jobs=1 su render_merged_streams (onset assoluti)."""
+        import soundfile as sf
+
+        def _streams():
+            return [
+                make_mock_stream('s1', onset=0.0, duration=0.5,
+                                 grains=make_dense_grains(n=24)),
+                make_mock_stream('s2', onset=0.3, duration=0.5,
+                                 grains=[make_grain(onset=0.3 + i * 0.01,
+                                                    duration=0.03)
+                                         for i in range(24)]),
+            ]
+
+        r_seq = self._make_renderer(tmp_path, jobs=1)
+        r_par = self._make_renderer(tmp_path, jobs=2)
+        try:
+            p_seq = str(tmp_path / 'mix_seq.aif')
+            p_par = str(tmp_path / 'mix_par.aif')
+            r_seq.render_merged_streams(_streams(), p_seq)
+            r_par.render_merged_streams(_streams(), p_par)
+
+            d_seq, _ = sf.read(p_seq)
+            d_par, _ = sf.read(p_par)
+            assert d_seq.shape == d_par.shape
+            assert np.max(np.abs(d_seq - d_par)) < self.TOL
+            assert np.max(np.abs(d_par)) > 1e-4
+        finally:
+            r_par.close()
+
+    def test_below_threshold_stays_sequential(self, tmp_path):
+        """Sotto min_parallel_grains nessun pool: render piccoli senza overhead."""
+        r = self._make_renderer(tmp_path, jobs=4, min_parallel_grains=10_000)
+        stream = make_mock_stream(duration=0.6, grains=make_dense_grains())
+        r.render_single_stream(stream, str(tmp_path / 'out.aif'))
+        assert r._executor is None
+
+    def test_jobs_one_never_creates_pool(self, tmp_path):
+        """jobs=1 esplicito: path sequenziale puro anche sopra soglia."""
+        r = self._make_renderer(tmp_path, jobs=1, min_parallel_grains=8)
+        stream = make_mock_stream(duration=0.6, grains=make_dense_grains())
+        r.render_single_stream(stream, str(tmp_path / 'out.aif'))
+        assert r._executor is None
+
+    def test_close_shuts_down_pool(self, tmp_path):
+        """close() spegne il pool e azzera lo stato."""
+        r = self._make_renderer(tmp_path, jobs=2)
+        stream = make_mock_stream(duration=0.6, grains=make_dense_grains())
+        r.render_single_stream(stream, str(tmp_path / 'out.aif'))
+        assert r._executor is not None
+        r.close()
+        assert r._executor is None
+        # close() idempotente
+        r.close()
+
+    def test_pool_reused_across_streams(self, tmp_path):
+        """STEMS: lo stesso pool serve tutti gli stream della run."""
+        r = self._make_renderer(tmp_path, jobs=2)
+        try:
+            r.render_single_stream(
+                make_mock_stream('s1', duration=0.6, grains=make_dense_grains()),
+                str(tmp_path / 's1.aif'))
+            first = r._executor
+            r.render_single_stream(
+                make_mock_stream('s2', duration=0.6, grains=make_dense_grains()),
+                str(tmp_path / 's2.aif'))
+            assert r._executor is first
+        finally:
+            r.close()
+

--- a/tests/rendering/test_numpy_audio_renderer.py
+++ b/tests/rendering/test_numpy_audio_renderer.py
@@ -1106,3 +1106,227 @@ class TestParallelRendering:
         assert not os.path.exists(out)  # clean → nessun file riscritto
         cache.update_after_build.assert_not_called()
 
+
+# =============================================================================
+# 10. TEST STREAM-PARALLEL (render_streams override, un task per stream)
+# =============================================================================
+
+class TestStreamParallel:
+    """render_streams override: STEMS con un task per stream al pool.
+
+    Contratto rafforzato: ogni stem prodotto dal path stream-parallel e'
+    BYTE-IDENTICO a jobs=1 (dentro il worker l'ordine delle somme float64 e'
+    quello storico), non solo < 1 LSB come il chunk path.
+    """
+
+    def _make_renderer(self, tmp_path, jobs, min_parallel_grains=8,
+                       cache_manager=None, stream_data_map=None):
+        reg, table_map = make_disk_sample_env(tmp_path)
+        return NumpyAudioRenderer(
+            sample_registry=reg,
+            window_registry=NumpyWindowRegistry(),
+            table_map=table_map,
+            output_sr=OUTPUT_SR,
+            jobs=jobs,
+            min_parallel_grains=min_parallel_grains,
+            cache_manager=cache_manager,
+            stream_data_map=stream_data_map,
+        )
+
+    def _stems(self):
+        return [
+            make_mock_stream('s1', duration=0.6, grains=make_dense_grains()),
+            make_mock_stream('s2', duration=0.6,
+                             grains=make_dense_grains(n=40, hop=0.012)),
+        ]
+
+    def test_stream_parallel_matches_sequential_bit_exact(self, tmp_path):
+        """jobs=2 vs jobs=1 su render_streams: ogni stem byte-identico."""
+        import soundfile as sf
+
+        r_seq = self._make_renderer(tmp_path, jobs=1)
+        r_par = self._make_renderer(tmp_path, jobs=2)
+        try:
+            seq_pairs = [(s, str(tmp_path / f'seq_{s.stream_id}.aif'))
+                         for s in self._stems()]
+            par_pairs = [(s, str(tmp_path / f'par_{s.stream_id}.aif'))
+                         for s in self._stems()]
+
+            seq_out = r_seq.render_streams(seq_pairs)
+            par_out = r_par.render_streams(par_pairs)
+
+            assert [p for _, p in seq_pairs] == seq_out
+            assert [p for _, p in par_pairs] == par_out
+            for (_, sp), (_, pp) in zip(seq_pairs, par_pairs):
+                d_seq, _ = sf.read(sp)
+                d_par, _ = sf.read(pp)
+                assert d_seq.shape == d_par.shape
+                assert np.array_equal(d_seq, d_par)
+                assert np.max(np.abs(d_par)) > 1e-4  # non-silente
+        finally:
+            r_par.close()
+
+    def test_two_dirty_streams_use_pool(self, tmp_path):
+        """Sopra soglia, 2 stream dirty, jobs>1 → il pool viene creato."""
+        r = self._make_renderer(tmp_path, jobs=2)
+        try:
+            pairs = [(s, str(tmp_path / f'{s.stream_id}.aif'))
+                     for s in self._stems()]
+            r.render_streams(pairs)
+            assert r._executor is not None
+        finally:
+            r.close()
+
+    def test_dispatch_is_stream_level_not_per_stream_loop(self, tmp_path):
+        """Sopra soglia, 2+ stream dirty, jobs>1 → dispatch PER STREAM.
+
+        Discrimina il path stream-level dal default dell'ABC: il parent NON
+        chiama render_single_stream (che parallelizzerebbe solo intra-stream,
+        via chunk path). Ogni stream diventa un task per il pool
+        (render_stream_to_file), cosi' overlap-add + dc_block + write girano
+        nel worker.
+        """
+        from unittest.mock import patch
+
+        r = self._make_renderer(tmp_path, jobs=2)
+        try:
+            pairs = [(s, str(tmp_path / f'{s.stream_id}.aif'))
+                     for s in self._stems()]
+            with patch.object(
+                r, 'render_single_stream',
+                wraps=r.render_single_stream) as spy:
+                r.render_streams(pairs)
+            spy.assert_not_called()
+            # entrambi gli stem prodotti dal path stream-level
+            assert os.path.exists(pairs[0][1])
+            assert os.path.exists(pairs[1][1])
+        finally:
+            r.close()
+
+    def test_single_stream_falls_back_to_chunk_path(self, tmp_path):
+        """Un solo stream → nessun dispatch stream-level (dirty < 2).
+
+        Il singolo stem resta sul path per-stream (render_single_stream, che
+        sotto ha il chunk path). Output byte-identico a jobs=1.
+        """
+        import soundfile as sf
+
+        r_seq = self._make_renderer(tmp_path, jobs=1)
+        r_par = self._make_renderer(tmp_path, jobs=2)
+        try:
+            s = make_mock_stream('solo', duration=0.6, grains=make_dense_grains())
+            seq_p = str(tmp_path / 'seq.aif')
+            par_p = str(tmp_path / 'par.aif')
+            r_seq.render_streams([(make_mock_stream('solo', duration=0.6,
+                                                    grains=make_dense_grains()), seq_p)])
+            r_par.render_streams([(s, par_p)])
+
+            d_seq, _ = sf.read(seq_p)
+            d_par, _ = sf.read(par_p)
+            assert np.array_equal(d_seq, d_par)
+        finally:
+            r_par.close()
+
+    def test_below_total_threshold_stays_sequential(self, tmp_path):
+        """Grani totali sotto min_parallel_grains → nessun pool stream-level."""
+        r = self._make_renderer(tmp_path, jobs=4, min_parallel_grains=10_000)
+        try:
+            pairs = [(make_mock_stream('s1', duration=0.3,
+                                       grains=make_dense_grains(n=4)),
+                      str(tmp_path / 's1.aif')),
+                     (make_mock_stream('s2', duration=0.3,
+                                       grains=make_dense_grains(n=4)),
+                      str(tmp_path / 's2.aif'))]
+            r.render_streams(pairs)
+            assert r._executor is None
+        finally:
+            r.close()
+
+    def test_clean_streams_not_dispatched(self, tmp_path):
+        """Cache: stream clean non generano e non vengono dispatchati.
+
+        Con un solo stream dirty (l'altro clean) la policy stream-level non
+        scatta (dirty < 2): il dirty passa dal path per-stream, il clean
+        ritorna il suo path senza toccare .voices ne' la cache.
+        """
+        from unittest.mock import MagicMock
+
+        cache = MagicMock()
+        # s1 clean, s2 dirty
+        cache.is_dirty.side_effect = lambda d, p: d['stream_id'] == 's2'
+        r = self._make_renderer(
+            tmp_path, jobs=2, min_parallel_grains=8,
+            cache_manager=cache,
+            stream_data_map={'s1': {'stream_id': 's1'},
+                             's2': {'stream_id': 's2'}})
+        try:
+            p1 = str(tmp_path / 's1.aif')
+            p2 = str(tmp_path / 's2.aif')
+            out = r.render_streams([
+                (make_mock_stream('s1', duration=0.6, grains=make_dense_grains()), p1),
+                (make_mock_stream('s2', duration=0.6, grains=make_dense_grains()), p2),
+            ])
+            assert out == [p1, p2]
+            assert not os.path.exists(p1)  # clean → nessun file
+            assert os.path.exists(p2)      # dirty → prodotto
+            # cache aggiornata solo per lo stream dirty
+            built = [c.args[0] for c in cache.update_after_build.call_args_list]
+            assert [{'stream_id': 's2'}] in built
+            assert [{'stream_id': 's1'}] not in built
+        finally:
+            r.close()
+
+    def test_two_dirty_streams_update_cache_each(self, tmp_path):
+        """Path parallelo: la cache viene aggiornata per ogni stream riuscito."""
+        from unittest.mock import MagicMock
+
+        cache = MagicMock()
+        cache.is_dirty.return_value = True
+        r = self._make_renderer(
+            tmp_path, jobs=2, min_parallel_grains=8,
+            cache_manager=cache,
+            stream_data_map={'s1': {'stream_id': 's1'},
+                             's2': {'stream_id': 's2'}})
+        try:
+            pairs = [(s, str(tmp_path / f'{s.stream_id}.aif'))
+                     for s in self._stems()]
+            r.render_streams(pairs)
+            built = [c.args[0] for c in cache.update_after_build.call_args_list]
+            assert [{'stream_id': 's1'}] in built
+            assert [{'stream_id': 's2'}] in built
+        finally:
+            r.close()
+
+    def test_worker_exception_propagates_and_skips_cache(self, tmp_path):
+        """Eccezione nel worker → propagata da render_streams; la cache dello
+        stream non completato NON viene aggiornata."""
+        from unittest.mock import MagicMock, patch
+
+        cache = MagicMock()
+        cache.is_dirty.return_value = True
+        r = self._make_renderer(
+            tmp_path, jobs=2, min_parallel_grains=8,
+            cache_manager=cache,
+            stream_data_map={'s1': {'stream_id': 's1'},
+                             's2': {'stream_id': 's2'}})
+        try:
+            pairs = [(s, str(tmp_path / f'{s.stream_id}.aif'))
+                     for s in self._stems()]
+
+            class _Boom(RuntimeError):
+                pass
+
+            with patch.object(r, '_ensure_executor') as ens:
+                fake_exec = MagicMock()
+                fut = MagicMock()
+                fut.result.side_effect = _Boom("worker crash")
+                fake_exec.submit.return_value = fut
+                ens.return_value = fake_exec
+
+                with pytest.raises(_Boom):
+                    r.render_streams(pairs)
+
+            cache.update_after_build.assert_not_called()
+        finally:
+            r.close()
+

--- a/tests/rendering/test_numpy_parallel.py
+++ b/tests/rendering/test_numpy_parallel.py
@@ -1,0 +1,280 @@
+# tests/rendering/test_numpy_parallel.py
+"""
+TDD suite per numpy_parallel — primitive del rendering NumPy multi-processo.
+
+Il modulo fornisce:
+- resolve_jobs(spec): policy del numero di worker ('auto' → cores-1, min 1)
+- chunk_grains(items, n): split contiguo deterministico in chunk bilanciati
+- resolve_table_name(table_map, num, kind): risoluzione table condivisa
+  parent/worker (stessa semantica di NumpyAudioRenderer._resolve_*)
+- init_worker(config) + render_grain_chunk(chunk): lato worker del pool.
+  Qui testati IN-PROCESS (senza pool): init_worker costruisce i registry
+  globali del modulo, render_grain_chunk rende un chunk di
+  (grain, onset_sample) in un buffer locale e ritorna (offset, buffer).
+
+L'integrazione con ProcessPoolExecutor e' coperta dai test di
+NumpyAudioRenderer (TestParallelRendering).
+"""
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+from core.grain import Grain
+from rendering import numpy_parallel as npar
+from rendering.grain_renderer import GrainRenderer
+from rendering.sample_registry import SampleRegistry
+from rendering.numpy_window_registry import NumpyWindowRegistry
+
+
+OUTPUT_SR = 48000
+
+
+# =============================================================================
+# HELPERS
+# =============================================================================
+
+def make_grain(**overrides):
+    """Factory per grani con default sensati."""
+    defaults = dict(
+        onset=0.0,
+        duration=0.05,
+        pointer_pos=0.5,
+        pitch_ratio=1.0,
+        volume=0.0,
+        pan=45.0,
+        sample_table=1,
+        envelope_table=2,
+    )
+    defaults.update(overrides)
+    return Grain(**defaults)
+
+
+@pytest.fixture
+def worker_env(tmp_path):
+    """Scrive un wav di test e ritorna il config dict per init_worker."""
+    sr = OUTPUT_SR
+    n = sr * 2
+    t = np.linspace(0, 2.0, n, endpoint=False)
+    audio = (0.4 * np.sin(2 * np.pi * 330 * t)).astype(np.float32)
+    sf.write(str(tmp_path / 'tone.wav'), audio, sr)
+
+    return {
+        'base_path': str(tmp_path) + '/',
+        'sample_names': ['tone.wav'],
+        'table_map': {1: ('sample', 'tone.wav'), 2: ('window', 'hanning')},
+        'output_sr': OUTPUT_SR,
+    }
+
+
+def make_reference_renderer(worker_env):
+    """GrainRenderer indipendente sugli stessi file: riferimento sequenziale."""
+    reg = SampleRegistry(base_path=worker_env['base_path'])
+    for name in worker_env['sample_names']:
+        reg.load(name)
+    return GrainRenderer(
+        sample_registry=reg,
+        window_registry=NumpyWindowRegistry(),
+        output_sr=worker_env['output_sr'],
+    )
+
+
+# =============================================================================
+# 1. resolve_jobs
+# =============================================================================
+
+class TestResolveJobs:
+    """Policy del numero di worker."""
+
+    def test_explicit_int_passthrough(self):
+        assert npar.resolve_jobs(1) == 1
+        assert npar.resolve_jobs(4) == 4
+
+    def test_auto_is_cores_minus_one(self, monkeypatch):
+        monkeypatch.setattr(npar.os, 'sched_getaffinity',
+                            lambda pid: set(range(8)), raising=False)
+        assert npar.resolve_jobs('auto') == 7
+
+    def test_auto_minimum_is_one(self, monkeypatch):
+        """Su macchine a 1-2 core auto non deve mai scendere sotto 1."""
+        monkeypatch.setattr(npar.os, 'sched_getaffinity',
+                            lambda pid: {0}, raising=False)
+        assert npar.resolve_jobs('auto') == 1
+        monkeypatch.setattr(npar.os, 'sched_getaffinity',
+                            lambda pid: {0, 1}, raising=False)
+        assert npar.resolve_jobs('auto') == 1
+
+    def test_none_means_auto(self, monkeypatch):
+        monkeypatch.setattr(npar.os, 'sched_getaffinity',
+                            lambda pid: set(range(4)), raising=False)
+        assert npar.resolve_jobs(None) == 3
+
+    def test_auto_falls_back_to_cpu_count(self, monkeypatch):
+        """Senza sched_getaffinity (macOS) usa os.cpu_count()."""
+        monkeypatch.delattr(npar.os, 'sched_getaffinity', raising=False)
+        monkeypatch.setattr(npar.os, 'cpu_count', lambda: 4)
+        assert npar.resolve_jobs('auto') == 3
+
+    def test_auto_survives_affinity_failure(self, monkeypatch):
+        """sched_getaffinity che alza → fallback cpu_count, niente crash."""
+        def _boom(pid):
+            raise OSError("affinity non disponibile")
+        monkeypatch.setattr(npar.os, 'sched_getaffinity', _boom, raising=False)
+        monkeypatch.setattr(npar.os, 'cpu_count', lambda: 6)
+        assert npar.resolve_jobs('auto') == 5
+
+    @pytest.mark.parametrize("bad", [0, -1, -7, 2.5, 'quattro', [], {}])
+    def test_invalid_spec_raises_value_error(self, bad):
+        with pytest.raises(ValueError):
+            npar.resolve_jobs(bad)
+
+    def test_bool_rejected(self):
+        """bool e' subclass di int ma non e' un numero di worker valido."""
+        with pytest.raises(ValueError):
+            npar.resolve_jobs(True)
+
+
+# =============================================================================
+# 2. chunk_grains
+# =============================================================================
+
+class TestChunkGrains:
+    """Split contiguo deterministico."""
+
+    def test_concatenation_preserves_input(self):
+        items = list(range(10))
+        chunks = npar.chunk_grains(items, 3)
+        flat = [x for c in chunks for x in c]
+        assert flat == items
+
+    def test_chunks_are_balanced(self):
+        chunks = npar.chunk_grains(list(range(10)), 3)
+        sizes = [len(c) for c in chunks]
+        assert max(sizes) - min(sizes) <= 1
+        assert len(chunks) == 3
+
+    def test_no_empty_chunks_when_items_fewer_than_chunks(self):
+        chunks = npar.chunk_grains([1, 2], 5)
+        assert len(chunks) == 2
+        assert all(len(c) == 1 for c in chunks)
+
+    def test_single_chunk(self):
+        items = list(range(7))
+        chunks = npar.chunk_grains(items, 1)
+        assert chunks == [items]
+
+    def test_empty_input(self):
+        assert npar.chunk_grains([], 4) == []
+
+    def test_deterministic(self):
+        items = list(range(23))
+        assert npar.chunk_grains(items, 4) == npar.chunk_grains(items, 4)
+
+
+# =============================================================================
+# 3. resolve_table_name
+# =============================================================================
+
+class TestResolveTableName:
+    """Risoluzione table condivisa parent/worker."""
+
+    TABLE_MAP = {1: ('sample', 'tone.wav'), 2: ('window', 'hanning')}
+
+    def test_resolves_sample(self):
+        assert npar.resolve_table_name(self.TABLE_MAP, 1, 'sample') == 'tone.wav'
+
+    def test_resolves_window(self):
+        assert npar.resolve_table_name(self.TABLE_MAP, 2, 'window') == 'hanning'
+
+    def test_missing_table_raises_key_error(self):
+        with pytest.raises(KeyError, match="non trovato"):
+            npar.resolve_table_name(self.TABLE_MAP, 999, 'sample')
+
+    def test_wrong_type_raises_key_error(self):
+        with pytest.raises(KeyError, match="tipo"):
+            npar.resolve_table_name(self.TABLE_MAP, 1, 'window')
+
+
+# =============================================================================
+# 4. init_worker + render_grain_chunk (in-process, senza pool)
+# =============================================================================
+
+class TestRenderGrainChunk:
+    """Il worker rende un chunk in un buffer locale (offset, buffer)."""
+
+    def test_matches_sequential_reference_bit_exact(self, worker_env):
+        """Stessi grani, stesso ordine → buffer bit-identico al riferimento.
+
+        Il worker esegue le stesse operazioni nello stesso ordine del path
+        sequenziale (render per grano + add in ordine), quindi il risultato
+        deve essere identico bit a bit, non solo entro tolleranza.
+        """
+        npar.init_worker(worker_env)
+        onsets = [0, 1200, 2400]
+        chunk = [(make_grain(onset=o / OUTPUT_SR), o) for o in onsets]
+
+        offset, buffer = npar.render_grain_chunk(chunk)
+
+        ref = make_reference_renderer(worker_env)
+        grain_len = int(0.05 * OUTPUT_SR)
+        expected = np.zeros((onsets[-1] + grain_len, 2), dtype=np.float64)
+        for grain, onset_sample in chunk:
+            gbuf = ref.render(grain, 'tone.wav', 'hanning')
+            expected[onset_sample:onset_sample + gbuf.shape[0]] += gbuf
+
+        assert offset == 0
+        assert buffer.shape == expected.shape
+        assert np.array_equal(buffer, expected)
+
+    def test_offset_is_chunk_start(self, worker_env):
+        """Chunk che inizia a meta' timeline → offset = primo onset_sample."""
+        npar.init_worker(worker_env)
+        start = 9600
+        chunk = [(make_grain(onset=start / OUTPUT_SR), start)]
+
+        offset, buffer = npar.render_grain_chunk(chunk)
+
+        assert offset == start
+        assert buffer.shape[0] == int(0.05 * OUTPUT_SR)
+
+    def test_buffer_is_stereo_float64(self, worker_env):
+        npar.init_worker(worker_env)
+        chunk = [(make_grain(), 0)]
+        _, buffer = npar.render_grain_chunk(chunk)
+        assert buffer.ndim == 2
+        assert buffer.shape[1] == 2
+        assert buffer.dtype == np.float64
+
+    def test_negative_onset_trims_grain_head(self, worker_env):
+        """CLAMP 1: onset_sample < 0 → testa del grano tagliata, offset 0."""
+        npar.init_worker(worker_env)
+        trim = 100
+        grain = make_grain()
+        offset, buffer = npar.render_grain_chunk([(grain, -trim)])
+
+        ref = make_reference_renderer(worker_env)
+        gbuf = ref.render(grain, 'tone.wav', 'hanning')
+
+        assert offset == 0
+        assert buffer.shape[0] == gbuf.shape[0] - trim
+        assert np.array_equal(buffer, gbuf[trim:])
+
+    def test_grain_entirely_before_buffer_is_skipped(self, worker_env):
+        """Grano interamente prima di t=0 → scartato; chunk vuoto → None."""
+        npar.init_worker(worker_env)
+        grain = make_grain(duration=0.01)
+        n = int(0.01 * OUTPUT_SR)
+        result = npar.render_grain_chunk([(grain, -2 * n)])
+        assert result is None
+
+    def test_empty_chunk_returns_none(self, worker_env):
+        npar.init_worker(worker_env)
+        assert npar.render_grain_chunk([]) is None
+
+    def test_overlapping_grains_summed(self, worker_env):
+        """Due grani identici sovrapposti → il buffer e' la somma (2x)."""
+        npar.init_worker(worker_env)
+        grain = make_grain()
+        _, single = npar.render_grain_chunk([(grain, 0)])
+        _, double = npar.render_grain_chunk([(grain, 0), (grain, 0)])
+        assert np.allclose(double, 2.0 * single)

--- a/tests/rendering/test_numpy_parallel.py
+++ b/tests/rendering/test_numpy_parallel.py
@@ -278,3 +278,126 @@ class TestRenderGrainChunk:
         _, single = npar.render_grain_chunk([(grain, 0)])
         _, double = npar.render_grain_chunk([(grain, 0), (grain, 0)])
         assert np.allclose(double, 2.0 * single)
+
+
+# =============================================================================
+# 6. render_stream_to_file (worker per il parallelismo a livello di stream)
+# =============================================================================
+
+def make_single_stream_renderer(worker_env, jobs=1):
+    """NumpyAudioRenderer sequenziale sugli stessi file: oracolo per l'intero
+    path di render_single_stream (overlap-add + dc_block + write)."""
+    from rendering.numpy_audio_renderer import NumpyAudioRenderer
+    reg = SampleRegistry(base_path=worker_env['base_path'])
+    for name in worker_env['sample_names']:
+        reg.load(name)
+    return NumpyAudioRenderer(
+        sample_registry=reg,
+        window_registry=NumpyWindowRegistry(),
+        table_map=worker_env['table_map'],
+        output_sr=worker_env['output_sr'],
+        jobs=jobs,
+    )
+
+
+def build_stream_task(npar_mod, grains, stream_onset, stream_duration,
+                      output_path, output_sr, sf_format='AIFF',
+                      sf_subtype='FLOAT'):
+    """Costruisce lo StreamRenderTask con le pairs relative, come farebbe il
+    parent in render_streams (onset_sample relativi allo stream)."""
+    onset_samples = [round((g.onset - stream_onset) * output_sr) for g in grains]
+    if grains:
+        max_end_rel = max(g.onset + g.duration for g in grains) - stream_onset
+        max_end_rel = max(max_end_rel, stream_duration)
+    else:
+        max_end_rel = stream_duration
+    n_total = max(1, round(max_end_rel * output_sr))
+    return npar_mod.StreamRenderTask(
+        pairs=list(zip(grains, onset_samples)),
+        n_total=n_total,
+        output_path=output_path,
+        sf_format=sf_format,
+        sf_subtype=sf_subtype,
+        output_sr=output_sr,
+    )
+
+
+class TestRenderStreamToFile:
+    """La primitiva scrive uno stem completo (overlap-add + dc_block + write),
+    byte-identico al path sequenziale di render_single_stream."""
+
+    def test_matches_render_single_stream_bit_exact(self, worker_env, tmp_path):
+        """Stem prodotto dal worker == stem di render_single_stream (campioni)."""
+        from unittest.mock import MagicMock
+        npar.init_worker(worker_env)
+
+        grains = [make_grain(onset=i * 0.01, duration=0.03) for i in range(6)]
+        sr = worker_env['output_sr']
+
+        # Oracolo: render_single_stream sequenziale
+        stream = MagicMock()
+        stream.stream_id = 's1'
+        stream.onset = 0.0
+        stream.duration = 0.2
+        stream.voices = [grains]
+        oracle = make_single_stream_renderer(worker_env)
+        ref_path = str(tmp_path / 'ref.aif')
+        oracle.render_single_stream(stream, ref_path)
+
+        # Worker: stesso task
+        out_path = str(tmp_path / 'worker.aif')
+        task = build_stream_task(npar, grains, 0.0, 0.2, out_path, sr)
+        result = npar.render_stream_to_file(task)
+
+        assert result == out_path
+        d_ref, _ = sf.read(ref_path)
+        d_out, _ = sf.read(out_path)
+        assert d_ref.shape == d_out.shape
+        assert np.array_equal(d_ref, d_out)
+
+    def test_returns_output_path(self, worker_env, tmp_path):
+        npar.init_worker(worker_env)
+        out_path = str(tmp_path / 'out.aif')
+        task = build_stream_task(
+            npar, [make_grain()], 0.0, 0.1, out_path, worker_env['output_sr'])
+        assert npar.render_stream_to_file(task) == out_path
+
+    def test_negative_onset_clamp(self, worker_env, tmp_path):
+        """CLAMP 1: un grano con onset relativo negativo → testa tagliata,
+        stessa semantica del path sequenziale (verificato via oracolo)."""
+        from unittest.mock import MagicMock
+        npar.init_worker(worker_env)
+        sr = worker_env['output_sr']
+
+        # stream.onset > 0, un grano che parte prima dell'onset dello stream
+        grains = [make_grain(onset=0.01, duration=0.05),
+                  make_grain(onset=0.06, duration=0.05)]
+        stream = MagicMock()
+        stream.stream_id = 's1'
+        stream.onset = 0.03  # grano 0 parte a -0.02s relativi → CLAMP 1
+        stream.duration = 0.1
+        stream.voices = [grains]
+        oracle = make_single_stream_renderer(worker_env)
+        ref_path = str(tmp_path / 'ref.aif')
+        oracle.render_single_stream(stream, ref_path)
+
+        out_path = str(tmp_path / 'worker.aif')
+        task = build_stream_task(npar, grains, 0.03, 0.1, out_path, sr)
+        npar.render_stream_to_file(task)
+
+        d_ref, _ = sf.read(ref_path)
+        d_out, _ = sf.read(out_path)
+        assert np.array_equal(d_ref, d_out)
+
+    def test_empty_task_writes_silence(self, worker_env, tmp_path):
+        """Task senza grani → file di n_total campioni (silenzio dopo dc_block)."""
+        npar.init_worker(worker_env)
+        sr = worker_env['output_sr']
+        out_path = str(tmp_path / 'silent.aif')
+        task = build_stream_task(npar, [], 0.0, 0.1, out_path, sr)
+        npar.render_stream_to_file(task)
+
+        d, read_sr = sf.read(out_path)
+        assert read_sr == sr
+        assert d.shape == (round(0.1 * sr), 2)
+        assert np.max(np.abs(d)) == 0.0

--- a/tests/rendering/test_rendering_strategies.py
+++ b/tests/rendering/test_rendering_strategies.py
@@ -34,10 +34,20 @@ def make_mock_stream(stream_id='s1', onset=0.0, duration=1.0, voices=None):
 
 
 def make_mock_renderer():
-    """Mock AudioRenderer atomico."""
+    """Mock AudioRenderer atomico.
+
+    render_single_stream rispetta il contratto ABC (ritorna il path
+    prodotto); render_streams replica il default concreto dell'ABC
+    (loop su render_single_stream), cosi' i test sul loop restano validi.
+    """
     renderer = MagicMock()
-    renderer.render_single_stream = MagicMock(return_value='/out/s1.aif')
+    renderer.render_single_stream = MagicMock(side_effect=lambda stream, path: path)
     renderer.render_merged_streams = MagicMock(return_value='/out/mix.aif')
+    renderer.render_streams = MagicMock(
+        side_effect=lambda pairs: [
+            renderer.render_single_stream(stream, path) for stream, path in pairs
+        ]
+    )
     return renderer
 
 
@@ -228,6 +238,29 @@ class TestStemsRenderMode:
 
         assert len(result) == 1
         assert result[0] == '/out/base__solo.aif'
+
+    def test_delegates_loop_to_render_streams(self):
+        """execute delega il loop a renderer.render_streams con le coppie
+        (stream, path) del naming: il mode decide COSA (stems), il renderer
+        decide COME (seriale o parallelo)."""
+        from rendering.render_mode import StemsRenderMode
+        from rendering.naming_strategy import DefaultNamingStrategy
+
+        mode = StemsRenderMode()
+        renderer = make_mock_renderer()
+        naming = DefaultNamingStrategy()
+
+        streams = [make_mock_stream('s1'), make_mock_stream('s2')]
+
+        result = mode.execute(renderer, naming, streams, '/out/base.aif')
+
+        renderer.render_streams.assert_called_once()
+        (pairs,) = renderer.render_streams.call_args.args
+        assert pairs == [
+            (streams[0], '/out/base__s1.aif'),
+            (streams[1], '/out/base__s2.aif'),
+        ]
+        assert result == ['/out/base__s1.aif', '/out/base__s2.aif']
 
 
 # =============================================================================

--- a/tests/test_main_jobs_flag.py
+++ b/tests/test_main_jobs_flag.py
@@ -1,0 +1,112 @@
+# tests/test_main_jobs_flag.py
+"""
+Test per il flag CLI --jobs (rendering NumPy multi-processo).
+
+_parse_jobs(argv) e' l'helper testabile di main.py, stile --format:
+- assente → 'auto' (default: parallelo, core disponibili - 1)
+- --jobs N (intero >= 1) → N
+- --jobs auto (case-insensitive) → 'auto'
+- --jobs 0 | negativo | non numerico → messaggio + exit(1)
+- --jobs senza valore → default (coerente con gli altri flag di main)
+
+La risoluzione 'auto' → intero avviene in NumpyAudioRenderer via
+numpy_parallel.resolve_jobs; qui si testa solo il parsing.
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+from main import _parse_jobs
+
+
+class TestParseJobs:
+    """Parsing del flag --jobs."""
+
+    def test_absent_defaults_to_auto(self):
+        assert _parse_jobs(['main.py', 'file.yml']) == 'auto'
+
+    def test_explicit_integer(self):
+        assert _parse_jobs(['main.py', 'file.yml', '--jobs', '4']) == 4
+
+    def test_explicit_one(self):
+        """--jobs 1 = path sequenziale garantito byte-identico."""
+        assert _parse_jobs(['main.py', 'file.yml', '--jobs', '1']) == 1
+
+    def test_auto_keyword(self):
+        assert _parse_jobs(['main.py', 'file.yml', '--jobs', 'auto']) == 'auto'
+
+    def test_auto_keyword_case_insensitive(self):
+        assert _parse_jobs(['main.py', 'file.yml', '--jobs', 'AUTO']) == 'auto'
+
+    def test_zero_exits_with_message(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            _parse_jobs(['main.py', 'file.yml', '--jobs', '0'])
+        assert exc.value.code == 1
+        assert '--jobs' in capsys.readouterr().out
+
+    def test_negative_exits_with_message(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            _parse_jobs(['main.py', 'file.yml', '--jobs', '-3'])
+        assert exc.value.code == 1
+        assert '--jobs' in capsys.readouterr().out
+
+    def test_non_numeric_exits_with_message(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            _parse_jobs(['main.py', 'file.yml', '--jobs', 'tanti'])
+        assert exc.value.code == 1
+        assert '--jobs' in capsys.readouterr().out
+
+    def test_missing_value_keeps_default(self):
+        """--jobs come ultimo token: default, come gli altri flag di main."""
+        assert _parse_jobs(['main.py', 'file.yml', '--jobs']) == 'auto'
+
+
+class TestBuildRendererJobsWiring:
+    """_build_renderer propaga jobs fino a NumpyAudioRenderer."""
+
+    def _make_generator_stub(self, tmp_path):
+        """Generator minimale: table_map senza sample (nessun load da disco)."""
+        from unittest.mock import Mock
+        import soundfile as sf
+        import numpy as np
+
+        sf.write(str(tmp_path / 'tone.wav'),
+                 np.zeros(1000, dtype=np.float32), 48000)
+
+        gen = Mock()
+        gen.ftable_manager.get_all_tables.return_value = {
+            1: ('sample', 'tone.wav'),
+            2: ('window', 'hanning'),
+        }
+        gen.stream_data_map = {}
+        return gen
+
+    def test_jobs_reaches_renderer(self, tmp_path, monkeypatch):
+        from main import _build_renderer
+        monkeypatch.chdir(tmp_path)
+        # SampleRegistry default base_path='./refs/'
+        (tmp_path / 'refs').mkdir()
+        import soundfile as sf
+        import numpy as np
+        sf.write(str(tmp_path / 'refs' / 'tone.wav'),
+                 np.zeros(1000, dtype=np.float32), 48000)
+
+        gen = self._make_generator_stub(tmp_path)
+        renderer = _build_renderer('numpy', gen, jobs=3)
+        assert renderer.jobs == 3
+
+    def test_auto_resolved_to_positive_int(self, tmp_path, monkeypatch):
+        from main import _build_renderer
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / 'refs').mkdir()
+        import soundfile as sf
+        import numpy as np
+        sf.write(str(tmp_path / 'refs' / 'tone.wav'),
+                 np.zeros(1000, dtype=np.float32), 48000)
+
+        gen = self._make_generator_stub(tmp_path)
+        renderer = _build_renderer('numpy', gen, jobs='auto')
+        assert isinstance(renderer.jobs, int)
+        assert renderer.jobs >= 1

--- a/tests/test_main_jobs_flag.py
+++ b/tests/test_main_jobs_flag.py
@@ -110,3 +110,20 @@ class TestBuildRendererJobsWiring:
         renderer = _build_renderer('numpy', gen, jobs='auto')
         assert isinstance(renderer.jobs, int)
         assert renderer.jobs >= 1
+
+    def test_csound_ignores_jobs(self, tmp_path, monkeypatch):
+        """--renderer csound: jobs viene scartato, non propagato né errore.
+
+        Il ramo csound di _build_renderer non inoltra jobs al factory: il
+        renderer risultante non ha attributo jobs (parallelismo solo NumPy).
+        """
+        from unittest.mock import Mock
+        from main import _build_renderer
+        monkeypatch.chdir(tmp_path)
+
+        gen = Mock()
+        gen.score_writer = Mock()
+        gen.stream_data_map = {}
+        renderer = _build_renderer('csound', gen, jobs=4)
+        assert renderer.__class__.__name__ == 'CsoundRenderer'
+        assert not hasattr(renderer, 'jobs')


### PR DESCRIPTION
## Sommario

Aggiunge rendering multi-processo al renderer NumPy tramite il flag CLI `--jobs` (variabile Make `JOBS`). Il rendering dei grani è puro e parallelizzabile; la generazione resta nel parent per preservare la riproducibilità. Default: `auto` (core disponibili - 1, min 1); con `--jobs 1` l'output è byte-identico al path sequenziale storico.

La PR copre **due livelli** di parallelismo:
1. **Overlap-add intra-stream** (plan 2026-07-02-001): chunk di grani ai worker dentro un singolo stream.
2. **STEMS a livello di stream** (plan 2026-07-04-001): un task per stream al pool, con overlap-add + dc_block + scrittura interamente nel worker.

Motivazione (profiling su stream 30s, density 200, ~6000 grani): la generazione grani pesa il 7.5% del tempo ed è stateful (`random` globale seminato in `Generator.create_elements()`), il rendering pesa il 92.5% ed è puro — quindi si parallelizza solo il rendering. `RenderMode`, `RenderingEngine`, cache manager e `CsoundRenderer` restano invariati (OCP).

## Cambiamenti principali

### Nuovo modulo `src/rendering/numpy_parallel.py`
- **`resolve_jobs(spec)`**: policy worker (int >= 1, 'auto', None) con fallback `sched_getaffinity` → `cpu_count`
- **`chunk_grains(items, n_chunks)`**: split contiguo deterministico in chunk bilanciati
- **`resolve_table_name(table_map, num, kind)`**: risoluzione table condivisa parent/worker
- **`init_worker(config)`**: initializer pool — carica registries e GrainRenderer una volta per worker
- **`render_grain_chunk(chunk)`**: rende coppie (grain, onset_sample) in buffer locale con overlap-add e CLAMP 1 (onset negativo → trim testa)
- **`StreamRenderTask` + `render_stream_to_file(task)`** (2026-07-04): task picklable e primitiva che rende UNO stream in UN file interamente nel worker (overlap-add nell'ordine storico + dc_block + write). L'IPC di ritorno è la sola stringa `output_path`: nessun buffer audio attraversa il confine di processo.

### Modifiche `src/rendering/numpy_audio_renderer.py`
- Aggiunto kwarg `jobs` (default 1: API libreria conservativa) e `min_parallel_grains` (default 1024)
- Lazy `ProcessPoolExecutor` con contesto `spawn`, riusato tra stream (STEMS), chiuso da `close()`
- Refactored overlap-add: `_relative_onset_sample()`, `_absolute_onset_sample()`, `_overlap_add()` (path sequenziale invariato bit a bit, nuovo path parallelo sopra soglia)
- **`render_streams(pairs)` override** (2026-07-04): dispatch a livello di stream (un task per stream) sotto policy conservativa (jobs>1, >=2 stream dirty, grani totali sopra soglia); altrimenti fallback al path per-stream (che conserva il chunk path intra-stream). `render_single_stream` refactored in helper riusabili (`_cache_skip`, `_render_single_stream_body`, `_update_cache`, `_build_stream_task`); path sequenziale invariato bit a bit.
- Il check cache (`is_dirty` prima di `.voices`, issue #117) e la generazione lazy sono invariati: i grani si materializzano nel parent, in ordine di stream, prima del dispatch.

### Astrazione rendering (2026-07-04)
- **`src/rendering/audio_renderer.py`**: `render_streams(pairs)` metodo **concreto** sull'ABC (default = loop su `render_single_stream`). `CsoundRenderer` eredita il default senza modifiche (OCP).
- **`src/rendering/render_mode.py`**: `StemsRenderMode.execute` delega il loop a `renderer.render_streams(paths_map)`: il mode decide COSA (stems), il renderer decide COME (seriale o parallelo).

### CLI e Make
- **`src/main.py`**: `_parse_jobs(argv)` parsa `--jobs N|auto` (default 'auto'), propagato a `_build_renderer` → `NumpyAudioRenderer`; valori non validi → messaggio + exit 1; ignorato con `--renderer csound`
- **`Makefile` / `make/build.mk`**: variabile `JOBS` (vuota = auto di main.py)

### Pickle per multiprocessing
- **`src/core/grain.py`**: aggiunto `__reduce__()` — frozen + `__slots__` manuale rompeva l'unpickle (`FrozenInstanceError`); la ricostruzione via `__init__` preserva immutabilità e validazione

### Test
- **`tests/rendering/test_numpy_parallel.py`**: primitive worker (resolve_jobs, chunk_grains, resolve_table_name, init_worker, render_grain_chunk) + **`TestRenderStreamToFile`** (2026-07-04): stem byte-identico al riferimento sequenziale, CLAMP 1, task vuoto.
- **`tests/rendering/test_numpy_audio_renderer.py`**: `TestParallelRendering` (chunk path) + **`TestStreamParallel`** (2026-07-04): dispatch stream-level (non loop per-stream), byte-identità jobs=2 vs jobs=1, cache clean non dispatchata, aggiornamento cache solo per stem riusciti, propagazione eccezione worker, fallback sotto soglia.
- **`tests/rendering/test_audio_renderer.py`**: `TestRenderStreamsDefault` — default concreto dell'ABC.
- **`tests/rendering/test_rendering_strategies.py`**: `StemsRenderMode` delega a `render_streams`.
- **`tests/core/test_grain.py`**: `TestGrainPickle` — roundtrip pickle.
- **`tests/test_main_jobs_flag.py`**: parsing `--jobs` e wiring fino al renderer.
- **`tests/e2e/test_numpy_renderer_e2e.py`**: `TestNumpyStemsParallel`, `TestNumpyMixParallelAuto` + **`TestNumpyStemsStreamParallel`** (2026-07-04): 3 stream densi, stem byte-identici (`==`) tra JOBS=1 e JOBS=2, seconda run tutta clean con cache.

### Documentazione
- **`docs/reference/cli.md`**: flag `--jobs N|auto`, bounds e contratto di determinismo
- **`docs/explanation/architecture.md`**: sezione "Rendering NumPy multi-processo" + sottosezione "Parallelismo a livello di stream (STEMS)"
- **`docs/plans/2026-07-02-001-...`** e **`docs/plans/2026-07-04-001-...`** (quest'ultimo `status: done`)

## Contratto di determinismo

- `--jobs 1` → bit-identico al rendering sequenziale storico
- a parità di `--jobs` → output byte-identico tra run
- **overlap-add intra-stream** (chunk path): tra valori di `--jobs` diversi la differenza è < 1 LSB a 24 bit
- **STEMS a livello di stream** (contratto rafforzato): ogni stem prodotto è **byte-identico a `--jobs 1`** — dentro il worker le somme float64 sono nell'ordine storico.

## Verifica end-to-end

- Overlap-add: sandbox 4 core, YAML 2-4 stream, ~72-90k grani; MIX/STEMS `JOBS=1` vs auto bit-identici; wall ~1.5x. Cache STEMS: seconda run clean senza re-render.
- Stream-level (2026-07-04): verify d'integrazione `RenderingEngine → StemsRenderMode → render_streams` con pool `spawn` reale, 3 stream densi → stem byte-identici tra jobs=1 e jobs=2, pool creato solo con jobs=2. Suite unit completa verde (`make tests`).

## Aggiornamento: copertura e2e MIX

- **`tests/e2e/test_numpy_renderer_e2e.py`**: `TestNumpyMixParallelAuto` — colma il buco e2e sul default reale della CLI (`JOBS` vuoto → `auto`) su MIX multi-stream.

## Aggiornamento 2: STEMS multi-processo a livello di stream (plan 2026-07-04-001, implementato in questa PR)

Il parallelismo overlap-add copre solo il singolo stream: in STEMS il resto (generazione, dc_block, scrittura) resta seriale per-stream, limitando il guadagno reale a ~1.5x su wall totale nonostante il render puro scali ~3x. Questa PR **implementa** il follow-up: `NumpyAudioRenderer.render_streams` sposta il parallelismo a livello di stream (un task per stream al pool), coprendo ~il 100% del lavoro per-stream → scaling quasi lineare con molti stem. Le invarianti sono preservate (cache prima di `.voices`, generazione nel parent in ordine di stream, cache aggiornata solo per stem riusciti) e il contratto di determinismo è rafforzato a byte-identità.

## Impatto cross-repo

- **PGE-ls**: nessun impatto (superficie YAML invariata)
- **PGE-ui**: nuovo flag CLI opzionale, nessun aggiornamento obbligatorio
- **Paper CIM 2026**: il default `auto` tocca il comportamento del rendering. Per STEMS con `jobs>1` l'output diventa ora byte-identico al sequenziale (prima < 1 LSB) → cambiamento migliorativo; valutare bump del submodule per regola `submodule-sync-cim`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3zHVB6f9YNqpBf69uTb85