### PR TITLE
Fix race condition TOCTOU nella creazione di log_dir (issue #159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,16 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   decimali (un grano da 1 campione appariva `0.0ms`). Il contenuto testuale
   degli `.sco` generati cambia.
 
+### Corretto
+
+- Race condition (TOCTOU) in `configure_engine_logger` (issue #159): con render
+  paralleli subito dopo la rimozione della dir dei log (es. `make clean; make
+  render` con `ProcessPoolExecutor`), i worker superavano insieme il check
+  `not os.path.exists(log_dir)` e chiamavano tutti `os.makedirs`, facendo
+  crashare tutti tranne il primo con `FileExistsError`. La creazione ora è
+  atomica e idempotente (`os.makedirs(log_dir, exist_ok=True)`), chiudendo la
+  finestra di race.
+
 ## [v4.1.0] — "Parallel Grains" — 2026-07-04
 
 ### Aggiunto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   crashare tutti tranne il primo con `FileExistsError`. La creazione ora è
   atomica e idempotente (`os.makedirs(log_dir, exist_ok=True)`), chiudendo la
   finestra di race.
+- Stessa race TOCTOU corretta anche in `get_clip_logger` (pattern identico
+  sulla stessa dir `./logs`). Rimosso il messaggio console "Creata directory
+  log" che dipendeva dal check non atomico.
 
 ## [v4.1.0] — "Parallel Grains" — 2026-07-04
 

--- a/src/shared/logger.py
+++ b/src/shared/logger.py
@@ -161,8 +161,9 @@ def configure_engine_logger(yaml_name: str | None = None, log_dir: str = './logs
     """Configura logger engine: scrive ERROR + traceback su <log_dir>/<yaml_name>_engine.log."""
     global _engine_logger, _engine_log_path
 
-    if not os.path.exists(log_dir):
-        os.makedirs(log_dir)
+    # Creazione atomica e idempotente: exist_ok=True chiude la finestra di race
+    # (issue #159) quando più worker paralleli tentano di creare log_dir insieme.
+    os.makedirs(log_dir, exist_ok=True)
 
     name = yaml_name if yaml_name else datetime.now().strftime("%Y%m%d_%H%M%S")
     log_filename = f'{name}_engine.log'

--- a/src/shared/logger.py
+++ b/src/shared/logger.py
@@ -96,10 +96,9 @@ def get_clip_logger():
     if CLIP_LOG_CONFIG['file_enabled']:
         log_dir = CLIP_LOG_CONFIG['log_dir']
         
-        # Crea directory se non esiste
-        if not os.path.exists(log_dir):
-            os.makedirs(log_dir)
-            print(f"📁 Creata directory log: {log_dir}")
+        # Creazione atomica e idempotente: exist_ok=True chiude la finestra di
+        # race (issue #159), come in configure_engine_logger.
+        os.makedirs(log_dir, exist_ok=True)
         
         # Nome file
         if CLIP_LOG_CONFIG.get('yaml_name'):

--- a/tests/shared/test_engine_logger.py
+++ b/tests/shared/test_engine_logger.py
@@ -10,6 +10,7 @@ con livello ERROR e traceback completo.
 import logging
 import os
 import pytest
+from unittest.mock import patch
 
 from shared.logger import (
     configure_engine_logger,
@@ -17,6 +18,26 @@ from shared.logger import (
     get_engine_log_path,
     get_clip_logger,
 )
+
+
+def test_configure_engine_logger_idempotent_on_existing_dir(tmp_path):
+    """La creazione di log_dir è atomica: nessun FileExistsError sulla race TOCTOU.
+
+    Riproduce la finestra di race (issue #159): più worker paralleli superano il
+    check `not os.path.exists(log_dir)` mentre la dir non esiste ancora, poi
+    chiamano `os.makedirs` — il primo la crea, gli altri la trovano già presente.
+    Qui la dir esiste sul filesystem ma `os.path.exists` è forzato a False per
+    simulare quel momento; la funzione non deve sollevare.
+    """
+    log_dir = tmp_path / '.logs'
+    log_dir.mkdir()  # la dir esiste già (creata dal worker che ha vinto la race)
+
+    with patch('shared.logger.os.path.exists', return_value=False):
+        configure_engine_logger(yaml_name='granstudies', log_dir=str(log_dir))
+
+    log_path = get_engine_log_path()
+    assert log_path is not None
+    assert log_path.endswith('granstudies_engine.log')
 
 
 def test_configure_engine_logger_creates_file_handler(tmp_path):

--- a/tests/shared/test_logger.py
+++ b/tests/shared/test_logger.py
@@ -179,6 +179,31 @@ class TestGetClipLoggerLazyInit:
         l2 = get_clip_logger()
         assert l1 is l2
 
+    def test_creates_log_dir_idempotent_on_existing_dir(self, tmp_path):
+        """La creazione di log_dir e' atomica: nessun FileExistsError sulla race TOCTOU.
+
+        Stessa race di configure_engine_logger (issue #159): la dir esiste sul
+        filesystem ma `os.path.exists` e' forzato a False per simulare il worker
+        che perde la corsa; get_clip_logger non deve sollevare.
+        """
+        log_dir = tmp_path / '.logs'
+        log_dir.mkdir()  # dir gia' creata dal processo che ha vinto la race
+
+        configure_clip_logger(
+            enabled=True,
+            file_enabled=True,
+            console_enabled=False,
+            log_dir=str(log_dir),
+            yaml_name='race'
+        )
+        with patch('shared.logger.os.path.exists', return_value=False):
+            result = get_clip_logger()
+
+        assert result is not None
+        log_path = get_clip_log_path()
+        assert log_path is not None
+        assert log_path.endswith('envelope_clips_race.log')
+
     def test_initialized_flag_true_after_call(self, tmp_path):
         configure_clip_logger(
             enabled=True,


### PR DESCRIPTION
## Sommario

Risolve una race condition (TOCTOU) nella creazione della directory dei log che causava `FileExistsError` quando più processi paralleli tentavano di creare la directory contemporaneamente. Il fix è applicato a **entrambe** le occorrenze del pattern in `src/shared/logger.py`: `configure_engine_logger` (oggetto della issue #159) e `get_clip_logger` (pattern identico sulla stessa dir di default `./logs`, emerso in review).

## Modifiche principali

- **src/shared/logger.py — `configure_engine_logger`**: sostituito il check `if not os.path.exists(log_dir): os.makedirs(log_dir)` con `os.makedirs(log_dir, exist_ok=True)` per rendere la creazione atomica e idempotente.

- **src/shared/logger.py — `get_clip_logger`**: stesso fix sul pattern gemello. Rimosso il messaggio console "Creata directory log" che dipendeva dal check non atomico. Dopo questa PR non resta alcun `os.makedirs` senza `exist_ok=True` in `src/`.

- **tests/shared/test_engine_logger.py**: test `test_configure_engine_logger_idempotent_on_existing_dir` che riproduce la race mockando `os.path.exists` a False con la directory realmente esistente; la funzione non deve sollevare.

- **tests/shared/test_logger.py**: test speculare `test_creates_log_dir_idempotent_on_existing_dir` per `get_clip_logger` (rosso sul codice precedente con lo stesso `FileExistsError`, verde col fix).

- **CHANGELOG.md**: entrambe le correzioni documentate nella sezione "Corretto" di Unreleased.

## Dettagli implementativi

La race si verificava quando:
1. Più processi paralleli superavano insieme il check `not os.path.exists(log_dir)` mentre la directory non esisteva ancora
2. Tutti chiamavano `os.makedirs(log_dir)` quasi simultaneamente
3. Il primo creava la directory, gli altri ricevevano `FileExistsError`

`exist_ok=True` rende l'operazione idempotente e chiude completamente la finestra di race tra check e creazione, allineandosi alla convenzione già in uso nel resto del codebase (`csound_renderer.py`, `stream_cache_manager.py`, `score_visualizer.py`, ecc.).

## Impatto cross-repo

Nessun impatto su `PGE-ls` e `PGE-ui`: la modifica non tocca sintassi YAML, bounds, gerarchia errori parsata a valle, CLI o formati di output — sparisce solo un crash `FileExistsError` interno (più il messaggio console "Creata directory log", non parsato da nessuno dei due repo). Niente issue da aprire.

## Test

`make tests`: 4840 passed, 2 skipped.

https://claude.ai/code/session_018PHXM3hTZN6kYgzoHgfdUT