### PR TITLE
Seeding per-componente: solo/mute e cache non alterano più i grani con seed fissato (issue #154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,31 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Modificato
 
+- Seeding: il random globale dei grani (`random.seed` in `create_elements`,
+  issue #81 meccanismo 2) è sostituito da **RNG locali derivati per
+  componente** via `sha256(f"{seed}:{stream_id}:{componente}")`
+  (`shared/seeding.py::component_rng`, issue #154). Componenti: nome del
+  parametro per la variazione `_range`, `gate:<chiave>` per i probability
+  gate, `iot` (Truax async), `window` (selezione finestra), `detune` (detune
+  implicito EDO). Con seed fissato: `solo`/`mute` e la cache stems non
+  alterano più i grani degli stream superstiti (il solo suona esattamente ciò
+  che suona nel mix), l'ordine di materializzazione lazy è irrilevante, i
+  render sopravvivono ai refactor che non toccano il componente specifico e
+  ogni strategy è testabile in isolamento con i numeri reali del render.
+  Senza `seed:` nello YAML il Generator genera ora un **seed di sessione**
+  dal timestamp e lo logga (`[SEED] ...`): ogni run resta ricostruibile a
+  posteriori copiando il valore nello YAML (`Generator.seed_is_session`).
+  Le voci stocastiche (issue #81 meccanismo 1) restano invariate.
+  **Breaking**: i render con `seed:` fissato prodotti col vecchio schema
+  cambiano una volta (i valori per-grano sono diversi); i render senza seed
+  non cambiano di natura. Nuovo campo `StreamConfig.seed`; `Parameter`,
+  `DistributionFactory/DistributionStrategy`, `RandomGate`/`EnvelopeGate`,
+  `GateFactory.create_gate`, le window strategy stocastiche e
+  `UnitPitchStrategy` accettano un kwarg opzionale `rng` (default: random
+  globale, retrocompatibile). Rimossi i metodi morti
+  `Parameter._strategy_additive/_strategy_quantized/_strategy_invert` e la
+  docstring obsoleta "Functional Strategy (Dispatch Dictionary)" —
+  la variazione è delegata a `VariationStrategy` dal registry. Issue #154.
 - Sample di riferimento dei config rinominato: `weNeedToTalkAboutIt.wav` →
   `voice.wav` (`refs/voice.wav`). Aggiornati tutti i `configs/*.yml` che lo
   citavano (`PGE_cim`, `PGE_density_experiment`, `PGE_pitch_units_showcase`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,7 +208,11 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   globale, retrocompatibile). Rimossi i metodi morti
   `Parameter._strategy_additive/_strategy_quantized/_strategy_invert` e la
   docstring obsoleta "Functional Strategy (Dispatch Dictionary)" —
-  la variazione è delegata a `VariationStrategy` dal registry. Issue #154.
+  la variazione è delegata a `VariationStrategy` dal registry. Anche
+  `ChoiceVariation` (selezione da lista discreta) pesca ora dall'RNG
+  per-componente della distribuzione (`distribution.rng.choice`) invece che
+  dal `random` globale: nessun sito stocastico dei grani resta fuori dal
+  seeding per-componente. Issue #154.
 - Sample di riferimento dei config rinominato: `weNeedToTalkAboutIt.wav` →
   `voice.wav` (`refs/voice.wav`). Aggiornati tutti i `configs/*.yml` che lo
   citavano (`PGE_cim`, `PGE_density_experiment`, `PGE_pitch_units_showcase`,

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -10,7 +10,7 @@ sources:
   - src/strategies/
   - src/envelopes/
   - src/shared/seeding.py
-last_synced_commit: e829fc1
+last_synced_commit: e3b4b35
 entry_for: [yaml-syntax, envelope-syntax]
 ---
 
@@ -86,22 +86,46 @@ streams:
     sample: "sample.wav"
 ```
 
-- **Assente** (default): comportamento storico. I meccanismi stocastici (IOT
-  async di `distribution`, variazione `_range`, gate di probabilità, selezione
-  finestra, offset stocastici delle voci) cambiano a ogni processo.
 - **Presente**: lo stesso YAML produce lo stesso render NumPy fra processi
-  diversi. Copre due meccanismi:
-  - **random globale dei grani** — `random.seed(seed)` chiamato una volta a
-    inizio `create_elements`, prima della generazione (lazy) dei grani.
-  - **RNG locale delle voci stocastiche** (`voices.{pitch,onset,pointer,pan}` con
-    `strategy: stochastic`) — seed derivato
-    via `hashlib.sha256(f"{seed}:{stream_id}:{voice_index}")`, deterministico e
-    indipendente da `PYTHONHASHSEED`.
+  diversi.
+- **Assente** (default): il Generator genera un **seed di sessione** dal
+  timestamp e lo logga (`[SEED] ... seed di sessione N`). Il run resta non
+  riproducibile a priori (ogni run ha un seed diverso), ma è **ricostruibile a
+  posteriori**: aggiungendo `seed: N` allo YAML si riottiene lo stesso render.
+
+Tutti i siti stocastici usano **RNG locali derivati per componente**
+(`src/shared/seeding.py`, issue #154): nessun random globale condiviso.
+
+- **RNG per-componente** — ogni sito pesca dal proprio generatore derivato via
+  `hashlib.sha256(f"{seed}:{stream_id}:{componente}")`, deterministico e
+  indipendente da `PYTHONHASHSEED`. Componenti: il nome del parametro per la
+  variazione `_range` (es. `grain_duration`, `pitch_semitones`),
+  `gate:<chiave>` per i gate di probabilità (dephase), `iot` per la
+  distribuzione Truax async, `window` per la selezione finestra, `detune` per
+  il detune implicito EDO.
+- **RNG locale delle voci stocastiche** (`voices.{pitch,onset,pointer,pan}` con
+  `strategy: stochastic`) — invariato (issue #81): seed derivato via
+  `hashlib.sha256(f"{seed}:{stream_id}:{voice_index}")`.
+
+Conseguenze della derivazione per-componente:
+
+- `solo`/`mute` **non alterano** i grani degli stream superstiti: il solo fa
+  ascoltare in isolamento esattamente quello che suona nel mix.
+- La cache stems (`STEMS=true CACHE=true`) è coerente col seed: i grani di uno
+  stream dirty non dipendono da quali altri stream sono clean in quel run.
+- I render con seed sopravvivono ai refactor che non toccano il componente
+  specifico (aggiungere un draw a un componente non shifta gli altri).
+- Ogni componente è testabile in isolamento con gli stessi valori del render.
 
 `seed: 0` è un valore valido e distinto da assente. Sono accettati interi (anche
 negativi) e stringhe.
 
-**Limite (Csound):** `seed` semina solo il `random` di Python (renderer NumPy).
+**Breaking (issue #154):** i render con `seed:` fissato prodotti col vecchio
+schema (`random.seed` globale, issue #81) NON sono riproducibili dopo il
+passaggio alla derivazione per-componente: i valori per-grano cambiano una
+volta. I render senza seed non cambiano di natura.
+
+**Limite (Csound):** `seed` governa solo il random di Python (renderer NumPy).
 Csound ha un RNG proprio: con `--renderer csound` i due renderer NON sono
 bit-identici nemmeno col seed. Le tendency mask restano stocastiche per natura —
 l'obiettivo è riprodurre *lo stesso run*, non l'identità bit-a-bit.

--- a/src/controllers/density_controller.py
+++ b/src/controllers/density_controller.py
@@ -8,11 +8,11 @@ Implementa il modello Truax per la distribuzione temporale:
 """
 from __future__ import annotations
 
-import random
 from parameters.parameter_schema import DENSITY_PARAMETER_SCHEMA
 from strategies.strategy_registry import StrategyFactory, DENSITY_STRATEGIES
 from core.stream_config import StreamConfig
 from parameters.parameter_orchestrator import ParameterOrchestrator
+from shared.seeding import component_rng
 
 class DensityController:
     """
@@ -34,7 +34,14 @@ class DensityController:
         """
         Inizializza il controller di densità.
         """
-                
+        # RNG dedicato all'IOT async (issue #154): i draw della distribuzione
+        # Truax non dipendono dagli altri componenti né dagli altri stream.
+        self._rng = component_rng(
+            getattr(config, 'seed', None),
+            config.context.stream_id,
+            'iot',
+        )
+
         # Create orchestrator
         self._orchestrator = ParameterOrchestrator(config=config)
 
@@ -117,9 +124,9 @@ class DensityController:
             # Sync: IOT costante
             return avg_iot
         else:
-            # Async: random 0..2×avg
-            async_iot = random.uniform(0.0, 2.0 * avg_iot)
-            
+            # Async: random 0..2×avg (RNG locale del componente 'iot')
+            async_iot = self._rng.uniform(0.0, 2.0 * avg_iot)
+
             # Blend lineare tra sync e async
             return (1.0 - dist_val) * avg_iot + dist_val * async_iot
     

--- a/src/controllers/pitch_controller.py
+++ b/src/controllers/pitch_controller.py
@@ -17,6 +17,7 @@ from parameters.pitch_unit import make_pitch_unit, PITCH_UNIT_PRESETS
 from strategies.strategie import UnitPitchStrategy
 from shared.exceptions import InvalidFieldValueError
 from core.stream_config import StreamConfig
+from shared.seeding import component_rng
 
 # Chiavi-unità riconosciute nel blocco pitch. `edo` è parametrico
 # ({divisions, value}); gli altri sono preset nominali.
@@ -59,7 +60,15 @@ class PitchController:
             bounds=unit.value_bounds(),
             dephase_key='pitch',
         )
-        self._strategy = UnitPitchStrategy(self._active_param, unit, unit.name)
+        # RNG dedicato al detune implicito (issue #154, componente 'detune').
+        self._strategy = UnitPitchStrategy(
+            self._active_param, unit, unit.name,
+            rng=component_rng(
+                getattr(config, 'seed', None),
+                config.context.stream_id,
+                'detune',
+            ),
+        )
 
     # =========================================================================
     # SELEZIONE UNITÀ

--- a/src/controllers/window_controller.py
+++ b/src/controllers/window_controller.py
@@ -11,6 +11,7 @@ from controllers.window_selection_strategy import (
 from core.stream_config import StreamConfig
 from parameters.gate_factory import GateFactory
 from parameters.parameter_definitions import DEFAULT_PROB
+from shared.seeding import component_rng
 
 
 def _is_transition_spec(envelope_spec) -> bool:
@@ -123,6 +124,11 @@ class WindowController:
         envelope_spec = params.get('envelope', 'hanning')
         self._windows = self.parse_window_list(params, config.context.stream_id)
 
+        # RNG per-componente (issue #154): 'window' per la selezione,
+        # 'gate:pc_rand_envelope' per il gate — draw isolati dagli altri siti.
+        seed = getattr(config, 'seed', None)
+        stream_id = config.context.stream_id
+
         uses_gate = not (_is_transition_spec(envelope_spec) or _is_multistate_spec(envelope_spec))
         gate = GateFactory.create_gate(
             dephase=config.dephase if uses_gate else False,
@@ -132,9 +138,11 @@ class WindowController:
             range_always_active=config.range_always_active,
             duration=config.context.duration,
             time_mode=config.time_mode,
+            rng=component_rng(seed, stream_id, 'gate:pc_rand_envelope'),
         )
         self._strategy: WindowSelectionStrategy = WindowStrategyFactory.from_spec(
-            envelope_spec, config, self._windows, gate
+            envelope_spec, config, self._windows, gate,
+            rng=component_rng(seed, stream_id, 'window'),
         )
 
     @property

--- a/src/controllers/window_selection_strategy.py
+++ b/src/controllers/window_selection_strategy.py
@@ -110,17 +110,21 @@ class RandomWindowStrategy(WindowSelectionStrategy):
 
     Corrisponde a: envelope: ['hanning', 'expodec', 'gaussian']
     Con gate chiuso → sempre prima finestra.
-    Con gate aperto → random.choice tra tutte le finestre.
+    Con gate aperto → choice sull'RNG locale tra tutte le finestre.
+
+    RNG locale (issue #154): `rng` iniettato isola la selezione finestra
+    dagli altri componenti; None → modulo random globale (legacy).
     """
 
-    def __init__(self, windows: List[str], gate: ProbabilityGate):
+    def __init__(self, windows: List[str], gate: ProbabilityGate, rng=None):
         self._windows = windows
         self._gate = gate
+        self._rng = rng if rng is not None else random
 
     def select(self, elapsed_time: float) -> str:
         if not self._gate.should_apply(elapsed_time):
             return self._windows[0]
-        return random.choice(self._windows)
+        return self._rng.choice(self._windows)
 
 
 class TransitionWindowStrategy(WindowSelectionStrategy):
@@ -151,6 +155,7 @@ class TransitionWindowStrategy(WindowSelectionStrategy):
         time_mode:   se 'normalized', elapsed_time viene diviso per duration
                      prima di essere passato alla curve; altrimenti usa i secondi
                      assoluti direttamente.
+        rng:         random.Random locale (issue #154); None → random globale.
     """
 
     def __init__(
@@ -161,6 +166,7 @@ class TransitionWindowStrategy(WindowSelectionStrategy):
         duration: float = 1.0,
         time_mode: Optional[str] = None,
         stream_id: str = 'unknown',
+        rng=None,
     ):
         _validate_curve_range(curve, duration, time_mode, stream_id)
         self._from = from_window
@@ -168,12 +174,13 @@ class TransitionWindowStrategy(WindowSelectionStrategy):
         self._curve = curve
         self._duration = duration
         self._time_mode = time_mode
+        self._rng = rng if rng is not None else random
 
     def select(self, elapsed_time: float) -> str:
         t = (elapsed_time / self._duration) if self._time_mode == 'normalized' else elapsed_time
         blend = float(self._curve.evaluate(t))
         blend = max(0.0, min(1.0, blend))  # clamp per sicurezza
-        return self._to if random.random() < blend else self._from
+        return self._to if self._rng.random() < blend else self._from
 
 
 class MultiStateWindowStrategy(WindowSelectionStrategy):
@@ -206,6 +213,7 @@ class MultiStateWindowStrategy(WindowSelectionStrategy):
         curve:     Envelope che mappa tempo → valore blend
         duration:  durata totale dello stream (per normalizzazione time_mode)
         time_mode: se 'normalized', elapsed_time viene diviso per duration
+        rng:       random.Random locale (issue #154); None → random globale.
     """
 
     def __init__(
@@ -215,6 +223,7 @@ class MultiStateWindowStrategy(WindowSelectionStrategy):
         duration: float = 1.0,
         time_mode: Optional[str] = None,
         stream_id: str = 'unknown',
+        rng=None,
     ):
         if len(states) < 2:
             raise InvalidStrategyConfigError(
@@ -236,6 +245,7 @@ class MultiStateWindowStrategy(WindowSelectionStrategy):
         self._curve = curve
         self._duration = duration
         self._time_mode = time_mode
+        self._rng = rng if rng is not None else random
 
     def select(self, elapsed_time: float) -> str:
         t = (elapsed_time / self._duration) if self._time_mode == 'normalized' else elapsed_time
@@ -255,7 +265,7 @@ class MultiStateWindowStrategy(WindowSelectionStrategy):
             v_hi, w_hi = self._states[i + 1]
             if v_lo <= v < v_hi:
                 blend = (v - v_lo) / (v_hi - v_lo)
-                return w_hi if random.random() < blend else w_lo
+                return w_hi if self._rng.random() < blend else w_lo
 
         # Fallback (non raggiungibile se states è ordinato e v è clamped)
         return self._states[-1][1]
@@ -322,6 +332,7 @@ class WindowStrategyFactory:
         config,
         windows: List[str],
         gate,
+        rng=None,
     ) -> WindowSelectionStrategy:
         """
         Crea la strategy corretta a partire dalla spec YAML envelope.
@@ -331,6 +342,8 @@ class WindowStrategyFactory:
             config:        StreamConfig con duration, time_mode, stream_id
             windows:       lista di finestre già parsata da parse_window_list()
             gate:          ProbabilityGate creato da WindowController
+            rng:           random.Random locale iniettato nelle strategy
+                           stocastiche (issue #154); None → random globale
 
         Returns:
             Istanza di WindowSelectionStrategy appropriata
@@ -352,6 +365,7 @@ class WindowStrategyFactory:
                 duration=duration,
                 time_mode=time_mode,
                 stream_id=stream_id,
+                rng=rng,
             )
 
         # --- Transition ---
@@ -365,11 +379,12 @@ class WindowStrategyFactory:
                 duration=duration,
                 time_mode=time_mode,
                 stream_id=stream_id,
+                rng=rng,
             )
 
         # --- Random (lista con più finestre) ---
         if len(windows) > 1:
-            return WindowStrategyFactory.create('random', windows=windows, gate=gate)
+            return WindowStrategyFactory.create('random', windows=windows, gate=gate, rng=rng)
 
         # --- Single ---
         return WindowStrategyFactory.create('single', window=windows[0], gate=gate)

--- a/src/core/stream.py
+++ b/src/core/stream.py
@@ -83,12 +83,15 @@ class Stream:
 
         Args:
             params: dizionario parametri dallo YAML
-            seed: seed YAML top-level (issue #81), propagato alle voice strategy
-                  stocastiche per la riproducibilità fra processi. None (default)
-                  → comportamento legacy (hash() per-voce).
+            seed: seed effettivo del run (issue #81/#154): YAML top-level o
+                  session seed del Generator. Propagato alle voice strategy
+                  stocastiche e, via StreamConfig, agli RNG per-componente
+                  (parameter/gate/iot/window/detune). None (default) →
+                  comportamento legacy (hash() per-voce, random globale
+                  per i componenti).
         """
         # Seed di riproducibilità: iniettato nelle strategy stocastiche in
-        # _init_voice_manager. None → fallback hash() (retrocompat).
+        # _init_voice_manager e in StreamConfig per gli RNG per-componente.
         self.seed = seed
         # === 3. CONFIGURATION ===
         sample = params.get('sample')
@@ -106,7 +109,11 @@ class Stream:
             err.stream_id = stream_id
             raise
         self._check_required_context_fields(params, stream_id)
-        config = StreamConfig.from_yaml(params, StreamContext.from_yaml(params, sample_dur_sec=sample_dur))
+        config = StreamConfig.from_yaml(
+            params,
+            StreamContext.from_yaml(params, sample_dur_sec=sample_dur),
+            seed=seed,
+        )
         self._init_stream_context(params)
         # === 4. PARAMETRI SPECIALI ===
         self._init_grain_reverse(params)

--- a/src/core/stream_config.py
+++ b/src/core/stream_config.py
@@ -52,10 +52,15 @@ class StreamConfig:
     time_scale: float = 1.0
     clip_strategy: str = 'overflow_margin'
     clip_margin: float = 0.0
+    # Seed effettivo del run (issue #154): YAML top-level o session seed,
+    # iniettato da Stream (non letto dal dict per-stream). None → fallback
+    # legacy sul random globale nei componenti stocastici.
+    seed: Optional[Union[int, str]] = None
     context: Optional[StreamContext] = None
 
     @classmethod
-    def from_yaml(cls, yaml_data: dict, context: StreamContext, allow_none: bool = True) -> 'StreamConfig':
+    def from_yaml(cls, yaml_data: dict, context: StreamContext, allow_none: bool = True,
+                  seed: Optional[Union[int, str]] = None) -> 'StreamConfig':
         """
         Regole di processo per la sintesi granulare.
         
@@ -73,9 +78,12 @@ class StreamConfig:
         else:
             # Includi solo campi con valori non-None
             kwargs = {
-                name: yaml_data[name] 
-                for name in field_names 
+                name: yaml_data[name]
+                for name in field_names
                 if name in yaml_data and yaml_data[name] is not None
             }
         kwargs['context'] = context
+        # Il seed è top-level nello YAML (non per-stream): arriva dal chiamante
+        # e sovrascrive qualsiasi chiave omonima nel dict dello stream.
+        kwargs['seed'] = seed
         return cls(**kwargs)

--- a/src/engine/generator.py
+++ b/src/engine/generator.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import yaml
 import re
 import math
-import random
 from typing import List, Dict, Any
 
 from core.stream import Stream
@@ -22,6 +21,7 @@ from rendering.ftable_manager import FtableManager
 from rendering.score_writer import ScoreWriter
 from controllers.window_controller import WindowController
 from shared.exceptions import ConfigError, SampleNotFoundError
+from shared.seeding import session_seed
 
 class Generator:
     """
@@ -56,9 +56,11 @@ class Generator:
         self.yaml_path = yaml_path
         self.data: Dict[str, Any] = None
         self.streams: List[Stream] = []
-        # Seed di riproducibilità (issue #81): popolato da load_yaml dalla chiave
-        # top-level `seed`. None → comportamento attuale (non riproducibile).
+        # Seed di riproducibilità (issue #81/#154): popolato da load_yaml dalla
+        # chiave top-level `seed`. Se assente, create_elements genera un seed
+        # di sessione (loggato) e lo assegna qui: seed_is_session=True.
         self.seed = None
+        self.seed_is_session = False
 
         # Delegati specializzati
         self.ftable_manager = FtableManager(start_num=1)
@@ -85,8 +87,10 @@ class Generator:
             raw_data = yaml.safe_load(f)
 
         self.data = self._eval_math_expressions(raw_data)
-        # Seed top-level opzionale (issue #81): None se assente.
+        # Seed top-level opzionale (issue #81): None se assente (il session
+        # seed viene derivato in create_elements, non qui).
         self.seed = self.data.get('seed') if isinstance(self.data, dict) else None
+        self.seed_is_session = False
         return self.data
     
     def create_elements(self) -> List[Stream]:
@@ -104,13 +108,20 @@ class Generator:
         if self.data is None:
             raise ValueError("Devi prima caricare il YAML con load_yaml()")
 
-        # Seed del random globale (issue #81, meccanismo 2): semina UNA volta
-        # qui, prima della generazione (lazy) dei grani. Copre tutti i siti
-        # `random.*` consumati durante generate_grains (density async, variazione
-        # _range, probability gate, window selection, ...). Assente → nessun
-        # seeding, comportamento attuale (non riproducibile fra processi).
-        if self.seed is not None:
-            random.seed(self.seed)
+        # Seed effettivo del run (issue #154): niente random globale. Ogni sito
+        # stocastico riceve un RNG derivato per (seed, stream_id, componente)
+        # via shared.seeding.component_rng — solo/mute, cache stems e ordine di
+        # materializzazione non alterano i grani degli altri stream. Senza
+        # `seed:` nello YAML si genera un seed di sessione, loggato: il run
+        # resta ricostruibile a posteriori copiandolo nello YAML.
+        if self.seed is None:
+            self.seed = session_seed()
+            self.seed_is_session = True
+            print(
+                f"[SEED] Nessun seed nello YAML: seed di sessione {self.seed}. "
+                f"Per riprodurre questo run aggiungi 'seed: {self.seed}' allo YAML.",
+                flush=True,
+            )
 
         # Estrai e filtra stream
         stream_data_list = self.data.get('streams', [])

--- a/src/parameters/gate_factory.py
+++ b/src/parameters/gate_factory.py
@@ -59,10 +59,12 @@ class GateFactory:
         default_prob: float = 0.0,
         has_explicit_range: bool = False,
         range_always_active: bool = False,
-        duration: float = 1.0,       
-        time_mode: str = 'absolute'         
+        duration: float = 1.0,
+        time_mode: str = 'absolute',
+        rng=None,
     ) -> ProbabilityGate:
-
+        """rng: random.Random locale iniettato nei gate stocastici
+        (RandomGate/EnvelopeGate, issue #154); None → random globale."""
         if param_key is None:
             return NeverGate()
         if has_explicit_range and range_always_active is None:
@@ -73,13 +75,13 @@ class GateFactory:
         if mode == DephaseMode.DISABLED:
             return GateFactory._range_only_gate(has_explicit_range)
         elif mode == DephaseMode.IMPLICIT:
-            return GateFactory._create_probability_gate(default_prob)
+            return GateFactory._create_probability_gate(default_prob, rng)
         elif mode == DephaseMode.GLOBAL:
-            return GateFactory._create_probability_gate(float(dephase))
+            return GateFactory._create_probability_gate(float(dephase), rng)
         elif mode == DephaseMode.GLOBAL_ENV:
             # Crea Envelope dai dati grezzi
             envelope = create_scaled_envelope(dephase, duration, time_mode)
-            return EnvelopeGate(envelope)
+            return EnvelopeGate(envelope, rng=rng)
         elif mode == DephaseMode.SPECIFIC:
             # Chiave assente o null: il parametro non è dephased esplicitamente e
             # segue la semantica range-only (come dephase:false). Il range
@@ -94,9 +96,9 @@ class GateFactory:
                 elif GateFactory._is_envelope_like(raw_value):
                     # Valore envelope per questo parametro specifico
                     envelope = create_scaled_envelope(raw_value, duration, time_mode)
-                    return EnvelopeGate(envelope)
+                    return EnvelopeGate(envelope, rng=rng)
                 else:
-                    return GateFactory._parse_raw_value(raw_value, duration, time_mode)
+                    return GateFactory._parse_raw_value(raw_value, duration, time_mode, rng)
             else:
                 return GateFactory._range_only_gate(has_explicit_range)
         return NeverGate()
@@ -114,10 +116,10 @@ class GateFactory:
         return AlwaysGate() if has_explicit_range else NeverGate()
 
     @staticmethod
-    def _create_probability_gate(probability: float) -> ProbabilityGate:
+    def _create_probability_gate(probability: float, rng=None) -> ProbabilityGate:
         """
         Helper per creare gate da valore numerico.
-        
+
         Evita di ripetere la logica 0→Never, 100→Always, altro→Random.
         """
         if probability <= 0:
@@ -125,10 +127,10 @@ class GateFactory:
         elif probability >= 100:
             return AlwaysGate()
         else:
-            return RandomGate(probability)
+            return RandomGate(probability, rng=rng)
 
     @staticmethod
-    def _parse_raw_value(raw_value: Any, duration: float, time_mode: str) -> ProbabilityGate:
+    def _parse_raw_value(raw_value: Any, duration: float, time_mode: str, rng=None) -> ProbabilityGate:
         # Numero
         if isinstance(raw_value, (int, float)):
             prob = float(raw_value)
@@ -137,13 +139,13 @@ class GateFactory:
             elif prob >= 100:
                 return AlwaysGate()
             else:
-                return RandomGate(prob)
-        
+                return RandomGate(prob, rng=rng)
+
         # Envelope (con gestione errori)
         if isinstance(raw_value, (list, dict)):
             try:
                 envelope = create_scaled_envelope(raw_value, duration, time_mode)
-                return EnvelopeGate(envelope)
+                return EnvelopeGate(envelope, rng=rng)
             except Exception as e:
                 # Envelope malformato - fallback con logging
                 import logging

--- a/src/parameters/parameter.py
+++ b/src/parameters/parameter.py
@@ -5,9 +5,15 @@ Definisce la classe Smart Parameter (Model).
 Questa classe incapsula il valore (statico o Envelope), i bounds di sicurezza
 e la logica di variazione stocastica (Randomness).
 
-Utilizza un approccio 'Functional Strategy' (Dispatch Dictionary) per gestire 
-le diverse modalità di variazione ('additive', 'quantized', 'invert') senza 
-usare catene di if/elif, garantendo estensibilità e pulizia.
+La variazione è delegata alle VariationStrategy del registry
+(strategies/variation_registry.py: 'additive', 'quantized', 'invert',
+'choice'), selezionate da bounds.variation_mode; la forma della distribuzione
+è delegata alle DistributionStrategy (shared/distribution_strategy.py).
+
+RNG locale (issue #154): il Parameter riceve alla costruzione un
+`random.Random` derivato per (seed, stream_id, nome) e lo inietta nella
+propria DistributionStrategy: i draw di un parametro non dipendono da quelli
+degli altri componenti. Senza rng si usa il random globale (legacy).
 """
 from __future__ import annotations
 
@@ -45,22 +51,24 @@ class Parameter:
 
     def __init__(
         self,
-        name: str,                       
-        value: ParamInput,               
-        bounds: ParameterBounds,         
-        mod_range: Optional[ParamInput] = None,  
+        name: str,
+        value: ParamInput,
+        bounds: ParameterBounds,
+        mod_range: Optional[ParamInput] = None,
         owner_id: str = "unknown",
-        distribution_mode: str = 'uniform'
+        distribution_mode: str = 'uniform',
+        rng: Optional[random.Random] = None,
     ):
         self.name = name
         self.owner_id = owner_id
-        
+
         self._value = value
         self._bounds = bounds
         self._mod_range = mod_range
         self._probability_gate = NeverGate()
 
-        self._distribution = DistributionFactory.create(distribution_mode)                
+        # RNG locale del parametro (issue #154): None → random globale.
+        self._distribution = DistributionFactory.create(distribution_mode, rng=rng)
         self._variation_strategy = VariationFactory.create(bounds.variation_mode)
         
     def set_probability_gate(self, gate: ProbabilityGate):
@@ -107,42 +115,6 @@ class Parameter:
         )
         # 5. Safety Clamp e Ritorno
         return self._clamp(final_val, time)
-
-    # =========================================================================
-    # STRATEGIE DI VARIAZIONE (Private)
-    # =========================================================================
-
-    def _strategy_additive(self, base: float, rng: float) -> float:
-        """
-        Variazione continua usando DistributionStrategy.
-        
-        Invece di hardcoded uniform, delega alla strategia configurata.
-        """
-        if rng > 0:
-            # ← CAMBIATO: usa distribution strategy invece di random.uniform
-            return self._distribution.sample(base, rng)
-        return base
-
-    def _strategy_quantized(self, base: float, rng: float) -> float:
-        """
-        Variazione discreta.
-        
-        Per gaussiana: genera valore float e arrotonda a intero.
-        """
-        if rng >= 1.0:
-            # Genera campione dalla distribuzione
-            raw_sample = self._distribution.sample(0.0, rng)  # center=0 per simmetria
-            # Arrotonda a intero
-            return base + round(raw_sample)
-        return base
-    
-    def _strategy_invert(self, base: float) -> float:
-        """
-        Variazione booleana: inverte 0.0 <-> 1.0.
-        Usata per: Reverse.
-        Ignora il parametro 'rng' perché comandata solo dalla probabilità.
-        """
-        return 1.0 - base
 
     # =========================================================================
     # HELPERS

--- a/src/parameters/parameter_orchestrator.py
+++ b/src/parameters/parameter_orchestrator.py
@@ -14,6 +14,7 @@ from parameters.parameter_schema import ParameterSpec
 from parameters.parameter_definitions import DEFAULT_PROB
 from parameters.exclusive_selector import ExclusiveGroupSelector
 from core.stream_config import StreamConfig
+from shared.seeding import component_rng
 
 class ParameterOrchestrator:
     """
@@ -72,20 +73,30 @@ class ParameterOrchestrator:
         # Controlla se range è esplicitato
         has_explicit_range = param.has_explicit_range
 
-        # 2. Crea il ProbabilityGate corrispondente
+        # 2. Crea il ProbabilityGate corrispondente, con RNG per-componente
+        # (issue #154): i draw del gate non shiftano gli altri componenti.
         gate = GateFactory.create_gate(
-            dephase=self._config.dephase,       
+            dephase=self._config.dephase,
             param_key=param_spec.dephase_key,
             default_prob=DEFAULT_PROB,
             has_explicit_range=has_explicit_range,
             range_always_active=self._config.range_always_active,
             duration=self._config.context.duration,
-            time_mode=self._config.time_mode
-        )        
+            time_mode=self._config.time_mode,
+            rng=self._gate_rng(param_spec.dephase_key),
+        )
         # 3. Inietta il gate nel Parameter (modifica la classe Parameter)
         param.set_probability_gate(gate)
-        
+
         return param
+
+    def _gate_rng(self, dephase_key: Optional[str]):
+        """RNG locale del gate, derivato da (seed, stream_id, gate:<key>)."""
+        return component_rng(
+            getattr(self._config, 'seed', None),
+            self._config.context.stream_id,
+            f"gate:{dephase_key}",
+        )
     
     def create_pitch_parameter(
         self,
@@ -116,6 +127,7 @@ class ParameterOrchestrator:
             range_always_active=self._config.range_always_active,
             duration=self._config.context.duration,
             time_mode=self._config.time_mode,
+            rng=self._gate_rng(dephase_key),
         )
         param.set_probability_gate(gate)
         return param

--- a/src/parameters/parser.py
+++ b/src/parameters/parser.py
@@ -17,6 +17,7 @@ from parameters.parameter import Parameter, ParamInput
 from envelopes.envelope import Envelope, create_scaled_envelope
 from parameters.parameter_definitions import get_parameter_definition
 from shared.exceptions import InvalidParameterError, ParameterBoundError
+from shared.seeding import component_rng
 
 class GranularParser:
     """
@@ -39,6 +40,9 @@ class GranularParser:
         self.sample_dur_sec = config.context.sample_dur_sec
         self.time_mode = config.time_mode
         self.distribution_mode = config.distribution_mode
+        # Seed effettivo del run (issue #154): deriva l'RNG per-parametro.
+        # getattr difensivo: i config parziali dei test possono non averlo.
+        self.seed = getattr(config, 'seed', None)
 
     def parse_parameter(
         self,
@@ -101,14 +105,18 @@ class GranularParser:
             value_type='probability'
         ) if clean_prob is not None else None
 
-        # 4. Assembla e restituisce l'oggetto Smart Parameter
+        # 4. Assembla e restituisce l'oggetto Smart Parameter.
+        # RNG per-componente (issue #154): ogni parametro pesca dal proprio
+        # stream derivato da (seed, stream_id, nome) — i draw di un parametro
+        # non shiftano quelli degli altri (solo/mute e cache invarianti).
         return Parameter(
             name=name,
             value=validated_value,
             bounds=bounds,
             mod_range=validated_range,
             owner_id=self.stream_id,
-            distribution_mode=self.distribution_mode
+            distribution_mode=self.distribution_mode,
+            rng=component_rng(self.seed, self.stream_id, name),
         )
 
     # =========================================================================

--- a/src/shared/distribution_strategy.py
+++ b/src/shared/distribution_strategy.py
@@ -19,11 +19,24 @@ from shared.exceptions import (
 class DistributionStrategy(ABC):
     """
     Strategy astratta per distribuzioni statistiche.
-    
+
     Ogni strategia implementa un metodo sample() che genera
     un valore random secondo una specifica distribuzione.
+
+    RNG locale (issue #154): il costruttore accetta un `random.Random`
+    iniettato; i sample pescano da quello, così ogni Parameter ha il proprio
+    stream di draw isolato. Senza rng si usa il modulo `random` globale
+    (comportamento legacy).
     """
-    
+
+    def __init__(self, rng=None):
+        self._rng = rng if rng is not None else random
+
+    @property
+    def rng(self):
+        """RNG locale della strategia (random.Random o modulo random)."""
+        return self._rng
+
     @abstractmethod
     def sample(self, center: float, spread: float) -> float:        # pragma: no cover
         """
@@ -72,13 +85,13 @@ class UniformDistribution(DistributionStrategy):
     def sample(self, center: float, spread: float) -> float:
         """
         Genera valore uniformemente distribuito.
-        
-        Formula: center + random.uniform(-0.5, 0.5) * spread
+
+        Formula: center + rng.uniform(-0.5, 0.5) * spread
         """
         if spread <= 0:
             return center
-        
-        return center + random.uniform(-0.5, 0.5) * spread
+
+        return center + self._rng.uniform(-0.5, 0.5) * spread
     
     @property
     def name(self) -> str:
@@ -111,13 +124,13 @@ class GaussianDistribution(DistributionStrategy):
     def sample(self, center: float, spread: float) -> float:
         """
         Genera valore con distribuzione gaussiana.
-        
-        Formula: random.gauss(μ=center, σ=spread)
+
+        Formula: rng.gauss(μ=center, σ=spread)
         """
         if spread <= 0:
             return center
-        
-        return random.gauss(center, spread)
+
+        return self._rng.gauss(center, spread)
     
     @property
     def name(self) -> str:
@@ -147,16 +160,18 @@ class DistributionFactory:
     }
     
     @classmethod
-    def create(cls, mode: str) -> DistributionStrategy:
+    def create(cls, mode: str, rng=None) -> DistributionStrategy:
         """
         Crea una strategia di distribuzione.
-        
+
         Args:
             mode: Nome della distribuzione ('uniform', 'gaussian')
-        
+            rng: random.Random locale da iniettare (issue #154);
+                 None → modulo random globale (legacy)
+
         Returns:
             Istanza di DistributionStrategy
-        
+
         Raises:
             ValueError: Se mode non è riconosciuto
         """
@@ -166,15 +181,18 @@ class DistributionFactory:
                 name=mode,
                 available=list(cls._registry.keys()),
             )
-        
+
         strategy_class = cls._registry[mode]
-        return strategy_class()
+        return strategy_class(rng=rng)
     
     @classmethod
     def register(cls, name: str, strategy_class: type):
         """
         Registra una nuova distribuzione (estensibilità futura).
-        
+
+        Nota: la classe deve accettare il kwarg `rng` nel costruttore
+        (basta non ridefinire __init__ ed ereditare da DistributionStrategy).
+
         Esempio:
             DistributionFactory.register('triangular', TriangularDistribution)
         """

--- a/src/shared/probability_gate.py
+++ b/src/shared/probability_gate.py
@@ -60,13 +60,18 @@ class AlwaysGate(ProbabilityGate):
 
 
 class RandomGate(ProbabilityGate):
-    """Gate con probabilità costante."""
-    
-    def __init__(self, probability: float):
+    """Gate con probabilità costante.
+
+    RNG locale (issue #154): `rng` iniettato isola i draw del gate dagli
+    altri componenti; None → modulo random globale (legacy).
+    """
+
+    def __init__(self, probability: float, rng=None):
         self._probability = min(100.0, max(0.0, probability))
-    
+        self._rng = rng if rng is not None else random
+
     def should_apply(self, time: float) -> bool:
-        return random.uniform(0, 100) < self._probability
+        return self._rng.uniform(0, 100) < self._probability
     
     def get_probability_value(self, time: float) -> float:
         return self._probability
@@ -82,14 +87,19 @@ class RandomGate(ProbabilityGate):
 
 
 class EnvelopeGate(ProbabilityGate):
-    """Gate con probabilità variabile nel tempo (envelope)."""
-    
-    def __init__(self, envelope: Envelope):
+    """Gate con probabilità variabile nel tempo (envelope).
+
+    RNG locale (issue #154): `rng` iniettato isola i draw del gate dagli
+    altri componenti; None → modulo random globale (legacy).
+    """
+
+    def __init__(self, envelope: Envelope, rng=None):
         self._envelope = envelope
-    
+        self._rng = rng if rng is not None else random
+
     def should_apply(self, time: float) -> bool:
         prob = self._envelope.evaluate(time)
-        return random.uniform(0, 100) < prob
+        return self._rng.uniform(0, 100) < prob
     
     def get_probability_value(self, time: float) -> float:
         return self._envelope.evaluate(time)

--- a/src/shared/seeding.py
+++ b/src/shared/seeding.py
@@ -1,25 +1,39 @@
 # src/shared/seeding.py
 """
-seeding.py — derivazione deterministica del RNG per-voce (issue #81).
+seeding.py — derivazione deterministica degli RNG locali (issue #81, #154).
 
-Singola fonte di verità per il seed locale delle voice strategy stocastiche
-(`StochasticPitchStrategy`, `StochasticOnsetStrategy`, `StochasticPointerStrategy`,
-`StochasticPanStrategy`). Mantenere allineate le quattro strategy: tutte delegano qui.
+Singola fonte di verità per la derivazione dei generatori pseudo-casuali:
 
-Due regimi:
+- `voice_rng` (issue #81): RNG per-voce delle voice strategy stocastiche
+  (`StochasticPitchStrategy`, `StochasticOnsetStrategy`,
+  `StochasticPointerStrategy`, `StochasticPanStrategy`).
+- `component_rng` (issue #154): RNG per-componente di tutti gli altri siti
+  stocastici della generazione grani (variazione `_range` dei Parameter,
+  probability gate, IOT async, selezione finestra, detune implicito).
+  Ogni componente pesca dal proprio stream: solo/mute, cache stems e ordine
+  di materializzazione non alterano i draw degli altri componenti.
+- `session_seed` (issue #154): seed di sessione derivato da timestamp per i
+  run senza `seed:` nello YAML — loggato dal Generator, così ogni run resta
+  ricostruibile a posteriori.
 
-- `seed is None` → comportamento legacy: `hash(stream_id + str(voice_index))`.
-  Stabile ENTRO un run, NON riproducibile fra processi: `hash()` su stringa è
-  randomizzato per-processo (PYTHONHASHSEED non è fissato nel repo).
-- `seed` valorizzato (int/str) → derivazione `hashlib.sha256` su
-  `f"{seed}:{stream_id}:{voice_index}"`. `hashlib` è deterministico per
+Regimi di derivazione:
+
+- `seed` valorizzato (int/str) → `hashlib.sha256` su
+  `f"{seed}:{stream_id}:{discriminante}"`. `hashlib` è deterministico per
   costruzione: il valore non dipende da PYTHONHASHSEED, quindi è riproducibile
-  fra processi diversi. Copre `seed: 0` e seed negativi/stringa senza casi speciali.
+  fra processi diversi. Copre `seed: 0` e seed negativi/stringa senza casi
+  speciali.
+- `seed is None` → comportamento legacy, diverso per funzione:
+  `voice_rng` usa `hash(stream_id + str(voice_index))` (stabile ENTRO un run,
+  NON riproducibile fra processi); `component_rng` restituisce il modulo
+  `random` globale (per le costruzioni dirette fuori dal Generator — il
+  Generator non passa mai None: senza seed YAML genera un session seed).
 """
 from __future__ import annotations
 
 import hashlib
 import random
+import time
 
 
 def voice_rng(seed, stream_id: str, voice_index: int) -> random.Random:
@@ -41,3 +55,39 @@ def voice_rng(seed, stream_id: str, voice_index: int) -> random.Random:
         ).hexdigest()
         derived = int(digest, 16)
     return random.Random(derived)
+
+
+def component_rng(seed, stream_id: str, component: str):
+    """Restituisce l'RNG locale per (seed, stream_id, component) — issue #154.
+
+    Componenti in uso: il nome del Parameter (es. `grain_duration`,
+    `pitch_semitones`), `gate:<dephase_key>` per i probability gate, `iot`
+    (distribuzione Truax async), `window` (selezione finestra), `detune`
+    (detune implicito EDO). Componenti distinti → stream RNG indipendenti.
+
+    Args:
+        seed: seed effettivo (YAML o di sessione) oppure None.
+        stream_id: id dello stream proprietario del componente.
+        component: discriminante testuale del sito stocastico.
+
+    Returns:
+        `random.Random` seminato via sha256 se `seed` è valorizzato; il modulo
+        `random` globale se `seed` è None (fallback legacy per costruzioni
+        dirette di Stream/controller fuori dal Generator).
+    """
+    if seed is None:
+        return random
+    digest = hashlib.sha256(
+        f"{seed}:{stream_id}:{component}".encode()
+    ).hexdigest()
+    return random.Random(int(digest, 16))
+
+
+def session_seed() -> int:
+    """Genera il seed di sessione per i run senza `seed:` nello YAML.
+
+    Derivato dal timestamp (ns) e ridotto a 9 cifre per essere comodo da
+    copiare nello YAML (`seed: <valore loggato>`): il run torna riproducibile
+    a posteriori con la stessa derivazione dei seed espliciti.
+    """
+    return time.time_ns() % 1_000_000_000

--- a/src/strategies/strategie.py
+++ b/src/strategies/strategie.py
@@ -51,12 +51,16 @@ class UnitPitchStrategy(PitchStrategy):
     continuo in ±implicit_detune_cents, poi richiuso nei bounds ratio dell'unità.
     Il detune opera sul ratio positivo: l'eventuale negazione reverse resta a
     valle in PitchController.
+
+    RNG locale (issue #154): il detune pesca da `rng` iniettato (componente
+    'detune'), isolato dagli altri siti; None → modulo random globale (legacy).
     """
 
-    def __init__(self, param: Parameter, unit: PitchUnit, name: str):
+    def __init__(self, param: Parameter, unit: PitchUnit, name: str, rng=None):
         self._param = param
         self._unit = unit
         self._name = name
+        self._rng = rng if rng is not None else random
         # bounds in ratio-space: il detune bypassa il clamp value-space di
         # Parameter, va richiuso qui
         bounds = unit.value_bounds()
@@ -69,7 +73,7 @@ class UnitPitchStrategy(PitchStrategy):
         if (cents > 0.0
                 and not self._param.has_explicit_range
                 and self._param.variation_allowed(elapsed_time)):
-            ratio *= 2.0 ** (random.uniform(-cents, cents) / 1200.0)
+            ratio *= 2.0 ** (self._rng.uniform(-cents, cents) / 1200.0)
             ratio = max(self._ratio_min, min(self._ratio_max, ratio))
         return ratio
 

--- a/src/strategies/variation_strategy.py
+++ b/src/strategies/variation_strategy.py
@@ -5,7 +5,6 @@ from abc import ABC, abstractmethod
 from shared.distribution_strategy import DistributionStrategy
 from shared.exceptions import InvalidParameterError
 from typing import Any
-import random
 
 class VariationStrategy(ABC):
     """Strategia di applicazione randomness a un valore base."""
@@ -78,5 +77,7 @@ class ChoiceVariation(VariationStrategy):
         if mod_range == 0:
             return value[0] if value else 'hanning'
         
-        # Altrimenti, scelta random
-        return random.choice(value)
+        # Altrimenti, scelta random dall'RNG per-componente della distribuzione
+        # (issue #154): la selezione rientra nel seeding per (seed, stream_id,
+        # componente) invece di pescare dal random globale condiviso.
+        return distribution.rng.choice(value)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,8 @@ def mock_config():
     config.distribution_mode = 'uniform'
     config.dephase = False
     config.range_always_active = False
+    # issue #154: seed None → fallback legacy sul random globale
+    config.seed = None
 
     return config
 

--- a/tests/controllers/test_density_controller.py
+++ b/tests/controllers/test_density_controller.py
@@ -658,8 +658,9 @@ class TestTruaxFormula:
         avg_iot = 0.025
         d = 0.7
 
-        # Mock random per risultato deterministico
-        with patch('controllers.density_controller.random.uniform', return_value=0.03):
+        # Mock dell'RNG locale del componente 'iot' (issue #154)
+        with patch.object(dc, '_rng') as mock_rng:
+            mock_rng.uniform.return_value = 0.03
             result = dc._apply_truax_distribution(avg_iot, 0.0)
 
             # expected = (1-0.7)*0.025 + 0.7*0.03 = 0.0075 + 0.021 = 0.0285
@@ -671,7 +672,8 @@ class TestTruaxFormula:
         params = _build_fill_factor_params(fill_factor=2.0, distribution=1.0)
         dc = _make_density_controller(mock_config, params)
 
-        with patch('controllers.density_controller.random.uniform', return_value=0.0):
+        with patch.object(dc, '_rng') as mock_rng:
+            mock_rng.uniform.return_value = 0.0
             result = dc._apply_truax_distribution(0.025, 0.0)
             # d=1.0: (1-1)*0.025 + 1*0 = 0.0
             assert result == pytest.approx(0.0)
@@ -682,7 +684,8 @@ class TestTruaxFormula:
         dc = _make_density_controller(mock_config, params)
 
         avg_iot = 0.025
-        with patch('controllers.density_controller.random.uniform', return_value=2.0 * avg_iot):
+        with patch.object(dc, '_rng') as mock_rng:
+            mock_rng.uniform.return_value = 2.0 * avg_iot
             result = dc._apply_truax_distribution(avg_iot, 0.0)
             # d=1.0: (1-1)*0.025 + 1*0.05 = 0.05
             assert result == pytest.approx(2.0 * avg_iot)

--- a/tests/controllers/test_pointer_controller.py
+++ b/tests/controllers/test_pointer_controller.py
@@ -1250,6 +1250,8 @@ def mock_config():
     config = Mock(spec=StreamConfig)
     config.context = context
     config.time_mode = 'absolute'
+    # issue #154: seed None → fallback legacy sul random globale
+    config.seed = None
 
     return config
 

--- a/tests/core/test_stream_config.py
+++ b/tests/core/test_stream_config.py
@@ -270,20 +270,33 @@ class TestStreamConfigDefaults:
         assert config.time_scale == 1.0
         assert config.clip_strategy == 'overflow_margin'
         assert config.clip_margin == 0.0
+        assert config.seed is None
         assert config.context is None
 
     def test_field_count(self):
-        """StreamConfig ha esattamente 8 campi."""
-        assert len(fields(StreamConfig)) == 8
+        """StreamConfig ha esattamente 9 campi (issue #154: +seed)."""
+        assert len(fields(StreamConfig)) == 9
 
     def test_field_names(self):
         """Nomi campi nell'ordine atteso."""
         names = [f.name for f in fields(StreamConfig)]
         expected = [
             'dephase', 'range_always_active', 'distribution_mode',
-            'time_mode', 'time_scale', 'clip_strategy', 'clip_margin', 'context'
+            'time_mode', 'time_scale', 'clip_strategy', 'clip_margin',
+            'seed', 'context'
         ]
         assert names == expected
+
+    def test_seed_injected_via_from_yaml_kwarg(self, stream_context):
+        """Il seed arriva dal kwarg esplicito (top-level YAML), non dal dict
+        per-stream: una chiave 'seed' nel dict dello stream viene ignorata."""
+        config = StreamConfig.from_yaml({'seed': 99}, context=stream_context, seed=42)
+        assert config.seed == 42
+
+    def test_seed_default_none_from_yaml(self, stream_context):
+        """from_yaml senza kwarg seed → None (fallback legacy)."""
+        config = StreamConfig.from_yaml({}, context=stream_context)
+        assert config.seed is None
 
     def test_clip_strategy_from_yaml_passthrough(self, stream_context):
         """from_yaml legge clip_strategy=passthrough."""

--- a/tests/engine/test_generator.py
+++ b/tests/engine/test_generator.py
@@ -639,27 +639,30 @@ class TestCreateElements:
 
         mock_filter.assert_called_once_with([])
 
-    def test_create_elements_seeds_global_random_when_seed_present(self, gen):
-        """Col seed, create_elements semina il random globale (meccanismo 2, issue #81)."""
+    def test_create_elements_keeps_explicit_seed(self, gen):
+        """Col seed YAML, create_elements lo usa così com'è (issue #154):
+        nessun random globale, nessun session seed."""
         m = mock_open(read_data=yaml.dump({'seed': 42, 'streams': []}))
         with patch('builtins.open', m):
             gen.load_yaml()
         with patch.object(gen, '_filter_solo_mute', return_value=[]), \
-             patch.object(gen, '_create_streams'), \
-             patch('engine.generator.random.seed') as mock_seed:
+             patch.object(gen, '_create_streams'):
             gen.create_elements()
-        mock_seed.assert_called_once_with(42)
+        assert gen.seed == 42
+        assert gen.seed_is_session is False
 
-    def test_create_elements_no_seed_skips_global_random(self, gen):
-        """Senza seed, create_elements NON semina il random globale (retrocompat)."""
+    def test_create_elements_no_seed_generates_session_seed(self, gen, capsys):
+        """Senza seed YAML, create_elements genera un seed di sessione e lo
+        logga (issue #154): il run resta ricostruibile a posteriori."""
         m = mock_open(read_data=yaml.dump({'streams': []}))
         with patch('builtins.open', m):
             gen.load_yaml()
         with patch.object(gen, '_filter_solo_mute', return_value=[]), \
-             patch.object(gen, '_create_streams'), \
-             patch('engine.generator.random.seed') as mock_seed:
+             patch.object(gen, '_create_streams'):
             gen.create_elements()
-        mock_seed.assert_not_called()
+        assert isinstance(gen.seed, int)
+        assert gen.seed_is_session is True
+        assert '[SEED]' in capsys.readouterr().out
 
 # =============================================================================
 # 6. TEST _create_streams()

--- a/tests/engine/test_seed_component_isolation.py
+++ b/tests/engine/test_seed_component_isolation.py
@@ -1,0 +1,420 @@
+# tests/engine/test_seed_component_isolation.py
+"""
+test_seed_component_isolation.py
+
+Test dell'isolamento per-componente del random dei grani (issue #154).
+
+Il meccanismo 2 dell'issue #81 (random.seed globale) rendeva il valore di ogni
+grano dipendente dalla posizione del suo draw nella sequenza globale: solo/mute
+e la materializzazione lazy (cache stems) cambiavano i grani degli stream
+superstiti anche a seed fissato. Qui si verifica il modello per-componente:
+
+- INVARIANZA SOLO/MUTE: con seed fissato, i grani di uno stream sono identici
+  fra render completo, render in solo e render con altri stream muted.
+- INVARIANZA D'ORDINE (lazy/cache): l'ordine di materializzazione dei grani
+  non cambia i valori (gli stream cache-clean non consumano draw altrui).
+- INIEZIONE RNG: DistributionStrategy, ProbabilityGate, window strategy,
+  DensityController e detune implicito accettano un RNG locale iniettato.
+- SESSION SEED: senza `seed:` nello YAML il Generator genera un seed di
+  sessione, lo logga, e il run resta ricostruibile a posteriori.
+
+Non richiede csound/sox né sample reali (get_sample_duration mockato).
+"""
+
+import random
+
+import pytest
+import yaml
+from unittest.mock import patch
+
+from engine.generator import Generator
+from core.stream_config import StreamConfig, StreamContext
+from shared.distribution_strategy import DistributionFactory
+from shared.probability_gate import AlwaysGate, RandomGate, EnvelopeGate
+from controllers.density_controller import DensityController
+from controllers.window_selection_strategy import (
+    RandomWindowStrategy,
+    TransitionWindowStrategy,
+    MultiStateWindowStrategy,
+)
+from envelopes.envelope import Envelope
+from parameters.parser import GranularParser
+
+
+# =============================================================================
+# HELPERS
+# =============================================================================
+
+def _stream_dict(stream_id, mark=None):
+    """Stream con più componenti stocastici attivi (iot, range, window, pitch)."""
+    d = {
+        'stream_id': stream_id,
+        'onset': 0.0,
+        'duration': 4.0,
+        'sample': 'test.wav',
+        'density': 30,
+        'distribution': 1.0,
+        'volume': -6.0,
+        'volume_range': 4.0,
+        'grain': {
+            'duration': 0.05,
+            'duration_range': 0.03,
+            'envelope': ['hanning', 'expodec'],
+        },
+        'pitch': {'semitones': 0, 'range': 2},
+    }
+    if mark is not None:
+        d[mark] = None  # 'solo:' / 'mute:' — chiave presente, valore vuoto
+    return d
+
+
+def _yaml_data(streams, seed=42):
+    data = {'streams': streams}
+    if seed is not None:
+        data['seed'] = seed
+    return data
+
+
+def _render_streams(tmp_path, yaml_data, filename='iso.yml'):
+    """Crea il Generator e materializza i grani nell'ordine degli stream."""
+    cfg = tmp_path / filename
+    cfg.write_text(yaml.safe_dump(yaml_data))
+    gen = Generator(str(cfg))
+    gen.load_yaml()
+    with patch('core.stream.get_sample_duration', return_value=10.0):
+        gen.create_elements()
+        for s in gen.streams:
+            _ = s.grains  # materializza (lazy)
+    return gen
+
+
+def _grain_signature(stream):
+    """Firma simbolica dei grani, indipendente dalla numerazione ftable."""
+    inv_windows = {v: k for k, v in stream.window_table_map.items()}
+    return [
+        (
+            round(g.onset, 9),
+            round(g.duration, 9),
+            round(g.pointer_pos, 9),
+            round(g.pitch_ratio, 9),
+            round(g.volume, 9),
+            round(g.pan, 9),
+            inv_windows[g.envelope_table],
+        )
+        for g in stream.grains
+    ]
+
+
+def _signature_of(gen, stream_id):
+    for s in gen.streams:
+        if s.stream_id == stream_id:
+            return _grain_signature(s)
+    raise AssertionError(f"stream {stream_id} non trovato")
+
+
+# =============================================================================
+# 1. INVARIANZA SOLO/MUTE (fix del punto 1 dell'issue #154)
+# =============================================================================
+
+class TestSoloMuteInvariance:
+
+    def test_solo_does_not_change_surviving_stream(self, tmp_path):
+        """Con seed fissato, mettere s2 in solo NON cambia i suoi grani
+        rispetto al render completo."""
+        full = _render_streams(
+            tmp_path, _yaml_data([_stream_dict('s1'), _stream_dict('s2')])
+        )
+        solo = _render_streams(
+            tmp_path,
+            _yaml_data([_stream_dict('s1'), _stream_dict('s2', mark='solo')]),
+        )
+        sig_full = _signature_of(full, 's2')
+        sig_solo = _signature_of(solo, 's2')
+        assert len(sig_full) > 10
+        assert sig_full == sig_solo
+
+    def test_mute_does_not_change_surviving_stream(self, tmp_path):
+        """Con seed fissato, mutare s1 NON cambia i grani di s2."""
+        full = _render_streams(
+            tmp_path, _yaml_data([_stream_dict('s1'), _stream_dict('s2')])
+        )
+        muted = _render_streams(
+            tmp_path,
+            _yaml_data([_stream_dict('s1', mark='mute'), _stream_dict('s2')]),
+        )
+        assert _signature_of(full, 's2') == _signature_of(muted, 's2')
+
+    def test_adding_stream_does_not_change_existing_one(self, tmp_path):
+        """Aggiungere uno stream allo YAML non altera i grani degli altri
+        (robustezza compositiva: i componenti non condividono draw)."""
+        only_s2 = _render_streams(tmp_path, _yaml_data([_stream_dict('s2')]))
+        both = _render_streams(
+            tmp_path, _yaml_data([_stream_dict('s1'), _stream_dict('s2')])
+        )
+        assert _signature_of(only_s2, 's2') == _signature_of(both, 's2')
+
+
+# =============================================================================
+# 2. INVARIANZA D'ORDINE DI MATERIALIZZAZIONE (fix del punto 2 — cache stems)
+# =============================================================================
+
+class TestLazyOrderInvariance:
+
+    def test_materialization_order_is_irrelevant(self, tmp_path):
+        """I grani non dipendono dall'ordine di lettura di .grains: uno
+        stream cache-clean saltato non shifta i draw degli stream dirty."""
+        data = _yaml_data([_stream_dict('s1'), _stream_dict('s2')])
+
+        cfg = tmp_path / 'order_a.yml'
+        cfg.write_text(yaml.safe_dump(data))
+        gen_a = Generator(str(cfg))
+        gen_a.load_yaml()
+        with patch('core.stream.get_sample_duration', return_value=10.0):
+            gen_a.create_elements()
+            _ = gen_a.streams[0].grains  # s1 prima
+            _ = gen_a.streams[1].grains
+
+        cfg_b = tmp_path / 'order_b.yml'
+        cfg_b.write_text(yaml.safe_dump(data))
+        gen_b = Generator(str(cfg_b))
+        gen_b.load_yaml()
+        with patch('core.stream.get_sample_duration', return_value=10.0):
+            gen_b.create_elements()
+            _ = gen_b.streams[1].grains  # s2 prima (come con s1 cache-clean)
+            _ = gen_b.streams[0].grains
+
+        assert _signature_of(gen_a, 's2') == _signature_of(gen_b, 's2')
+        assert _signature_of(gen_a, 's1') == _signature_of(gen_b, 's1')
+
+
+# =============================================================================
+# 3. INIEZIONE RNG NEI COMPONENTI
+# =============================================================================
+
+class TestDistributionRngInjection:
+
+    def test_uniform_deterministic_with_injected_rng(self):
+        d1 = DistributionFactory.create('uniform', rng=random.Random(7))
+        d2 = DistributionFactory.create('uniform', rng=random.Random(7))
+        assert [d1.sample(1.0, 0.5) for _ in range(20)] == \
+               [d2.sample(1.0, 0.5) for _ in range(20)]
+
+    def test_gaussian_deterministic_with_injected_rng(self):
+        d1 = DistributionFactory.create('gaussian', rng=random.Random(7))
+        d2 = DistributionFactory.create('gaussian', rng=random.Random(7))
+        assert [d1.sample(0.0, 1.0) for _ in range(20)] == \
+               [d2.sample(0.0, 1.0) for _ in range(20)]
+
+    def test_injected_rngs_are_isolated(self):
+        """Consumare draw da una strategy non shifta l'altra."""
+        d1 = DistributionFactory.create('uniform', rng=random.Random(7))
+        d2 = DistributionFactory.create('uniform', rng=random.Random(7))
+        _ = [d1.sample(0.0, 1.0) for _ in range(50)]  # draw extra su d1
+        d1_next = DistributionFactory.create('uniform', rng=random.Random(7))
+        assert d2.sample(0.0, 1.0) == d1_next.sample(0.0, 1.0)
+
+
+class TestGateRngInjection:
+
+    def test_random_gate_deterministic_with_injected_rng(self):
+        g1 = RandomGate(50.0, rng=random.Random(11))
+        g2 = RandomGate(50.0, rng=random.Random(11))
+        seq1 = [g1.should_apply(0.0) for _ in range(50)]
+        seq2 = [g2.should_apply(0.0) for _ in range(50)]
+        assert seq1 == seq2
+        assert True in seq1 and False in seq1  # gate davvero stocastico
+
+    def test_envelope_gate_deterministic_with_injected_rng(self):
+        env = Envelope([[0, 50], [10, 50]])
+        g1 = EnvelopeGate(env, rng=random.Random(11))
+        g2 = EnvelopeGate(env, rng=random.Random(11))
+        assert [g1.should_apply(5.0) for _ in range(50)] == \
+               [g2.should_apply(5.0) for _ in range(50)]
+
+
+class TestWindowStrategyRngInjection:
+
+    def test_random_window_strategy_deterministic(self):
+        s1 = RandomWindowStrategy(['a', 'b', 'c'], AlwaysGate(), rng=random.Random(3))
+        s2 = RandomWindowStrategy(['a', 'b', 'c'], AlwaysGate(), rng=random.Random(3))
+        assert [s1.select(0.0) for _ in range(50)] == \
+               [s2.select(0.0) for _ in range(50)]
+
+    def test_transition_window_strategy_deterministic(self):
+        def make():
+            return TransitionWindowStrategy(
+                from_window='a', to_window='b',
+                curve=Envelope([[0, 0], [10, 1]]),
+                duration=10.0, rng=random.Random(3),
+            )
+        s1, s2 = make(), make()
+        assert [s1.select(5.0) for _ in range(50)] == \
+               [s2.select(5.0) for _ in range(50)]
+
+    def test_multistate_window_strategy_deterministic(self):
+        def make():
+            return MultiStateWindowStrategy(
+                states=[(0.0, 'a'), (0.5, 'b'), (1.0, 'c')],
+                curve=Envelope([[0, 0], [10, 1]]),
+                duration=10.0, rng=random.Random(3),
+            )
+        s1, s2 = make(), make()
+        assert [s1.select(2.5) for _ in range(50)] == \
+               [s2.select(2.5) for _ in range(50)]
+
+
+class TestDensityControllerRng:
+
+    def _make_config(self, seed):
+        ctx = StreamContext(
+            stream_id='s1', onset=0.0, duration=10.0,
+            sample='test.wav', sample_dur_sec=10.0,
+        )
+        return StreamConfig(context=ctx, seed=seed)
+
+    def test_async_iot_deterministic_with_config_seed(self):
+        """Due controller identici con lo stesso config.seed producono la
+        stessa sequenza di IOT async (componente 'iot' isolato)."""
+        params = {'density': 20, 'distribution': 1.0}
+        dc1 = DensityController(dict(params), self._make_config(seed=42))
+        dc2 = DensityController(dict(params), self._make_config(seed=42))
+        seq1 = [dc1.calculate_inter_onset(0.0, 0.05) for _ in range(50)]
+        seq2 = [dc2.calculate_inter_onset(0.0, 0.05) for _ in range(50)]
+        assert seq1 == seq2
+        assert max(seq1) > min(seq1)  # davvero async
+
+    def test_async_iot_differs_with_different_seed(self):
+        params = {'density': 20, 'distribution': 1.0}
+        dc1 = DensityController(dict(params), self._make_config(seed=1))
+        dc2 = DensityController(dict(params), self._make_config(seed=2))
+        seq1 = [dc1.calculate_inter_onset(0.0, 0.05) for _ in range(20)]
+        seq2 = [dc2.calculate_inter_onset(0.0, 0.05) for _ in range(20)]
+        assert seq1 != seq2
+
+
+class TestImplicitDetuneRng:
+
+    def test_detune_deterministic_with_injected_rng(self):
+        """Il detune implicito EDO (issue #95) usa l'RNG iniettato."""
+        from strategies.strategie import UnitPitchStrategy
+        from parameters.pitch_unit import make_pitch_unit
+        from parameters.parameter import Parameter
+
+        unit = make_pitch_unit({'edo': 12})
+
+        def make_strategy(rng):
+            param = Parameter(
+                name='pitch_edo12', value=7.0, bounds=unit.value_bounds(),
+                owner_id='s1',
+            )
+            param.set_probability_gate(AlwaysGate())
+            return UnitPitchStrategy(param, unit, 'edo12', rng=rng)
+
+        s1 = make_strategy(random.Random(9))
+        s2 = make_strategy(random.Random(9))
+        seq1 = [s1.calculate(0.0) for _ in range(30)]
+        seq2 = [s2.calculate(0.0) for _ in range(30)]
+        assert seq1 == seq2
+        assert len(set(seq1)) > 1  # il detune varia davvero
+
+
+class TestParameterComponentIsolation:
+
+    def _make_config(self, seed):
+        ctx = StreamContext(
+            stream_id='s1', onset=0.0, duration=10.0,
+            sample='test.wav', sample_dur_sec=10.0,
+        )
+        return StreamConfig(context=ctx, seed=seed)
+
+    def test_same_parameter_same_sequence(self):
+        """Due Parameter identici (stesso stream, stesso nome, stesso seed)
+        producono la stessa sequenza di valori: testabilità in isolamento
+        con i numeri reali del render (punto 4 dell'issue)."""
+        cfg = self._make_config(seed=42)
+        parser = GranularParser(cfg)
+
+        def make_param():
+            p = parser.parse_parameter('grain_duration', 0.05, range_raw=0.03)
+            p.set_probability_gate(AlwaysGate())
+            return p
+
+        p1, p2 = make_param(), make_param()
+        seq1 = [p1.get_value(0.1 * i) for i in range(30)]
+        seq2 = [p2.get_value(0.1 * i) for i in range(30)]
+        assert seq1 == seq2
+        assert len(set(seq1)) > 1
+
+    def test_parameters_do_not_share_draws(self):
+        """I draw di un parametro non shiftano quelli di un altro."""
+        cfg = self._make_config(seed=42)
+
+        parser_a = GranularParser(cfg)
+        vol_a = parser_a.parse_parameter('volume', 0.0, range_raw=6.0)
+        vol_a.set_probability_gate(AlwaysGate())
+        seq_isolated = [vol_a.get_value(0.1 * i) for i in range(20)]
+
+        parser_b = GranularParser(cfg)
+        vol_b = parser_b.parse_parameter('volume', 0.0, range_raw=6.0)
+        vol_b.set_probability_gate(AlwaysGate())
+        pan_b = parser_b.parse_parameter('pan', 0.0, range_raw=30.0)
+        pan_b.set_probability_gate(AlwaysGate())
+        seq_interleaved = []
+        for i in range(20):
+            seq_interleaved.append(vol_b.get_value(0.1 * i))
+            _ = pan_b.get_value(0.1 * i)  # draw interleaved sull'altro componente
+
+        assert seq_isolated == seq_interleaved
+
+
+# =============================================================================
+# 4. SESSION SEED (seed assente → seed di sessione loggato)
+# =============================================================================
+
+class TestSessionSeedGenerator:
+
+    def _make_generator(self, tmp_path, yaml_data, filename='session.yml'):
+        cfg = tmp_path / filename
+        cfg.write_text(yaml.safe_dump(yaml_data))
+        gen = Generator(str(cfg))
+        gen.load_yaml()
+        return gen
+
+    def test_no_seed_generates_session_seed(self, tmp_path, capsys):
+        """Senza `seed:` il Generator genera un seed di sessione e lo logga."""
+        gen = self._make_generator(tmp_path, _yaml_data([_stream_dict('s1')], seed=None))
+        with patch('core.stream.get_sample_duration', return_value=10.0):
+            gen.create_elements()
+        assert isinstance(gen.seed, int)
+        assert gen.seed_is_session is True
+        out = capsys.readouterr().out
+        assert '[SEED]' in out
+        assert str(gen.seed) in out
+
+    def test_explicit_seed_is_not_session(self, tmp_path, capsys):
+        """Con `seed:` esplicito nessun session seed viene generato."""
+        gen = self._make_generator(tmp_path, _yaml_data([_stream_dict('s1')], seed=42))
+        with patch('core.stream.get_sample_duration', return_value=10.0):
+            gen.create_elements()
+        assert gen.seed == 42
+        assert gen.seed_is_session is False
+        assert '[SEED]' not in capsys.readouterr().out
+
+    def test_session_run_is_reconstructable(self, tmp_path):
+        """Un run senza seed è riproducibile aggiungendo allo YAML il session
+        seed loggato (`ogni run resta ricostruibile a posteriori`)."""
+        gen1 = self._make_generator(
+            tmp_path, _yaml_data([_stream_dict('s1')], seed=None), 'run1.yml'
+        )
+        with patch('core.stream.get_sample_duration', return_value=10.0):
+            gen1.create_elements()
+            sig1 = _signature_of(gen1, 's1')
+
+        gen2 = self._make_generator(
+            tmp_path, _yaml_data([_stream_dict('s1')], seed=gen1.seed), 'run2.yml'
+        )
+        with patch('core.stream.get_sample_duration', return_value=10.0):
+            gen2.create_elements()
+            sig2 = _signature_of(gen2, 's1')
+
+        assert sig1 == sig2

--- a/tests/shared/test_seeding.py
+++ b/tests/shared/test_seeding.py
@@ -1,0 +1,113 @@
+# tests/shared/test_seeding.py
+"""
+test_seeding.py
+
+Test della derivazione RNG in shared/seeding.py (issue #81 + #154).
+
+Copre:
+- voice_rng: derivazione per-voce (issue #81), invariata.
+- component_rng: derivazione per-componente (issue #154) — RNG isolato per
+  (seed, stream_id, component), deterministico via hashlib (indipendente da
+  PYTHONHASHSEED). Con seed None restituisce il modulo `random` globale
+  (fallback legacy per costruzioni dirette fuori dal Generator).
+- session_seed: seed di sessione derivato da timestamp per i run senza
+  `seed:` nello YAML (ogni run resta ricostruibile a posteriori).
+"""
+
+import hashlib
+import random
+
+import pytest
+
+from shared.seeding import voice_rng, component_rng, session_seed
+
+
+# =============================================================================
+# component_rng — derivazione per-componente
+# =============================================================================
+
+class TestComponentRng:
+
+    def test_deterministic_same_args(self):
+        """Stessi (seed, stream_id, component) → stessa sequenza."""
+        r1 = component_rng(42, 's1', 'iot')
+        r2 = component_rng(42, 's1', 'iot')
+        assert [r1.random() for _ in range(20)] == [r2.random() for _ in range(20)]
+
+    def test_derivation_formula_is_sha256(self):
+        """La derivazione è sha256(f\"{seed}:{stream_id}:{component}\"):
+        contratto esplicito, indipendente da PYTHONHASHSEED."""
+        digest = hashlib.sha256("42:s1:iot".encode()).hexdigest()
+        expected = random.Random(int(digest, 16)).random()
+        assert component_rng(42, 's1', 'iot').random() == expected
+
+    def test_different_component_different_sequence(self):
+        """Componenti diversi → sequenze indipendenti."""
+        a = [component_rng(42, 's1', 'iot').random() for _ in range(3)]
+        b = [component_rng(42, 's1', 'window').random() for _ in range(3)]
+        assert a != b
+
+    def test_different_stream_different_sequence(self):
+        """Stream diversi → sequenze indipendenti."""
+        a = component_rng(42, 's1', 'iot').random()
+        b = component_rng(42, 's2', 'iot').random()
+        assert a != b
+
+    def test_different_seed_different_sequence(self):
+        a = component_rng(1, 's1', 'iot').random()
+        b = component_rng(2, 's1', 'iot').random()
+        assert a != b
+
+    def test_seed_zero_is_valid(self):
+        """seed: 0 è valido e deterministico (non confuso con assente)."""
+        assert component_rng(0, 's1', 'iot').random() == \
+               component_rng(0, 's1', 'iot').random()
+
+    def test_string_seed_supported(self):
+        assert component_rng('mix-a', 's1', 'iot').random() == \
+               component_rng('mix-a', 's1', 'iot').random()
+
+    def test_seed_none_falls_back_to_global_random(self):
+        """seed None → il chiamante usa il random globale (comportamento
+        legacy per costruzioni dirette fuori dal Generator)."""
+        rng = component_rng(None, 's1', 'iot')
+        random.seed(5)
+        a = rng.uniform(0, 1)
+        random.seed(5)
+        b = rng.uniform(0, 1)
+        assert a == b  # legato allo stato del modulo random globale
+
+
+# =============================================================================
+# session_seed — seed di sessione da timestamp
+# =============================================================================
+
+class TestSessionSeed:
+
+    def test_returns_non_negative_int(self):
+        s = session_seed()
+        assert isinstance(s, int)
+        assert s >= 0
+
+    def test_usable_as_component_seed(self):
+        """Il session seed alimenta la stessa derivazione dei seed espliciti."""
+        s = session_seed()
+        assert component_rng(s, 's1', 'iot').random() == \
+               component_rng(s, 's1', 'iot').random()
+
+
+# =============================================================================
+# voice_rng — regressione (issue #81, invariato)
+# =============================================================================
+
+class TestVoiceRngRegression:
+
+    def test_voice_rng_deterministic_with_seed(self):
+        assert voice_rng(42, 's1', 3).random() == voice_rng(42, 's1', 3).random()
+
+    def test_voice_and_component_namespaces_coexist(self):
+        """voice_rng e component_rng derivano dallo stesso schema ma con
+        componenti distinti: nessuna collisione fra voce 1 e componente '1'
+        è attesa (stessa stringa → stesso RNG, per costruzione)."""
+        assert voice_rng(42, 's1', 1).random() == \
+               component_rng(42, 's1', '1').random()

--- a/tests/strategies/test_variation_strategy.py
+++ b/tests/strategies/test_variation_strategy.py
@@ -16,7 +16,8 @@ Strategia di mocking:
       delle variation strategy dal campionamento stocastico.
     - WindowRegistry viene mockato tramite sys.modules injection
       per ChoiceVariation quando value=True.
-    - random.choice viene patchato per test deterministici di ChoiceVariation.
+    - l'rng della distribuzione iniettata controlla ChoiceVariation
+      (issue #154): la selezione da lista pesca da distribution.rng.choice.
 """
 
 import sys
@@ -469,9 +470,9 @@ class TestChoiceVariationTrueExpansion:
         fake_module = self._make_mock_registry(window_names)
 
         with patch.dict('sys.modules', {'window_registry': fake_module}):
-            with patch('random.choice', return_value='hamming'):
-                result = choice.apply(True, 1.0, mock_distribution)
-                assert result in window_names
+            mock_distribution.rng.choice.return_value = 'hamming'
+            result = choice.apply(True, 1.0, mock_distribution)
+            assert result == 'hamming'
 
     def test_true_with_mod_range_zero(self, choice, mock_distribution):
         """value=True + mod_range=0 -> ritorna primo elemento (default)."""
@@ -485,16 +486,16 @@ class TestChoiceVariationTrueExpansion:
                 fake_module.WindowRegistry.WINDOWS.keys()
             )[0]
 
-    def test_true_with_positive_mod_range_calls_random_choice(self, choice, mock_distribution):
-        """value=True + mod_range > 0 -> chiama random.choice."""
+    def test_true_with_positive_mod_range_calls_rng_choice(self, choice, mock_distribution):
+        """value=True + mod_range > 0 -> chiama l'rng della distribuzione."""
         window_names = ['hanning', 'hamming']
         fake_module = self._make_mock_registry(window_names)
 
         with patch.dict('sys.modules', {'window_registry': fake_module}):
-            with patch('random.choice', return_value='hamming') as mock_rc:
-                result = choice.apply(True, 1.0, mock_distribution)
-                mock_rc.assert_called_once()
-                assert result == 'hamming'
+            mock_distribution.rng.choice.return_value = 'hamming'
+            result = choice.apply(True, 1.0, mock_distribution)
+            mock_distribution.rng.choice.assert_called_once()
+            assert result == 'hamming'
 
 
 # =============================================================================
@@ -504,7 +505,7 @@ class TestChoiceVariationTrueExpansion:
 class TestChoiceVariationListInput:
     """
     Test con value=lista.
-    Comportamento: se mod_range > 0 -> random.choice(lista),
+    Comportamento: se mod_range > 0 -> distribution.rng.choice(lista),
                    se mod_range == 0 -> ritorna lista[0].
     """
 
@@ -513,13 +514,13 @@ class TestChoiceVariationListInput:
         result = choice.apply(['hanning', 'hamming', 'bartlett'], 0, mock_distribution)
         assert result == 'hanning'
 
-    def test_list_mod_range_positive_random_choice(self, choice, mock_distribution):
-        """mod_range > 0 con lista -> selezione random."""
+    def test_list_mod_range_positive_rng_choice(self, choice, mock_distribution):
+        """mod_range > 0 con lista -> selezione dall'rng della distribuzione."""
         options = ['a', 'b', 'c']
-        with patch('random.choice', return_value='b') as mock_rc:
-            result = choice.apply(options, 1.0, mock_distribution)
-            mock_rc.assert_called_once_with(options)
-            assert result == 'b'
+        mock_distribution.rng.choice.return_value = 'b'
+        result = choice.apply(options, 1.0, mock_distribution)
+        mock_distribution.rng.choice.assert_called_once_with(options)
+        assert result == 'b'
 
     def test_single_element_list_mod_range_zero(self, choice, mock_distribution):
         """Lista con un solo elemento + mod_range=0 -> ritorna quell'elemento."""
@@ -527,27 +528,29 @@ class TestChoiceVariationListInput:
         assert result == 'only_one'
 
     def test_single_element_list_mod_range_positive(self, choice, mock_distribution):
-        """Lista singola + mod_range > 0 -> random.choice comunque."""
-        with patch('random.choice', return_value='only_one'):
-            result = choice.apply(['only_one'], 1.0, mock_distribution)
-            assert result == 'only_one'
+        """Lista singola + mod_range > 0 -> passa comunque dall'rng."""
+        mock_distribution.rng.choice.return_value = 'only_one'
+        result = choice.apply(['only_one'], 1.0, mock_distribution)
+        assert result == 'only_one'
 
     def test_empty_list_mod_range_zero_returns_default(self, choice, mock_distribution):
         """Lista vuota + mod_range=0 -> ritorna 'hanning' (default)."""
         result = choice.apply([], 0, mock_distribution)
         assert result == 'hanning'
 
-    def test_empty_list_mod_range_positive_raises_or_handles(self, choice, mock_distribution):
-        """Lista vuota + mod_range > 0 -> random.choice([]) solleva IndexError."""
+    def test_empty_list_mod_range_positive_raises_or_handles(self, choice):
+        """Lista vuota + mod_range > 0 -> rng.choice([]) solleva IndexError."""
+        from shared.distribution_strategy import UniformDistribution
+        dist = UniformDistribution(rng=random.Random(0))
         with pytest.raises(IndexError):
-            choice.apply([], 1.0, mock_distribution)
+            choice.apply([], 1.0, dist)
 
     def test_list_of_numbers(self, choice, mock_distribution):
         """Lista di numeri funziona."""
         options = [1, 2, 3, 4, 5]
-        with patch('random.choice', return_value=3):
-            result = choice.apply(options, 1.0, mock_distribution)
-            assert result == 3
+        mock_distribution.rng.choice.return_value = 3
+        result = choice.apply(options, 1.0, mock_distribution)
+        assert result == 3
 
     def test_list_mod_range_zero_always_deterministic(self, choice, mock_distribution):
         """mod_range=0 -> sempre primo elemento, nessuna stocasticita'."""
@@ -631,28 +634,68 @@ class TestChoiceVariationStatistical:
     Verifica distribuzione uniforme della selezione.
     """
 
-    def test_list_selection_covers_all_options(self, choice, mock_distribution):
+    def test_list_selection_covers_all_options(self, choice):
         """Con mod_range > 0, tutti gli elementi della lista vengono scelti."""
+        from shared.distribution_strategy import UniformDistribution
+        dist = UniformDistribution(rng=random.Random(42))
         options = ['a', 'b', 'c', 'd']
         results = set()
         for _ in range(500):
-            r = choice.apply(options, 1.0, mock_distribution)
+            r = choice.apply(options, 1.0, dist)
             results.add(r)
         assert results == set(options)
 
-    def test_list_selection_roughly_uniform(self, choice, mock_distribution):
+    def test_list_selection_roughly_uniform(self, choice):
         """La distribuzione e' approssimativamente uniforme."""
+        from shared.distribution_strategy import UniformDistribution
+        dist = UniformDistribution(rng=random.Random(7))
         options = ['a', 'b', 'c']
         counts = {o: 0 for o in options}
         n = 3000
         for _ in range(n):
-            r = choice.apply(options, 1.0, mock_distribution)
+            r = choice.apply(options, 1.0, dist)
             counts[r] += 1
 
         expected = n / len(options)
         for option, count in counts.items():
             assert abs(count - expected) < expected * 0.15, \
                 f"Opzione '{option}': {count} vs atteso ~{expected}"
+
+
+# =============================================================================
+# 10b. TEST ChoiceVariation - Iniezione RNG per-componente (issue #154)
+# =============================================================================
+
+class TestChoiceVariationRngInjection:
+    """
+    issue #154: la scelta pesca dall'rng della distribuzione iniettata
+    (contratto per-componente), non dal random globale. Così anche la
+    selezione da lista rientra nel seeding per (seed, stream_id, componente).
+    """
+
+    def _uniform(self, rng):
+        from shared.distribution_strategy import UniformDistribution
+        return UniformDistribution(rng=rng)
+
+    def test_deterministic_with_injected_rng(self):
+        """Stesso seed sull'rng della distribuzione -> stessa sequenza di scelte."""
+        options = ['a', 'b', 'c', 'd']
+        cv = ChoiceVariation()
+        d1 = self._uniform(random.Random(123))
+        d2 = self._uniform(random.Random(123))
+        seq1 = [cv.apply(options, 1.0, d1) for _ in range(40)]
+        seq2 = [cv.apply(options, 1.0, d2) for _ in range(40)]
+        assert seq1 == seq2
+        assert set(seq1) == set(options)  # davvero stocastico
+
+    def test_does_not_use_global_random(self):
+        """La scelta non tocca il random.choice globale del modulo."""
+        options = ['a', 'b', 'c']
+        cv = ChoiceVariation()
+        d = self._uniform(random.Random(1))
+        with patch('random.choice') as gchoice:
+            cv.apply(options, 1.0, d)
+            gchoice.assert_not_called()
 
 
 # =============================================================================


### PR DESCRIPTION
Chiude #154.

## Problema

Il meccanismo 2 dell'issue #81 (`random.seed(seed)` globale in `create_elements`) rendeva il valore di ogni grano dipendente dalla posizione del suo draw nella sequenza globale condivisa. Conseguenze verificate sul codice:

1. `solo`/`mute` cambiavano i grani degli stream superstiti (gli stream filtrati non consumano draw);
2. con la cache stems i grani di uno stream dirty dipendevano da quali altri stream erano clean in quel run (generazione lazy, issue #117);
3. qualunque refactor che aggiunge/rimuove un draw shiftava silenziosamente tutti i render con seed;
4. nessun componente stocastico era testabile in isolamento con i valori reali del render.

## Soluzione

Esteso a tutti i siti stocastici il modello già adottato per le voci (issue #81): RNG derivato per componente via `sha256(f"{seed}:{stream_id}:{componente}")` (`shared/seeding.py::component_rng`), iniettato come `random.Random` locale.

| Componente | Sito |
|---|---|
| nome del `Parameter` (es. `grain_duration`, `pitch_semitones`) | variazione `_range` via `DistributionStrategy.sample` |
| `gate:&lt;dephase_key&gt;` | `RandomGate`/`EnvelopeGate` (dephase) |
| `iot` | `DensityController._apply_truax_distribution` (Truax async) |
| `window` / `gate:pc_rand_envelope` | window strategy stocastiche e loro gate |
| `detune` | detune implicito EDO in `UnitPitchStrategy` (issue #95, sito non elencato nella issue ma necessario per il fix completo) |

Il seed viaggia nel nuovo campo `StreamConfig.seed` (iniettato da `Stream`, mai letto dal dict per-stream). Tutti i costruttori toccati accettano un kwarg opzionale `rng` con fallback sul random globale: le costruzioni dirette fuori dal Generator restano retrocompatibili.

**Seed assente** (decisione concordata): il Generator genera un **seed di sessione** dal timestamp e lo logga (`[SEED] Nessun seed nello YAML: seed di sessione N. ...`). Ogni run resta ricostruibile a posteriori aggiungendo `seed: N` allo YAML (`Generator.seed_is_session`).

**Secondaria** (dalla issue): rimossi i metodi morti `Parameter._strategy_additive/_strategy_quantized/_strategy_invert` e la docstring obsoleta "Functional Strategy (Dispatch Dictionary)".

## Breaking change

I render con `seed:` fissato prodotti col vecchio schema cambiano una volta (valori per-grano diversi). I render senza seed non cambiano di natura. Dichiarato nel CHANGELOG e in `docs/reference/yaml.md`.

## Test (TDD rosso → verde)

- Nuovi: `tests/shared/test_seeding.py` (contratto di derivazione `component_rng`/`session_seed`) e `tests/engine/test_seed_component_isolation.py` (invarianza solo/mute, invarianza d'ordine di materializzazione lazy, iniezione RNG in distribution/gate/window/density/detune, session seed) — 34 test, confermati rossi prima dell'implementazione.
- Aggiornati: `test_generator.py` (semantica session seed), `test_density_controller.py` (patch su `_rng` invece del modulo random), `test_stream_config.py` (campo `seed`), fixture `mock_config`.
- `make tests`: **4666 passed** (baseline 4632).
- Verifica end-to-end reale (renderer NumPy, sample sintetico): stesso YAML + `seed: 42` → audio **bit-identico** fra due processi; stem di `v2` **bit-identico** fra render completo e render in solo; log `[SEED]` presente nei run senza seed.

## Impatto cross-repo

Nessuna modifica alla sintassi YAML (la chiave `seed` è invariata), agli errori, alla CLI o ai formati di output: **nessuna issue necessaria su PGE-ls / PGE-ui**. Il solo comportamento osservabile nuovo è la riga di log `[SEED]` sui run senza seed.

## Paper CIM 2026

Gli esempi del paper non usano `seed:` (confermato dall'utente): il loro rendering non cambia, **nessun bump del submodule necessario**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hw7K84LRL9u8EQXVAr5R2W

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hw7K84LRL9u8EQXVAr5R2W)_