### PR TITLE
feat(grain): duration_unit milliseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Aggiunto
 
+- **`grain.duration_unit: milliseconds`**: terza unità per `grain.duration` e
+  `grain.duration_range`, accanto a `seconds` (default) e `samples`. I valori
+  sono convertiti in secondi al parse con fattore fisso `1e-3`
+  (`SECONDS_PER_MILLISECOND` in `shared/constants.py`), quindi — a differenza
+  di `samples` — la conversione non dipende da `output_sr` e lo stesso YAML dà
+  le stesse durate a qualunque frequenza di rendering. Vale su scalari ed
+  envelope (solo i valori Y, l'asse tempo resta invariato) e condivide con
+  `samples` la regola della durata esplicita: senza `grain.duration` la base
+  resterebbe in secondi mentre `duration_range` sarebbe in millisecondi →
+  `MissingFieldError`, con hint che nomina l'unità dichiarata. Motivazione:
+  la grana udibile vive fra 1 e 1000 ms, dove in secondi si scrivono solo
+  numeri molto piccoli e difficili da leggere. Nessun comportamento esistente
+  cambia: `duration_unit` assente o `seconds` resta un no-op.
+  Reference: `docs/reference/yaml.md` §Blocco Grain.
 - **`rng_group`: sequenza RNG condivisa fra stream** (issue #169): nuova
   chiave YAML per-stream opzionale che sostituisce lo `stream_id` come
   identità nella derivazione degli RNG locali (`shared/seeding.py`). Stream

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -331,14 +331,23 @@ grain:
   duration: [[0, 0.02], [30, 0.2]]
   duration_range: 0.01     # ±0.01s randomizzazione
 
-  # Unità di misura per duration e duration_range (default: seconds).
-  # Con 'samples' i valori sono campioni alla frequenza di output del
-  # motore (48000 Hz) e vengono convertiti in secondi al parse; vale per
+  # Unità di misura per duration e duration_range: seconds (default) |
+  # samples | milliseconds. La conversione avviene al parse e vale per
   # scalari ed envelope (solo i valori, l'asse tempo resta invariato).
+
+  # 'samples': campioni alla frequenza di output del motore (48000 Hz).
   duration_unit: samples
   duration: 512            # 512 campioni = 512/48000 s
   duration_range: 64       # ±64 campioni
   duration: [[0, 48], [30, 4800]]   # envelope: Y in campioni
+
+  # 'milliseconds': fattore fisso 1e-3, indipendente dal sample rate.
+  # È la scala comoda per la grana udibile, dove in secondi si scriverebbero
+  # solo numeri molto piccoli.
+  duration_unit: milliseconds
+  duration: 50             # 50 ms = 0.05 s
+  duration_range: 4.5      # ±4.5 ms
+  duration: [[0, 1], [30, 100]]     # envelope: Y in millisecondi
 
   envelope: hanning        # finestra per shape del grano (default: hanning)
   # Vedi sezione "Finestre Disponibili" per tutti i valori validi.
@@ -367,15 +376,18 @@ grain:
   # ERRORE: reverse: true / reverse: false / reverse: auto
 ```
 
-Con `duration_unit: samples` la `grain.duration` va **sempre indicata
-esplicitamente**: il default `0.05` è in secondi e non verrebbe convertito, per
-cui base (secondi) e `duration_range` (campioni) finirebbero in domini diversi.
-Ometterla → `MissingFieldError`. `output_sr` è una config globale del motore
-(48000 Hz), non impostabile per-stream nello YAML.
+Con qualunque `duration_unit` diverso da `seconds` la `grain.duration` va
+**sempre indicata esplicitamente**: il default `0.05` è in secondi e non
+verrebbe convertito, per cui base (secondi) e `duration_range` (campioni o
+millisecondi) finirebbero in domini diversi. Ometterla → `MissingFieldError`.
+`output_sr` è una config globale del motore (48000 Hz), non impostabile
+per-stream nello YAML — per questo `milliseconds`, che non lo usa, dà le stesse
+durate a qualunque frequenza di rendering mentre `samples` no.
 
 Bounds: `grain_duration` ∈ [1 campione (`1/48000` s), 10 s] — in `samples`:
-[1, 480000]. Valori frazionari di campioni sono ammessi: il renderer
-arrotonda al campione più vicino (`n_out = max(1, round(dur * sr))`).
+[1, 480000]; in `milliseconds`: [1/48, 10000]. Valori frazionari sono ammessi
+in ogni unità: il renderer arrotonda al campione più vicino
+(`n_out = max(1, round(dur * sr))`).
 
 Note sui grani a precisione di campione:
 
@@ -1918,7 +1930,7 @@ un envelope dal YAML al runtime è:
 | `density` | 0.01 | 4000 | — | grani/secondo |
 | `fill_factor` | 0.001 | 50 | 2.0 | priorità su density |
 | `distribution` | 0 | 1 | 0.0 | 0=sync, 1=async |
-| `grain_duration` | 1/48000 (1 campione) | 10 | 0.05 | secondi; con `duration_unit: samples` i valori sono campioni |
+| `grain_duration` | 1/48000 (1 campione) | 10 | 0.05 | secondi; `duration_unit` li porta in `samples` o `milliseconds` |
 | `volume` | -120 | 12 | 0.0 | dB |
 | `pan` | -3600 | 3600 | 0.0 | gradi |
 | `pitch_ratio` | 0.001 | 8 | 1.0 | ratio diretto |

--- a/src/pge/core/stream.py
+++ b/src/pge/core/stream.py
@@ -24,6 +24,7 @@ from pge.controllers.window_controller import WindowController
 from pge.controllers.pointer_controller import PointerController
 from pge.controllers.pitch_controller import PitchController
 from pge.controllers.density_controller import DensityController
+from pge.shared.constants import SECONDS_PER_MILLISECOND
 from pge.shared.utils import get_sample_duration
 from pge.shared.exceptions import (
     InvalidFieldValueError,
@@ -46,8 +47,16 @@ from dataclasses import fields, MISSING as dataclass_MISSING
 
 # Unita' di misura ammesse per grain.duration / grain.duration_range.
 # 'seconds' e' il default storico; 'samples' esprime i valori in campioni
-# alla frequenza di output del motore (StreamContext.output_sr).
-GRAIN_DURATION_UNITS = ('seconds', 'samples')
+# alla frequenza di output del motore (StreamContext.output_sr);
+# 'milliseconds' e' la scala comoda per la grana udibile (1-1000 ms) e usa un
+# fattore fisso, indipendente dal sample rate.
+GRAIN_DURATION_UNITS = ('seconds', 'samples', 'milliseconds')
+
+# Etichette per i messaggi d'errore: unita' -> nome dei valori attesi.
+_GRAIN_DURATION_UNIT_LABELS = {
+    'samples': 'campioni',
+    'milliseconds': 'millisecondi',
+}
 
 
 def _parse_strategy_kwarg(value, duration: float, stream_time_mode: str = 'absolute'):
@@ -414,9 +423,10 @@ class Stream:
         """
         Conversione di unita' per la durata del grano (modello loop_unit).
 
-        Se grain.duration_unit == 'samples', scala grain.duration e
-        grain.duration_range da campioni a secondi (fattore 1/output_sr),
-        su scalari ed envelope-like (solo i valori Y; l'asse X resta tempo).
+        Se grain.duration_unit non e' 'seconds', scala grain.duration e
+        grain.duration_range fino ai secondi su scalari ed envelope-like (solo
+        i valori Y; l'asse X resta tempo). Il fattore dipende dall'unita':
+        1/output_sr per 'samples', 1e-3 per 'milliseconds'.
 
         Unico punto del sistema che legge 'duration_unit' dal dizionario
         grezzo: e' un meta-parametro che controlla l'interpretazione degli
@@ -440,21 +450,26 @@ class Stream:
         if unit == 'seconds':
             return params
 
-        # samples: il default seconds (0.05) NON viene scalato. Se grain.duration
-        # non e' esplicito, la base resterebbe in secondi mentre duration_range
-        # e' in campioni -> due domini diversi nello stesso blocco. Pretendi una
-        # duration esplicita (l'unita' governa base e range insieme).
+        # Unita' non-secondi: il default seconds (0.05) NON viene scalato. Se
+        # grain.duration non e' esplicito, la base resterebbe in secondi mentre
+        # duration_range e' nell'unita' dichiarata -> due domini diversi nello
+        # stesso blocco. Pretendi una duration esplicita (l'unita' governa base
+        # e range insieme).
+        label = _GRAIN_DURATION_UNIT_LABELS[unit]
         if grain.get('duration') is None:
             err = MissingFieldError(
                 field='grain.duration',
-                hint=("con grain.duration_unit: samples la durata va indicata "
-                      "esplicitamente in campioni (il default 0.05 e' in "
+                hint=(f"con grain.duration_unit: {unit} la durata va indicata "
+                      f"esplicitamente in {label} (il default 0.05 e' in "
                       "secondi e non verrebbe convertito)."),
             )
             err.stream_id = self.stream_id
             raise err
 
-        factor = 1.0 / output_sr
+        # 'samples' dipende dal sample rate di output, 'milliseconds' no.
+        factor = (
+            1.0 / output_sr if unit == 'samples' else SECONDS_PER_MILLISECOND
+        )
         scaled_grain = dict(grain)
         for key in ('duration', 'duration_range'):
             if key in scaled_grain and scaled_grain[key] is not None:

--- a/src/pge/shared/constants.py
+++ b/src/pge/shared/constants.py
@@ -10,3 +10,9 @@ from __future__ import annotations
 # campioni <-> secondi (grain.duration_unit). Deve restare coerente con
 # csound/main.orc (sr=48000), che oggi lo hardcoda.
 DEFAULT_OUTPUT_SR = 48000
+
+# Secondi per millisecondo: fattore della conversione millisecondi -> secondi
+# (grain.duration_unit: milliseconds). A differenza di 'samples' non dipende
+# dal sample rate, quindi lo stesso YAML da' le stesse durate a qualunque
+# frequenza di rendering.
+SECONDS_PER_MILLISECOND = 1e-3

--- a/tests/core/test_grain_duration_unit.py
+++ b/tests/core/test_grain_duration_unit.py
@@ -7,6 +7,8 @@ grain.duration_range.
 - 'seconds' (default): comportamento storico, nessuna conversione
 - 'samples': valori espressi in campioni, convertiti in secondi al parse
   tramite il sample rate di output del motore (StreamContext.output_sr)
+- 'milliseconds': valori espressi in millisecondi, convertiti in secondi al
+  parse (fattore fisso 1e-3, nessuna dipendenza dal sample rate)
 
 La conversione e' osservabile dall'esterno: i Grain generati portano
 duration in secondi qualunque sia l'unita' dichiarata nello YAML.
@@ -96,6 +98,78 @@ class TestDurationUnitSamples:
             g.duration == pytest.approx(48.5 / DEFAULT_OUTPUT_SR)
             for g in s.grains
         )
+
+
+class TestDurationUnitMilliseconds:
+    """duration_unit: milliseconds converte i valori con fattore fisso 1e-3."""
+
+    def test_scalar_duration_in_milliseconds(self):
+        s = _make_stream({'duration': 10, 'duration_unit': 'milliseconds'})
+        assert len(s.grains) > 0
+        assert all(g.duration == pytest.approx(0.01) for g in s.grains)
+
+    def test_conversion_factor_is_fixed_not_sample_rate(self):
+        """Il fattore e' 1e-3, non 1/output_sr: lo stesso numero letto come
+        millisecondi e come campioni da' due durate diverse."""
+        ms = _make_stream({'duration': 50, 'duration_unit': 'milliseconds'})
+        smp = _make_stream({'duration': 50, 'duration_unit': 'samples'})
+        assert ms.grains[0].duration == pytest.approx(0.05)
+        assert smp.grains[0].duration == pytest.approx(50 / DEFAULT_OUTPUT_SR)
+
+    def test_envelope_duration_in_milliseconds(self):
+        """Envelope: i valori Y sono millisecondi, l'asse X resta tempo."""
+        s = _make_stream({
+            'duration': [[0.0, 1], [1.0, 100]],
+            'duration_unit': 'milliseconds',
+        })
+        first = s.grains[0]
+        assert first.duration == pytest.approx(0.001, rel=1e-3)
+        assert max(g.duration for g in s.grains) > 10 * first.duration
+
+    def test_duration_range_in_milliseconds(self):
+        """duration_range condivide l'unita' del blocco: i grani variano
+        dentro value +/- range/2 espressi in millisecondi."""
+        s = _make_stream(
+            {'duration': 10, 'duration_range': 4,
+             'duration_unit': 'milliseconds'},
+            range_always_active=True,
+        )
+        durations = [g.duration for g in s.grains]
+        lo = (10 - 2) / 1000.0
+        hi = (10 + 2) / 1000.0
+        assert all(lo - 1e-12 <= d <= hi + 1e-12 for d in durations)
+        assert len(set(durations)) > 1  # la variazione e' attiva
+
+    def test_fractional_milliseconds_allowed(self):
+        s = _make_stream({'duration': 4.5, 'duration_unit': 'milliseconds'})
+        assert all(g.duration == pytest.approx(0.0045) for g in s.grains)
+
+    def test_below_one_sample_in_milliseconds_rejected(self):
+        """Il bound minimo resta 1 campione: 0.001 ms sta sotto."""
+        with pytest.raises(ParameterBoundError):
+            _make_stream({'duration': 0.001, 'duration_unit': 'milliseconds'})
+
+    def test_milliseconds_without_explicit_duration_rejected(self):
+        """Stessa regola di 'samples': il default 0.05 e' in secondi e non
+        verrebbe convertito, quindi base e range vivrebbero in domini diversi."""
+        with pytest.raises(MissingFieldError) as exc_info:
+            _make_stream({'duration_range': 4, 'duration_unit': 'milliseconds'})
+        assert 'duration' in str(exc_info.value)
+
+    def test_milliseconds_bare_unit_without_duration_rejected(self):
+        with pytest.raises(MissingFieldError):
+            _make_stream({'duration_unit': 'milliseconds'})
+
+    def test_unknown_unit_hint_lists_milliseconds(self):
+        with pytest.raises(InvalidFieldValueError) as exc_info:
+            _make_stream({'duration': 10, 'duration_unit': 'ms'})
+        assert 'milliseconds' in exc_info.value.user_message()
+
+    def test_original_params_not_mutated(self):
+        grain = {'duration': 10, 'duration_unit': 'milliseconds'}
+        _make_stream(grain)
+        assert grain['duration'] == 10
+        assert grain['duration_unit'] == 'milliseconds'
 
 
 class TestDurationUnitSeconds:


### PR DESCRIPTION
## Cosa

Terza unità per `grain.duration` / `grain.duration_range`, accanto a `seconds` (default) e `samples`:

```yaml
grain:
  duration_unit: milliseconds
  duration: 50             # 50 ms = 0.05 s
  duration_range: 4.5      # ±4.5 ms
  duration: [[0, 1], [30, 100]]   # envelope: Y in millisecondi
```

## Perché

La grana udibile vive fra 1 e 1000 ms. In secondi si scrivono solo numeri molto piccoli (`.001`, `.0045`, `.35`) che sono scomodi da leggere e da modificare a mano. `samples` risolve il problema solo all'estremo corto della scala.

La richiesta nasce da `granulation-studies`, dove quattro studi sulla scala della grana (1-10 ms, 10-50 ms, 50-300 ms, 300-1000 ms) sono oggi scritti in secondi: vedi DMGiulioRomano/granulation-studies#41.

## Come

- `GRAIN_DURATION_UNITS` diventa `('seconds', 'samples', 'milliseconds')`.
- Il fattore di conversione è fisso: `SECONDS_PER_MILLISECOND = 1e-3` in `shared/constants.py`. A differenza di `samples` non passa da `output_sr`, quindi lo stesso YAML dà le stesse durate a qualunque frequenza di rendering — e `output_sr` non è impostabile per-stream, quindi è una proprietà utile e non un dettaglio.
- La regola della **durata esplicita**, finora scritta su misura per `samples`, diventa comune a tutte le unità non-secondi: senza `grain.duration` la base resterebbe in secondi mentre `duration_range` sarebbe nell'unità dichiarata. L'hint di `MissingFieldError` nomina ora l'unità e i suoi valori attesi (campioni / millisecondi) invece di dire sempre "samples".
- Il punto di conversione resta unico (`Stream._pre_normalize_grain_params`), e il dict YAML originale continua a non essere mutato.

## Compatibilità

Nessun comportamento esistente cambia: `duration_unit` assente o `seconds` resta un no-op, la conversione `samples` è identica. L'unica differenza osservabile su un input già valido è il testo dell'hint di `MissingFieldError`, che ora nomina l'unità dichiarata.

Bounds invariati: il minimo resta 1 campione, quindi in millisecondi la banda utile è `[1/48, 10000]`.

## Test

TDD, rossi prima dell'implementazione — `TestDurationUnitMilliseconds` in `tests/core/test_grain_duration_unit.py`:

- scalare, envelope (Y in ms, asse X invariato), `duration_range`, valori frazionari;
- confronto esplicito ms vs samples sullo stesso numero, per fissare che il fattore non è il sample rate;
- bound minimo (0.001 ms → `ParameterBoundError`);
- durata mancante con unità dichiarata, sia con `duration_range` sia da sola → `MissingFieldError`;
- hint di unità sconosciuta che elenca `milliseconds`;
- il dict grezzo non viene mutato.

Suite completa verde (`make tests`), `make docs-lint` OK.

## Docs

`docs/reference/yaml.md` (Blocco Grain + tabella bounds) e `CHANGELOG.md` sotto Unreleased/Aggiunto.

## Impatto cross-repo

La superficie YAML pubblica cresce di un valore di enum: `PGE-ls` deve accettare `milliseconds` in `grain.duration_unit` (oggi lo segnalerebbe come valore invalido) e adeguare l'eventuale controllo di bounds unit-aware. Da valutare anche `PGE-ui`. Non ho aperto issue su quei repo: dimmi se vuoi che lo faccia.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgBefWG9MeMzPtM6LNjcnd)_