### PR TITLE
fix(visualizer): pannello envelope per-stream allineato ai grani (issue #113)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,18 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Corretto
 
+- Score visualizer: il pannello envelope e' ora **un subplot per stream**
+  (issue #113), allineato 1:1 e verticalmente al subplot dei grani del
+  rispettivo stream — la simmetria introdotta da #109 per i grani, estesa
+  agli envelope. Prima tutti gli envelope vivevano in un unico asse condiviso
+  in fondo alla pagina e gli stream senza envelope dinamici perdevano la
+  lane (filtro sul dict vuoto): con 4 stream di cui 2 tutti statici si
+  ottenevano 4 subplot grani ma 2 sole lane envelope. Ora ogni stream ha la
+  sua riga envelope subito sotto i grani (stessa colonna, stesso asse
+  temporale), presente anche se vuota (con label stream), con legenda
+  per-stream nella colonna sinistra e asse "Time (s)" solo sull'ultima riga.
+  `envelope_panel_ratio` (0.3) e' ora la frazione della banda di ogni stream
+  riservata alla riga envelope (proporzione complessiva invariata).
 - Race condition (TOCTOU) in `configure_engine_logger` (issue #159): con render
   paralleli subito dopo la rimozione della dir dei log (es. `make clean; make
   render` con `ProcessPoolExecutor`), i worker superavano insieme il check

--- a/src/pge/rendering/score_visualizer.py
+++ b/src/pge/rendering/score_visualizer.py
@@ -202,7 +202,11 @@ class ScoreVisualizer:
             },
 
             'envelope_colors': dict(ENVELOPE_COLORS),
-            'envelope_panel_ratio': 0.3,      # 30% altezza per envelope
+            # Frazione della banda di OGNI stream riservata alla sua riga
+            # envelope (issue #113: un subplot envelope per stream, sotto i
+            # grani). Prima del fix era la frazione di pagina del pannello
+            # envelope unico condiviso: la proporzione complessiva resta 30%.
+            'envelope_panel_ratio': 0.3,
 
             # Scaling data-driven puro delle curve envelope (issue #114): ogni
             # curva scala sull'escursione reale dei suoi valori nella finestra
@@ -564,6 +568,12 @@ class ScoreVisualizer:
         stream condividono lo stesso sample (la waveform viene ridisegnata in
         ciascuno). Cosi' 4 stream producono 4 subplot anche se due puntano allo
         stesso file, e le label non collidono piu' su un asse condiviso.
+
+        issue #113: la stessa simmetria vale per gli envelope — ogni stream ha
+        la propria riga envelope subito sotto i suoi grani (stessa colonna,
+        stesso asse temporale), anche se non ha envelope dinamici (lane vuota
+        con label). Il vecchio pannello unico condiviso in fondo alla pagina
+        non esiste piu'.
         """
         
         layout = self.page_layouts[page_idx]
@@ -616,16 +626,22 @@ class ScoreVisualizer:
         colorbar_ratio = self.config['colorbar_width_ratio']
         envelope_ratio = self.config['envelope_panel_ratio'] if has_envelopes else 0.0
 
-        # Altezza per stream (divisa equamente)
-        stream_total_ratio = 1.0 - envelope_ratio
-        stream_row_height = stream_total_ratio / n_streams
+        # Altezza banda per stream (divisa equamente). Con envelope attivi ogni
+        # banda si sdoppia in due righe contigue: grani sopra, envelope sotto
+        # (issue #113) — la riga envelope prende envelope_panel_ratio della
+        # banda del suo stream, cosi' ogni stream ha il proprio subplot
+        # envelope allineato verticalmente ai suoi grani (simmetria 1:1 con
+        # #109), anche quando non ha envelope dinamici (lane vuota).
+        stream_band = 1.0 / n_streams
 
-        # Crea height_ratios
         if has_envelopes:
-            height_ratios = [stream_row_height] * n_streams + [envelope_ratio]
-            n_rows = n_streams + 1
+            height_ratios = []
+            for _ in range(n_streams):
+                height_ratios += [stream_band * (1.0 - envelope_ratio),
+                                  stream_band * envelope_ratio]
+            n_rows = 2 * n_streams
         else:
-            height_ratios = [stream_row_height] * n_streams
+            height_ratios = [stream_band] * n_streams
             n_rows = n_streams
 
         # GridSpec: n_rows righe × 3 colonne [waveform, contenuto, colorbar].
@@ -675,9 +691,13 @@ class ScoreVisualizer:
         # magnify è spenta.
         stream_entries = []
         for i, stream in enumerate(active_streams):
+            # Riga dei grani: con envelope attivi le bande sono sdoppiate
+            # (grani=2i, envelope=2i+1); senza envelope una riga per stream.
+            grain_row = 2 * i if has_envelopes else i
+
             # Crea subplot per questo stream
-            ax_wave = fig.add_subplot(gs[i, 0])
-            ax_grain = fig.add_subplot(gs[i, 1])
+            ax_wave = fig.add_subplot(gs[grain_row, 0])
+            ax_grain = fig.add_subplot(gs[grain_row, 1])
 
             # Sample e durata dello stream corrente
             sample_path = stream.sample
@@ -705,8 +725,8 @@ class ScoreVisualizer:
             })
 
             # Legenda della scala colore pitch (auto-zoomata o fissa) nella
-            # colonna dedicata gs[i, 2]: non ruba larghezza al subplot dei grani.
-            self._add_pitch_colorbar(fig, gs[i, 2], cents_range,
+            # colonna dedicata della riga grani: non ruba larghezza al subplot.
+            self._add_pitch_colorbar(fig, gs[grain_row, 2], cents_range,
                                      [stream], page_start, page_end)
             # Configura assi waveform
             ax_wave.set_ylim(-0.02, sample_duration+0.02)
@@ -743,59 +763,57 @@ class ScoreVisualizer:
                 ax_grain.set_xlabel("Time (s)", fontsize=self._fs(self.config['label_fontsize']))
             else:
                 ax_grain.set_xticklabels([])
-        
-        # =========================================================================
-        # SUBPLOT ENVELOPE (se presenti)
-        # =========================================================================
-        if has_envelopes:
-            ax_env = fig.add_subplot(gs[n_streams, 1])
 
-            # Layout condiviso lane/legenda (issue #91): stesso ordinamento e
-            # stesse y, cosi' la legenda non appare mirrorata rispetto alle curve.
-            lanes, legend_entries = self._compute_env_legend_layout(active_streams)
+            # =====================================================================
+            # RIGA ENVELOPE DELLO STREAM (issue #113)
+            # =====================================================================
+            # Un subplot envelope per stream, subito sotto i suoi grani, nella
+            # stessa colonna centrale: stesso bordo destro/sinistro e stesso
+            # asse temporale. Presente anche per stream senza envelope dinamici
+            # (lane vuota), cosi' il conteggio resta 1:1 coi subplot dei grani.
+            if has_envelopes:
+                ax_env = fig.add_subplot(gs[grain_row + 1, 1],
+                                         label=f'env:{stream.stream_id}')
 
-            for slot_idx, lane in enumerate(lanes):
-                stream = lane['stream']
-                y_base = lane['y_base']
-                y_height = lane['y_height']
+                # Layout condiviso lane/legenda (issue #91), ora calcolato per
+                # il singolo stream: 0 lane (stream tutto statico) o 1 lane.
+                lanes, legend_entries = self._compute_env_legend_layout([stream])
 
-                # Disegna envelope in questa "corsia"
-                self._draw_envelopes(ax_env, stream, y_base, y_height,
-                                     page_start, page_end)
+                for lane in lanes:
+                    self._draw_envelopes(ax_env, lane['stream'], lane['y_base'],
+                                         lane['y_height'], page_start, page_end)
 
-                # Label stream nella corsia envelope
+                # Label stream nella lane envelope: presente anche a lane
+                # vuota, cosi' la corsia resta attribuibile al suo stream.
                 ax_env.text(
-                    page_start + 0.3,
-                    y_base + y_height * 0.5,
-                    stream.stream_id,
+                    0.01, 0.5, stream.stream_id,
+                    transform=ax_env.transAxes,
                     fontsize=self._fs(self.config['label_fontsize'] - 2),
                     verticalalignment='center',
                     color='gray',
                     alpha=0.6
                 )
-                # ========== LINEE DIVISORIE ==========
-                # Linea sopra questa corsia (non sulla prima)
-                if slot_idx > 0:
-                    ax_env.axhline(y=y_base - 0.02, color='darkgray',
-                                   linewidth=1, alpha=0.4, linestyle='-')
 
-            # Configura assi envelope
-            ax_env.set_xlim(page_start, page_end)
-            ax_env.set_ylim(0, 1)
-            ax_env.set_xlabel("Time (s)", fontsize=self._fs(self.config['label_fontsize']))
-            ax_env.set_ylabel("", fontsize=self._fs(self.config['label_fontsize']))
-            ax_env.set_yticklabels([])
-            ax_env.tick_params(axis='y', length=0)
-            ax_env.grid(True, alpha=0.3, linestyle='--', axis='x')
+                # Configura assi envelope
+                ax_env.set_xlim(page_start, page_end)
+                ax_env.set_ylim(0, 1)
+                ax_env.set_yticklabels([])
+                ax_env.tick_params(axis='y', length=0)
+                ax_env.grid(True, alpha=0.3, linestyle='--', axis='x')
 
-            ax_env.spines['top'].set_position(('axes', 1))     
-            ax_env.spines['bottom'].set_position(('axes', 0))  
+                # Asse tempo descritto una sola volta, sull'ultima riga della
+                # pagina (l'envelope dell'ultimo stream).
+                if i == n_streams - 1:
+                    ax_env.set_xlabel("Time (s)",
+                                      fontsize=self._fs(self.config['label_fontsize']))
+                else:
+                    ax_env.set_xticklabels([])
 
-
-            # Legenda envelope (per-lane, allineata alle curve — issue #91)
-            if legend_entries:
-                ax_legend = fig.add_subplot(gs[n_streams, 0])
-                self._draw_envelope_legend(ax_legend, legend_entries)
+                # Legenda envelope (per-lane, allineata alle curve — issue #91)
+                # nella colonna sinistra della riga envelope dello stream.
+                if legend_entries:
+                    ax_legend = fig.add_subplot(gs[grain_row + 1, 0])
+                    self._draw_envelope_legend(ax_legend, legend_entries)
         # =========================================================================
         # LENTE DI INGRANDIMENTO (magnify)
         # =========================================================================
@@ -1818,6 +1836,11 @@ class ScoreVisualizer:
 
         Lane e legenda devono usare lo stesso ordinamento e le stesse y,
         altrimenti la legenda appare mirrorata rispetto alle curve.
+
+        Dal fix #113 render_page la invoca con UN solo stream per volta (ogni
+        stream ha il proprio asse envelope): il risultato e' 0 lane (stream
+        tutto statico -> l'asse resta, vuoto) o 1 lane a tutta altezza. La
+        geometria multi-stream resta supportata per compatibilita'.
 
         Returns:
             (lanes, legend_entries)

--- a/tests/rendering/test_score_visualizer.py
+++ b/tests/rendering/test_score_visualizer.py
@@ -178,6 +178,23 @@ def issue_109_shared_sample_scene():
     ]
 
 
+def issue_113_mixed_envelope_scene():
+    """Caso PGE_pino2.yml (issue #113): 4 stream, di cui solo i primi due hanno
+    envelope dinamici; stream4 e stream5 sono tutti statici (dict envelope
+    vuoto coi flag di default). stream4 condivide il sample con texture2.
+    Pre-fix: pannello envelope unico in fondo con 2 sole lane (filtro `if e`)."""
+    from pge.envelopes.envelope import Envelope
+    streams = [
+        make_stream('texture2', onset=0.0, duration=20.0, sample='001-0_0-3_0.wav'),
+        make_stream('texture3', onset=0.0, duration=20.0, sample='001-29_5-7_5.wav'),
+        make_stream('stream4',  onset=0.0, duration=20.0, sample='001-0_0-3_0.wav'),
+        make_stream('stream5',  onset=0.0, duration=20.0, sample='001-8_5-4_5.wav'),
+    ]
+    streams[0].density = Envelope([[0, 10.0], [20, 100.0]])
+    streams[1].pointer_speed = Envelope([[0, -2.0], [20, 4.0]])
+    return streams
+
+
 # =============================================================================
 # GROUP 1 - Pipeline analyze → render_all (scenario singolo stream)
 # =============================================================================
@@ -1111,7 +1128,11 @@ class TestLegendDisplayName:
 class TestEnvelopeLegendPerLane:
     """La legenda envelope deve essere allineata per-lane: la voce di legenda di
     ogni envelope-type cade nella lane dello stream che lo possiede, alla stessa
-    y delle curve. Pre-fix legenda globale alfabetica -> swap apparente."""
+    y delle curve. Pre-fix legenda globale alfabetica -> swap apparente.
+
+    Nota (issue #113): render_page ora invoca _compute_env_legend_layout con un
+    solo stream per volta (un asse envelope per stream); la geometria
+    multi-stream qui testata resta il contratto della funzione."""
 
     def _two_streams(self):
         s_low = make_stream('s_low', onset=0.0, duration=10.0)
@@ -1165,6 +1186,148 @@ class TestEnvelopeLegendPerLane:
                 [s_low, s_high])
         assert lanes == []
         assert legend_entries == []
+
+
+# =============================================================================
+# GROUP - Pannello envelope per-stream (issue #113)
+# =============================================================================
+
+class TestEnvelopePerStreamPanel:
+    """issue #113 - il pannello envelope deve essere un subplot per stream,
+    allineato 1:1 e verticalmente al rispettivo subplot dei grani (la simmetria
+    di #109 estesa agli envelope). Pre-fix: un unico asse condiviso in fondo
+    alla pagina, con lane solo per gli stream con envelope dinamici."""
+
+    @staticmethod
+    def _env_axes(fig, page_start=0.0, page_end=30.0):
+        """Assi envelope: xlim == pagina e ylim == (0, 1) (i grani hanno
+        ylim = durata sample; waveform/legenda/colorbar hanno xlim diversi)."""
+        out = []
+        for ax in fig.axes:
+            lo, hi = ax.get_xlim()
+            ylo, yhi = ax.get_ylim()
+            same_page = abs(lo - page_start) < 1e-9 and abs(hi - page_end) < 1e-9
+            is_env = abs(ylo - 0.0) < 1e-9 and abs(yhi - 1.0) < 1e-9
+            if same_page and is_env:
+                out.append(ax)
+        return out
+
+    @staticmethod
+    def _env_by_id(fig):
+        """Mappa stream_id -> asse envelope (label matplotlib 'env:<id>')."""
+        return {str(ax.get_label())[len('env:'):]: ax for ax in fig.axes
+                if str(ax.get_label()).startswith('env:')}
+
+    def _render(self, streams, **cfg):
+        viz = make_viz(streams, config={'page_duration': 30.0, **cfg})
+        with patch('soundfile.read', return_value=(FAKE_AUDIO, SR)):
+            viz.analyze()
+            fig = viz.render_page(0)
+        fig.canvas.draw()  # finalizza le posizioni dei subplot
+        return fig
+
+    def test_envelope_axes_count_equals_stream_count(self):
+        """Cuore della issue: 4 stream di cui 2 con soli statici -> 4 assi
+        envelope, come i 4 subplot dei grani (pre-fix: 1 pannello, 2 lane)."""
+        fig = self._render(issue_113_mixed_envelope_scene())
+        assert len(self._env_axes(fig)) == 4
+
+    def test_envelope_axis_adjacent_and_aligned_to_its_stream(self):
+        """L'asse envelope dello stream i sta subito sotto il suo asse grani
+        (bordo superiore == bordo inferiore dei grani) e ne condivide i bordi
+        sinistro/destro (stessa colonna centrale => stesso asse temporale).
+        Pre-fix tutti gli envelope vivevano in fondo alla pagina."""
+        streams = issue_113_mixed_envelope_scene()
+        ids = [s.stream_id for s in streams]
+        fig = self._render(streams)
+
+        # Mappa stream -> asse grani: porta la label testuale dello stream e
+        # NON e' un asse envelope (ylim != (0,1)); la label compare anche
+        # nella lane envelope, che va esclusa dalla mappa.
+        env_axes = set(self._env_axes(fig))
+        grain_by_id = {}
+        for ax in fig.axes:
+            if ax in env_axes:
+                continue
+            for t in ax.texts:
+                if t.get_text() in ids:
+                    grain_by_id[t.get_text()] = ax
+        env_by_id = self._env_by_id(fig)
+
+        assert set(env_by_id) == set(ids)
+        for sid in ids:
+            g = grain_by_id[sid].get_position()
+            e = env_by_id[sid].get_position()
+            assert abs(e.x0 - g.x0) < 1e-6          # stesso bordo sinistro
+            assert abs(e.x1 - g.x1) < 1e-6          # stesso bordo destro
+            assert abs(e.y1 - g.y0) < 1e-6          # adiacente, subito sotto
+            assert env_by_id[sid].get_xlim() == grain_by_id[sid].get_xlim()
+
+    def test_stream_without_dynamic_envelopes_gets_empty_labeled_lane(self):
+        """Stream tutto statico (flag di default): la sua lane envelope esiste
+        comunque — nessuna curva ma label dello stream visibile — mentre gli
+        stream con envelope dinamici hanno curve E label (pre-fix il filtro
+        `if e` ometteva del tutto la lane degli stream statici)."""
+        fig = self._render(issue_113_mixed_envelope_scene())
+        env_by_id = self._env_by_id(fig)
+
+        for sid in ('stream4', 'stream5'):          # tutti statici
+            ax = env_by_id[sid]
+            assert len(ax.lines) == 0               # lane vuota
+            assert any(t.get_text() == sid for t in ax.texts)
+
+        for sid in ('texture2', 'texture3'):        # envelope dinamici
+            ax = env_by_id[sid]
+            assert len(ax.lines) > 0                # curve presenti
+            assert any(t.get_text() == sid for t in ax.texts)
+
+    def test_no_envelopes_at_all_no_env_axes(self):
+        """Retro-compatibilita': nessuno stream con envelope dinamici ->
+        nessuna riga envelope, layout #109 invariato (solo grani)."""
+        fig = self._render(issue_109_shared_sample_scene())
+        assert self._env_axes(fig) == []
+        assert self._env_by_id(fig) == {}
+
+    def test_shared_sample_streams_keep_distinct_env_lanes(self):
+        """texture2 e stream4 condividono il sample ma le lane envelope non
+        collassano: assi distinti su bande verticali disgiunte (la regressione
+        #109 sui grani, estesa agli envelope)."""
+        fig = self._render(issue_113_mixed_envelope_scene())
+        env_by_id = self._env_by_id(fig)
+        a, b = env_by_id['texture2'], env_by_id['stream4']
+        assert a is not b
+        pa, pb = a.get_position(), b.get_position()
+        assert pa.y0 >= pb.y1 - 1e-9 or pb.y0 >= pa.y1 - 1e-9
+
+    def test_legend_entries_live_in_owning_stream_row(self):
+        """La voce di legenda di un envelope sta nella colonna sinistra della
+        riga envelope dello stream proprietario (issue #91 portata al layout
+        per-stream), non piu' in un'unica colonna in fondo alla pagina."""
+        fig = self._render(issue_113_mixed_envelope_scene())
+        env_by_id = self._env_by_id(fig)
+
+        # nome di legenda atteso per ciascuno stream con envelope dinamici
+        for sid, legend_text in (('texture2', 'density'),
+                                 ('texture3', 'ptr spd')):
+            e = env_by_id[sid].get_position()
+            found = False
+            for ax in fig.axes:
+                p = ax.get_position()
+                same_row = abs(p.y0 - e.y0) < 1e-6 and abs(p.y1 - e.y1) < 1e-6
+                left_of_env = p.x1 <= e.x0 + 1e-6
+                if same_row and left_of_env and \
+                        any(t.get_text() == legend_text for t in ax.texts):
+                    found = True
+            assert found, f"legenda '{legend_text}' assente nella riga di {sid}"
+
+    def test_time_axis_label_only_on_last_row(self):
+        """"Time (s)" compare una sola volta, sull'asse envelope dell'ultimo
+        stream (l'ultima riga della pagina)."""
+        streams = issue_113_mixed_envelope_scene()
+        fig = self._render(streams)
+        labeled = [ax for ax in fig.axes if ax.get_xlabel() == "Time (s)"]
+        assert len(labeled) == 1
+        assert labeled[0] is self._env_by_id(fig)[streams[-1].stream_id]
 
 
 # =============================================================================


### PR DESCRIPTION
Closes #113

## Problema

Il fix #109 ha reso per-stream i subplot di grani/waveform, ma il pannello envelope era rimasto **un singolo subplot condiviso** in fondo alla pagina (`gs[n_streams, 1]`, altezza fissa `envelope_panel_ratio = 0.3`) suddiviso internamente in lane. In piu' `_compute_env_legend_layout` scartava gli stream senza envelope dinamici (filtro `if e`): con `PGE_pino2.yml` (4 stream, di cui `stream4` e `stream5` tutti statici coi flag di default) si ottenevano **4 subplot grani ma 2 sole lane envelope**, non allineate verticalmente agli stream.

## Soluzione (Opzione A della issue)

Un **subplot envelope per stream**, subito sotto la riga dei suoi grani:

- il gridspec sdoppia la banda di ogni stream in due righe contigue (grani sopra, envelope sotto) nella stessa colonna centrale: stesso bordo sinistro/destro e stesso asse temporale -> allineamento verticale 1:1;
- la riga envelope esiste **anche per gli stream senza envelope dinamici** (lane vuota con la label dello stream), cosi' il conteggio resta simmetrico ai subplot dei grani;
- `_compute_env_legend_layout` viene invocata per singolo stream (0 o 1 lane a tutta altezza, niente piu' collasso); la geometria multi-stream resta supportata e testata;
- la legenda per-lane (#91) vive nella colonna sinistra della riga envelope del proprio stream;
- "Time (s)" e i tick temporali compaiono solo sull'ultima riga della pagina;
- `envelope_panel_ratio` e' ora la frazione della **banda di ogni stream** riservata alla riga envelope (prima: frazione di pagina del pannello unico; proporzione complessiva invariata, 30%);
- senza alcun envelope il layout resta quello di #109 (solo righe grani, xlabel sull'ultimo stream).

## Test (TDD rosso->verde)

Nuova classe `TestEnvelopePerStreamPanel` (7 test) in `tests/rendering/test_score_visualizer.py`:

- conteggio assi envelope == numero stream su scena `PGE_pino2`-like (4 stream, 2 tutti statici) — il tracer bullet, rosso pre-fix (1 asse vs 4);
- adiacenza e allineamento geometrico envelope<->grani per ogni stream (stessi bordi, bande contigue, stesso xlim);
- lane vuota ma etichettata per gli stream tutti statici; curve presenti per gli altri;
- retro-compatibilita': nessun envelope -> nessuna riga envelope;
- regressione: stream con sample condiviso mantengono lane envelope distinte;
- voci di legenda nella riga envelope dello stream proprietario;
- "Time (s)" una sola volta, sull'asse envelope dell'ultimo stream.

`make tests`: **5010 passed, 0 failed** (2 skip attesi con `refs/` vuota). I test esistenti (`TestEnvelopeLegendPerLane` #91, `TestEnvelopeStreamWidthAlignment`, per-segment #68) restano verdi senza modifiche.

## Verifica visiva

Pagina 1/10 di `configs/PGE_pino2.yml` rigenerata con sample sintetici: 4 subplot grani e 4 lane envelope allineate (texture2: 5 curve; texture3: 4; stream4/stream5: lane vuote etichettate), legenda per-stream, asse tempo unico in fondo.

## Impatto cross-repo

**Nessun impatto su PGE-ls / PGE-ui** (come dichiarato nella issue): rendering interno del PDF di partitura — nessuna modifica a sintassi/schema YAML, bounds, CLI/flag, errori o formati consumati a valle. Nessuna issue cross-repo da aprire.

## Nota paper CIM 2026 (regola submodule-sync-cim)

La modifica tocca lo score visualizer, osservabile dagli esempi del paper: le partiture rigenerate avranno il layout envelope per-stream (solo output visivo — firma di `ScoreVisualizer` e chiavi di config invariate, `envelope_panel_ratio` conserva default e proporzione). **Promemoria**: dopo il merge valutare il bump del submodule `raw/PythonGranularEngine` in `cim2026-granular-engine-paper` (poi `make link-refs` e `make examples`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KckHQ617oWQmTJKrz19u3q

---
_Generated by [Claude Code](https://claude.ai/code/session_01KckHQ617oWQmTJKrz19u3q)_