### PR TITLE
Espone parameter_bounds() e ParameterBounds in pge.api (issue #163)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Aggiunto
 
+- `pge.api.parameter_bounds(output_sr=..., sample_dur_sec=...)` (issue #163):
+  bounds di tutti i parametri del registry `GRANULAR_PARAMETERS` con gli
+  override dinamici gia' calcolati internamente da
+  `get_parameter_definition` — `grain_duration.min_val = 1/output_sr`
+  (un campione), `loop_dur/loop_start/loop_end.max_val = sample_dur_sec`.
+  Argomenti non positivi sollevano `ValueError`. Re-export di
+  `ParameterBounds` da `pge.api`: i consumer esterni (es.
+  `granulation-studies`) non importano piu' il modulo interno
+  `pge.parameters.parameter_definitions`.
 - Packaging (Fase 4 del refactor library/CLI): `pyproject.toml` PEP 621
   (nome distribuzione `pge`, versione `5.0.0.dev0`), install editable
   `pip install -e ".[dev]"` fatto da `make venv-setup`, console script

--- a/src/pge/api.py
+++ b/src/pge/api.py
@@ -24,6 +24,10 @@ from typing import List, Optional, Union
 
 from pge.shared.constants import DEFAULT_OUTPUT_SR
 from pge.rendering.audio_format import DEFAULT_FORMAT, FORMATS
+# Value Object leggero (dataclass frozen, nessuna dipendenza pesante):
+# re-export a livello di modulo cosi' i consumer di parameter_bounds()
+# tipizzano il risultato senza importare pge.parameters.
+from pge.parameters.parameter_definitions import ParameterBounds  # noqa: F401
 
 
 @dataclass(frozen=True)
@@ -48,6 +52,45 @@ class RenderResult:
     jobs: Optional[int] = None         # jobs risolti (renderer.jobs); None per csound
     cache_manifest_path: Optional[str] = None
     gc_removed: List[str] = field(default_factory=list)  # stream orfani rimossi dal GC
+
+
+def parameter_bounds(
+    *,
+    output_sr: Optional[int] = None,
+    sample_dur_sec: Optional[float] = None,
+):
+    """Bounds di tutti i parametri registrati (issue #163).
+
+    Ritorna un dict nuovo {nome: ParameterBounds} costruito dal registry
+    GRANULAR_PARAMETERS via get_parameter_definition, cosi' i consumer
+    esterni non importano il modulo interno parameter_definitions.
+
+    Args:
+        output_sr: sample rate di render; se fornito, grain_duration.min_val
+            diventa 1 campione (1/output_sr).
+        sample_dur_sec: durata del file audio in secondi; se fornita,
+            max_val di loop_dur/loop_start/loop_end diventa la durata.
+
+    Raises:
+        ValueError: se output_sr o sample_dur_sec non sono positivi.
+    """
+    if output_sr is not None and output_sr <= 0:
+        raise ValueError(
+            f"output_sr deve essere positivo, ricevuto: {output_sr!r}")
+    if sample_dur_sec is not None and sample_dur_sec <= 0:
+        raise ValueError(
+            f"sample_dur_sec deve essere positivo, ricevuto: {sample_dur_sec!r}")
+
+    from pge.parameters.parameter_definitions import (
+        GRANULAR_PARAMETERS,
+        get_parameter_definition,
+    )
+
+    return {
+        name: get_parameter_definition(
+            name, sample_dur_sec=sample_dur_sec, output_sr=output_sr)
+        for name in GRANULAR_PARAMETERS
+    }
 
 
 def load_generator(yaml_path: str, *, samples_dir: Optional[str] = None):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -863,3 +863,106 @@ class TestSamplesDirNormalization:
         api_mocks['api'].build_renderer('csound', gen, samples_dir='/campioni')
         kwargs = api_mocks['RendererFactory'].create.call_args.kwargs
         assert kwargs['csound_config']['env_vars']['SSDIR'] == '/campioni'
+
+
+# =============================================================================
+# parameter_bounds (issue #163)
+# =============================================================================
+
+class TestParameterBoundsApi:
+    """parameter_bounds(): esposizione pubblica dei bounds del registry con
+    override dinamici (grain_duration <- output_sr, loop_* <- sample_dur_sec).
+
+    Funzione pura senza dipendenze pesanti: si importa pge.api reale,
+    senza la fixture api_mocks.
+    """
+
+    def test_no_args_returns_static_registry(self):
+        """Senza argomenti: tutte le chiavi del registry, bounds statici."""
+        from pge import api
+        from pge.parameters.parameter_definitions import GRANULAR_PARAMETERS
+
+        result = api.parameter_bounds()
+
+        assert set(result) == set(GRANULAR_PARAMETERS)
+        for name, bounds in result.items():
+            assert bounds == GRANULAR_PARAMETERS[name]
+
+    @pytest.mark.parametrize('sr', [44100, 48000, 96000])
+    def test_output_sr_overrides_grain_duration_min(self, sr):
+        """Con output_sr: grain_duration.min_val = 1 campione (1/output_sr),
+        tutti gli altri parametri restano statici."""
+        from pge import api
+        from pge.parameters.parameter_definitions import GRANULAR_PARAMETERS
+
+        result = api.parameter_bounds(output_sr=sr)
+
+        assert result['grain_duration'].min_val == 1.0 / sr
+        assert result['grain_duration'].max_val == \
+            GRANULAR_PARAMETERS['grain_duration'].max_val
+        for name, bounds in result.items():
+            if name != 'grain_duration':
+                assert bounds == GRANULAR_PARAMETERS[name]
+
+    def test_sample_dur_sec_overrides_loop_max(self):
+        """Con sample_dur_sec: max_val dei parametri loop = durata del file,
+        tutti gli altri parametri restano statici."""
+        from pge import api
+        from pge.parameters.parameter_definitions import GRANULAR_PARAMETERS
+
+        result = api.parameter_bounds(sample_dur_sec=7.5)
+
+        loop_params = {'loop_dur', 'loop_start', 'loop_end'}
+        for name in loop_params:
+            assert result[name].max_val == 7.5
+            assert result[name].min_val == GRANULAR_PARAMETERS[name].min_val
+        for name, bounds in result.items():
+            if name not in loop_params:
+                assert bounds == GRANULAR_PARAMETERS[name]
+
+    def test_both_overrides_together(self):
+        """output_sr e sample_dur_sec insieme: entrambi gli override attivi."""
+        from pge import api
+
+        result = api.parameter_bounds(output_sr=48000, sample_dur_sec=3.2)
+
+        assert result['grain_duration'].min_val == 1.0 / 48000
+        assert result['loop_dur'].max_val == 3.2
+        assert result['loop_start'].max_val == 3.2
+        assert result['loop_end'].max_val == 3.2
+
+    def test_returns_fresh_dict(self):
+        """Il dict e' nuovo a ogni chiamata: mutarlo non tocca il registry."""
+        from pge import api
+        from pge.parameters.parameter_definitions import GRANULAR_PARAMETERS
+
+        result = api.parameter_bounds()
+        result.pop('density')
+        result['fittizio'] = None
+
+        assert 'density' in GRANULAR_PARAMETERS
+        assert 'fittizio' not in GRANULAR_PARAMETERS
+        assert 'density' in api.parameter_bounds()
+
+    @pytest.mark.parametrize('kwargs', [
+        {'output_sr': 0},
+        {'output_sr': -44100},
+        {'sample_dur_sec': 0.0},
+        {'sample_dur_sec': -1.0},
+    ])
+    def test_non_positive_args_raise_value_error(self, kwargs):
+        """Contratto api.py: argomenti API invalidi -> ValueError."""
+        from pge import api
+
+        with pytest.raises(ValueError):
+            api.parameter_bounds(**kwargs)
+
+    def test_parameter_bounds_type_is_reexported(self):
+        """pge.api.ParameterBounds e' la stessa classe del modulo interno:
+        i consumer tipizzano il risultato senza import interni."""
+        from pge import api
+        from pge.parameters.parameter_definitions import ParameterBounds
+
+        assert api.ParameterBounds is ParameterBounds
+        assert isinstance(
+            api.parameter_bounds()['density'], api.ParameterBounds)


### PR DESCRIPTION
Closes #163

## Cosa cambia

Nuova funzione pubblica in `pge.api`:

```python
def parameter_bounds(*, output_sr: int | None = None,
                     sample_dur_sec: float | None = None) -> dict[str, ParameterBounds]
```

Restituisce i bounds di tutti i parametri del registry `GRANULAR_PARAMETERS`, applicando gli override dinamici già calcolati internamente da `get_parameter_definition`:

- `output_sr` → `grain_duration.min_val = 1/output_sr` (un campione, il vero pavimento dipendente dal sample rate di render, invece dello statico 1 ms);
- `sample_dur_sec` → `loop_dur/loop_start/loop_end.max_val = sample_dur_sec`.

Argomenti non positivi sollevano `ValueError`, coerente col contratto di `api.py` (errori come eccezioni). `ParameterBounds` è ora re-esportato da `pge.api`, così i consumer esterni (es. `granulation-studies/granstudies/bounds.py`) non importano più il modulo interno `pge.parameters.parameter_definitions`.

## Come

Modifica puramente additiva, sviluppata in TDD (rosso→verde, un test per ciclo): 12 test nella nuova classe `tests/test_api.py::TestParameterBoundsApi` coprono registry statico, override singoli e combinati (parametrizzati su 44100/48000/96000), freschezza del dict restituito, validazione `ValueError` e re-export del tipo.

## Test

`make tests`: 4958 passed, 2 skipped (preesistenti, sample non disponibili).

## Impatto cross-repo

- **PGE-ls / PGE-ui**: nessuna modifica a YAML, errori, CLI o formati — superficie solo additiva lato API Python. Come nota la issue, se in futuro servissero bound dinamici per autocomplete/validazione, questa API li copre; nessuna issue aperta ora (repo fuori dallo scope della sessione).
- **Paper CIM 2026**: superficie non usata da `render_example.py` → nessun bump del submodule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMfEF4uzWJKnu7GJGuovk9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMfEF4uzWJKnu7GJGuovk9)_