### PR TITLE
feat: grain.duration_unit samples — durata minima 1 campione

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,30 +10,6 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Aggiunto
 
-- Grain: nuova meta-chiave `grain.duration_unit` (`seconds` | `samples`) sul
-  modello di `loop_unit`. Con `samples` i valori di `grain.duration` e
-  `grain.duration_range` sono espressi in campioni alla frequenza di output
-  del motore (48000 Hz) e convertiti in secondi al parse, su scalari ed
-  envelope (solo i valori Y). Default `seconds`: nessun YAML esistente cambia
-  comportamento. Unità sconosciuta → `InvalidFieldValueError` con hint.
-- Costante di sistema `DEFAULT_OUTPUT_SR` (`shared/constants.py`) e campo
-  `StreamContext.output_sr`: unica fonte di verità per il sample rate di
-  output, al posto dei letterali 48000 sparsi.
-
-### Modificato
-
-- La durata minima di un grano scende da 1 ms a **1 campione**
-  (`1/output_sr`, ~20.8 µs a 48 kHz), per entrambe le unità: bound dinamico
-  in `get_parameter_definition('grain_duration', output_sr=...)`.
-- Renderer NumPy: `n_out = max(1, round(duration * sr))` — prima il
-  troncamento con `int()` poteva perdere un campione e produrre buffer vuoti
-  su grani da 1 campione. Su durate non esatte i render possono differire di
-  ±1 campione a bordo finestra rispetto alle versioni precedenti.
-- Score Csound: `p2`/`p3` serializzati con 8 decimali (prima 6) per reggere
-  la precisione di campione; l'header formatta i valori sotto 0.1 con 4
-  decimali (un grano da 1 campione appariva `0.0ms`). Il contenuto testuale
-  degli `.sco` generati cambia.
-
 - Multi-voice: nuova strategy pitch `chord_progression` (issue #86) — progressioni
   armoniche in cui l'accordo è funzione del tempo (envelope di accordi). Per ogni
   voce si costruisce un `Envelope` di offset in semitoni interpolato tra i voicing
@@ -47,6 +23,35 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   stream (con `normalized` i tempi `0..1` sono mappati sulla `duration`, come gli
   envelope). SEMITONE_LOCKED (solo `unit: semitones`). Nessun YAML esistente
   rotto: `chord` statico invariato.
+- Grain: nuova meta-chiave `grain.duration_unit` (`seconds` | `samples`) sul
+  modello di `loop_unit`. Con `samples` i valori di `grain.duration` e
+  `grain.duration_range` sono espressi in campioni alla frequenza di output
+  del motore (48000 Hz) e convertiti in secondi al parse, su scalari ed
+  envelope (solo i valori Y). Default `seconds`: nessun YAML esistente cambia
+  comportamento. Unità sconosciuta → `InvalidFieldValueError` con hint; con
+  `samples` la `grain.duration` va indicata esplicitamente (il default 0.05 è
+  in secondi e non verrebbe convertito).
+- Costante di sistema `DEFAULT_OUTPUT_SR` (`shared/constants.py`) e campo
+  `StreamContext.output_sr`: unica fonte di verità per il sample rate di
+  output, al posto dei letterali 48000 sparsi. È una config **globale** del
+  motore: non viene letta dallo YAML del singolo stream (resterebbe divergente
+  dal sample rate con cui il renderer viene costruito).
+
+### Modificato
+
+- La durata minima di un grano scende da 1 ms a **1 campione**
+  (`1/output_sr`, ~20.8 µs a 48 kHz), per entrambe le unità: bound dinamico
+  in `get_parameter_definition('grain_duration', output_sr=...)`.
+- Renderer NumPy: `n_out = max(1, round(duration * sr))` — prima il
+  troncamento con `int()` poteva perdere un campione e produrre buffer vuoti
+  su grani da 1 campione. Su durate non esatte i render possono differire di
+  ±1 campione a bordo finestra rispetto alle versioni precedenti. L'overlap-add
+  ora clampa la coda del grano al buffer: con `round()` la fine poteva sforare
+  di 1 campione e sollevare un `ValueError` di broadcast.
+- Score Csound: `p2`/`p3` serializzati con 8 decimali (prima 6) per reggere
+  la precisione di campione; l'header formatta i valori sotto 0.1 con 4
+  decimali (un grano da 1 campione appariva `0.0ms`). Il contenuto testuale
+  degli `.sco` generati cambia.
 
 ## [v4.1.0] — "Parallel Grains" — 2026-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Aggiunto
 
+- Grain: nuova meta-chiave `grain.duration_unit` (`seconds` | `samples`) sul
+  modello di `loop_unit`. Con `samples` i valori di `grain.duration` e
+  `grain.duration_range` sono espressi in campioni alla frequenza di output
+  del motore (48000 Hz) e convertiti in secondi al parse, su scalari ed
+  envelope (solo i valori Y). Default `seconds`: nessun YAML esistente cambia
+  comportamento. Unità sconosciuta → `InvalidFieldValueError` con hint.
+- Costante di sistema `DEFAULT_OUTPUT_SR` (`shared/constants.py`) e campo
+  `StreamContext.output_sr`: unica fonte di verità per il sample rate di
+  output, al posto dei letterali 48000 sparsi.
+
+### Modificato
+
+- La durata minima di un grano scende da 1 ms a **1 campione**
+  (`1/output_sr`, ~20.8 µs a 48 kHz), per entrambe le unità: bound dinamico
+  in `get_parameter_definition('grain_duration', output_sr=...)`.
+- Renderer NumPy: `n_out = max(1, round(duration * sr))` — prima il
+  troncamento con `int()` poteva perdere un campione e produrre buffer vuoti
+  su grani da 1 campione. Su durate non esatte i render possono differire di
+  ±1 campione a bordo finestra rispetto alle versioni precedenti.
+- Score Csound: `p2`/`p3` serializzati con 8 decimali (prima 6) per reggere
+  la precisione di campione; l'header formatta i valori sotto 0.1 con 4
+  decimali (un grano da 1 campione appariva `0.0ms`). Il contenuto testuale
+  degli `.sco` generati cambia.
+
 - Multi-voice: nuova strategy pitch `chord_progression` (issue #86) — progressioni
   armoniche in cui l'accordo è funzione del tempo (envelope di accordi). Per ogni
   voce si costruisce un `Envelope` di offset in semitoni interpolato tra i voicing

--- a/docs/plans/2026-07-05-002-feat-grain-duration-samples-unit-plan.md
+++ b/docs/plans/2026-07-05-002-feat-grain-duration-samples-unit-plan.md
@@ -1,0 +1,339 @@
+---
+title: "feat: unità 'samples' per grain.duration — durata minima 1 campione"
+type: feat
+status: active
+date: 2026-07-05
+issue: null
+---
+
+# feat: unità `samples` per `grain.duration` — durata minima 1 campione
+
+## Overview
+
+Oggi `grain.duration` è espresso solo in secondi, con bound minimo hardcoded a
+0.001 s (1 ms). L'obiettivo è duplice e inscindibile:
+
+1. **Abbassare la durata minima del grano a 1 campione** (a 48 kHz:
+   ~20.8 µs), per granulazione a soglia di impulso.
+2. **Aggiungere l'unità di misura `samples`** al parametro durata grano, così
+   che durate a precisione di campione siano esprimibili in modo naturale
+   (`duration: 1` campione, non `duration: 0.0000208333`).
+
+La superficie YAML cresce di una sola chiave (`grain.duration_unit`), il
+default resta `seconds`: nessun YAML esistente cambia comportamento.
+
+---
+
+## Stato attuale (analisi d'impatto)
+
+### Catena del parametro `grain_duration`
+
+| Fase | File | Ruolo oggi |
+|---|---|---|
+| Schema | `src/parameters/parameter_schema.py:83` | `ParameterSpec(name='grain_duration', yaml_path='grain.duration', default=0.05, range_path='grain.duration_range', dephase_key='duration')` |
+| Bounds | `src/parameters/parameter_definitions.py:87` | `min_val=0.001, max_val=10.0, max_range=1.0, default_jitter=0.01, variation_mode='additive'` |
+| Parsing | `src/parameters/parser.py` | `_parse_input` (scalare → float, lista/dict → Envelope con scaling X) poi `_validate_and_clip` sui bounds |
+| Creazione | `src/parameters/parameter_orchestrator.py` + `parameter_factory.py` | pipeline generica schema-driven (con gate dephase) |
+| Consumo | `src/core/stream.py:459,470` | `self.grain_duration.get_value(t)` → **secondi**, passati a `_create_grain` |
+| IR | `src/core/grain.py` | `Grain.duration: float` in secondi (frozen dataclass) |
+| Density | `src/strategies/strategie.py:134` | `density = fill_factor / grain_duration` |
+| Render NumPy | `src/rendering/grain_renderer.py:70` | `n_out = int(grain.duration * output_sr)` |
+| Render Csound | `src/core/grain.py:64` (`to_score_line`, p3 con `.6f`) + `csound/main.orc` (`sr=48000`, envelope `poscil:a(iAmp, 1/p3, iEnvTable)`) |
+| Visual | `src/rendering/score_visualizer.py:171,1718,1733` | asse fisso `(0.001, 1.0)` s, conversione ×1000 in ms |
+| Header sco | `src/rendering/score_writer.py:130` | commento "Grain duration ... ms" |
+
+### Sample rate: dove vive oggi
+
+Il sample rate di output è **hardcoded a 48000 in tre punti indipendenti**:
+`src/main.py` (default kwargs), `src/rendering/renderer_factory.py`,
+`csound/main.orc` (`sr=48000`, `kr=48000` → `ksmps=1`). `Stream` e la catena
+parametri **non lo conoscono**: conoscono solo `sample_dur_sec` (durata del
+file sorgente, via `StreamContext`). Il sample rate *sorgente* (`file_sr` in
+`SampleRegistry`) è un'altra cosa e non c'entra con la durata del grano, che
+vive sulla timeline di output.
+
+### Precedenti architetturali nel codebase
+
+- **`loop_unit: normalized`** (`PointerController._pre_normalize_loop_params`):
+  meta-chiave letta dal dict grezzo che ri-scala i **valori Y** dei parametri
+  fratelli (scalari o envelope-like, via `Envelope._scale_raw_values_y`),
+  prima che il pipeline parser standard li veda. È esattamente il nostro
+  problema.
+- **Pitch unit-driven** (`PitchUnit.value_bounds()`): bounds che dipendono
+  dall'unità, iniettati con `bounds_override` nel parser.
+- **Bounds dinamici** (`get_parameter_definition(name, sample_dur_sec=...)`):
+  i loop param ricevono `max_val` a runtime. Stesso meccanismo estendibile per
+  un `min_val` dinamico di `grain_duration`.
+
+---
+
+## Design proposto
+
+### 1. Superficie YAML
+
+```yaml
+grain:
+  duration: 512            # valore nell'unità dichiarata
+  duration_range: 64       # stessa unità della duration
+  duration_unit: samples   # NUOVA chiave: seconds (default) | samples
+
+# invariato / retrocompatibile:
+grain:
+  duration: 0.05           # seconds implicito
+  duration: [[0, 64], [30, 4800]]   # envelope: Y in campioni se unit=samples
+```
+
+Scelte e motivazioni:
+
+- **Meta-chiave `duration_unit`** sul modello di `loop_unit`, non forma dict
+  stile pitch (`duration: {samples: 512}`): la forma dict **collide** con le
+  forme dict degli envelope (`points:`, `cycle_duration:`, ...) e renderebbe
+  ambiguo il parsing. La meta-chiave convive invece con tutte le forme di
+  valore (scalare, espressione math, envelope compatto, envelope dict,
+  compact-reps).
+- `duration_unit` governa **sia `duration` sia `duration_range`** (una sola
+  unità per blocco, coerente con il modello pitch).
+- Valori frazionari di campioni ammessi (es. `duration_range: 0.5`): la
+  quantizzazione avviene comunque al render (`n_out`). `variation_mode` resta
+  `additive`.
+- Valori validi: `seconds`, `samples`. Unità sconosciuta →
+  `InvalidFieldValueError(field='grain.duration_unit', hint="unità disponibili:
+  ['seconds', 'samples']")`.
+- Estensione futura a costo zero: `ms` (fattore 1/1000). Fuori scope ora.
+
+### 2. Sample rate di riferimento
+
+- Nuova costante unica `DEFAULT_OUTPUT_SR = 48000` in `src/shared/constants.py`
+  (nuovo modulo, o in `shared/utils.py` se si preferisce non creare file).
+- `StreamContext` acquisisce il campo `output_sr: int = DEFAULT_OUTPUT_SR`:
+  punto unico da cui leggeranno conversione unità e bounds dinamici.
+- `main.py` e `renderer_factory.py` sostituiscono i `48000` letterali con la
+  costante (refactoring meccanico, nessun cambio di comportamento).
+- **Fuori scope ma spianato**: rendere `output_sr` configurabile da YAML/CLI e
+  generare `sr=` nell'orchestra Csound. Il piano non lo implementa, ma dopo
+  questo lavoro basterà popolare `StreamContext.output_sr` dal YAML.
+
+### 3. Conversione: pre-normalizzazione dei dati grezzi
+
+Nuovo metodo `Stream._pre_normalize_grain_params(params)` (chiamato in
+`__init__` prima di `_init_stream_parameters`), speculare a
+`PointerController._pre_normalize_loop_params`:
+
+1. legge `grain.duration_unit` dal dict grezzo (default `'seconds'` → return
+   immediato, zero overhead);
+2. valida l'unità (errore con hint se sconosciuta);
+3. se `samples`: copia superficiale del blocco `grain` e riscala `duration` e
+   `duration_range` con fattore `1.0 / output_sr`:
+   - scalare → moltiplicazione;
+   - envelope-like → `Envelope._scale_raw_values_y(raw, factor)` (gestisce già
+     compact, dict `points`, 3-tuple, `{t,v}`, compact-reps);
+4. rimuove/ignora `duration_unit` a valle (meta-parametro, non sintetizzabile).
+
+Il fattore di scala scalare/envelope è la stessa logica di
+`PointerController._scale_value`: **estrarre un helper condiviso**
+`scale_raw_param_values(value, factor)` (proposto in `shared/utils.py` o
+`envelopes/envelope.py`) e fare usare quello a entrambi (DRY, secondo
+micro-refactoring behavior-preserving del piano).
+
+Tutto il downstream (Parameter, gate dephase, Grain, density, renderer,
+visualizer, export) continua a vedere **secondi**: un solo punto di
+conversione, nessuna unità che "perde" attraverso l'IR.
+
+### 4. Bounds: minimo dinamico a 1 campione
+
+- `parameter_definitions.py`: `grain_duration.min_val` scende da `0.001` al
+  **valore dinamico `1.0 / output_sr`** (a 48 kHz ≈ 2.083e-5 s). Meccanismo:
+  estendere `get_parameter_definition(param_name, sample_dur_sec=None,
+  output_sr=None)` — per `grain_duration`, se `output_sr` è fornito,
+  restituisce bounds con `min_val = 1.0 / output_sr` (stesso pattern già usato
+  per il `max_val` dei loop param).
+- `GranularParser.parse_parameter` passa `output_sr=self.output_sr` (nuovo
+  attributo letto da `config.context`, con `getattr` difensivo per i config
+  parziali dei test, come già fatto per `seed`).
+- Il minimo vale per **entrambe le unità**: anche in `seconds` ora si può
+  scendere fino a 1 campione (era questo l'obiettivo primario). `max_val`
+  resta 10 s (= 480000 campioni a 48 kHz). `max_range` resta 1.0 s
+  (= 48000 campioni).
+- Nota comportamentale (da documentare, non "fixare"): `default_jitter` resta
+  0.01 s — con dephase attivo senza range esplicito su grani ultra-corti il
+  jitter implicito è enorme in proporzione e viene clampato al bound minimo.
+  È il comportamento già osservabile oggi con grani da 1 ms, solo amplificato.
+
+### 5. Fix necessari nel renderer NumPy
+
+`src/rendering/grain_renderer.py:70`:
+
+```python
+# oggi:  n_out = int(grain.duration * self.output_sr)
+# dopo:  n_out = max(1, round(grain.duration * self.output_sr))
+```
+
+Motivazione: con `duration = 1/48000` il prodotto float può cadere sotto 1.0 e
+`int()` tronca a 0 → `InvalidWindowError` in `NumpyWindowRegistry.get` (n<=0).
+`round()` è la semantica corretta ("il numero di campioni più vicino alla
+durata richiesta"), `max(1, ...)` garantisce l'invariante n_out ≥ 1.
+
+**Attenzione — cambio osservabile**: `int→round` può variare di ±1 campione
+`n_out` dei grani *esistenti* con durate non esatte (envelope interpolati).
+L'ampiezza a bordo finestra è ~0, quindi è musicalmente impercettibile, ma i
+render non sono più bit-identici. Alternativa conservativa scartata:
+`max(1, int(...))` preserva il bit-exact ma renderebbe 1 campione un grano
+richiesto di 2 (`(2/48000)*48000` può dare 1.999...). Da verificare l'impatto
+su eventuali test snapshot e sul paper CIM (v. sotto).
+
+Finestre a n piccolissimi (comportamento da **testare e documentare**, non da
+correggere):
+
+- `np.hanning(1) = [1.0]` → grano di 1 campione = impulso pieno. Corretto.
+- `np.hanning(2) = [0, 0]`, `np.hanning(3) = [0, 1, 0]` → finestre simmetriche
+  con estremi nulli annullano quasi tutto su grani di 2-3 campioni: è la
+  matematica della finestra, non un bug. Documentare: per grani ultra-corti
+  usare finestre a estremi non nulli (`hamming`) o famiglia `expodec`
+  (partono da 1.0). Testare la famiglia GEN16 custom per n ∈ {1,2,3}.
+  Possibile follow-up separato: finestra `rectangular`.
+
+### 6. Percorso Csound
+
+- `Grain.to_score_line` serializza p3 con `.6f`: 1 campione a 48 kHz =
+  `0.000021` (errore ~0.7%, ri-quantizza comunque a 1 campione). A 96 kHz
+  però `.6f` introduce errori del 4%. Proposta: portare onset e duration a
+  **`.8f`** nella score line. Nota: cambia il byte-content di *tutti* gli
+  `.sco` → lo stream cache (fingerprint YAML) non è impattato, ma eventuali
+  diff testuali su golden file vanno rigenerati.
+- `main.orc` ha `ksmps=1` (`kr=48000`): l'instr `Grain` può durare 1 solo
+  campione. L'envelope è letto con `poscil:a(iAmp, 1/p3, iEnvTable)` → su un
+  grano di 1 campione legge solo il primo punto della tabella finestra: per
+  `hanning` (GEN20) vale 0 → **grano silenzioso in Csound** dove NumPy rende
+  un impulso pieno. Divergenza da documentare in yaml.md (i due renderer non
+  sono mai stati dichiarati bit-equivalenti); nessun cambio all'orchestra in
+  questo piano.
+
+### 7. Aggiustamenti collaterali
+
+- `src/rendering/score_visualizer.py:171`: range asse `grain_duration` fisso
+  `(0.001, 1.0)` → minimo dinamico `1/output_sr` (o semplicemente il min dei
+  dati). Conversione ms invariata (1 campione = 0.0208 ms, leggibile).
+- `src/rendering/score_writer.py:130`: header informativo in ms — invariato,
+  verificare solo che non tronchi a 0 ("0.02 ms").
+- Density: `density = fill_factor / grain_duration` con grani da 1 campione e
+  `fill_factor=2` darebbe 96000 g/s → già clampato a 4000 dai bounds di
+  `density`/`effective_density` (IOT minimo 0.25 ms). Comportamento sano,
+  serve solo un test che lo fissi.
+
+---
+
+## File coinvolti
+
+Produzione:
+
+- `src/shared/constants.py` (nuovo) — `DEFAULT_OUTPUT_SR`
+- `src/core/stream_config.py` — `StreamContext.output_sr`
+- `src/core/stream.py` — `_pre_normalize_grain_params` + chiamata in `__init__`
+- `src/parameters/parameter_definitions.py` — min dinamico `grain_duration`
+- `src/parameters/parser.py` — propagazione `output_sr` ai bounds
+- `src/shared/utils.py` (o `envelopes/envelope.py`) — helper condiviso
+  `scale_raw_param_values`; `src/controllers/pointer_controller.py` lo riusa
+- `src/rendering/grain_renderer.py` — `n_out = max(1, round(...))`
+- `src/core/grain.py` — precisione score line `.8f`
+- `src/rendering/score_visualizer.py` — range asse duration
+- `src/main.py`, `src/rendering/renderer_factory.py` — costante al posto di 48000
+
+Documentazione:
+
+- `docs/reference/yaml.md` — Blocco Grain: `duration_unit`, nuovi bounds,
+  esempi, nota finestre/Csound su grani ultra-corti
+- `docs/INDEX.md` — rigenerato (`make docs-index`), lint (`make docs-lint`)
+- `CHANGELOG.md` — sezione Unreleased (Added: unità samples; Changed: bound
+  minimo, `n_out` round, precisione sco)
+
+## Test coinvolti (path esatti)
+
+Esistenti a rischio di rottura:
+
+- `tests/parameters/test_parameter_definitions.py` — asserzioni sui bounds di
+  `grain_duration` (min 0.001) da aggiornare
+- `tests/parameters/test_parser.py` / `test_parser_errors.py` — casi di bound
+  violation sotto 0.001 che ora diventano validi
+- `tests/rendering/test_grain_renderer.py` — eventuali asserzioni su `n_out`
+  troncato
+- `tests/rendering/test_score_writer.py` + `tests/core/test_grain.py` — formato
+  `.6f` della score line
+- `tests/core/test_stream.py` — eventuali fixture con durate limite
+
+Nuovi (TDD, rosso→verde via `/tdd`, un vertical slice per step):
+
+1. `tests/core/test_stream.py::TestGrainDurationUnit` (o file dedicato
+   `tests/core/test_grain_duration_unit.py`):
+   - `duration: 512, duration_unit: samples` → tutti i grani con
+     `duration == 512/48000`
+   - envelope compatto e compact-reps con Y in campioni → conversione corretta
+   - `duration_range` scalato nella stessa unità
+   - chiave assente → identico a oggi (retrocompatibilità)
+   - `duration_unit: foo` → `InvalidFieldValueError` con hint
+   - `duration: 1` campione accettato (bound minimo)
+2. `tests/parameters/test_parameter_definitions.py` —
+   `get_parameter_definition('grain_duration', output_sr=48000).min_val ==
+   1/48000`; senza `output_sr` → retrocompat
+3. `tests/parameters/test_parser.py` — in seconds, `duration: 0.5/48000` →
+   `ParameterBoundError` (strict); `duration: 1/48000` → ok
+4. `tests/rendering/test_grain_renderer.py` — grano da 1 campione → buffer
+   shape `(1, 2)` non nullo con `hanning`; `n_out` mai 0; durate che con
+   `int()` davano n-1
+5. `tests/rendering/test_numpy_window_registry.py` — tutte le finestre per
+   n ∈ {1, 2, 3} (nessuna eccezione, valori attesi)
+6. `tests/strategies/test_strategies.py` — fill_factor con grain_duration da
+   1 campione → density clampata al max
+7. e2e leggero in `tests/rendering/` — mini-YAML con `duration_unit: samples`
+   renderizzato NumPy → click train non silente
+
+## Rischi architetturali
+
+1. **`int→round` su `n_out`**: render NumPy non più bit-identici per durate
+   non esatte. Mitigazione: test dedicati, nota in changelog, verifica
+   snapshot.
+2. **Precisione score line `.8f`**: diff su tutti gli `.sco` generati; golden
+   file da rigenerare.
+3. **Divergenza NumPy/Csound su grani 1-3 campioni** (envelope poscil vs
+   finestra campionata): documentata, non risolta qui.
+4. **Grani ultra-corti + finestre simmetriche = silenzio**: percepibile come
+   bug dall'utente; mitigazione via documentazione (e follow-up
+   `rectangular`).
+5. **`duration_unit` è la terza meta-chiave di unità** (dopo `loop_unit` e le
+   unit pitch) con tre meccanismi simili ma non identici: il piano riduce il
+   debito estraendo l'helper condiviso di Y-scaling, ma una futura
+   unificazione "unit framework" resta fuori scope.
+6. **Jitter implicito dephase** (0.01 s) sproporzionato su grani corti:
+   comportamento preesistente, documentato.
+
+## Impatto cross-repo (regola `cross-repo-impact`)
+
+La superficie pubblica cambia: nuova chiave YAML `grain.duration_unit`, nuovo
+bound minimo di `grain_duration`, nuovo messaggio d'errore per unità invalida.
+A design approvato, contestualmente alla PR:
+
+- **PGE-ls**: issue per autocomplete/validazione/hover della nuova chiave
+  (valori `seconds|samples`), aggiornamento bounds nella diagnostica.
+- **PGE-ui**: issue per il controllo unità nel form del blocco grain e la
+  validazione client dei nuovi limiti.
+
+## Sync paper CIM 2026 (regola `submodule-sync-cim`)
+
+La feature in sé è retrocompatibile (default `seconds`, gli `exN.yml` del
+paper non la usano), **ma** `n_out int→round` e la precisione `.sco` toccano
+il comportamento del rendering, osservabile dagli esempi → alla PR andrà
+chiesto all'utente (AskUserQuestion) se bumpare il submodule nel repo del
+paper.
+
+## Sequenza di implementazione (commit atomici, test gate su ognuno)
+
+1. refactor: costante `DEFAULT_OUTPUT_SR` + `StreamContext.output_sr`
+   (behavior-preserving)
+2. refactor: helper condiviso `scale_raw_param_values` + riuso in
+   `PointerController` (behavior-preserving)
+3. feat: bounds dinamici `grain_duration` (test rosso → verde)
+4. feat: `grain.duration_unit` con pre-normalizzazione (test rosso → verde)
+5. fix: `n_out = max(1, round(...))` + test finestre n piccoli
+   (test rosso → verde)
+6. fix: precisione score line `.8f` + visualizer (test rosso → verde)
+7. docs: yaml.md + INDEX + changelog (`make docs-index && make docs-lint`)
+8. a PR aperta: issue PGE-ls / PGE-ui, proposta bump paper CIM

--- a/docs/plans/done/2026-07-05-002-feat-grain-duration-samples-unit-plan.md
+++ b/docs/plans/done/2026-07-05-002-feat-grain-duration-samples-unit-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: unità 'samples' per grain.duration — durata minima 1 campione"
 type: feat
-status: active
+status: done
 date: 2026-07-05
 issue: null
 ---

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -322,6 +322,12 @@ grain:
   # ERRORE: reverse: true / reverse: false / reverse: auto
 ```
 
+Con `duration_unit: samples` la `grain.duration` va **sempre indicata
+esplicitamente**: il default `0.05` è in secondi e non verrebbe convertito, per
+cui base (secondi) e `duration_range` (campioni) finirebbero in domini diversi.
+Ometterla → `MissingFieldError`. `output_sr` è una config globale del motore
+(48000 Hz), non impostabile per-stream nello YAML.
+
 Bounds: `grain_duration` ∈ [1 campione (`1/48000` s), 10 s] — in `samples`:
 [1, 480000]. Valori frazionari di campioni sono ammessi: il renderer
 arrotonda al campione più vicino (`n_out = max(1, round(dur * sr))`).

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -10,7 +10,7 @@ sources:
   - src/strategies/
   - src/envelopes/
   - src/shared/seeding.py
-last_synced_commit: e3b4b35
+last_synced_commit: c7ad14b
 entry_for: [yaml-syntax, envelope-syntax]
 ---
 
@@ -286,6 +286,15 @@ grain:
   duration: [[0, 0.02], [30, 0.2]]
   duration_range: 0.01     # ±0.01s randomizzazione
 
+  # Unità di misura per duration e duration_range (default: seconds).
+  # Con 'samples' i valori sono campioni alla frequenza di output del
+  # motore (48000 Hz) e vengono convertiti in secondi al parse; vale per
+  # scalari ed envelope (solo i valori, l'asse tempo resta invariato).
+  duration_unit: samples
+  duration: 512            # 512 campioni = 512/48000 s
+  duration_range: 64       # ±64 campioni
+  duration: [[0, 48], [30, 4800]]   # envelope: Y in campioni
+
   envelope: hanning        # finestra per shape del grano (default: hanning)
   # Vedi sezione "Finestre Disponibili" per tutti i valori validi.
 
@@ -313,7 +322,25 @@ grain:
   # ERRORE: reverse: true / reverse: false / reverse: auto
 ```
 
-Bounds: `grain_duration` ∈ [0.001, 10].
+Bounds: `grain_duration` ∈ [1 campione (`1/48000` s), 10 s] — in `samples`:
+[1, 480000]. Valori frazionari di campioni sono ammessi: il renderer
+arrotonda al campione più vicino (`n_out = max(1, round(dur * sr))`).
+
+Note sui grani a precisione di campione:
+
+- **Finestre simmetriche su grani di 2-3 campioni**: `hanning`, `bartlett`,
+  `blackman`, `half_sine`, `sinc` hanno estremi nulli — a 2 campioni il grano
+  è silenzio, a 3 sopravvive solo il campione centrale. È la matematica della
+  finestra, non un bug. Per grani ultra-corti usare `rectangle` (piatta),
+  `hamming` (estremi 0.08) o la famiglia `expodec` (parte da 1.0).
+- **Divergenza NumPy/Csound**: il renderer NumPy campiona la finestra a
+  `n_out` punti (`hanning` a 1 campione = `[1.0]`, impulso pieno); Csound
+  legge la tabella finestra con `poscil` a `1/p3` Hz e su un grano di 1
+  campione ne legge solo il primo punto (per `hanning` = 0, grano silente).
+  I due renderer non sono mai stati dichiarati bit-equivalenti; a queste
+  durate la scelta della finestra domina il risultato.
+- **Densità derivata**: con `fill_factor` e grani da 1 campione la density
+  `fill_factor/duration` satura al bound massimo (4000 g/s).
 
 ---
 
@@ -1776,7 +1803,7 @@ un envelope dal YAML al runtime è:
 | `density` | 0.01 | 4000 | — | grani/secondo |
 | `fill_factor` | 0.001 | 50 | 2.0 | priorità su density |
 | `distribution` | 0 | 1 | 0.0 | 0=sync, 1=async |
-| `grain_duration` | 0.001 | 10 | 0.05 | secondi |
+| `grain_duration` | 1/48000 (1 campione) | 10 | 0.05 | secondi; con `duration_unit: samples` i valori sono campioni |
 | `volume` | -120 | 12 | 0.0 | dB |
 | `pan` | -3600 | 3600 | 0.0 | gradi |
 | `pitch_ratio` | 0.001 | 8 | 1.0 | ratio diretto |

--- a/src/controllers/pointer_controller.py
+++ b/src/controllers/pointer_controller.py
@@ -12,7 +12,7 @@ Ispirato al DMX-1000 di Barry Truax (1988)
 from __future__ import annotations
 
 from typing import Callable
-from envelopes.envelope import Envelope
+from envelopes.envelope import Envelope, scale_raw_param_values
 from parameters.parameter_schema import POINTER_PARAMETER_SCHEMA
 from parameters.parameter_orchestrator import ParameterOrchestrator
 from core.stream_config import StreamConfig
@@ -206,14 +206,10 @@ class PointerController:
     def _scale_value(self, value, scale: float):
             """
             Scala un valore che puo' essere scalare, envelope, o dict.
-            Restituisce dati raw (stesso formato dell'input) per compatibilita'
-            col pipeline parser a valle.
+            Delega all'helper condiviso scale_raw_param_values (stesso
+            meccanismo di grain.duration_unit).
             """
-            if isinstance(value, (int, float)):
-                return value * scale
-            if Envelope.is_envelope_like(value):
-                return Envelope._scale_raw_values_y(value, scale)
-            return value
+            return scale_raw_param_values(value, scale)
 
 
     def _init_loop_state(self) -> None:

--- a/src/core/grain.py
+++ b/src/core/grain.py
@@ -61,7 +61,10 @@ class Grain:
         Args:
             onset_offset: sottratto dall'onset (usato in STEMS mode per onset relativi).
         """
-        return (f'i "Grain" {self.onset - onset_offset:.6f} {self.duration:.6f} '
+        # p2/p3 a 8 decimali: con grain.duration_unit samples un grano puo'
+        # durare 1 campione (~2e-5 s); 6 decimali introducevano fino al 4%
+        # di errore di quantizzazione a 96 kHz.
+        return (f'i "Grain" {self.onset - onset_offset:.8f} {self.duration:.8f} '
                 f'{self.pointer_pos:.6f} {self.pitch_ratio:.6f} '
                 f'{self.volume:.2f} {self.pan:.3f} '
                 f'{self.sample_table} {self.envelope_table}\n')

--- a/src/core/stream.py
+++ b/src/core/stream.py
@@ -41,7 +41,7 @@ from strategies.voice_onset_strategy import VoiceOnsetStrategyFactory
 from strategies.voice_pointer_strategy import VoicePointerStrategyFactory
 from strategies.voice_pan_strategy import VoicePanStrategyFactory
 from strategies.grain_clip_strategy import GrainClipStrategyFactory, OverflowMarginClipStrategy
-from dataclasses import fields
+from dataclasses import fields, MISSING as dataclass_MISSING
 
 
 def _parse_strategy_kwarg(value, duration: float, stream_time_mode: str = 'absolute'):
@@ -141,10 +141,20 @@ class Stream:
         self._grains: List[Grain] = []  # backward compatibility (flat)
         self.generated = False
 
+    @staticmethod
+    def _required_context_fields() -> set:
+        """Campi StreamContext che il YAML deve fornire: quelli senza default
+        (sample_dur_sec escluso: derivato dal file audio, mai dal YAML)."""
+        return {
+            field.name for field in fields(StreamContext)
+            if field.name != 'sample_dur_sec'
+            and field.default is dataclass_MISSING
+            and field.default_factory is dataclass_MISSING
+        }
+
     def _check_required_context_fields(self, params, stream_id):
         """Verifica campi obbligatori StreamContext prima di StreamConfig.from_yaml."""
-        base = {field.name for field in fields(StreamContext) if field.name != 'sample_dur_sec'}
-        missing = base - set(params.keys())
+        missing = self._required_context_fields() - set(params.keys())
         if missing:
             missing_list = sorted(missing)
             err = MissingFieldError(fields=missing_list)
@@ -153,8 +163,7 @@ class Stream:
 
     def _init_stream_context(self, params):
         self._check_required_context_fields(params, params.get('stream_id', 'unknown'))
-        base = {field.name for field in fields(StreamContext) if field.name != 'sample_dur_sec'}
-        for key in base:
+        for key in self._required_context_fields():
             setattr(self, key, params[key])
         self.sample_dur_sec = get_sample_duration(self.sample)
 

--- a/src/core/stream.py
+++ b/src/core/stream.py
@@ -429,6 +429,20 @@ class Stream:
         if unit == 'seconds':
             return params
 
+        # samples: il default seconds (0.05) NON viene scalato. Se grain.duration
+        # non e' esplicito, la base resterebbe in secondi mentre duration_range
+        # e' in campioni -> due domini diversi nello stesso blocco. Pretendi una
+        # duration esplicita (l'unita' governa base e range insieme).
+        if grain.get('duration') is None:
+            err = MissingFieldError(
+                field='grain.duration',
+                hint=("con grain.duration_unit: samples la durata va indicata "
+                      "esplicitamente in campioni (il default 0.05 e' in "
+                      "secondi e non verrebbe convertito)."),
+            )
+            err.stream_id = self.stream_id
+            raise err
+
         factor = 1.0 / output_sr
         scaled_grain = dict(grain)
         for key in ('duration', 'duration_range'):

--- a/src/core/stream.py
+++ b/src/core/stream.py
@@ -19,7 +19,7 @@ from math import ceil, floor, log10
 from typing import List, Optional, Union
 
 from core.grain import Grain
-from envelopes.envelope import Envelope, create_scaled_envelope
+from envelopes.envelope import Envelope, create_scaled_envelope, scale_raw_param_values
 from controllers.window_controller import WindowController
 from controllers.pointer_controller import PointerController
 from controllers.pitch_controller import PitchController
@@ -42,6 +42,12 @@ from strategies.voice_pointer_strategy import VoicePointerStrategyFactory
 from strategies.voice_pan_strategy import VoicePanStrategyFactory
 from strategies.grain_clip_strategy import GrainClipStrategyFactory, OverflowMarginClipStrategy
 from dataclasses import fields, MISSING as dataclass_MISSING
+
+
+# Unita' di misura ammesse per grain.duration / grain.duration_range.
+# 'seconds' e' il default storico; 'samples' esprime i valori in campioni
+# alla frequenza di output del motore (StreamContext.output_sr).
+GRAIN_DURATION_UNITS = ('seconds', 'samples')
 
 
 def _parse_strategy_kwarg(value, duration: float, stream_time_mode: str = 'absolute'):
@@ -115,6 +121,10 @@ class Stream:
             seed=seed,
         )
         self._init_stream_context(params)
+        # === 3.5. UNITA' DI MISURA DURATA GRANO ===
+        # Da qui in poi grain.duration/duration_range sono in secondi,
+        # qualunque sia l'unita' dichiarata nello YAML.
+        params = self._pre_normalize_grain_params(params, config.context.output_sr)
         # === 4. PARAMETRI SPECIALI ===
         self._init_grain_reverse(params)
         # === 5. PARAMETRI DIRETTI (riceve config) ===
@@ -388,6 +398,46 @@ class Stream:
             pan_strategy=pan_strategy,
             pitch_unit=pitch_unit,
         )
+
+    def _pre_normalize_grain_params(self, params: dict, output_sr: int) -> dict:
+        """
+        Conversione di unita' per la durata del grano (modello loop_unit).
+
+        Se grain.duration_unit == 'samples', scala grain.duration e
+        grain.duration_range da campioni a secondi (fattore 1/output_sr),
+        su scalari ed envelope-like (solo i valori Y; l'asse X resta tempo).
+
+        Unico punto del sistema che legge 'duration_unit' dal dizionario
+        grezzo: e' un meta-parametro che controlla l'interpretazione degli
+        altri, non un valore sintetizzabile. Il dict originale non viene
+        mutato (cache fingerprint e stream_data_map leggono i dati grezzi).
+        """
+        grain = params.get('grain')
+        if not isinstance(grain, dict) or 'duration_unit' not in grain:
+            return params
+
+        unit = grain['duration_unit']
+        if unit not in GRAIN_DURATION_UNITS:
+            err = InvalidFieldValueError(
+                field='grain.duration_unit',
+                value=unit,
+                hint=f"unità disponibili: {list(GRAIN_DURATION_UNITS)}",
+            )
+            err.stream_id = self.stream_id
+            raise err
+
+        if unit == 'seconds':
+            return params
+
+        factor = 1.0 / output_sr
+        scaled_grain = dict(grain)
+        for key in ('duration', 'duration_range'):
+            if key in scaled_grain and scaled_grain[key] is not None:
+                scaled_grain[key] = scale_raw_param_values(scaled_grain[key], factor)
+
+        scaled_params = dict(params)
+        scaled_params['grain'] = scaled_grain
+        return scaled_params
 
     def _init_grain_reverse(self, params: dict) -> None:
         """

--- a/src/core/stream_config.py
+++ b/src/core/stream_config.py
@@ -3,14 +3,20 @@ from __future__ import annotations
 
 from dataclasses import dataclass,fields
 from typing import Optional, Union
-    
+
+from shared.constants import DEFAULT_OUTPUT_SR
+
 @dataclass(frozen=True)
 class StreamContext:
     stream_id: str
     onset: float
     duration: float
     sample: str
-    sample_dur_sec: float          
+    sample_dur_sec: float
+    # Sample rate di output del motore: riferimento per le conversioni
+    # campioni <-> secondi (grain.duration_unit) e per il bound minimo
+    # dinamico di grain_duration (1 campione).
+    output_sr: int = DEFAULT_OUTPUT_SR
 
     @classmethod
     def from_yaml(cls, yaml_data: dict, sample_dur_sec: float, allow_none: bool = True) -> 'StreamConfig':

--- a/src/core/stream_config.py
+++ b/src/core/stream_config.py
@@ -20,10 +20,19 @@ class StreamContext:
 
     @classmethod
     def from_yaml(cls, yaml_data: dict, sample_dur_sec: float, allow_none: bool = True) -> 'StreamConfig':
-        """        
-        Contiene solo configurazioni che determinano il l'identità e il contesto dello stream.        
         """
-        field_names = [f.name for f in fields(cls) if f.name != 'sample_dur_sec']
+        Contiene solo configurazioni che determinano il l'identità e il contesto dello stream.
+        """
+        # Campi NON letti dal dict per-stream:
+        # - sample_dur_sec: derivato dal file audio, mai dal YAML.
+        # - output_sr: config GLOBALE del motore. Deve restare la costante di
+        #   sistema (con cui il renderer viene costruito, main.py): leggerlo
+        #   dallo YAML del singolo stream farebbe divergere la conversione
+        #   samples->secondi e il bound minimo dal sample rate del rendering.
+        #   Resta al default finche' una vera configurabilita' globale non e'
+        #   cablata su entrambi (context E renderer).
+        _engine_global = {'sample_dur_sec', 'output_sr'}
+        field_names = [f.name for f in fields(cls) if f.name not in _engine_global]
 
         
         if allow_none:

--- a/src/envelopes/envelope.py
+++ b/src/envelopes/envelope.py
@@ -439,6 +439,24 @@ class Envelope:
         scaled_raw = Envelope._scale_raw_values_y(raw_data, scale_factor)
         return Envelope(scaled_raw)
 
+
+def scale_raw_param_values(value, scale_factor: float):
+    """
+    Scala un valore parametro grezzo (scalare, envelope-like o altro) per
+    scale_factor, restituendo dati raw nello stesso formato dell'input,
+    compatibili col pipeline parser a valle.
+
+    Punto unico per le conversioni di unita' sui valori Y dei parametri:
+    loop_unit normalized (PointerController) e grain.duration_unit samples
+    (Stream). Tipi non numerici e non envelope-like passano invariati.
+    """
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return value * scale_factor
+    if Envelope.is_envelope_like(value):
+        return Envelope._scale_raw_values_y(value, scale_factor)
+    return value
+
+
 def create_scaled_envelope(
     raw_data: Union[List, Dict],
     duration: float,

--- a/src/main.py
+++ b/src/main.py
@@ -11,6 +11,7 @@ from shared.logger import (
     configure_engine_logger, get_engine_logger, get_engine_log_path,
 )
 from shared.exceptions import EngineError
+from shared.constants import DEFAULT_OUTPUT_SR
 from engine.generator import Generator
 from rendering.score_visualizer import ScoreVisualizer, PLOT_ENVELOPE_KEYS
 
@@ -73,7 +74,7 @@ def _build_renderer(renderer_type: str, generator, **kwargs):
             sample_registry=sample_reg,
             window_registry=window_reg,
             table_map=table_map,
-            output_sr=kwargs.get('output_sr', 48000),
+            output_sr=kwargs.get('output_sr', DEFAULT_OUTPUT_SR),
             cache_manager=cache_manager,
             stream_data_map=generator.stream_data_map,
             audio_format=kwargs.get('audio_format', DEFAULT_FORMAT),
@@ -424,7 +425,7 @@ def main():
         renderer = _build_renderer(
             renderer_type,
             generator,
-            output_sr=48000,
+            output_sr=DEFAULT_OUTPUT_SR,
             jobs=jobs,
             orc_path=orc_path,
             incdir=incdir,

--- a/src/parameters/parameter_definitions.py
+++ b/src/parameters/parameter_definitions.py
@@ -204,18 +204,26 @@ _LOOP_PARAMS = frozenset({'loop_dur', 'loop_start', 'loop_end'})
 def get_parameter_definition(
     param_name: str,
     sample_dur_sec: float | None = None,
+    output_sr: int | None = None,
 ) -> ParameterBounds:
     """
     Recupera la definizione di un parametro dal registro.
 
     Per loop_dur, loop_start e loop_end, se sample_dur_sec è fornito,
     restituisce un nuovo ParameterBounds con max_val = sample_dur_sec.
-    Tutti gli altri campi (min_val, min_range, ...) rimangono invariati.
+
+    Per grain_duration, se output_sr è fornito, restituisce un nuovo
+    ParameterBounds con min_val = 1 campione (1/output_sr): la durata
+    minima di un grano è la risoluzione temporale del motore.
+
+    Tutti gli altri campi rimangono invariati.
 
     Args:
         param_name: Il nome del parametro (es. 'density')
         sample_dur_sec: Durata del file audio in secondi (opzionale).
             Se fornito, sovrascrive max_val per i parametri loop.
+        output_sr: Sample rate di output del motore (opzionale).
+            Se fornito, sovrascrive min_val per grain_duration.
 
     Returns:
         ParameterBounds: L'oggetto configurazione.
@@ -230,6 +238,15 @@ def get_parameter_definition(
         return ParameterBounds(
             min_val=bounds.min_val,
             max_val=sample_dur_sec,
+            min_range=bounds.min_range,
+            max_range=bounds.max_range,
+            default_jitter=bounds.default_jitter,
+            variation_mode=bounds.variation_mode,
+        )
+    if output_sr is not None and param_name == 'grain_duration':
+        return ParameterBounds(
+            min_val=1.0 / output_sr,
+            max_val=bounds.max_val,
             min_range=bounds.min_range,
             max_range=bounds.max_range,
             default_jitter=bounds.default_jitter,

--- a/src/parameters/parser.py
+++ b/src/parameters/parser.py
@@ -38,6 +38,9 @@ class GranularParser:
         self.stream_id = config.context.stream_id
         self.duration = config.context.duration
         self.sample_dur_sec = config.context.sample_dur_sec
+        # Sample rate di output: bound minimo dinamico di grain_duration
+        # (1 campione). getattr difensivo per i context parziali dei test.
+        self.output_sr = getattr(config.context, 'output_sr', None)
         self.time_mode = config.time_mode
         self.distribution_mode = config.distribution_mode
         # Seed effettivo del run (issue #154): deriva l'RNG per-parametro.
@@ -68,9 +71,12 @@ class GranularParser:
             Un'istanza configurata di Parameter.
         """
         # 1. Recupera la definizione (Bounds & Rules) dal Registry, salvo override.
-        # Per loop_dur/loop_start/loop_end il bound massimo è la durata del file audio.
+        # Per loop_dur/loop_start/loop_end il bound massimo è la durata del file
+        # audio; per grain_duration il bound minimo è 1 campione (1/output_sr).
         bounds = (bounds_override if bounds_override is not None
-                  else get_parameter_definition(name, sample_dur_sec=self.sample_dur_sec))
+                  else get_parameter_definition(name,
+                                                sample_dur_sec=self.sample_dur_sec,
+                                                output_sr=self.output_sr))
 
         # 2. Converte i dati grezzi in formati utilizzabili (float o Envelope)
         # Qui avviene la normalizzazione temporale se necessaria

--- a/src/rendering/grain_renderer.py
+++ b/src/rendering/grain_renderer.py
@@ -67,7 +67,11 @@ class GrainRenderer:
             Array NumPy float64 di shape (n_samples, 2) -- stereo L/R
         """
         # --- 1. Parametri dal grano ---
-        n_out = int(grain.duration * self.output_sr)
+        # round: numero di campioni piu' vicino alla durata richiesta
+        # (int troncava, perdendo fino a 1 campione). max(1, ...): un grano
+        # valido non produce mai un buffer vuoto, anche quando la durata
+        # minima (1 campione) scivola sotto 1.0 per errore float.
+        n_out = max(1, round(grain.duration * self.output_sr))
 
         # --- 2. Leggi sample dalla registry ---
         samples, file_sr = self.sample_registry.get(sample_name)

--- a/src/rendering/grain_renderer.py
+++ b/src/rendering/grain_renderer.py
@@ -28,6 +28,7 @@ import numpy as np
 from rendering.sample_registry import SampleRegistry
 from rendering.numpy_window_registry import NumpyWindowRegistry
 from core.grain import Grain
+from shared.constants import DEFAULT_OUTPUT_SR
 
 
 class GrainRenderer:
@@ -42,7 +43,7 @@ class GrainRenderer:
         self,
         sample_registry: SampleRegistry,
         window_registry: NumpyWindowRegistry,
-        output_sr: int = 48000,
+        output_sr: int = DEFAULT_OUTPUT_SR,
     ):
         self.sample_registry = sample_registry
         self.window_registry = window_registry

--- a/src/rendering/numpy_audio_renderer.py
+++ b/src/rendering/numpy_audio_renderer.py
@@ -36,6 +36,7 @@ from rendering.numpy_parallel import (
     StreamRenderTask,
     chunk_grains,
     init_worker,
+    overlap_add_clamped,
     render_grain_chunk,
     render_stream_to_file,
     resolve_jobs,
@@ -418,7 +419,10 @@ class NumpyAudioRenderer(AudioRenderer):
             if result is None:
                 continue
             offset, local = result
-            buffer[offset:offset + local.shape[0]] += local
+            # Somma clampata alla coda: il buffer locale del chunk copre
+            # l'extent dei suoi grani, che con l'arrotondamento puo' finire
+            # 1 campione oltre n_total (vedi overlap_add_clamped).
+            overlap_add_clamped(buffer, local, offset)
 
     def _ensure_executor(self) -> ProcessPoolExecutor:
         """Crea il pool alla prima necessita' e lo riusa per tutta la run."""
@@ -474,18 +478,17 @@ class NumpyAudioRenderer(AudioRenderer):
         window_name = self._resolve_window_name(grain.envelope_table)
 
         grain_buffer = self._grain_renderer.render(grain, sample_name, window_name)
-        grain_len = grain_buffer.shape[0]
 
         # CLAMP 1 — onset negativo: taglia inizio del grano (legittimo, indipendente
         # dai bounds dello stream).
         if onset_sample < 0:
             grain_buffer = grain_buffer[-onset_sample:]
-            grain_len = grain_buffer.shape[0]
             onset_sample = 0
 
-        end_sample = onset_sample + grain_len
-        if grain_buffer.shape[0] > 0:
-            buffer[onset_sample:end_sample] += grain_buffer
+        # Somma clampata alla coda del buffer: l'unico sforo legittimo e'
+        # l'off-by-one da arrotondamento al campione (vedi overlap_add_clamped),
+        # non un clamp semantico (CLAMP 2/3 restano di GrainClipStrategy).
+        overlap_add_clamped(buffer, grain_buffer, onset_sample)
 
     # =========================================================================
     # INTERNAL - Table resolution

--- a/src/rendering/numpy_audio_renderer.py
+++ b/src/rendering/numpy_audio_renderer.py
@@ -30,6 +30,7 @@ from rendering.grain_renderer import GrainRenderer
 from rendering.sample_registry import SampleRegistry
 from rendering.numpy_window_registry import NumpyWindowRegistry
 from rendering.dc_blocker import dc_block
+from shared.constants import DEFAULT_OUTPUT_SR
 from rendering.numpy_parallel import (
     DEFAULT_MIN_PARALLEL_GRAINS,
     StreamRenderTask,
@@ -70,7 +71,7 @@ class NumpyAudioRenderer(AudioRenderer):
         sample_registry: SampleRegistry,
         window_registry: NumpyWindowRegistry,
         table_map: Dict[int, Tuple[str, str]],
-        output_sr: int = 48000,
+        output_sr: int = DEFAULT_OUTPUT_SR,
         cache_manager=None,
         stream_data_map: Optional[Dict[str, dict]] = None,
         audio_format: AudioFormat = DEFAULT_FORMAT,

--- a/src/rendering/numpy_parallel.py
+++ b/src/rendering/numpy_parallel.py
@@ -128,6 +128,38 @@ def chunk_grains(items: Sequence, n_chunks: int) -> List[List]:
 
 
 # =============================================================================
+# OVERLAP-ADD CLAMPATO (condiviso parent/worker)
+# =============================================================================
+
+def overlap_add_clamped(target: np.ndarray, local: np.ndarray, offset: int) -> None:
+    """
+    Somma `local` in `target` a partire da `offset`, troncando la coda che
+    sfora il buffer.
+
+    Necessario per l'arrotondamento al campione: la fine di un grano vale
+    round(onset*sr) + round(dur*sr), mentre il buffer e' dimensionato da un
+    round separato della somma, round((onset+dur)*sr). Quando entrambe le
+    parti frazionarie superano 0.5, round(a) + round(b) == round(a+b) + 1:
+    l'ultimo grano finisce 1 campione oltre il buffer e senza clamp l'overlap-add
+    esplode con un ValueError di broadcast. Il campione tagliato e' a bordo
+    finestra (ampiezza ~0), musicalmente impercettibile.
+
+    Con il vecchio int() (troncamento) la coda non poteva mai sforare
+    (floor(a)+floor(b) <= floor(a+b)); questo helper ripristina quella garanzia
+    di sicurezza per il round(). onset_sample negativo e' gia' gestito a monte
+    (CLAMP 1) dai chiamanti.
+    """
+    n = target.shape[0]
+    if offset >= n or local.shape[0] == 0:
+        return
+    end = offset + local.shape[0]
+    if end > n:
+        local = local[:n - offset]
+        end = n
+    target[offset:end] += local
+
+
+# =============================================================================
 # RISOLUZIONE TABLE (condivisa parent/worker)
 # =============================================================================
 
@@ -317,9 +349,9 @@ def render_stream_to_file(task: StreamRenderTask) -> str:
             grain_buffer = grain_buffer[-onset_sample:]
             onset_sample = 0
 
-        end_sample = onset_sample + grain_buffer.shape[0]
-        if grain_buffer.shape[0] > 0:
-            buffer[onset_sample:end_sample] += grain_buffer
+        # Somma clampata alla coda del buffer (off-by-one da round, vedi
+        # overlap_add_clamped): byte-identica al path sequenziale.
+        overlap_add_clamped(buffer, grain_buffer, onset_sample)
 
     buffer = dc_block(buffer, task.output_sr)
     np.clip(buffer, -1.0, 1.0, out=buffer)

--- a/src/rendering/renderer_factory.py
+++ b/src/rendering/renderer_factory.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from typing import Dict, Any
 
 from rendering.audio_renderer import AudioRenderer
+from shared.constants import DEFAULT_OUTPUT_SR
 from shared.exceptions import InvalidRendererError
 
 
@@ -65,7 +66,7 @@ class RendererFactory:
                 sample_registry=kwargs['sample_registry'],
                 window_registry=kwargs['window_registry'],
                 table_map=kwargs['table_map'],
-                output_sr=kwargs.get('output_sr', 48000),
+                output_sr=kwargs.get('output_sr', DEFAULT_OUTPUT_SR),
                 cache_manager=kwargs.get('cache_manager'),
                 stream_data_map=kwargs.get('stream_data_map'),
                 audio_format=kwargs.get('audio_format', DEFAULT_FORMAT),

--- a/src/rendering/score_visualizer.py
+++ b/src/rendering/score_visualizer.py
@@ -15,6 +15,8 @@ import soundfile as sf
 import re
 from math import ceil
 
+from shared.constants import DEFAULT_OUTPUT_SR
+
 # Path samples (stesso del progetto)
 PATHSAMPLES = './refs/'
 
@@ -168,7 +170,7 @@ class ScoreVisualizer:
                 'pan_prob': (0, 100),         # probabilità %
                 
                 # === GRAIN ===
-                'grain_duration': (1.0 / 48000, 1.0),  # secondi (min 1 campione)
+                'grain_duration': (1.0 / DEFAULT_OUTPUT_SR, 1.0),  # secondi (min 1 campione)
                 'grain_duration_prob': (0, 100),  # probabilità %
                 'reverse': (0, 1),            # boolean
                 'reverse_prob': (0, 100),     # probabilità %

--- a/src/rendering/score_visualizer.py
+++ b/src/rendering/score_visualizer.py
@@ -168,7 +168,7 @@ class ScoreVisualizer:
                 'pan_prob': (0, 100),         # probabilità %
                 
                 # === GRAIN ===
-                'grain_duration': (0.001, 1.0),  # secondi
+                'grain_duration': (1.0 / 48000, 1.0),  # secondi (min 1 campione)
                 'grain_duration_prob': (0, 100),  # probabilità %
                 'reverse': (0, 1),            # boolean
                 'reverse_prob': (0, 100),     # probabilità %

--- a/src/rendering/score_writer.py
+++ b/src/rendering/score_writer.py
@@ -179,6 +179,10 @@ class ScoreWriter:
         # Formatta numero
         try:
             value = float(param) * multiplier
+            # Sotto 0.1 un solo decimale collasserebbe a 0.0 (es. grani da
+            # 1 campione = 0.0208 ms): servono piu' cifre significative.
+            if 0 < abs(value) < 0.1:
+                return f"{value:.4f}{unit}"
             return f"{value:.1f}{unit}"
         except (ValueError, TypeError):
             # Fallback se non è un numero

--- a/src/shared/constants.py
+++ b/src/shared/constants.py
@@ -1,0 +1,12 @@
+"""
+constants.py
+
+Costanti di sistema condivise tra parsing, generazione e rendering.
+"""
+from __future__ import annotations
+
+# Sample rate di output del motore, in Hz. Unica fonte di verita' per i
+# default di main.py / RendererFactory / renderer NumPy e per le conversioni
+# campioni <-> secondi (grain.duration_unit). Deve restare coerente con
+# csound/main.orc (sr=48000), che oggi lo hardcoda.
+DEFAULT_OUTPUT_SR = 48000

--- a/tests/core/test_grain.py
+++ b/tests/core/test_grain.py
@@ -120,8 +120,8 @@ class TestGrainToScoreLine:
         result = grain.to_score_line()
         
         # Verifica precisione
-        assert '1.234568' in result  # onset a 6 decimali
-        assert '0.987654' in result  # duration a 6 decimali
+        assert '1.23456789' in result  # onset a 8 decimali
+        assert '0.98765432' in result  # duration a 8 decimali
         assert '0.123457' in result  # pointer_pos a 6 decimali
         assert '1.059463' in result  # pitch_ratio a 6 decimali
         assert '-6.54' in result  # volume a 2 decimali
@@ -530,3 +530,40 @@ class TestGrainPickle:
         ]
         restored = pickle.loads(pickle.dumps(grains))
         assert restored == grains
+
+# =============================================================================
+# TEST to_score_line A PRECISIONE DI CAMPIONE (grain.duration_unit samples)
+# =============================================================================
+
+class TestScoreLineSamplePrecision:
+    """p2/p3 serializzati con 8 decimali: un grano da 1 campione deve
+    sopravvivere al roundtrip testo -> float senza errori percettibili."""
+
+    @staticmethod
+    def _make_grain(duration, onset=0.0):
+        return Grain(
+            onset=onset, duration=duration, pointer_pos=0.5,
+            pitch_ratio=1.0, volume=0.0, pan=0.0,
+            sample_table=1, envelope_table=2,
+        )
+
+    @pytest.mark.parametrize("sr", [48000, 96000, 192000])
+    def test_one_sample_duration_roundtrip(self, sr):
+        dur = 1.0 / sr
+        line = self._make_grain(dur).to_score_line()
+        p3 = float(line.split()[3])
+        # errore relativo < 0.1% (con .6f era ~0.8% a 48k, 4% a 96k)
+        assert abs(p3 - dur) / dur < 0.001
+        # ri-quantizzato al sr corrispondente resta 1 campione
+        assert round(p3 * sr) == 1
+
+    def test_onset_sample_precision_roundtrip(self):
+        """Anche p2 (onset) regge la precisione di campione: due grani
+        adiacenti da 1 campione non collassano sullo stesso onset."""
+        sr = 48000
+        line_a = self._make_grain(1.0 / sr, onset=1.0 / sr).to_score_line()
+        line_b = self._make_grain(1.0 / sr, onset=2.0 / sr).to_score_line()
+        p2_a = float(line_a.split()[2])
+        p2_b = float(line_b.split()[2])
+        assert p2_a != p2_b
+        assert round((p2_b - p2_a) * sr) == 1

--- a/tests/core/test_grain_duration_unit.py
+++ b/tests/core/test_grain_duration_unit.py
@@ -1,0 +1,149 @@
+"""
+test_grain_duration_unit.py
+
+grain.duration_unit: unita' di misura per grain.duration e
+grain.duration_range.
+
+- 'seconds' (default): comportamento storico, nessuna conversione
+- 'samples': valori espressi in campioni, convertiti in secondi al parse
+  tramite il sample rate di output del motore (StreamContext.output_sr)
+
+La conversione e' osservabile dall'esterno: i Grain generati portano
+duration in secondi qualunque sia l'unita' dichiarata nello YAML.
+"""
+
+import pytest
+from unittest.mock import patch
+
+from core.stream import Stream
+from shared.constants import DEFAULT_OUTPUT_SR
+from shared.exceptions import InvalidFieldValueError, ParameterBoundError
+
+
+SAMPLE_DUR = 10.0
+
+
+def _make_stream(grain_block, **extra):
+    params = {
+        'stream_id': 's1',
+        'onset': 0.0,
+        'duration': 1.0,
+        'sample': 'test.wav',
+        'density': 20,
+        'grain': grain_block,
+    }
+    params.update(extra)
+    with patch('core.stream.get_sample_duration', return_value=SAMPLE_DUR):
+        stream = Stream(params, seed=42)
+    # Riferimenti Csound normalmente assegnati dal Generator
+    stream.sample_table_num = 1
+    stream.window_table_map = {'hanning': 2}
+    return stream
+
+
+class TestDurationUnitSamples:
+    """duration_unit: samples converte i valori in secondi via output_sr."""
+
+    def test_scalar_duration_in_samples(self):
+        s = _make_stream({'duration': 480, 'duration_unit': 'samples'})
+        assert len(s.grains) > 0
+        assert all(
+            g.duration == pytest.approx(480 / DEFAULT_OUTPUT_SR)
+            for g in s.grains
+        )
+
+    def test_one_sample_grain_is_valid(self):
+        """La durata minima raggiungibile e' 1 campione."""
+        s = _make_stream({'duration': 1, 'duration_unit': 'samples'})
+        assert all(
+            g.duration == pytest.approx(1.0 / DEFAULT_OUTPUT_SR)
+            for g in s.grains
+        )
+        assert len(s.grains) > 0
+
+    def test_envelope_duration_in_samples(self):
+        """Envelope: i valori Y sono campioni, l'asse X resta tempo."""
+        s = _make_stream({
+            'duration': [[0.0, 48], [1.0, 4800]],
+            'duration_unit': 'samples',
+        })
+        first = s.grains[0]
+        assert first.duration == pytest.approx(48 / DEFAULT_OUTPUT_SR, rel=1e-3)
+        assert max(g.duration for g in s.grains) > 10 * first.duration
+
+    def test_duration_range_in_samples(self):
+        """duration_range condivide l'unita' del blocco: i grani variano
+        dentro value +/- range/2 espressi in campioni."""
+        s = _make_stream(
+            {'duration': 480, 'duration_range': 96,
+             'duration_unit': 'samples'},
+            range_always_active=True,
+        )
+        durations = [g.duration for g in s.grains]
+        lo = (480 - 48) / DEFAULT_OUTPUT_SR
+        hi = (480 + 48) / DEFAULT_OUTPUT_SR
+        assert all(lo - 1e-12 <= d <= hi + 1e-12 for d in durations)
+        assert len(set(durations)) > 1  # la variazione e' attiva
+
+    def test_fractional_samples_allowed(self):
+        """Valori frazionari di campioni sono ammessi (quantizza il render)."""
+        s = _make_stream({'duration': 48.5, 'duration_unit': 'samples'})
+        assert all(
+            g.duration == pytest.approx(48.5 / DEFAULT_OUTPUT_SR)
+            for g in s.grains
+        )
+
+
+class TestDurationUnitSeconds:
+    """Default e 'seconds' esplicito: nessuna conversione."""
+
+    def test_default_unit_is_seconds(self):
+        s = _make_stream({'duration': 0.05})
+        assert all(g.duration == pytest.approx(0.05) for g in s.grains)
+
+    def test_explicit_seconds_is_noop(self):
+        s = _make_stream({'duration': 0.05, 'duration_unit': 'seconds'})
+        assert all(g.duration == pytest.approx(0.05) for g in s.grains)
+
+    def test_seconds_down_to_one_sample_valid(self):
+        """Anche in secondi la soglia minima e' ora 1 campione, non 1 ms."""
+        s = _make_stream({'duration': 1.0 / DEFAULT_OUTPUT_SR})
+        assert all(
+            g.duration == pytest.approx(1.0 / DEFAULT_OUTPUT_SR)
+            for g in s.grains
+        )
+
+    def test_seconds_below_one_sample_rejected(self):
+        with pytest.raises(ParameterBoundError):
+            _make_stream({'duration': 0.5 / DEFAULT_OUTPUT_SR})
+
+
+class TestDurationUnitValidation:
+    """Unita' sconosciute -> errore parlante."""
+
+    def test_unknown_unit_raises(self):
+        with pytest.raises(InvalidFieldValueError) as exc_info:
+            _make_stream({'duration': 480, 'duration_unit': 'frames'})
+        err = exc_info.value
+        assert 'duration_unit' in str(err)
+        assert 'samples' in err.user_message()  # hint con le unita' disponibili
+
+    def test_empty_unit_raises(self):
+        """Chiave presente ma vuota (None da YAML) -> errore, non default."""
+        with pytest.raises(InvalidFieldValueError):
+            _make_stream({'duration': 480, 'duration_unit': None})
+
+    def test_below_one_sample_in_samples_rejected(self):
+        with pytest.raises(ParameterBoundError):
+            _make_stream({'duration': 0.5, 'duration_unit': 'samples'})
+
+
+class TestDurationUnitDoesNotLeak:
+    """La conversione non deve toccare il dict YAML originale (cache
+    fingerprint e stream_data_map leggono i dati grezzi)."""
+
+    def test_original_params_not_mutated(self):
+        grain = {'duration': 480, 'duration_unit': 'samples'}
+        _make_stream(grain)
+        assert grain['duration'] == 480
+        assert grain['duration_unit'] == 'samples'

--- a/tests/core/test_grain_duration_unit.py
+++ b/tests/core/test_grain_duration_unit.py
@@ -147,3 +147,39 @@ class TestDurationUnitDoesNotLeak:
         _make_stream(grain)
         assert grain['duration'] == 480
         assert grain['duration_unit'] == 'samples'
+
+
+class TestSamplesUnitRenderIntegration:
+    """Filiera completa: YAML in campioni -> Stream -> Grain -> render NumPy.
+    Un treno di grani da 1 campione produce impulsi non silenti."""
+
+    def test_one_sample_grains_render_as_impulses(self):
+        import numpy as np
+        from rendering.grain_renderer import GrainRenderer
+        from rendering.sample_registry import SampleRegistry
+        from rendering.numpy_window_registry import NumpyWindowRegistry
+
+        s = _make_stream({
+            'duration': 1,
+            'duration_unit': 'samples',
+            'envelope': 'rectangle',
+        })
+        s.window_table_map = {'rectangle': 2}
+
+        # Sorgente costante a 1.0: qualunque pointer_pos legge segnale pieno
+        reg = SampleRegistry.__new__(SampleRegistry)
+        reg.base_path = './refs/'
+        reg._cache = {
+            'test.wav': (
+                np.ones(int(SAMPLE_DUR * DEFAULT_OUTPUT_SR), dtype=np.float32),
+                DEFAULT_OUTPUT_SR,
+            )
+        }
+        renderer = GrainRenderer(reg, NumpyWindowRegistry(),
+                                 output_sr=DEFAULT_OUTPUT_SR)
+
+        assert len(s.grains) > 0
+        for grain in s.grains[:10]:
+            buf = renderer.render(grain, 'test.wav', 'rectangle')
+            assert buf.shape == (1, 2)          # esattamente 1 frame stereo
+            assert np.abs(buf).max() > 0.5      # impulso non silente

--- a/tests/core/test_grain_duration_unit.py
+++ b/tests/core/test_grain_duration_unit.py
@@ -17,7 +17,11 @@ from unittest.mock import patch
 
 from core.stream import Stream
 from shared.constants import DEFAULT_OUTPUT_SR
-from shared.exceptions import InvalidFieldValueError, ParameterBoundError
+from shared.exceptions import (
+    InvalidFieldValueError,
+    MissingFieldError,
+    ParameterBoundError,
+)
 
 
 SAMPLE_DUR = 10.0
@@ -136,6 +140,27 @@ class TestDurationUnitValidation:
     def test_below_one_sample_in_samples_rejected(self):
         with pytest.raises(ParameterBoundError):
             _make_stream({'duration': 0.5, 'duration_unit': 'samples'})
+
+    def test_samples_without_explicit_duration_rejected(self):
+        """Con duration_unit: samples il default 0.05 (secondi) non e'
+        scalato: base e duration_range vivrebbero in domini diversi
+        (secondi vs campioni). Serve un grain.duration esplicito."""
+        with pytest.raises(MissingFieldError) as exc_info:
+            _make_stream({'duration_range': 96, 'duration_unit': 'samples'})
+        assert 'duration' in str(exc_info.value)
+
+    def test_samples_bare_unit_without_duration_rejected(self):
+        """duration_unit: samples senza alcun valore di durata: stessa regola,
+        il default in secondi non e' un valore in campioni."""
+        with pytest.raises(MissingFieldError):
+            _make_stream({'duration_unit': 'samples'})
+
+    def test_samples_with_explicit_duration_and_range_ok(self):
+        """Il caso valido non regredisce: base e range entrambi in campioni."""
+        s = _make_stream(
+            {'duration': 480, 'duration_range': 96, 'duration_unit': 'samples'},
+        )
+        assert len(s.grains) > 0
 
 
 class TestDurationUnitDoesNotLeak:

--- a/tests/core/test_stream_config.py
+++ b/tests/core/test_stream_config.py
@@ -88,18 +88,45 @@ class TestStreamContextDirect:
         assert ctx.sample_dur_sec == 3.2
 
     def test_field_count(self):
-        """StreamContext ha esattamente 5 campi."""
-        assert len(fields(StreamContext)) == 5
+        """StreamContext ha esattamente 6 campi."""
+        assert len(fields(StreamContext)) == 6
 
     def test_field_names(self):
         """Nomi campi corretti e nell'ordine atteso."""
         names = [f.name for f in fields(StreamContext)]
-        assert names == ['stream_id', 'onset', 'duration', 'sample', 'sample_dur_sec']
+        assert names == ['stream_id', 'onset', 'duration', 'sample',
+                         'sample_dur_sec', 'output_sr']
 
     def test_missing_required_field_raises(self):
         """Campi mancanti nella costruzione diretta -> TypeError."""
         with pytest.raises(TypeError):
             StreamContext(stream_id='s1', onset=0.0)
+
+
+class TestStreamContextOutputSr:
+    """Il context espone il sample rate di output del motore."""
+
+    def test_default_output_sr_is_engine_constant(self):
+        """Senza indicazioni, output_sr e' la costante di sistema (48000)."""
+        from shared.constants import DEFAULT_OUTPUT_SR
+
+        ctx = StreamContext(
+            stream_id='s1', onset=0.0, duration=5.0,
+            sample='voice.wav', sample_dur_sec=3.2,
+        )
+        assert DEFAULT_OUTPUT_SR == 48000
+        assert ctx.output_sr == DEFAULT_OUTPUT_SR
+
+    def test_from_yaml_defaults_output_sr(self):
+        """from_yaml senza chiave output_sr usa il default di sistema."""
+        from shared.constants import DEFAULT_OUTPUT_SR
+
+        ctx = StreamContext.from_yaml(
+            {'stream_id': 's1', 'onset': 0.0, 'duration': 5.0,
+             'sample': 'voice.wav'},
+            sample_dur_sec=3.2,
+        )
+        assert ctx.output_sr == DEFAULT_OUTPUT_SR
 
 
 # =============================================================================

--- a/tests/core/test_stream_config.py
+++ b/tests/core/test_stream_config.py
@@ -128,6 +128,24 @@ class TestStreamContextOutputSr:
         )
         assert ctx.output_sr == DEFAULT_OUTPUT_SR
 
+    def test_from_yaml_ignores_per_stream_output_sr(self):
+        """output_sr e' una config GLOBALE del motore, non un campo per-stream:
+        una chiave nello YAML dello stream NON deve entrare nel context.
+
+        Altrimenti divergerebbe dal sample rate con cui il renderer viene
+        costruito (main.py lo passa a DEFAULT_OUTPUT_SR): la conversione
+        samples->secondi e il bound minimo userebbero un SR, il rendering un
+        altro, producendo grani di lunghezza sbagliata.
+        """
+        from shared.constants import DEFAULT_OUTPUT_SR
+
+        ctx = StreamContext.from_yaml(
+            {'stream_id': 's1', 'onset': 0.0, 'duration': 5.0,
+             'sample': 'voice.wav', 'output_sr': 96000},
+            sample_dur_sec=3.2,
+        )
+        assert ctx.output_sr == DEFAULT_OUTPUT_SR
+
 
 # =============================================================================
 # 2. STREAM CONTEXT - FROM_YAML PARSING

--- a/tests/envelopes/test_envelope_scaling.py
+++ b/tests/envelopes/test_envelope_scaling.py
@@ -482,3 +482,36 @@ class TestTimeUnitWithCompactFormat:
         assert env.breakpoints[0][0] == pytest.approx(0.0)
         assert env.breakpoints[1][0] == pytest.approx(10.0)   # 0.25 * 40
         assert env.breakpoints[2][0] == pytest.approx(40.0)   # 1.0 * 40
+
+# =============================================================================
+# 5. TEST SCALE_RAW_PARAM_VALUES (HELPER CONDIVISO SCALARE/ENVELOPE)
+# =============================================================================
+
+class TestScaleRawParamValues:
+    """
+    Testa envelopes.envelope.scale_raw_param_values: scaling di un valore
+    parametro grezzo che puo' essere scalare, envelope-like o altro.
+    Usato dalla pre-normalizzazione di loop_unit e grain.duration_unit.
+    """
+
+    def test_scalar_is_multiplied(self):
+        from envelopes.envelope import scale_raw_param_values
+        assert scale_raw_param_values(0.5, 10.0) == 5.0
+        assert scale_raw_param_values(512, 1.0 / 48000) == 512 / 48000
+
+    def test_envelope_like_list_scales_y_only(self):
+        from envelopes.envelope import scale_raw_param_values
+        result = scale_raw_param_values([[0.0, 0.5], [2.0, 1.0]], 100.0)
+        assert result == [[0.0, 50.0], [2.0, 100.0]]
+
+    def test_envelope_like_dict_scales_points(self):
+        from envelopes.envelope import scale_raw_param_values
+        raw = {'type': 'linear', 'points': [[0, 0.1], [1, 0.2]]}
+        result = scale_raw_param_values(raw, 10.0)
+        assert result['points'][0][1] == pytest.approx(1.0)
+        assert result['points'][1][1] == pytest.approx(2.0)
+
+    def test_non_envelope_value_passthrough(self):
+        from envelopes.envelope import scale_raw_param_values
+        assert scale_raw_param_values(None, 10.0) is None
+        assert scale_raw_param_values('hanning', 10.0) == 'hanning'

--- a/tests/parameters/test_parameter_definitions.py
+++ b/tests/parameters/test_parameter_definitions.py
@@ -1000,3 +1000,44 @@ class TestLoopParamsNoneMaxVal:
         bounds = ParameterBounds(min_val=0.0, max_val=None)
         assert bounds.max_val is None
         assert bounds.min_val == 0.0
+
+# =============================================================================
+# 16. BOUND MINIMO DINAMICO DI GRAIN_DURATION (1 CAMPIONE)
+# =============================================================================
+
+class TestGrainDurationDynamicMin:
+    """
+    get_parameter_definition('grain_duration', output_sr=SR) deve restituire
+    bounds con min_val = 1 campione (1/SR). Senza output_sr il registry
+    statico resta invariato (retrocompatibilita').
+    """
+
+    def test_min_val_is_one_sample_with_output_sr(self):
+        bounds = get_parameter_definition('grain_duration', output_sr=48000)
+        assert bounds.min_val == pytest.approx(1.0 / 48000)
+
+    @pytest.mark.parametrize("sr", [44100, 48000, 96000, 192000])
+    def test_various_output_srs(self, sr):
+        bounds = get_parameter_definition('grain_duration', output_sr=sr)
+        assert bounds.min_val == pytest.approx(1.0 / sr)
+
+    def test_other_fields_preserved_with_output_sr(self):
+        original = GRANULAR_PARAMETERS['grain_duration']
+        bounds = get_parameter_definition('grain_duration', output_sr=48000)
+        assert bounds.max_val == original.max_val
+        assert bounds.min_range == original.min_range
+        assert bounds.max_range == original.max_range
+        assert bounds.default_jitter == original.default_jitter
+        assert bounds.variation_mode == original.variation_mode
+
+    def test_registry_not_mutated(self):
+        get_parameter_definition('grain_duration', output_sr=48000)
+        assert GRANULAR_PARAMETERS['grain_duration'].min_val == 0.001
+
+    def test_without_output_sr_returns_static_object(self):
+        result = get_parameter_definition('grain_duration')
+        assert result is GRANULAR_PARAMETERS['grain_duration']
+
+    def test_non_duration_param_unaffected_by_output_sr(self):
+        bounds_with = get_parameter_definition('density', output_sr=48000)
+        assert bounds_with is GRANULAR_PARAMETERS['density']

--- a/tests/parameters/test_parameter_factory.py
+++ b/tests/parameters/test_parameter_factory.py
@@ -790,3 +790,40 @@ class TestParserDynamicLoopBounds:
         parser = GranularParser(config)
         param = parser.parse_parameter(name, 9999.0)
         assert param.get_value(0) == pytest.approx(9999.0)
+
+# =============================================================================
+# 10. BOUND MINIMO DINAMICO GRAIN_DURATION VIA PARSER (1 CAMPIONE)
+# =============================================================================
+
+class TestParserDynamicGrainDurationMin:
+    """
+    GranularParser deve propagare output_sr dal context ai bounds di
+    grain_duration: durata minima = 1 campione (1/output_sr), non piu' 1 ms.
+    """
+
+    def test_one_sample_duration_is_valid(self):
+        config = make_config()  # context con output_sr di default (48000)
+        parser = GranularParser(config)
+        param = parser.parse_parameter('grain_duration', 1.0 / 48000)
+        assert param.get_value(0) == pytest.approx(1.0 / 48000)
+
+    def test_sub_millisecond_duration_now_valid(self):
+        """Durate sotto il vecchio floor di 1 ms sono accettate."""
+        config = make_config()
+        parser = GranularParser(config)
+        param = parser.parse_parameter('grain_duration', 0.0001)
+        assert param.get_value(0) == pytest.approx(0.0001)
+
+    def test_below_one_sample_raises(self):
+        config = make_config()
+        parser = GranularParser(config)
+        with pytest.raises(ValueError):
+            parser.parse_parameter('grain_duration', 0.5 / 48000)
+
+    def test_envelope_breakpoint_below_one_sample_raises(self):
+        config = make_config()
+        parser = GranularParser(config)
+        with pytest.raises(ValueError):
+            parser.parse_parameter(
+                'grain_duration', [[0.0, 0.05], [5.0, 0.5 / 48000]]
+            )

--- a/tests/rendering/test_grain_renderer.py
+++ b/tests/rendering/test_grain_renderer.py
@@ -403,3 +403,41 @@ class TestEdgeCases:
         r_bwd = renderer.render(g_bwd, 'test.wav', 'hanning')
         # Devono essere diversi
         assert not np.allclose(r_fwd, r_bwd)
+
+
+# =============================================================================
+# 9. GRANI A PRECISIONE DI CAMPIONE
+# =============================================================================
+
+class TestSamplePrecisionGrains:
+    """Grani fino a 1 campione: n_out = max(1, round(duration * sr))."""
+
+    def test_one_sample_grain_renders_one_frame(self, renderer):
+        grain = make_grain(duration=1.0 / OUTPUT_SR)
+        result = renderer.render(grain, 'test.wav', 'hanning')
+        assert result.shape == (1, 2)
+
+    def test_one_sample_grain_carries_signal(self, renderer, sample_registry):
+        """Con hanning(1) = [1.0] il singolo campione sopravvive intero:
+        a pan 0 entrambi i canali valgono sample/sqrt(2)."""
+        grain = make_grain(duration=1.0 / OUTPUT_SR, pointer_pos=0.5, pan=0.0)
+        result = renderer.render(grain, 'test.wav', 'hanning')
+
+        samples, sr = sample_registry.get('test.wav')
+        source_value = samples[int(0.5 * sr)]  # pointer 0.5s -> indice 24000
+        expected = source_value / np.sqrt(2.0)
+        assert result[0, 0] == pytest.approx(expected, rel=1e-6)
+        assert result[0, 1] == pytest.approx(expected, rel=1e-6)
+
+    def test_duration_rounds_to_nearest_sample(self, renderer):
+        """100.6 campioni -> 101 frame (round, non troncamento a 100)."""
+        grain = make_grain(duration=100.6 / OUTPUT_SR)
+        result = renderer.render(grain, 'test.wav', 'hanning')
+        assert result.shape[0] == 101
+
+    def test_duration_just_below_one_sample_still_renders(self, renderer):
+        """Anche se la durata scivola sotto 1 campione per errore float,
+        il buffer non e' mai vuoto."""
+        grain = make_grain(duration=0.9 / OUTPUT_SR)
+        result = renderer.render(grain, 'test.wav', 'hanning')
+        assert result.shape[0] == 1

--- a/tests/rendering/test_numpy_window_registry.py
+++ b/tests/rendering/test_numpy_window_registry.py
@@ -498,3 +498,35 @@ class TestBlackmanHarrisWindow:
         w1 = registry.get('blackman_harris', 1024)
         w2 = registry.get('blackman_harris', 1024)
         assert w1 is w2
+
+
+# =============================================================================
+# FINESTRE A LUNGHEZZE MINIME (GRANI A PRECISIONE DI CAMPIONE)
+# =============================================================================
+
+class TestSmallWindows:
+    """Tutte le finestre devono essere generabili per n in {1, 2, 3}:
+    nessuna eccezione, lunghezza esatta, valori finiti e limitati."""
+
+    @pytest.mark.parametrize("n", [1, 2, 3])
+    def test_all_windows_small_n(self, n):
+        registry = NumpyWindowRegistry()
+        for name in registry.available_windows():
+            window = registry.get(name, n)
+            assert len(window) == n, f"{name} n={n}"
+            assert np.all(np.isfinite(window)), f"{name} n={n}"
+            assert np.all(window >= -1e-9), f"{name} n={n}"
+            assert np.all(window <= 1.0 + 1e-9), f"{name} n={n}"
+
+    def test_hanning_single_sample_is_unit(self):
+        """np.hanning(1) = [1.0]: un grano di 1 campione con hanning
+        passa intero, non azzerato."""
+        registry = NumpyWindowRegistry()
+        assert registry.get('hanning', 1)[0] == pytest.approx(1.0)
+
+    def test_rectangle_small_n_is_flat_unit(self):
+        """rectangle e' la finestra consigliata per grani ultra-corti:
+        piatta a 1.0 anche a n minimi."""
+        registry = NumpyWindowRegistry()
+        for n in (1, 2, 3):
+            assert np.all(registry.get('rectangle', n) == 1.0)

--- a/tests/rendering/test_overlap_add_bounds.py
+++ b/tests/rendering/test_overlap_add_bounds.py
@@ -1,0 +1,124 @@
+# tests/rendering/test_overlap_add_bounds.py
+"""
+Regressione: l'overlap-add non deve sforare il buffer per l'arrotondamento
+al campione.
+
+Con `n_out = round(duration * sr)` (grain_renderer) e onset = round(onset * sr)
+la fine di un grano vale round(onset*sr) + round(dur*sr); il buffer invece e'
+dimensionato da un round separato della somma, round((onset+dur)*sr). Quando
+entrambe le parti frazionarie superano 0.5:
+
+    round(a) + round(b) == round(a + b) + 1
+
+l'ultimo grano finisce 1 campione oltre il buffer. Con il vecchio int()
+(troncamento) era impossibile (floor(a)+floor(b) <= floor(a+b)); il passaggio a
+round() introdotto dalla feature samples lo rende raggiungibile e fa esplodere
+l'overlap-add con un ValueError di broadcast.
+
+I tre punti di somma (path sequenziale, stream-level parallelo, chunk parallelo)
+condividono lo stesso helper clampato: qui se ne verifica il contratto.
+"""
+
+import numpy as np
+import pytest
+
+from core.grain import Grain
+from rendering.numpy_audio_renderer import NumpyAudioRenderer
+from rendering.sample_registry import SampleRegistry
+from rendering.numpy_window_registry import NumpyWindowRegistry
+import rendering.numpy_parallel as npar
+
+
+OUTPUT_SR = 48000
+
+
+def _make_sample_registry():
+    reg = SampleRegistry.__new__(SampleRegistry)
+    reg.base_path = './refs/'
+    reg._cache = {'piano.wav': (np.ones(OUTPUT_SR, dtype=np.float32), OUTPUT_SR)}
+    return reg
+
+
+def _make_renderer():
+    return NumpyAudioRenderer(
+        sample_registry=_make_sample_registry(),
+        window_registry=NumpyWindowRegistry(),
+        table_map={1: ('sample', 'piano.wav'), 2: ('window', 'hanning')},
+        output_sr=OUTPUT_SR,
+    )
+
+
+def _make_grain(**overrides):
+    defaults = dict(
+        onset=0.0, duration=101.0 / OUTPUT_SR, pointer_pos=0.5,
+        pitch_ratio=1.0, volume=0.0, pan=0.0, sample_table=1, envelope_table=2,
+    )
+    defaults.update(overrides)
+    return Grain(**defaults)
+
+
+class TestOverlapAddClampedHelper:
+    """Contratto numerico dell'helper condiviso."""
+
+    def test_tail_overflow_is_truncated(self):
+        target = np.zeros((201, 2), dtype=np.float64)
+        local = np.ones((101, 2), dtype=np.float64)
+        # offset 101 -> end 202, oltre i 201 campioni del buffer
+        npar.overlap_add_clamped(target, local, 101)
+        # scritti solo i 100 campioni che entrano, nessun errore
+        assert np.all(target[101:201] == 1.0)
+        assert target[:101].sum() == 0.0
+
+    def test_offset_at_or_past_end_is_noop(self):
+        target = np.zeros((10, 2), dtype=np.float64)
+        npar.overlap_add_clamped(target, np.ones((5, 2)), 10)
+        npar.overlap_add_clamped(target, np.ones((5, 2)), 20)
+        assert target.sum() == 0.0
+
+    def test_fully_inside_is_exact_sum(self):
+        target = np.zeros((10, 2), dtype=np.float64)
+        npar.overlap_add_clamped(target, np.ones((4, 2)), 3)
+        assert np.all(target[3:7] == 1.0)
+        assert target[:3].sum() == 0.0 and target[7:].sum() == 0.0
+
+
+class TestSequentialPathNoOverflow:
+    """_add_grain_at_position: path sequenziale (default jobs=1)."""
+
+    def test_grain_ending_one_sample_past_buffer_does_not_crash(self):
+        r = _make_renderer()
+        grain = _make_grain(duration=101.0 / OUTPUT_SR)  # grain_len = 101
+        buffer = np.zeros((201, 2), dtype=np.float64)     # onset 101 -> end 202
+        r._add_grain_at_position(buffer, grain, 101)
+        # il grano ha contribuito (finestra hanning, coda ~0 ma non tutta)
+        assert buffer[101:201].any()
+
+
+class TestStreamLevelParallelPathNoOverflow:
+    """render_stream_to_file: path parallelo stream-level."""
+
+    def test_task_with_tail_overflow_renders_without_crash(self, tmp_path):
+        sr = OUTPUT_SR
+        import soundfile as sf
+        sf.write(str(tmp_path / 'tone.wav'),
+                 np.ones(sr, dtype=np.float32), sr)
+        npar.init_worker({
+            'base_path': str(tmp_path) + '/',
+            'sample_names': ['tone.wav'],
+            'table_map': {1: ('sample', 'tone.wav'), 2: ('window', 'hanning')},
+            'output_sr': sr,
+        })
+        grain = _make_grain(duration=101.0 / sr)
+        out = str(tmp_path / 'stem.aif')
+        task = npar.StreamRenderTask(
+            pairs=[(grain, 101)],   # onset 101 + len 101 = 202 > n_total 201
+            n_total=201,
+            output_path=out,
+            sf_format='AIFF',
+            sf_subtype='PCM_24',
+            output_sr=sr,
+        )
+        result = npar.render_stream_to_file(task)
+        assert result == out
+        data, _ = sf.read(out)
+        assert len(data) == 201

--- a/tests/rendering/test_score_writer.py
+++ b/tests/rendering/test_score_writer.py
@@ -586,6 +586,13 @@ class TestFormatParam:
         result = writer._format_param(0.05, 1000, "ms")
         assert result == "50.0ms"
 
+    def test_format_sample_precision_value_not_truncated_to_zero(self, writer):
+        """Un grano da 1 campione (0.0208 ms) non deve apparire come 0.0ms
+        nell'header: sotto 0.1 la formattazione aggiunge decimali."""
+        result = writer._format_param(1.0 / 48000, 1000, "ms")
+        assert result != "0.0ms"
+        assert "0.0208" in result
+
     def test_format_float_with_unit(self, writer):
         """Formattazione con unita' di misura."""
         result = writer._format_param(20.0, 1, " g/s")

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -614,6 +614,16 @@ class TestFillFactorStrategyClamping:
         result = strategy.calculate_density(0.0, grain_duration=0.001)
         assert result == pytest.approx(4000.0)
 
+    def test_one_sample_grain_duration_clamped_to_max(self):
+        """Grano da 1 campione (grain.duration_unit samples): la density
+        derivata (fill_factor/dur = 96000) resta clampata a 4000."""
+        ff_param = _make_param(2.0)
+        dist_param = _make_param(0.0)
+        strategy = FillFactorStrategy(ff_param, dist_param)
+
+        result = strategy.calculate_density(0.0, grain_duration=1.0 / 48000)
+        assert result == pytest.approx(4000.0)
+
     def test_clamps_to_min_density(self):
         """Risultato clampato al minimo di density (0.01)."""
         ff_param = _make_param(0.001)


### PR DESCRIPTION
## Sommario

Implementa il supporto per l'unità di misura `samples` nel parametro `grain.duration`, abbassando la durata minima di un grano da 1 ms a 1 campione (~20.8 µs a 48 kHz). La conversione avviene in un unico punto (pre-normalizzazione in `Stream`), il resto della pipeline continua a operare in secondi.

## Cambiamenti principali

### Superficie YAML
- Nuova meta-chiave `grain.duration_unit` (`seconds` | `samples`, default `seconds`)
- Governa sia `grain.duration` sia `grain.duration_range`
- Retrocompatibile: YAML esistente senza la chiave mantiene il comportamento storico
- Unità sconosciuta → `InvalidFieldValueError` con hint

### Architettura
- **Costante unica**: `DEFAULT_OUTPUT_SR = 48000` in `src/shared/constants.py`
- **StreamContext**: nuovo campo `output_sr` (default dalla costante)
- **Pre-normalizzazione**: `Stream._pre_normalize_grain_params()` converte valori in campioni a secondi via `1.0 / output_sr`, speculare a `PointerController._pre_normalize_loop_params()`
- **Helper condiviso**: `scale_raw_param_values()` in `envelopes/envelope.py` per scalare scalari ed envelope-like (riusato da `PointerController`)

### Bounds dinamici
- `get_parameter_definition('grain_duration', output_sr=48000)` restituisce `min_val = 1/output_sr` (1 campione)
- Meccanismo esteso da quello già usato per i loop param
- `GranularParser` propaga `output_sr` dal context ai bounds

### Renderer NumPy
- `n_out = max(1, round(duration * sr))` invece di `int()`: arrotonda al campione più vicino, garantisce n_out ≥ 1
- Nota: cambia il bit-exact dei render per durate non esatte (ampiezza a bordo finestra ~0, musicalmente impercettibile)

### Csound
- Precisione score line: `.8f` per onset e duration (era `.6f`), riduce errore di quantizzazione da ~0.7% a 48 kHz a <0.1%
- Nota documentata: divergenza su grani 1-3 campioni (envelope poscil vs finestra campionata)

### Collaterali
- `score_visualizer.py`: range asse `grain_duration` dinamico (minimo = 1/output_sr)
- `score_writer.py`: protezione da troncamento a 0.0 per valori < 0.1 ms
- `main.py`, `renderer_factory.py`: costante al posto di letterali 48000

## Test

- Nuova suite `tests/core/test_grain_duration_unit.py`: conversione scalare/envelope, retrocompatibilità, validazione unità
- Aggiornamenti: bounds dinamici, parser, renderer NumPy, finestre piccole (n ∈ {1,2,3}), density con grani ultra-corti
- Precisione score line: roundtrip testo → float per 1 campione a vari SR

## Documentazione

- `docs/reference/yaml.md`: blocco Grain con `duration_unit`, nuovi bounds, esempi, note su finestre simmetriche e divergenza Csound
- `CHANGELOG.md`: sezione Unreleased (Added, Changed)
- `docs/plans/done/2026-07-05-002-feat-grain-duration-samples-unit-plan.md`: piano completo (archivio storico)

## Rischi e mitigazioni

- **int→round su n_out**: render non bit-identici per durate non esatte; test dedicati

https://claude.ai/code/session_01HFTen97bfUpmu34tDUVicE