### PR TITLE
feat(seeding): rng_group per condividere la sequenza RNG fra stream (issue #169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,9 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   `stream_id`: hash identico a prima, **nessun render esistente cambia
   bit-per-bit**. Implementato come campo `rng_group` + property `rng_id` in
   `StreamContext`; le firme di `component_rng`/`voice_rng` non cambiano.
-  Reference: `docs/reference/yaml.md` §Seed.
+  `rng_group` entra nel fingerprint della cache stems (cambiarlo cambia
+  l'audio: lo stem diventa dirty); le sole chiavi escluse restano
+  `solo`/`mute`. Reference: `docs/reference/yaml.md` §Seed.
 - **Envelope BP group per-macrozona** (issue #64): un run di breakpoint puo'
   essere avvolto in un gruppo compatto `[points, interp]`, simmetrico ai loop
   block — due macrozone BP nello stesso envelope misto interpolano in modo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Aggiunto
 
+- **`rng_group`: sequenza RNG condivisa fra stream** (issue #169): nuova
+  chiave YAML per-stream opzionale che sostituisce lo `stream_id` come
+  identità nella derivazione degli RNG locali (`shared/seeding.py`). Stream
+  con lo stesso `rng_group` — e stessi parametri stocastici — pescano le
+  stesse sequenze su tutti i componenti (variazioni `_range`, gate, `iot`,
+  `window`, `detune`) e sulle voci stocastiche. Default assente → identità =
+  `stream_id`: hash identico a prima, **nessun render esistente cambia
+  bit-per-bit**. Implementato come campo `rng_group` + property `rng_id` in
+  `StreamContext`; le firme di `component_rng`/`voice_rng` non cambiano.
+  Reference: `docs/reference/yaml.md` §Seed.
 - **Envelope BP group per-macrozona** (issue #64): un run di breakpoint puo'
   essere avvolto in un gruppo compatto `[points, interp]`, simmetrico ai loop
   block — due macrozone BP nello stesso envelope misto interpolano in modo

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -10,7 +10,7 @@ sources:
   - src/pge/strategies/
   - src/pge/envelopes/
   - src/pge/shared/seeding.py
-last_synced_commit: 9ebe4df
+last_synced_commit: abea29b
 entry_for: [yaml-syntax, envelope-syntax]
 ---
 
@@ -33,7 +33,8 @@ Reference completa del formato YAML consumato da `main.py`: sintassi per stream,
 Sezioni rilevanti in questo doc:
 
 - [Minimal Stream](#minimal-stream) — schema minimo
-- [Seed (Riproducibilità)](#seed-riproducibilità) — render NumPy riproducibili
+- [Seed (Riproducibilità)](#seed-riproducibilità) — render NumPy riproducibili;
+  `rng_group` per condividere la sequenza fra stream
 - [Parameter Syntax](#parameter-syntax) — scalari, tuple, dict, envelope
 - [Campi Obbligatori di Stream](#campi-obbligatori-di-stream)
 - [Configurazione Processo (StreamConfig)](#configurazione-processo-streamconfig)
@@ -129,6 +130,43 @@ volta. I render senza seed non cambiano di natura.
 Csound ha un RNG proprio: con `--renderer csound` i due renderer NON sono
 bit-identici nemmeno col seed. Le tendency mask restano stocastiche per natura —
 l'obiettivo è riprodurre *lo stesso run*, non l'identità bit-a-bit.
+
+### Condividere la sequenza fra stream: `rng_group`
+
+Chiave **per-stream** opzionale (issue #169). Di default lo `stream_id` è
+dentro l'hash di derivazione: due stream non possono pescare la stessa
+sequenza nemmeno con lo stesso `seed` (isolamento voluto da #154).
+`rng_group` sostituisce lo `stream_id` come **identità** della derivazione:
+gli stream che dichiarano lo stesso gruppo condividono le sequenze
+pseudo-casuali di tutti i componenti (variazioni `_range`, gate, `iot`,
+`window`, `detune`) e delle voci stocastiche.
+
+```yaml
+seed: 1988
+streams:
+  - stream_id: "cugini_1"
+    rng_group: "cugini"    # stessa identità RNG di cugini_2
+    # ...
+  - stream_id: "cugini_2"
+    rng_group: "cugini"
+    # ...
+```
+
+- **Assente** (default): identità = `stream_id`, hash **identico a prima di
+  #169** — nessun render esistente cambia bit-per-bit.
+- **Presente**: identità = valore del gruppo. La derivazione diventa
+  `sha256(f"{seed}:{rng_group}:{componente}")` (e
+  `...:{voice_index}` per le voci).
+- Caso d'uso: stream "cugini" (spread su `pointer.start`/`pan`) letti come un
+  unico oggetto verticale, con la stessa griglia stocastica di `distribution`.
+- **Limite**: identità condivisa NON significa griglia temporale identica. Il
+  draw dell'IOT async avviene per grano e dipende da `avg_iot`: con `density`
+  o `distribution` diverse i due stream si desincronizzano subito pur
+  condividendo l'RNG. Griglia identica solo con density e distribution
+  identiche.
+- `rng_group` non entra in `solo`/`mute` né nella cache: restano invarianti
+  come da #154 (la condivisione è solo dell'identità di derivazione, non dei
+  draw a runtime — ogni stream materializza la propria copia della sequenza).
 
 ---
 

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -164,9 +164,15 @@ streams:
   o `distribution` diverse i due stream si desincronizzano subito pur
   condividendo l'RNG. Griglia identica solo con density e distribution
   identiche.
-- `rng_group` non entra in `solo`/`mute` né nella cache: restano invarianti
-  come da #154 (la condivisione è solo dell'identità di derivazione, non dei
-  draw a runtime — ogni stream materializza la propria copia della sequenza).
+- `rng_group` **entra nel fingerprint** della cache stems
+  (`StreamCacheManager.compute_fingerprint`): cambiarlo cambia i valori
+  pescati, quindi l'audio, e lo stem viene giustamente marcato dirty. Le
+  sole chiavi escluse dal fingerprint restano `solo`/`mute`, che non
+  toccano l'audio del singolo stem (issue #108).
+- L'invarianza di `solo`/`mute` garantita da #154 resta intatta: la
+  condivisione riguarda l'identità di derivazione, non i draw a runtime —
+  ogni stream materializza la propria copia della sequenza, quindi mettere
+  un cugino in solo non sposta i grani degli altri.
 
 ---
 

--- a/src/pge/controllers/density_controller.py
+++ b/src/pge/controllers/density_controller.py
@@ -36,9 +36,10 @@ class DensityController:
         """
         # RNG dedicato all'IOT async (issue #154): i draw della distribuzione
         # Truax non dipendono dagli altri componenti né dagli altri stream.
+        # Identità = rng_id (issue #169): stream_id, o rng_group se condiviso.
         self._rng = component_rng(
             getattr(config, 'seed', None),
-            config.context.stream_id,
+            config.context.rng_id,
             'iot',
         )
 

--- a/src/pge/controllers/pitch_controller.py
+++ b/src/pge/controllers/pitch_controller.py
@@ -61,11 +61,12 @@ class PitchController:
             dephase_key='pitch',
         )
         # RNG dedicato al detune implicito (issue #154, componente 'detune').
+        # Identità = rng_id (issue #169): stream_id, o rng_group se condiviso.
         self._strategy = UnitPitchStrategy(
             self._active_param, unit, unit.name,
             rng=component_rng(
                 getattr(config, 'seed', None),
-                config.context.stream_id,
+                config.context.rng_id,
                 'detune',
             ),
         )

--- a/src/pge/controllers/window_controller.py
+++ b/src/pge/controllers/window_controller.py
@@ -126,8 +126,9 @@ class WindowController:
 
         # RNG per-componente (issue #154): 'window' per la selezione,
         # 'gate:pc_rand_envelope' per il gate — draw isolati dagli altri siti.
+        # Identità = rng_id (issue #169): stream_id, o rng_group se condiviso.
         seed = getattr(config, 'seed', None)
-        stream_id = config.context.stream_id
+        rng_id = config.context.rng_id
 
         uses_gate = not (_is_transition_spec(envelope_spec) or _is_multistate_spec(envelope_spec))
         gate = GateFactory.create_gate(
@@ -138,11 +139,11 @@ class WindowController:
             range_always_active=config.range_always_active,
             duration=config.context.duration,
             time_mode=config.time_mode,
-            rng=component_rng(seed, stream_id, 'gate:pc_rand_envelope'),
+            rng=component_rng(seed, rng_id, 'gate:pc_rand_envelope'),
         )
         self._strategy: WindowSelectionStrategy = WindowStrategyFactory.from_spec(
             envelope_spec, config, self._windows, gate,
-            rng=component_rng(seed, stream_id, 'window'),
+            rng=component_rng(seed, rng_id, 'window'),
         )
 
     @property

--- a/src/pge/core/stream.py
+++ b/src/pge/core/stream.py
@@ -257,7 +257,9 @@ class Stream:
                 spread: 60.0
 
         - voices assente → VoiceManager(max_voices=1)
-        - strategy stochastiche: stream_id iniettato automaticamente
+        - strategy stochastiche: identità RNG iniettata automaticamente nel
+          kwarg `stream_id` — vale rng_id (issue #169): lo stream_id, o il
+          rng_group quando la sequenza è condivisa fra stream
         - spread estratto dal blocco pan
         """
         from pge.parameters.parameter import Parameter
@@ -333,7 +335,7 @@ class Stream:
                 raise err
             pitch_unit = make_pitch_unit(unit_spec)
             if name == 'stochastic':
-                kw['stream_id'] = self.stream_id
+                kw['stream_id'] = config.context.rng_id
                 kw['seed'] = self.seed
             # chord_progression: i kwarg strutturali NON sono envelope-like e
             # vanno estratti prima della comprehension. In particolare
@@ -359,7 +361,7 @@ class Stream:
             kw = dict(v['onset_offset'])
             name = kw.pop('strategy')
             if name == 'stochastic':
-                kw['stream_id'] = self.stream_id
+                kw['stream_id'] = config.context.rng_id
                 kw['seed'] = self.seed
             kw = {k: _parse_strategy_kwarg(val, self.duration, config.time_mode) for k, val in kw.items()}
             onset_strategy = VoiceOnsetStrategyFactory.create(name, **kw)
@@ -383,7 +385,7 @@ class Stream:
                 raise err
             self._voice_pointer_normalized = raw_normalized
             if name == 'stochastic':
-                kw['stream_id'] = self.stream_id
+                kw['stream_id'] = config.context.rng_id
                 kw['seed'] = self.seed
             kw = {k: _parse_strategy_kwarg(val, self.duration, config.time_mode) for k, val in kw.items()}
             pointer_strategy = VoicePointerStrategyFactory.create(name, **kw)
@@ -394,7 +396,7 @@ class Stream:
             kw = dict(v['pan'])
             name = kw.pop('strategy')
             if name == 'stochastic':
-                kw['stream_id'] = self.stream_id
+                kw['stream_id'] = config.context.rng_id
                 kw['seed'] = self.seed
             kw = {k: _parse_strategy_kwarg(val, self.duration, config.time_mode) for k, val in kw.items()}
             pan_strategy = VoicePanStrategyFactory.create(name, **kw)

--- a/src/pge/core/stream_config.py
+++ b/src/pge/core/stream_config.py
@@ -17,6 +17,17 @@ class StreamContext:
     # campioni <-> secondi (grain.duration_unit) e per il bound minimo
     # dinamico di grain_duration (1 campione).
     output_sr: int = DEFAULT_OUTPUT_SR
+    # Identità RNG condivisibile (issue #169): se valorizzato, sostituisce
+    # lo stream_id nella derivazione degli RNG locali (shared/seeding.py),
+    # così stream diversi con lo stesso rng_group pescano le stesse sequenze.
+    # None (default) → identità = stream_id, hash identico a prima di #169.
+    rng_group: Optional[str] = None
+
+    @property
+    def rng_id(self) -> str:
+        """Identità usata nella derivazione RNG: rng_group se dichiarato,
+        altrimenti stream_id (isolamento per-stream, contratto issue #154)."""
+        return self.rng_group if self.rng_group is not None else self.stream_id
 
     @classmethod
     def from_yaml(cls, yaml_data: dict, sample_dur_sec: float, allow_none: bool = True) -> 'StreamConfig':

--- a/src/pge/core/stream_config.py
+++ b/src/pge/core/stream_config.py
@@ -26,8 +26,10 @@ class StreamContext:
     @property
     def rng_id(self) -> str:
         """Identità usata nella derivazione RNG: rng_group se dichiarato,
-        altrimenti stream_id (isolamento per-stream, contratto issue #154)."""
-        return self.rng_group if self.rng_group is not None else self.stream_id
+        altrimenti stream_id (isolamento per-stream, contratto issue #154).
+        Falsy (None, stringa vuota) → fallback a stream_id: una stringa vuota
+        non deve diventare un'identità condivisa accidentale."""
+        return self.rng_group or self.stream_id
 
     @classmethod
     def from_yaml(cls, yaml_data: dict, sample_dur_sec: float, allow_none: bool = True) -> 'StreamConfig':

--- a/src/pge/parameters/parameter_orchestrator.py
+++ b/src/pge/parameters/parameter_orchestrator.py
@@ -91,10 +91,11 @@ class ParameterOrchestrator:
         return param
 
     def _gate_rng(self, dephase_key: Optional[str]):
-        """RNG locale del gate, derivato da (seed, stream_id, gate:<key>)."""
+        """RNG locale del gate, derivato da (seed, rng_id, gate:<key>) —
+        rng_id è stream_id o, se dichiarato, il rng_group (issue #169)."""
         return component_rng(
             getattr(self._config, 'seed', None),
-            self._config.context.stream_id,
+            self._config.context.rng_id,
             f"gate:{dephase_key}",
         )
     

--- a/src/pge/parameters/parser.py
+++ b/src/pge/parameters/parser.py
@@ -37,9 +37,10 @@ class GranularParser:
         """
         self.stream_id = config.context.stream_id
         # Identità di derivazione RNG (issue #169): rng_group se dichiarato,
-        # altrimenti stream_id. getattr difensivo come per output_sr (context
-        # parziali nei test). stream_id resta l'identità di log/errori.
-        self.rng_id = getattr(config.context, 'rng_id', self.stream_id)
+        # altrimenti stream_id. Accesso diretto come negli altri call site
+        # della derivazione: la property esiste sempre sulla dataclass.
+        # stream_id resta l'identità di log/errori.
+        self.rng_id = config.context.rng_id
         self.duration = config.context.duration
         self.sample_dur_sec = config.context.sample_dur_sec
         # Sample rate di output: bound minimo dinamico di grain_duration

--- a/src/pge/parameters/parser.py
+++ b/src/pge/parameters/parser.py
@@ -36,6 +36,10 @@ class GranularParser:
             time_mode: 'absolute' (sec) o 'normalized' (0-1). Default per gli envelope.
         """
         self.stream_id = config.context.stream_id
+        # Identità di derivazione RNG (issue #169): rng_group se dichiarato,
+        # altrimenti stream_id. getattr difensivo come per output_sr (context
+        # parziali nei test). stream_id resta l'identità di log/errori.
+        self.rng_id = getattr(config.context, 'rng_id', self.stream_id)
         self.duration = config.context.duration
         self.sample_dur_sec = config.context.sample_dur_sec
         # Sample rate di output: bound minimo dinamico di grain_duration
@@ -113,8 +117,10 @@ class GranularParser:
 
         # 4. Assembla e restituisce l'oggetto Smart Parameter.
         # RNG per-componente (issue #154): ogni parametro pesca dal proprio
-        # stream derivato da (seed, stream_id, nome) — i draw di un parametro
+        # stream derivato da (seed, rng_id, nome) — i draw di un parametro
         # non shiftano quelli degli altri (solo/mute e cache invarianti).
+        # rng_id = stream_id, o rng_group se condiviso (issue #169);
+        # owner_id resta lo stream_id (identità di log, non di derivazione).
         return Parameter(
             name=name,
             value=validated_value,
@@ -122,7 +128,7 @@ class GranularParser:
             mod_range=validated_range,
             owner_id=self.stream_id,
             distribution_mode=self.distribution_mode,
-            rng=component_rng(self.seed, self.stream_id, name),
+            rng=component_rng(self.seed, self.rng_id, name),
         )
 
     # =========================================================================

--- a/src/pge/shared/seeding.py
+++ b/src/pge/shared/seeding.py
@@ -1,6 +1,6 @@
 # src/shared/seeding.py
 """
-seeding.py — derivazione deterministica degli RNG locali (issue #81, #154).
+seeding.py — derivazione deterministica degli RNG locali (issue #81, #154, #169).
 
 Singola fonte di verità per la derivazione dei generatori pseudo-casuali:
 
@@ -15,6 +15,14 @@ Singola fonte di verità per la derivazione dei generatori pseudo-casuali:
 - `session_seed` (issue #154): seed di sessione derivato da timestamp per i
   run senza `seed:` nello YAML — loggato dal Generator, così ogni run resta
   ricostruibile a posteriori.
+
+Identità di derivazione (issue #169): il parametro `stream_id` di queste
+funzioni è l'*identità* della sequenza, non necessariamente l'id dello
+stream. I call site passano `StreamContext.rng_id`: lo stream_id di default
+(isolamento per-stream, contratto #154) oppure il `rng_group` dichiarato
+nello YAML per-stream — così stream diversi possono pescare la stessa
+sequenza pseudo-casuale. Le firme qui non cambiano: la leva è tutta nel
+valore passato dai chiamanti.
 
 Regimi di derivazione:
 

--- a/src/pge/strategies/voice_onset_strategy.py
+++ b/src/pge/strategies/voice_onset_strategy.py
@@ -110,6 +110,12 @@ class StochasticOnsetStrategy(VoiceOnsetStrategy):
     Offset fisso per voce entro un singolo run; la magnitudine può variare nel
     tempo se max_offset è un Envelope.
 
+    Identità RNG (issue #169): il kwarg `stream_id` è l'*identità* della
+    sequenza, non necessariamente l'id dello stream. Stream inietta
+    `context.rng_id`, che vale il `rng_group` quando più stream condividono
+    la sequenza; il nome del kwarg resta invariato per non rompere i
+    factory kwarg documentati.
+
     Seed (issue #81): se `seed` è None il RNG per-voce usa hash(stream_id+vi) —
     stabile ENTRO un run, NON riproducibile fra processi (hash() randomizzato
     per-processo, PYTHONHASHSEED non fissato). Se `seed` è valorizzato la

--- a/src/pge/strategies/voice_pan_strategy.py
+++ b/src/pge/strategies/voice_pan_strategy.py
@@ -135,6 +135,12 @@ class StochasticPanStrategy(VoicePanStrategy):
     _cache[voice_index] memorizza il fattore normalizzato in [-1, 1].
     Offset = _cache[vi] * spread / 2; la magnitudine può variare nel tempo
     se spread è un Envelope.
+    Identità RNG (issue #169): il kwarg `stream_id` è l'*identità* della
+    sequenza, non necessariamente l'id dello stream. Stream inietta
+    `context.rng_id`, che vale il `rng_group` quando più stream condividono
+    la sequenza; il nome del kwarg resta invariato per non rompere i
+    factory kwarg documentati.
+
     Seed (issue #81): se `seed` è None il RNG per-voce usa hash(stream_id+vi) —
     stabile ENTRO un run, NON riproducibile fra processi (hash() randomizzato
     per-processo, PYTHONHASHSEED non fissato). Se `seed` è valorizzato la

--- a/src/pge/strategies/voice_pitch_strategy.py
+++ b/src/pge/strategies/voice_pitch_strategy.py
@@ -452,6 +452,12 @@ class StochasticPitchStrategy(VoicePitchStrategy):
     Offset fisso per voce entro un singolo run; la direzione è fissa, la magnitudine
     può variare nel tempo se pitch_range è un Envelope.
 
+    Identità RNG (issue #169): il kwarg `stream_id` è l'*identità* della
+    sequenza, non necessariamente l'id dello stream. Stream inietta
+    `context.rng_id`, che vale il `rng_group` quando più stream condividono
+    la sequenza; il nome del kwarg resta invariato per non rompere i
+    factory kwarg documentati.
+
     Seed (issue #81): se `seed` è None il RNG per-voce usa hash(stream_id+vi) —
     stabile ENTRO un run, NON riproducibile fra processi (hash() randomizzato
     per-processo, PYTHONHASHSEED non fissato). Se `seed` è valorizzato la

--- a/src/pge/strategies/voice_pointer_strategy.py
+++ b/src/pge/strategies/voice_pointer_strategy.py
@@ -102,6 +102,12 @@ class StochasticPointerStrategy(VoicePointerStrategy):
     Offset fisso per voce entro un singolo run; la magnitudine può variare nel
     tempo se pointer_range è un Envelope.
 
+    Identità RNG (issue #169): il kwarg `stream_id` è l'*identità* della
+    sequenza, non necessariamente l'id dello stream. Stream inietta
+    `context.rng_id`, che vale il `rng_group` quando più stream condividono
+    la sequenza; il nome del kwarg resta invariato per non rompere i
+    factory kwarg documentati.
+
     Seed (issue #81): se `seed` è None il RNG per-voce usa hash(stream_id+vi) —
     stabile ENTRO un run, NON riproducibile fra processi (hash() randomizzato
     per-processo, PYTHONHASHSEED non fissato). Se `seed` è valorizzato la

--- a/tests/core/test_stream_config.py
+++ b/tests/core/test_stream_config.py
@@ -88,14 +88,14 @@ class TestStreamContextDirect:
         assert ctx.sample_dur_sec == 3.2
 
     def test_field_count(self):
-        """StreamContext ha esattamente 6 campi."""
-        assert len(fields(StreamContext)) == 6
+        """StreamContext ha esattamente 7 campi."""
+        assert len(fields(StreamContext)) == 7
 
     def test_field_names(self):
         """Nomi campi corretti e nell'ordine atteso."""
         names = [f.name for f in fields(StreamContext)]
         assert names == ['stream_id', 'onset', 'duration', 'sample',
-                         'sample_dur_sec', 'output_sr']
+                         'sample_dur_sec', 'output_sr', 'rng_group']
 
     def test_missing_required_field_raises(self):
         """Campi mancanti nella costruzione diretta -> TypeError."""
@@ -1001,3 +1001,64 @@ class TestRepr:
         config = StreamConfig(context=stream_context)
         r = repr(config)
         assert 'stream_01' in r
+
+
+# =============================================================================
+# 17. RNG_GROUP / RNG_ID (issue #169)
+# =============================================================================
+
+class TestRngGroup:
+    """Identità RNG condivisibile fra stream (issue #169).
+
+    `rng_group` è opzionale: assente → `rng_id` coincide con `stream_id`
+    (derivazione hash identica a prima, retrocompatibilità bit-per-bit);
+    presente → `rng_id` è il nome del gruppo, così stream diversi possono
+    pescare la stessa sequenza pseudo-casuale.
+    """
+
+    def test_default_rng_group_is_none(self, sample_dur):
+        ctx = StreamContext(
+            stream_id='s1', onset=0.0, duration=1.0,
+            sample='a.wav', sample_dur_sec=sample_dur,
+        )
+        assert ctx.rng_group is None
+
+    def test_rng_id_falls_back_to_stream_id(self, sample_dur):
+        """Senza rng_group l'identità RNG resta lo stream_id."""
+        ctx = StreamContext(
+            stream_id='s1', onset=0.0, duration=1.0,
+            sample='a.wav', sample_dur_sec=sample_dur,
+        )
+        assert ctx.rng_id == 's1'
+
+    def test_rng_id_uses_rng_group_when_set(self, sample_dur):
+        ctx = StreamContext(
+            stream_id='s1', onset=0.0, duration=1.0,
+            sample='a.wav', sample_dur_sec=sample_dur,
+            rng_group='cugini',
+        )
+        assert ctx.rng_id == 'cugini'
+
+    def test_from_yaml_reads_rng_group(self, full_yaml_context, sample_dur):
+        """from_yaml legge rng_group dal dict per-stream."""
+        data = dict(full_yaml_context, rng_group='cugini')
+        ctx = StreamContext.from_yaml(data, sample_dur_sec=sample_dur)
+        assert ctx.rng_group == 'cugini'
+        assert ctx.rng_id == 'cugini'
+
+    def test_from_yaml_without_key_defaults_none(self, full_yaml_context, sample_dur):
+        ctx = StreamContext.from_yaml(full_yaml_context, sample_dur_sec=sample_dur)
+        assert ctx.rng_group is None
+        assert ctx.rng_id == ctx.stream_id
+
+    def test_same_rng_group_same_rng_id_across_streams(self, sample_dur):
+        """Due stream con lo stesso rng_group condividono l'identità RNG."""
+        a = StreamContext(
+            stream_id='cugini_1', onset=0.0, duration=1.0,
+            sample='a.wav', sample_dur_sec=sample_dur, rng_group='cugini',
+        )
+        b = StreamContext(
+            stream_id='cugini_2', onset=0.0, duration=1.0,
+            sample='a.wav', sample_dur_sec=sample_dur, rng_group='cugini',
+        )
+        assert a.rng_id == b.rng_id

--- a/tests/core/test_stream_config.py
+++ b/tests/core/test_stream_config.py
@@ -1046,6 +1046,16 @@ class TestRngGroup:
         assert ctx.rng_group == 'cugini'
         assert ctx.rng_id == 'cugini'
 
+    def test_empty_string_falls_back_to_stream_id(self, sample_dur):
+        """rng_group vuoto NON diventa un'identità condivisa accidentale:
+        falsy → fallback a stream_id, come rng_group assente."""
+        ctx = StreamContext(
+            stream_id='s1', onset=0.0, duration=1.0,
+            sample='a.wav', sample_dur_sec=sample_dur,
+            rng_group='',
+        )
+        assert ctx.rng_id == 's1'
+
     def test_from_yaml_without_key_defaults_none(self, full_yaml_context, sample_dur):
         ctx = StreamContext.from_yaml(full_yaml_context, sample_dur_sec=sample_dur)
         assert ctx.rng_group is None

--- a/tests/engine/test_rng_group.py
+++ b/tests/engine/test_rng_group.py
@@ -1,0 +1,181 @@
+# tests/engine/test_rng_group.py
+"""
+test_rng_group.py
+
+Test della condivisione della sequenza RNG fra stream (issue #169).
+
+`rng_group` è una chiave YAML per-stream opzionale che sostituisce lo
+`stream_id` come identità nella derivazione degli RNG locali
+(shared/seeding.py): due stream con lo stesso `rng_group` — e stessi
+parametri stocastici — pescano le stesse sequenze pseudo-casuali su tutti
+i componenti (iot, variazioni `_range`, gate, window, detune) e sulle
+voice strategy stocastiche.
+
+Garanzie verificate:
+
+- CONDIVISIONE: stesso `rng_group` + stessi parametri → grani identici
+  fra stream con `stream_id` diversi (era impossibile prima di #169).
+- ISOLAMENTO DI DEFAULT: senza `rng_group` il comportamento resta quello
+  dell'issue #154 — stream diversi, sequenze diverse.
+- RETROCOMPATIBILITÀ: aggiungere `rng_group: <stesso stream_id>` o non
+  aggiungerlo affatto produce grani bit-per-bit identici (l'identità di
+  derivazione non cambia).
+- VOICE STRATEGY: le voci stocastiche condividono i draw dentro il gruppo.
+
+Non richiede csound/sox né sample reali (get_sample_duration mockato).
+"""
+
+import yaml
+from unittest.mock import patch
+
+from pge.engine.generator import Generator
+
+
+# =============================================================================
+# HELPERS (stesso schema di test_seed_component_isolation.py)
+# =============================================================================
+
+def _stream_dict(stream_id, rng_group=None, voices=False):
+    """Stream con più componenti stocastici attivi (iot, range, window, pitch)."""
+    d = {
+        'stream_id': stream_id,
+        'onset': 0.0,
+        'duration': 4.0,
+        'sample': 'test.wav',
+        'density': 30,
+        'distribution': 1.0,
+        'volume': -6.0,
+        'volume_range': 4.0,
+        'grain': {
+            'duration': 0.05,
+            'duration_range': 0.03,
+            'envelope': ['hanning', 'expodec'],
+        },
+        'pitch': {'semitones': 0, 'range': 2},
+    }
+    if rng_group is not None:
+        d['rng_group'] = rng_group
+    if voices:
+        d['voices'] = {
+            'pitch': {'strategy': 'stochastic', 'pitch_range': 3.0},
+            'pan': {'strategy': 'stochastic', 'spread': 60.0},
+        }
+    return d
+
+
+def _render_streams(tmp_path, streams, seed=42, filename='rng_group.yml'):
+    data = {'streams': streams, 'seed': seed}
+    cfg = tmp_path / filename
+    cfg.write_text(yaml.safe_dump(data))
+    gen = Generator(str(cfg))
+    gen.load_yaml()
+    with patch('pge.core.stream.get_sample_duration', return_value=10.0):
+        gen.create_elements()
+        for s in gen.streams:
+            _ = s.grains  # materializza (lazy)
+    return gen
+
+
+def _grain_signature(stream):
+    """Firma simbolica dei grani, indipendente dalla numerazione ftable."""
+    inv_windows = {v: k for k, v in stream.window_table_map.items()}
+    return [
+        (
+            round(g.onset, 9),
+            round(g.duration, 9),
+            round(g.pointer_pos, 9),
+            round(g.pitch_ratio, 9),
+            round(g.volume, 9),
+            round(g.pan, 9),
+            inv_windows[g.envelope_table],
+        )
+        for g in stream.grains
+    ]
+
+
+def _signature_of(gen, stream_id):
+    for s in gen.streams:
+        if s.stream_id == stream_id:
+            return _grain_signature(s)
+    raise AssertionError(f"stream {stream_id} non trovato")
+
+
+# =============================================================================
+# 1. CONDIVISIONE — stesso rng_group → stessa sequenza
+# =============================================================================
+
+class TestSharedSequence:
+
+    def test_same_rng_group_same_grains(self, tmp_path):
+        """Due stream identici nei parametri ma con stream_id diversi:
+        con lo stesso rng_group i grani coincidono."""
+        gen = _render_streams(tmp_path, [
+            _stream_dict('cugini_1', rng_group='cugini'),
+            _stream_dict('cugini_2', rng_group='cugini'),
+        ])
+        sig1 = _signature_of(gen, 'cugini_1')
+        sig2 = _signature_of(gen, 'cugini_2')
+        assert len(sig1) > 10
+        assert sig1 == sig2
+
+    def test_same_rng_group_shared_voice_draws(self, tmp_path):
+        """Le voice strategy stocastiche condividono i draw nel gruppo."""
+        gen = _render_streams(tmp_path, [
+            _stream_dict('cugini_1', rng_group='cugini', voices=True),
+            _stream_dict('cugini_2', rng_group='cugini', voices=True),
+        ])
+        assert _signature_of(gen, 'cugini_1') == _signature_of(gen, 'cugini_2')
+
+    def test_different_rng_group_different_grains(self, tmp_path):
+        """Gruppi diversi → sequenze indipendenti."""
+        gen = _render_streams(tmp_path, [
+            _stream_dict('s1', rng_group='gruppo_a'),
+            _stream_dict('s2', rng_group='gruppo_b'),
+        ])
+        assert _signature_of(gen, 's1') != _signature_of(gen, 's2')
+
+
+# =============================================================================
+# 2. ISOLAMENTO DI DEFAULT — senza rng_group nulla cambia
+# =============================================================================
+
+class TestDefaultIsolation:
+
+    def test_without_rng_group_streams_stay_isolated(self, tmp_path):
+        """Senza rng_group due stream a parametri identici restano
+        indipendenti (contratto issue #154)."""
+        gen = _render_streams(tmp_path, [
+            _stream_dict('s1'),
+            _stream_dict('s2'),
+        ])
+        assert _signature_of(gen, 's1') != _signature_of(gen, 's2')
+
+
+# =============================================================================
+# 3. RETROCOMPATIBILITÀ — default None → hash identico a prima
+# =============================================================================
+
+class TestBackwardCompatibility:
+
+    def test_rng_group_equal_to_stream_id_is_identity(self, tmp_path):
+        """rng_group uguale allo stream_id → grani bit-per-bit identici al
+        render senza rng_group: l'identità di derivazione è la stessa."""
+        plain = _render_streams(tmp_path, [_stream_dict('s1')])
+        grouped = _render_streams(
+            tmp_path, [_stream_dict('s1', rng_group='s1')],
+            filename='rng_group_b.yml',
+        )
+        assert _signature_of(plain, 's1') == _signature_of(grouped, 's1')
+
+    def test_rng_group_on_one_stream_does_not_move_others(self, tmp_path):
+        """Aggiungere rng_group a uno stream non sposta i draw degli altri
+        (l'isolamento per-componente di #154 resta intatto)."""
+        before = _render_streams(tmp_path, [
+            _stream_dict('s1'),
+            _stream_dict('s2'),
+        ])
+        after = _render_streams(tmp_path, [
+            _stream_dict('s1', rng_group='cugini'),
+            _stream_dict('s2'),
+        ], filename='rng_group_c.yml')
+        assert _signature_of(before, 's2') == _signature_of(after, 's2')

--- a/tests/engine/test_rng_group.py
+++ b/tests/engine/test_rng_group.py
@@ -35,8 +35,14 @@ from pge.engine.generator import Generator
 # HELPERS (stesso schema di test_seed_component_isolation.py)
 # =============================================================================
 
-def _stream_dict(stream_id, rng_group=None, voices=False):
-    """Stream con più componenti stocastici attivi (iot, range, window, pitch)."""
+def _stream_dict(stream_id, rng_group=None, voices=False,
+                 pointer_start=None, pan=None):
+    """Stream con più componenti stocastici attivi (iot, range, window, pitch).
+
+    `pointer_start` e `pan` sono i parametri **deterministici** su cui i
+    "cugini" della issue #169 divergono: servono a distinguere la
+    condivisione dell'RNG dalla banale identità dei due stream.
+    """
     d = {
         'stream_id': stream_id,
         'onset': 0.0,
@@ -55,12 +61,27 @@ def _stream_dict(stream_id, rng_group=None, voices=False):
     }
     if rng_group is not None:
         d['rng_group'] = rng_group
+    if pointer_start is not None:
+        d['pointer'] = {'start': pointer_start}
+    if pan is not None:
+        d['pan'] = pan
+        d['pan_range'] = 20.0
+        # I `_range` devono pescare anche senza dephase: e' il jitter
+        # condiviso che si vuole osservare.
+        d['range_always_active'] = True
     if voices:
         d['voices'] = {
             'pitch': {'strategy': 'stochastic', 'pitch_range': 3.0},
             'pan': {'strategy': 'stochastic', 'spread': 60.0},
         }
     return d
+
+
+def _cousin(stream_id, rng_group, pointer_start, pan):
+    """Stream 'cugino': stessa grana stocastica, posizione di lettura e
+    pan diversi (lo spread verticale del caso d'uso della issue #169)."""
+    return _stream_dict(stream_id, rng_group=rng_group,
+                        pointer_start=pointer_start, pan=pan)
 
 
 def _render_streams(tmp_path, streams, seed=42, filename='rng_group.yml'):
@@ -133,6 +154,85 @@ class TestSharedSequence:
             _stream_dict('s2', rng_group='gruppo_b'),
         ])
         assert _signature_of(gen, 's1') != _signature_of(gen, 's2')
+
+
+# =============================================================================
+# 1b. IL CASO D'USO REALE — cugini con parametri deterministici diversi
+# =============================================================================
+
+class TestCousins:
+    """Il caso della issue #169: stream "cugini" di uno spread, che
+    differiscono su parametri *deterministici* (`pointer.start`, `pan`) ma
+    devono condividere la grana stocastica — la griglia temporale e il
+    jitter — per essere ascoltati come un unico oggetto verticale.
+
+    Qui la condivisione dice qualcosa di più forte del caso "due copie
+    identiche restano identiche": gli stream divergono davvero (asserito),
+    eppure la sequenza pescata resta la stessa.
+    """
+
+    def _onsets(self, gen, stream_id):
+        for s in gen.streams:
+            if s.stream_id == stream_id:
+                return [round(g.onset, 9) for g in s.grains]
+        raise AssertionError(f"stream {stream_id} non trovato")
+
+    def _field(self, gen, stream_id, attr):
+        for s in gen.streams:
+            if s.stream_id == stream_id:
+                return [round(getattr(g, attr), 9) for g in s.grains]
+        raise AssertionError(f"stream {stream_id} non trovato")
+
+    def test_cousins_share_the_temporal_grid(self, tmp_path):
+        """Stesso rng_group, `pointer.start` e `pan` diversi → stessa
+        griglia temporale (identico numero di grani e identici onset).
+        E' l'asserzione che la issue #169 chiede davvero."""
+        gen = _render_streams(tmp_path, [
+            _cousin('cugini_1', 'cugini', pointer_start=0.0, pan=-60.0),
+            _cousin('cugini_2', 'cugini', pointer_start=3.0, pan=60.0),
+        ])
+        o1 = self._onsets(gen, 'cugini_1')
+        o2 = self._onsets(gen, 'cugini_2')
+        assert len(o1) > 10
+        assert o1 == o2
+
+    def test_cousins_really_differ(self, tmp_path):
+        """Guardia anti-vacuità: i due cugini NON sono lo stesso stream —
+        leggono da posizioni diverse del sample."""
+        gen = _render_streams(tmp_path, [
+            _cousin('cugini_1', 'cugini', pointer_start=0.0, pan=-60.0),
+            _cousin('cugini_2', 'cugini', pointer_start=3.0, pan=60.0),
+        ])
+        p1 = self._field(gen, 'cugini_1', 'pointer_pos')
+        p2 = self._field(gen, 'cugini_2', 'pointer_pos')
+        assert p1 != p2
+
+    def test_cousins_share_the_random_jitter(self, tmp_path):
+        """Il jitter pescato è lo stesso: con `pan` base diverso e stesso
+        `pan_range`, la differenza fra i pan per-grano resta costante e
+        pari alla differenza dei valori base (120 gradi). Se i due stream
+        pescassero da sequenze diverse, la differenza oscillerebbe."""
+        gen = _render_streams(tmp_path, [
+            _cousin('cugini_1', 'cugini', pointer_start=0.0, pan=-60.0),
+            _cousin('cugini_2', 'cugini', pointer_start=3.0, pan=60.0),
+        ])
+        pan1 = self._field(gen, 'cugini_1', 'pan')
+        pan2 = self._field(gen, 'cugini_2', 'pan')
+        assert len(pan1) == len(pan2)
+        # Guardia anti-vacuità: il jitter deve esistere davvero, altrimenti
+        # (pan_range inattivo) il delta sarebbe costante per costruzione.
+        assert len(set(pan1)) > 1
+        deltas = {round(b - a, 6) for a, b in zip(pan1, pan2)}
+        assert deltas == {120.0}, sorted(deltas)
+
+    def test_cousins_without_group_do_not_share_the_grid(self, tmp_path):
+        """Controprova: senza rng_group gli stessi due cugini hanno griglie
+        temporali diverse — è esattamente il problema della issue."""
+        gen = _render_streams(tmp_path, [
+            _cousin('cugini_1', None, pointer_start=0.0, pan=-60.0),
+            _cousin('cugini_2', None, pointer_start=3.0, pan=60.0),
+        ], filename='rng_group_cousins.yml')
+        assert self._onsets(gen, 'cugini_1') != self._onsets(gen, 'cugini_2')
 
 
 # =============================================================================

--- a/tests/rendering/test_stream_cache_manager.py
+++ b/tests/rendering/test_stream_cache_manager.py
@@ -177,6 +177,24 @@ class TestFingerprintIgnoresMuteSolo:
         d2 = {'stream_id': 's1', 'volume': -12.0, 'mute': True}
         assert manager.compute_fingerprint(d1) != manager.compute_fingerprint(d2)
 
+    def test_rng_group_changes_fingerprint(self, manager):
+        """rng_group NON e' un flag non-audio: cambia l'identita' di
+        derivazione RNG, quindi i valori pescati e l'audio dello stem
+        (issue #169). Deve entrare nel fingerprint — mai aggiungerlo a
+        FINGERPRINT_IGNORE_KEYS, o gli stem restano stantii in silenzio."""
+        base = {'stream_id': 's1', 'volume': -6.0, 'sample': 'a.wav'}
+        grouped = {**base, 'rng_group': 'cugini'}
+        assert (
+            manager.compute_fingerprint(base)
+            != manager.compute_fingerprint(grouped)
+        )
+
+    def test_different_rng_group_changes_fingerprint(self, manager):
+        """Anche cambiare gruppo (non solo aggiungerlo) marca lo stem dirty."""
+        d1 = {'stream_id': 's1', 'volume': -6.0, 'rng_group': 'gruppo_a'}
+        d2 = {'stream_id': 's1', 'volume': -6.0, 'rng_group': 'gruppo_b'}
+        assert manager.compute_fingerprint(d1) != manager.compute_fingerprint(d2)
+
     def test_toggling_mute_does_not_mark_stream_dirty(self, manager, tmp_path):
         """Dirty-check end-to-end: aggiungere mute non marca lo stem dirty se
         il fingerprint precedente (senza mute) e' nel manifest e il .aif esiste.


### PR DESCRIPTION
Closes #169 — Piano A.

## Cosa cambia

Nuova chiave YAML per-stream opzionale `rng_group`: sostituisce lo `stream_id` come **identità** nella derivazione degli RNG locali (`shared/seeding.py`), così stream diversi con lo stesso gruppo — e stessi parametri stocastici — pescano le stesse sequenze pseudo-casuali su tutti i componenti (variazioni `_range`, gate, `iot`, `window`, `detune`) e sulle voci stocastiche.

```yaml
seed: 1988
streams:
  - stream_id: cugini_1
    rng_group: cugini
  - stream_id: cugini_2
    rng_group: cugini
```

## Come

- `StreamContext.rng_group: Optional[str] = None` + property `rng_id` (`rng_group or stream_id`, quindi anche una stringa vuota ricade su `stream_id` invece di creare un gruppo accidentale). `from_yaml` lo legge dal dict per-stream senza toccare il parser (field name fuori da `_engine_global`).
- I call site della derivazione passano `context.rng_id` al posto di `context.stream_id`:
  - `component_rng`: `density_controller` (`iot`), `window_controller` (`gate:pc_rand_envelope`, `window`), `pitch_controller` (`detune`), `parser` (variazione `_range`), `parameter_orchestrator` (`gate:<key>`);
  - `voice_rng`: i 4 siti di iniezione in `core/stream.py` (`voices.{pitch,onset_offset,pointer,pan}` stocastiche). Il kwarg delle strategy resta `stream_id` (rinominarlo sarebbe breaking sui factory kwarg documentati) ma ora riceve `rng_id`: le docstring delle quattro strategy lo dicono esplicitamente.
- `owner_id` dei Parameter e gli errori restano su `stream_id` (identità di log ≠ identità di derivazione).

## Retrocompatibilità e open/closed

- Default `None` → `rng_id == stream_id` → hash **identico a prima**: nessun render esistente cambia bit-per-bit (test dedicato: `rng_group: <stream_id>` ≡ assente).
- Le firme di `component_rng`/`voice_rng` **non cambiano**; strategy, gate e controller sono intoccati nella loro logica: estensione via campo di contesto, nessuna modifica delle astrazioni esistenti.
- L'isolamento di #154 resta il default: aggiungere `rng_group` a uno stream non sposta i draw degli altri (test dedicato).
- **Cache stems**: `rng_group` entra nel fingerprint (`compute_fingerprint` esclude solo `solo`/`mute`), quindi cambiarlo marca correttamente lo stem dirty — è il comportamento voluto, ora blindato da test.

## Test

- `tests/core/test_stream_config.py::TestRngGroup` — unit su campo/property/`from_yaml`, incluso il fallback della stringa vuota.
- `tests/engine/test_rng_group.py` — integrazione a due stream:
  - **cugini** (il caso d'uso della issue): stesso gruppo ma `pointer.start` e `pan` **diversi** → griglia temporale condivisa (onset identici) e jitter condiviso (delta pan costante), con guardie anti-vacuità (i cugini divergono davvero; il jitter esiste davvero) e controprova senza gruppo;
  - condivisione fra stream identici, anche con voci stocastiche; gruppi diversi indipendenti; isolamento di default; retrocompatibilità bit-per-bit; invarianza degli altri stream.
- `tests/rendering/test_stream_cache_manager.py` — aggiungere o cambiare `rng_group` marca lo stem dirty.
- `make tests`: **5029 passed, 2 skipped** (i 2 skip preesistenti per sample assenti).

## Doc

- `docs/reference/yaml.md` §Seed: sottosezione `rng_group` (sintassi, default, rapporto con il fingerprint della cache, limite noto: identità condivisa ≠ griglia IOT identica se density/distribution divergono).
- `CHANGELOG.md` Unreleased/Aggiunto; docstring di `shared/seeding.py` e delle quattro voice strategy.

## Impatto cross-repo

Nuova chiave YAML → issue di impact aperte e già svolte:

| Repo | Issue | PR |
|---|---|---|
| PGE-ls | DMGiulioRomano/PGE-ls#34 | DMGiulioRomano/PGE-ls#35 |
| PGE-ui | DMGiulioRomano/PGE-ui#112 | DMGiulioRomano/PGE-ui#113 |
| gl-ls | DMGiulioRomano/gl-ls#30 | DMGiulioRomano/gl-ls#31 |

Paper CIM 2026: nessun bump necessario — default invariato, gli esempi del paper non usano `rng_group` e i render non cambiano.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YbVErCNu5k4wNgLqtSixR