### PR TITLE
feat: range_anchor — banda dei _range ancorabile al minimo, gaussiana a banda troncata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,70 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ## [Unreleased]
 
+### Aggiunto
+
+- **`range_anchor: center | min`**: chiave per-stream che decide dove cade il
+  valore base dentro la banda di un `_range`. Default `center` — banda
+  `[base - range/2, base + range/2]`, il comportamento storico. Con `min` la
+  banda diventa `[base, base + range]`: `base` è il **minimo** e `range` la
+  forbice di apertura verso l'alto. Allinea la lettura dei range di PGE a
+  quella di `granulation-studies`, dove le bande sono `[base, base + range]`
+  e la stessa parola significava due cose dentro lo stesso `study.yml`.
+
+  Governa tutti e soli i `_range` che passano da `Parameter`: `volume_range`,
+  `pan_range`, `grain.duration_range`, `pointer.offset_range`, `pitch.range`,
+  compreso il pitch quantizzato delle unità EDO. **Non** governa il jitter
+  implicito (`default_jitter`), il detune implicito del pitch (±12 cents) né
+  lo spread delle voice strategy (`spread`, `pitch_range`, `pointer_range`):
+  non sono range dichiarati, non hanno una `base` di cui essere il minimo, e
+  restano simmetrici in ogni modalità.
+
+  Con `range_anchor: min` la banda arriva a `base + range` e può sforare
+  `max_val` dove la versione centrata non lo faceva: il motore lo verifica al
+  parse e solleva `ParameterBoundError` invece di lasciare che il safety clamp
+  schiacci la banda contro il tetto. Il controllo scatta quando il massimo è
+  esatto (scalare+scalare, envelope+scalare, scalare+envelope); con base e
+  range entrambi envelope resta il solo clamp.
+
+  Reference: `docs/reference/yaml.md` §La banda dei `_range`.
+
+### Modificato (breaking)
+
+- **`distribution_mode: gaussian` legge `range` come larghezza della banda,
+  non più come σ.** Prima la gaussiana era illimitata e richiusa solo dal clamp
+  ai bounds del parametro: `range: 200` su `base: 300` produceva valori grosso
+  modo fra 0 e 600. Ora è una gaussiana **troncata** sulla banda dichiarata —
+  σ = larghezza/6 (i bordi cadono a 3σ), coda clampata ai bordi — quindi
+  produce 200…400, con il picco su 300.
+
+  La ragione: `range` significava due cose diverse a seconda della
+  distribuzione — larghezza con `uniform`, σ con `gaussian` — e chi scriveva
+  `range: 200` si aspettava una banda larga 200 in entrambi i casi. Adesso
+  `range` è sempre la larghezza, la distribuzione decide solo come la banda
+  viene riempita, e `range_anchor` dove cade `base`.
+
+  `uniform` non cambia: il default resta identico bit per bit, dimostrato dal
+  golden `tests/engine/test_default_variation_identity.py`. Chi usava
+  `gaussian` e vuole un'escursione paragonabile a prima deve moltiplicare il
+  proprio `range` per circa 6.
+
+- **Il fingerprint della cache stems include la versione della semantica del
+  motore** (`VARIATION_SEMANTICS_VERSION` in `rendering/stream_cache_manager.py`).
+  Il fingerprint era lo SHA-256 del solo testo YAML per-stream, e il manifest
+  non porta traccia della versione del motore: col cambio di semantica della
+  gaussiana a YAML invariato, ogni stem già renderizzato sarebbe rimasto
+  marcato `clean` e si sarebbe continuato ad ascoltare l'audio vecchio, senza
+  nessun errore. Effetto pratico: **un re-render completo al primo run dopo
+  l'aggiornamento**, poi la cache incrementale riparte normalmente. La
+  costante va bumpata a ogni modifica futura che cambi i valori prodotti a
+  parità di YAML.
+
+### Corretto
+
+- `docs/reference/yaml.md` dichiarava `distribution_mode` "riservato, non usato
+  correntemente": era falso da tempo — la chiave arriva fino a ogni `Parameter`
+  via `StreamConfig` e sceglie la distribuzione dei `_range`.
+
 ---
 
 ## [v5.2.0] — "Millisecond Grain" — 2026-07-29

--- a/docs/plans/done/2026-07-29-001-feat-range-anchor-mode-plan.md
+++ b/docs/plans/done/2026-07-29-001-feat-range-anchor-mode-plan.md
@@ -1,0 +1,506 @@
+---
+title: "feat: range_anchor — interruttore fra range centrato (base ± range/2) e range ancorato al minimo (base → base + range)"
+type: feat
+status: done
+date: 2026-07-29
+issue: null
+---
+
+# feat: `range_anchor` — range centrato vs range ancorato al minimo
+
+## Overview
+
+PGE e `granulation-studies` usano la stessa parola — `range` — per due cose
+diverse:
+
+| | banda risultante | `base` è |
+|---|---|---|
+| **PGE** (`UniformDistribution.sample`) | `[base - range/2, base + range/2]` | il **centro** |
+| **granulation-studies** (`value_generators._band_at`) | `[base, base + range]` | il **minimo** |
+
+Chi scrive uno `study.yml` incontra le due semantiche a poche righe di
+distanza, perché granstudies risolve le proprie bande in breakpoint espliciti
+prima di emettere, ma il blocco `base:` passa **intatto** all'engine:
+
+```yaml
+axes:
+  grain.duration: {base: 300, range: 200}   # granstudies: [300, 500] ms
+base:
+  grain:
+    duration_range: 200                      # PGE, su base 300: [200, 400] ms
+```
+
+Obiettivo: un interruttore che faccia funzionare i range di PGE come in
+granstudies — `base` è il minimo, `range` è la forbice di apertura verso
+l'alto — lasciando il comportamento storico come default.
+
+Questo documento è **solo il piano**: nessuna riga di produzione è stata
+scritta. La domanda a cui risponde è *dove* va inserito l'interruttore.
+
+---
+
+## Stato attuale (analisi d'impatto)
+
+### 1. Dove vive davvero il `± range/2`
+
+Non nel parametro né nella variazione, ma nelle **distribuzioni**
+(`shared/distribution_strategy.py`):
+
+```python
+# UniformDistribution.sample  (riga 94)
+return center + self._rng.uniform(-0.5, 0.5) * spread
+
+# UniformDistribution.get_bounds  (riga 100)
+half_spread = spread / 2
+return (center - half_spread, center + half_spread)
+
+# GaussianDistribution.sample  (riga 133)
+return self._rng.gauss(center, spread)
+```
+
+La catena completa di un range esplicito:
+
+```
+YAML  <param>_range
+  → ParameterParser (parser.py:131, passa distribution_mode)
+    → Parameter.__init__ (parameter.py:71-72)
+        _distribution        = DistributionFactory.create(distribution_mode)
+        _variation_strategy  = VariationFactory.create(bounds.variation_mode)
+    → Parameter.get_value (parameter.py:94-115)
+        base_val      = _evaluate_input(...)      # envelope o scalare
+        current_range = _calculate_range(time)    # envelope o scalare
+        final_val     = _variation_strategy.apply(base_val, current_range, _distribution)
+        return _clamp(final_val, time)            # clamp ai bounds del parametro
+```
+
+`VariationStrategy` (`strategies/variation_strategy.py`) è un passacarte:
+
+- `AdditiveVariation` → `distribution.sample(base, mod_range)`;
+- `QuantizedVariation` → `base + round(distribution.sample(0.0, mod_range))`
+  — nota che campiona **attorno a 0** e somma dopo: l'ancora qui è implicita
+  in una formula diversa;
+- `InvertVariation` / `ChoiceVariation` → non usano il range come banda.
+
+### 2. La seconda divergenza, meno visibile: la gaussiana
+
+L'ancora non è l'unica differenza. `range` significa due cose diverse anche
+*dentro* la modalità gaussiana:
+
+| | `range` è | coda |
+|---|---|---|
+| PGE (`GaussianDistribution.sample`) | **σ** (deviazione standard) | illimitata, richiusa solo dal clamp ai bounds del parametro |
+| granstudies (`value_generators._draw:167-180`) | **larghezza piena** della banda, con `σ = (hi-lo)/6` | clampata ai bordi banda (i bordi cadono a 3σ) |
+
+Un `range_anchor` che sistemasse solo il centro lascerebbe la gaussiana
+divergente: con `range: 200` PGE oggi produce σ=200 (banda utile ~±600),
+granstudies una banda larga 200 con σ≈33. **Va deciso esplicitamente** cosa fa
+la gaussiana in modalità `min` — vedi Design, punto 4.
+
+### 3. Cosa vuol dire "tutti i range": inventario
+
+"Tutti i range di PGE" non è un solo percorso di codice. Oggi convivono
+**quattro** convenzioni diverse:
+
+| # | dove | formula | è un `_range` YAML? |
+|---|---|---|---|
+| 1 | `_range` via `Parameter` → distribuzione | `center ± spread/2` | **sì** — `volume_range`, `pan_range`, `grain.duration_range`, `offset_range` (`parameter_schema.py:69,76,87,134`), più il range di pitch via `pitch_unit` |
+| 2 | `QuantizedVariation` (pitch in semitoni) | `base + round(sample(0, range))` | sì, stesso `_range` |
+| 3 | detune implicito (`strategies/strategie.py:76`) | `uniform(-cents, +cents)` — ±**pieno**, non /2 | no: nasce da `implicit_detune_cents`, attivo solo *senza* range esplicito |
+| 4 | spread per-voce (`voice_pan_strategy.py:185`, e i gemelli pointer/pitch) | `uniform(-1, 1) * spread / 2`, cached per voce | no: è `spread` di una strategy |
+
+Fuori inventario ma citabile: l'`iot` async del `DensityController`
+(`density_controller.py:129`) usa `uniform(0, 2*avg)` — già ancorato al minimo,
+per ragioni sue.
+
+**Proposta di scope:** l'interruttore governa **(1) e (2)**, cioè tutto ciò che
+passa da `Parameter.get_value`. (3) e (4) restano invariati: non sono `_range`,
+non hanno una `base` di cui essere il minimo, e piegarli alla stessa regola
+cambierebbe il significato di `spread` delle voci senza che nessuno l'abbia
+chiesto. Va detto nella doc, altrimenti "tutti i range" resta una promessa
+ambigua.
+
+---
+
+## Revisione del piano — decisioni prese e correzioni
+
+> Questa sezione è stata aggiunta in fase di implementazione. Tutto quello che
+> segue sotto "Design proposto" è la **proposta originale**, conservata come
+> archivio: due suoi punti si sono rivelati sbagliati e sono stati sostituiti.
+> Quello che è stato implementato è descritto qui.
+
+### Le due decisioni aperte, chiuse
+
+**(a) La gaussiana in modalità `min`.** Deciso: **banda piena**, come
+granulation-studies — μ = centro banda, σ = larghezza/6 (i bordi cadono a 3σ),
+clamp ai bordi. Ma la decisione è andata oltre la modalità `min`: il vero
+problema è che `range` significava larghezza con `uniform` e σ con `gaussian`,
+e chi scrive `range: 200` si aspetta una banda larga 200 in entrambi i casi.
+Quindi **la gaussiana legge `range` come larghezza in ogni modalità**, anche
+in `center`, dove prima era σ.
+
+È un **cambio di comportamento non retrocompatibile del default** per chi usa
+`distribution_mode: gaussian`. È stato accettato consapevolmente dall'utente
+dopo che il costo è stato messo sul tavolo (vedi "Il rischio della cache" qui
+sotto), scavalcando il vincolo iniziale "default identico bit per bit" — che
+resta valido e verificato per `uniform`.
+
+**(b) Il nome.** Deciso: **`range_anchor: center | min`**, per-stream, default
+`center`. L'obiezione al nome nel piano originale (§Rischi 5: "dice l'ancora
+ma non che `range` apre verso l'alto") **decade** con la decisione (a): una
+volta che `range` è la larghezza della banda in ogni distribuzione e in ogni
+modalità, l'unica cosa che l'interruttore muove è dove cade `base` dentro la
+banda. È letteralmente un'ancora. `range_anchor` si estende inoltre a un terzo
+valore `max` senza rifare niente, cosa che `range_mode: centered | upward` non
+farebbe (servirebbe `downward`, e il default `centered` non sarebbe una
+direzione come gli altri due).
+
+### Il modello finale: tre concetti ortogonali
+
+| concetto | chiave | cosa decide |
+|---|---|---|
+| larghezza | il valore del `_range` | quanto è larga la banda |
+| forma | `distribution_mode` | come la banda viene riempita |
+| ancora | `range_anchor` | dove cade `base` dentro la banda |
+
+Con `base: 300`, `range: 200`:
+
+| forma | ancora | banda | picco |
+|---|---|---|---|
+| `uniform` | `center` | 200…400 | — (piatta) |
+| `uniform` | `min` | 300…500 | — (piatta) |
+| `gaussian` | `center` | 200…400 | 300 |
+| `gaussian` | `min` | 300…500 | 400 |
+
+### Correzione 1 — l'interruttore VA dentro le distribuzioni
+
+Il §1 del design originale ("Perché NON toccare le distribuzioni") è
+**sbagliato in tutti e tre i suoi argomenti**:
+
+- *«`sample(center, spread)` è usato da `QuantizedVariation` con `center=0`,
+  dove "minimo" non vuol dire niente»* — al contrario. `variation_strategy.py`
+  fa `base + round(sample(0.0, mod_range))`: sotto ancora `min`, `sample(0, r)`
+  pesca in `[0, r]` e la somma cade in `[base, base+r]`, che è esattamente il
+  comportamento voluto, **gratis**. Il design originale doveva invece applicare
+  l'offset una seconda volta dentro `QuantizedVariation`, duplicando la logica
+  dentro quello che lui stesso chiama un passacarte.
+- *«`get_bounds()` è documentazione/debug e va tenuto coerente»* — è un
+  argomento **a favore**: `get_bounds` vive nelle distribuzioni, e con l'ancora
+  lì dentro `sample` e `get_bounds` condividono una sola definizione della
+  banda (`_band`), senza possibilità che divergano.
+- *«tutti i test delle distribuzioni diventano rossi in blocco»* — falso.
+  Con l'ancora come **stato dell'istanza** e default `center`, il ramo di
+  default resta la stessa identica espressione. Verificato: gli unici rossi
+  della suite sono stati i 10 test che asserivano la vecchia semantica σ della
+  gaussiana, cioè esattamente ciò che la decisione (a) sostituisce.
+
+### Correzione 2 — la funzione pura `resolve` non può funzionare
+
+Il §3 proponeva una funzione pura `resolve(base, width, anchor) -> (center,
+spread)` chiamata in `Parameter.get_value`. È **incompatibile con la
+raccomandazione del §4 dello stesso documento**: una coppia `(center, spread)`
+non può esprimere σ = larghezza/6 per la gaussiana e σ = larghezza per
+l'uniforme senza sapere quale distribuzione sta alimentando (diventerebbe una
+tabella di dispatch sul nome della distribuzione), e non può in nessun caso
+esprimere il **clamp ai bordi**, che è un'operazione dopo il sample.
+
+### Il design implementato
+
+L'ancora è **stato dell'istanza della distribuzione**, legata alla
+costruzione:
+
+```python
+DistributionStrategy.__init__(self, rng=None, anchor=ANCHOR_CENTER)
+DistributionFactory.create(mode, rng=None, anchor=ANCHOR_CENTER)
+```
+
+Conseguenze:
+
+- la firma `sample(center, spread)` **non cambia** — nessun rosso gratuito, e
+  13 test che la chiamano a keyword (`sample(center=..., spread=...)`) restano
+  intatti (il parametro `center` non poteva essere rinominato);
+- `VariationStrategy` **non cambia**: resta il passacarte che è, e
+  `QuantizedVariation` diventa corretto senza una riga di modifica;
+- ogni distribuzione sa come la propria forma riempie una banda — il posto
+  giusto per quella conoscenza in uno Strategy pattern;
+- gli assi restano una **somma**, non un prodotto cartesiano: una nuova
+  distribuzione non va scritta due volte, e una terza ancora (`max`) è un ramo
+  per distribuzione, non un raddoppio del registro.
+
+Il jitter implicito si risolve in una riga, in `Parameter.__init__`:
+
+```python
+effective_anchor = range_anchor if mod_range is not None else ANCHOR_CENTER
+```
+
+`has_explicit_range` è costante per tutta la vita del Parameter, quindi la
+scelta si fa una volta invece che a ogni `get_value`.
+
+### Il rischio della cache, e come è stato chiuso
+
+Il §Rischi 3 del piano originale si preoccupava che `range_anchor` entrasse nel
+fingerprint. **Ci entra per costruzione**: `compute_fingerprint` hashea il dict
+YAML per-stream (`generator.stream_data_map`) escludendo solo `solo`/`mute`,
+quindi qualsiasi chiave per-stream vi rientra. Una chiave **top-level** invece
+non ci entrerebbe — è il buco che ha già `seed`. Questo, non la simmetria con
+`distribution_mode`, è la ragione per cui la chiave è per-stream.
+
+Il rischio vero era un altro, e il piano non lo vedeva: il fingerprint copriva
+il **testo** YAML ma non la **semantica** con cui il motore lo interpreta. Col
+cambio di significato della gaussiana a YAML invariato, ogni stem già
+renderizzato sarebbe rimasto `clean` — audio vecchio, nessun errore. Risolto
+con `VARIATION_SEMANTICS_VERSION` dentro l'hash: un re-render completo al primo
+run dopo l'aggiornamento, poi la cache incrementale riparte.
+
+### Punti che il piano lasciava "da verificare"
+
+- **`score_visualizer`**: nessun impatto, verificato. Non disegna nessuna banda
+  `base ± range/2`; `envelope_extractor` emette `<param>_range` come curva a sé
+  con la larghezza grezza, e il visualizer la scala data-driven (issue #114).
+  L'impatto grafico è su PGE-ui, dove `primitives.jsx:271` renderizza
+  letteralmente `±{range/2}`.
+- **Jitter implicito**: confermato, resta centrato in ogni modalità.
+
+### Bounds: validazione al parse (Rischi §4)
+
+Implementata, ma **solo per l'ancora `min`**: la banda arriva a `base + range`
+e può sforare `max_val` dove la centrata non lo faceva. La modalità `min`
+promette una banda esatta; se non è realizzabile lo si dice al parse invece di
+prometterla e poi tagliarla col safety clamp. Solo il tetto (il pavimento è
+`base`, già validato) e solo quando il massimo è **esatto**: scalare+scalare,
+envelope+scalare, scalare+envelope. Con due envelope il massimo della somma non
+è la somma dei massimi, e un falso positivo che blocca un render valido sarebbe
+peggio del clamp. L'ancora `center` non guadagna nessuna validazione nuova.
+
+### Scope: cosa l'interruttore NON governa
+
+Confermato l'inventario del §3 originale. `range_anchor` governa (1) e (2) —
+tutto ciò che passa da `Parameter.get_value`, cioè `volume_range`, `pan_range`,
+`grain.duration_range`, `pointer.offset_range`, `pitch.range` e il pitch
+quantizzato EDO. Restano **fuori e simmetrici**: il detune implicito del pitch
+(±12 cents, `strategie.py`), lo spread per-voce delle voice strategy
+(`spread`, `pitch_range`, `pointer_range`), l'`iot` async del
+`DensityController` (già ancorato al minimo, per ragioni sue) e il jitter
+implicito. Nessuno di questi è un `_range` dichiarato con una `base` di cui
+essere il minimo.
+
+### granulation-studies: nulla in questa PR
+
+L'adozione della modalità è lavoro a parte e comporta **rileggere i valori
+esistenti**: in `studies/stack_300-1000ms/study.yml` il `duration_range` arriva
+a 350 su base 300, cioè oggi `[125, 475]` e con `range_anchor: min`
+`[300, 650]`. I quattro study in ms vanno ripassati, e `stack_1-50smp` pure.
+
+---
+
+## Design proposto
+
+### 1. Perché NON toccare le distribuzioni
+
+La strada più corta — riscrivere `UniformDistribution.sample` — è la sbagliata:
+
+- il contratto `sample(center, spread)` è usato anche da `QuantizedVariation`
+  con `center=0`, dove "minimo" non vuol dire niente: la variazione diventerebbe
+  silenziosamente monodirezionale sul pitch;
+- `get_bounds()` è documentazione/debug e va tenuto coerente;
+- **tutti i test delle distribuzioni** (`tests/shared/test_distribution_strategy.py`)
+  fissano la formula attuale: cambiarla li rende rossi in blocco senza che il
+  comportamento di default sia cambiato per l'utente.
+
+### 2. Perché NON una nuova `distribution_mode`
+
+Registrare `uniform_min` / `gaussian_min` via `DistributionFactory.register` è
+tentante (il registry esiste già), ma confonde due assi ortogonali: la **forma**
+della distribuzione e l'**ancora** del range. Ogni distribuzione futura
+andrebbe scritta due volte, e gli enum di PGE-ls / PGE-ui crescerebbero come
+prodotto cartesiano invece che come somma.
+
+### 3. La proposta: `range_anchor`, asse separato in `StreamConfig`
+
+Fratello di `distribution_mode`, che vive già lì
+(`core/stream_config.py:78`, default `'uniform'`) e viaggia già fino a ogni
+`Parameter` (`parser.py:50,131`):
+
+```yaml
+# per-stream, default 'center' → nessuno YAML esistente cambia
+range_anchor: center | min
+```
+
+L'implementazione è **una funzione pura** che traduce `(base, range)` nella
+coppia `(center, spread)` che le distribuzioni già sanno consumare, chiamata in
+`Parameter.get_value` fra il calcolo del range e la delega alla
+`VariationStrategy` (`parameter.py:99-112`):
+
+```python
+# center: identico a oggi, bit-per-bit
+center, spread = base, rng_width
+
+# min: la banda diventa [base, base + rng_width]
+center, spread = base + rng_width / 2.0, rng_width
+```
+
+Proprietà che rendono questa la strada giusta:
+
+- le distribuzioni **non cambiano**: contratto e test restano validi;
+- `QuantizedVariation` continua a campionare attorno a 0 e a sommare — l'offset
+  `+range/2` va applicato lì con la stessa funzione, così anche il pitch
+  quantizzato diventa "da base in su" senza formule duplicate;
+- il default `center` è un no-op dimostrabile: `base + 0/2 == base`;
+- un solo punto da documentare, un solo punto da testare.
+
+Collocazione del modulo: `pge/parameters/range_anchor.py` (accanto a chi lo usa)
+oppure `pge/shared/` se si vuole riusarlo dalle strategy. Preferenza:
+`parameters/`, finché lo scope resta (1)+(2).
+
+### 4. La gaussiana in modalità `min` — decisione da prendere
+
+Due opzioni, non equivalenti:
+
+- **(a) allineare a granstudies**: `μ = base + range/2`, `σ = range/6`, **clamp
+  ai bordi banda**. `range` diventa una larghezza in entrambe le modalità e la
+  promessa "mai sotto `base`" è vera. Costo: in modalità `min` la gaussiana
+  cambia significato rispetto a `center` (dove `range` è σ), quindi `range_anchor`
+  non è più *solo* un'ancora.
+- **(b) spostare solo il centro**: `μ = base + range/2`, `σ = range`, nessun
+  clamp di banda. `range_anchor` resta ortogonale, ma "min" è una bugia: metà
+  dei valori cade sotto `base`.
+
+**Raccomandazione: (a)**, con il nome della modalità che lo dichiara. Se `min`
+non garantisce il minimo non serve a niente, ed è esattamente la garanzia che
+serve a granulation-studies. Va scritto in `docs/reference/yaml.md` che in
+modalità `min` la gaussiana legge `range` come larghezza.
+
+### 5. Superficie YAML
+
+```yaml
+streams:
+  - stream_id: s1
+    range_anchor: min        # NUOVA chiave per-stream: center (default) | min
+    volume: -6
+    volume_range: 12         # center: [-12, 0] · min: [-6, 6]
+```
+
+Non per-parametro. Un override tipo `volume_range_anchor` moltiplicherebbe la
+superficie per il numero di parametri e non risolve nessun caso reale noto: gli
+studi vogliono flippare il documento intero. Se servirà, si aggiunge dopo — il
+contrario non è vero.
+
+Da valutare: un default globale a livello di documento, come per altre config
+di processo. Non necessario in v1.
+
+---
+
+## File coinvolti
+
+| File | Modifica |
+|---|---|
+| `src/pge/parameters/range_anchor.py` | **nuovo**: enum/costanti + `resolve(base, width, anchor) -> (center, spread)` |
+| `src/pge/core/stream_config.py` | campo `range_anchor: str = 'center'` in `StreamConfig` (riga ~78, accanto a `distribution_mode`) |
+| `src/pge/parameters/parser.py` | legge `config.range_anchor` (come riga 50) e lo passa a `Parameter` (come riga 131) |
+| `src/pge/parameters/parameter.py` | kwarg `range_anchor`; applica `resolve` in `get_value` fra riga 99 e 105 |
+| `src/pge/strategies/variation_strategy.py` | `QuantizedVariation` riceve l'offset dell'ancora (o lo riceve già risolto, da decidere in TDD) |
+| `src/pge/rendering/stream_cache_manager.py` | verificare che la chiave entri nel fingerprint (non è fra le escluse, riga 27) |
+| `docs/reference/yaml.md` | nuova chiave, tabella delle bande, nota sulla gaussiana |
+| `CHANGELOG.md` | voce sotto Unreleased/Aggiunto |
+
+Da **verificare** in implementazione, non ancora accertati:
+
+- `rendering/envelope_extractor.py:181-191` esporta la serie `<param>_range` con
+  la larghezza grezza (`param._mod_range`). Chi la interpreta per disegnare la
+  banda — `score_visualizer`, e l'editor envelope di PGE-ui — deve conoscere
+  l'ancora, altrimenti la partitura grafica mente. Non ho trovato un disegno
+  esplicito `base ± range/2` nel visualizer: va cercato prima di dichiarare
+  l'impatto nullo.
+- il **jitter implicito** (`ParameterBounds.default_jitter`, attivo quando
+  `has_explicit_range` è falso): è un tremolio simmetrico attorno al valore, non
+  una banda. **Proposta: resta sempre centrato**, anche con `range_anchor: min`.
+  È la trappola più facile del piano.
+
+---
+
+## Test coinvolti
+
+Nuovi:
+
+- `tests/parameters/test_range_anchor.py` — la funzione pura: `center` è
+  identità; `min` porta la banda a `[base, base+range]`; `range=0` è no-op in
+  entrambe; range negativo → errore.
+- `tests/parameters/test_parameter.py` — con RNG seedato: stesso seed e stesso
+  `range`, `center` e `min` producono due valori il cui scarto è esattamente
+  `range/2`; in `min` nessun campione cade sotto `base` su N draw (uniform e,
+  se si sceglie (a), gaussian).
+- gaussiana in `min`: i bordi a 3σ e il clamp di banda.
+- pitch quantizzato in `min`: nessuno step sotto `base`.
+- fingerprint: due stream identici salvo `range_anchor` sono dirty.
+
+Da tenere **verdi senza modifiche** — è il criterio di successo del design:
+
+- `tests/shared/test_distribution_strategy.py` (le distribuzioni non cambiano);
+- gli 82 file di test che nominano `_range`: col default `center` nessuno di
+  loro deve accorgersi della modifica.
+
+---
+
+## Rischi architetturali
+
+1. **Superficie che sembra piccola e non lo è.** Una chiave sola cambia il
+   significato di ogni `_range` dello stream. Serve che la reference dica
+   esplicitamente *quali* range governa (inventario, punto 3) e quali no.
+2. **Render esistenti.** Col default `center` nessun render cambia
+   bit-per-bit — va verificato con un golden test, non asserito.
+3. **Cache stems.** Se `range_anchor` non entra nel fingerprint, cambiarlo
+   lascia stem vecchi in cache: audio sbagliato senza nessun errore. Stessa
+   attenzione riservata a `rng_group`.
+4. **Bounds.** In `min` la banda utile arriva a `base + range`: un valore che
+   passava la validazione centrato può sforare il tetto. Valutare una
+   validazione al parse (`base + range` dentro i bounds) invece del solo
+   safety clamp a valle.
+5. **Il nome.** `range_anchor: min` dice l'ancora ma non che `range` è
+   un'apertura verso l'alto. Alternative da discutere: `range_mode: centered |
+   upward`, oppure `range_from: center | base`.
+
+---
+
+## Impatto cross-repo (regola `cross-repo-impact`)
+
+- **PGE-ls**: nuova chiave per-stream con enum a due valori — completamento,
+  hover, diagnostica del valore non valido. È lo stesso lavoro già mappato per
+  `duration_unit` in DMGiulioRomano/PGE-ls#36.
+- **PGE-ui**: l'Inspector mostra i `_range` come "± valore"; con `min` l'etichetta
+  e la banda disegnata nell'editor envelope cambiano. Serve anche il controllo
+  per la nuova chiave.
+- **gl-ls**: `study.yml` eredita la chiave nel blocco `base:` (passthrough
+  engine). Ma soprattutto: se granulation-studies adotta `range_anchor: min`,
+  le due semantiche di `range` coincidono e gl-ls può finalmente descriverne
+  **una** — oggi deve spiegare che `axes.*.range` e `base.*_range` sono cose
+  diverse.
+- **granulation-studies**: adottare la modalità non è gratis. I valori dei
+  `base.*_range` esistenti vanno **riletti**: p.es. `stack_300-1000ms` ha
+  `duration_range` fino a 350 ms su base 300 → oggi la banda è `[125, 475]`,
+  con `min` diventa `[300, 650]`. I quattro study in ms vanno ripassati, e
+  `stack_1-50smp` pure.
+
+## Sync paper CIM 2026 (regola `submodule-sync-cim`)
+
+Il rendering cambia solo per chi attiva la chiave, e gli esempi del paper non la
+useranno. Nessun bump necessario, salvo che si voglia allineare il submodule per
+altri motivi.
+
+---
+
+## Sequenza di implementazione (commit atomici, test gate su ognuno)
+
+1. `test`: la funzione pura `resolve` (rossi) — fissa la semantica prima del
+   codice.
+2. `feat`: `range_anchor.py` + campo in `StreamConfig`, non ancora cablato.
+3. `test` + `feat`: cablaggio in `Parameter.get_value`, uniform, modalità
+   `center` dimostrata identità.
+4. `test` + `feat`: modalità `min` su `AdditiveVariation`.
+5. `test` + `feat`: `QuantizedVariation` (pitch).
+6. `test` + `feat`: gaussiana secondo la decisione del punto 4 del Design.
+7. `test` + `fix`: fingerprint della cache.
+8. `docs`: reference + CHANGELOG.
+9. Issue cross-repo su PGE-ls e PGE-ui.
+
+**Prima di partire dal punto 1 servono due decisioni** che non spettano a questo
+documento: la semantica della gaussiana in `min` (Design §4) e il nome della
+chiave (Rischi §5).

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -10,7 +10,8 @@ sources:
   - src/pge/strategies/
   - src/pge/envelopes/
   - src/pge/shared/seeding.py
-last_synced_commit: abea29b
+  - src/pge/shared/distribution_strategy.py
+last_synced_commit: 41a469c
 entry_for: [yaml-syntax, envelope-syntax]
 ---
 
@@ -38,6 +39,8 @@ Sezioni rilevanti in questo doc:
 - [Parameter Syntax](#parameter-syntax) — scalari, tuple, dict, envelope
 - [Campi Obbligatori di Stream](#campi-obbligatori-di-stream)
 - [Configurazione Processo (StreamConfig)](#configurazione-processo-streamconfig)
+- [La banda dei `_range`](#la-banda-dei-_range-distribution_mode-e-range_anchor) —
+  larghezza, forma (`distribution_mode`), ancora (`range_anchor`)
 - [Blocco Grain](#blocco-grain), [Pointer](#blocco-pointer), [Pitch](#blocco-pitch), [Dephase](#dephase-variazione-stocastica)
 - [Blocco Voices (Multi-Voice)](#blocco-voices-multi-voice)
 - [Envelopes](#envelopes) — sintassi envelope completa
@@ -54,6 +57,7 @@ Esempi runnable: [Esempi Completi](#esempi-completi). Casi envelope: sezione [En
 
 - `src/yaml_parser/` — parser
 - `src/pge/parameters/parameter_definitions.py`, `src/pge/parameters/parameter_schema.py` — bounds e schema
+- `src/pge/shared/distribution_strategy.py` — banda dei `_range`: distribuzioni e `range_anchor`
 - `src/pge/envelopes/` — sintassi envelope
 - Ultimo allineamento: vedi `last_synced_commit` in frontmatter
 
@@ -185,7 +189,7 @@ Qualsiasi parametro numerico accetta le seguenti forme:
 | Scalare | `density: 10` | Valore fisso |
 | Envelope lineare | `density: [[0, 10], [1, 50]]` | Interpolazione lineare tra breakpoint `[time, value]` |
 | Envelope annidata | `density: [[[0, 5], [10, 50]], 1.0, 5]` | Envelope di envelope |
-| Variazione | `grain: {duration: 0.05, duration_range: 0.01}` | `±0.01` randomizzazione |
+| Variazione | `grain: {duration: 0.05, duration_range: 0.01}` | banda larga `0.01` (default: `±0.005`) |
 | Espressione math | `onset: (pi)`, `duration: (10/2)` | Valutato via `safe_eval` |
 | Envelope normalizzato | `step: {points: [[0, 0], [1, 12]], time_mode: normalized}` | `[0, 1]` mappato su `duration` |
 | Envelope per-punto interp | `density: [[0, 5, 'cubic'], [0.5, 30, 'step'], [1, 5]]` | `type` per-segmento, override del default globale (issue #54) |
@@ -228,7 +232,11 @@ dephase: false          # Controllo variazione stocastica (vedi sezione Dephase)
 
 range_always_active: false  # true: i _range sono sempre attivi anche senza dephase
 
-distribution_mode: uniform  # (riservato, non usato correntemente)
+distribution_mode: uniform  # "uniform" (default) | "gaussian"
+                            # COME la banda del range viene riempita
+
+range_anchor: center    # "center" (default) | "min"
+                        # DOVE cade il valore base dentro la banda
 
 time_scale: 1.0         # fattore di scala temporale globale (default 1.0)
 
@@ -236,6 +244,71 @@ clip_strategy: overflow_margin  # "overflow_margin" (default) | "passthrough"
                                 # Decide quali grain entrano in stream.voices
 clip_margin: 0.0        # tolleranza in secondi per la coda dei grain (default 0.0)
 ```
+
+### La banda dei `_range`: `distribution_mode` e `range_anchor`
+
+Ogni parametro con un `_range` associato produce, per ogni grano, un valore
+pescato dentro una **banda**. La banda si descrive con tre concetti ortogonali,
+che vanno tenuti distinti:
+
+| concetto | chiave | cosa decide |
+|---|---|---|
+| larghezza | il valore del `_range` stesso | quanto è larga la banda |
+| forma | `distribution_mode` | come la banda viene riempita |
+| ancora | `range_anchor` | dove cade `base` dentro la banda |
+
+**`range` è sempre la larghezza della banda**, in ogni distribuzione e in
+entrambe le ancore. Non è mai una deviazione standard, non è mai una semi-ampiezza.
+
+```yaml
+range_anchor: center   # default — banda [base - range/2, base + range/2]
+range_anchor: min      # banda [base, base + range]: base è il MINIMO
+```
+
+Con `base: 300` e `range: 200`:
+
+| `distribution_mode` | `range_anchor` | banda | dove si addensa |
+|---|---|---|---|
+| `uniform` | `center` | 200 … 400 | piatta |
+| `uniform` | `min` | 300 … 500 | piatta |
+| `gaussian` | `center` | 200 … 400 | picco a 300 |
+| `gaussian` | `min` | 300 … 500 | picco a 400 |
+
+La gaussiana è **troncata**: σ = larghezza/6, quindi i bordi della banda cadono
+a 3σ dalla media, e la coda oltre i bordi (~0.3%) viene appiattita sull'estremo
+invece di uscire. Nessun campione cade fuori dalla banda dichiarata.
+
+**Cosa governa `range_anchor`.** Tutti e soli i `_range` che passano da
+`Parameter`: `volume_range`, `pan_range`, `grain.duration_range`,
+`pointer.offset_range`, `pitch.range`. Vale anche per il pitch quantizzato
+(unità EDO): con `min` gli step interi partono da `base` e salgono.
+
+**Cosa NON governa**, e resta simmetrico in ogni caso:
+
+- il **jitter implicito** (`ParameterBounds.default_jitter`, attivo sotto
+  dephase quando *non* c'è un `_range` dichiarato) — è un tremolio attorno al
+  valore, non una banda dichiarata: non c'è nessun `range` scritto da
+  reinterpretare, e ancorarlo al minimo lo renderebbe un offset positivo
+  sistematico;
+- il **detune implicito del pitch** (`±12 cents`, vedi
+  [Detune implicito](#detune-implicito-del-pitch-senza-range)) — stessa ragione;
+- lo **spread delle voice strategy** (`spread`, `pitch_range`, `pointer_range`):
+  non sono `_range` di un parametro, non hanno una `base` di cui essere il minimo.
+
+**Bounds.** Con `range_anchor: min` la banda arriva a `base + range`, quindi il
+tetto può sforare `max_val` dove la versione centrata (`base + range/2`) non lo
+faceva. Il motore lo verifica **al parse** e solleva `ParameterBoundError`
+invece di lasciare che il safety clamp schiacci la banda contro il tetto. Il
+controllo scatta quando il massimo è calcolabile esattamente (scalare+scalare,
+envelope+scalare, scalare+envelope); con base e range entrambi envelope il
+massimo della somma non è la somma dei massimi, quindi resta il solo clamp.
+
+> **Cambio di comportamento (post v5.2.0).** Fino alla v5.2.0 `gaussian` leggeva
+> `range` come **σ**, con la campana illimitata richiusa solo dal clamp ai bounds
+> del parametro: `range: 200` su `base: 300` produceva valori grosso modo fra 0 e
+> 600. Ora produce 200…400. `uniform` non cambia. Chi usava `distribution_mode:
+> gaussian` e vuole un'escursione paragonabile a prima deve moltiplicare il
+> proprio `range` per circa 6.
 
 ### clip_strategy — Controllo grain out-of-bounds
 
@@ -312,12 +385,17 @@ Bounds: `density` ∈ [0.01, 4000], `fill_factor` ∈ [0.001, 50], `distribution
 ```yaml
 volume: 0.0                        # dB, default 0.0
 volume: [[0, -12], [30, 0]]
-volume_range: 3.0                  # ±3 dB randomizzazione per grano
+volume_range: 3.0                  # banda larga 3 dB attorno al valore
+                                   # (con range_anchor: min → da 0 a +3 dB)
 
 pan: 0.0                           # gradi, 0 = centro, ±180 = estremi
 pan: [[0, -90], [30, 90]]
-pan_range: 30.0                    # ±30° randomizzazione per grano
+pan_range: 30.0                    # banda larga 30° attorno al valore
 ```
+
+I `_range` sono larghezze di banda: dove cade il valore base dentro la banda
+lo decide `range_anchor` (default `center` → `±range/2`). Vedi
+[La banda dei `_range`](#la-banda-dei-_range-distribution_mode-e-range_anchor).
 
 Bounds: `volume` ∈ [-120, 12], `pan` ∈ [-3600, 3600].
 
@@ -329,7 +407,7 @@ Bounds: `volume` ∈ [-120, 12], `pan` ∈ [-3600, 3600].
 grain:
   duration: 0.05           # secondi, default 0.05
   duration: [[0, 0.02], [30, 0.2]]
-  duration_range: 0.01     # ±0.01s randomizzazione
+  duration_range: 0.01     # banda larga 0.01 s (default: ±0.005 s)
 
   # Unità di misura per duration e duration_range: seconds (default) |
   # samples | milliseconds. La conversione avviene al parse e vale per
@@ -338,7 +416,7 @@ grain:
   # 'samples': campioni alla frequenza di output del motore (48000 Hz).
   duration_unit: samples
   duration: 512            # 512 campioni = 512/48000 s
-  duration_range: 64       # ±64 campioni
+  duration_range: 64       # banda larga 64 campioni (default: ±32)
   duration: [[0, 48], [30, 4800]]   # envelope: Y in campioni
 
   # 'milliseconds': fattore fisso 1e-3, indipendente dal sample rate.
@@ -346,7 +424,7 @@ grain:
   # solo numeri molto piccoli.
   duration_unit: milliseconds
   duration: 50             # 50 ms = 0.05 s
-  duration_range: 4.5      # ±4.5 ms
+  duration_range: 4.5      # banda larga 4.5 ms (default: ±2.25 ms)
   duration: [[0, 1], [30, 100]]     # envelope: Y in millisecondi
 
   envelope: hanning        # finestra per shape del grano (default: hanning)
@@ -418,7 +496,9 @@ pointer:
                           # 1.0 = velocità normale, -1.0 = indietro, 2.0 = doppia
                           # supporta envelope: [[0, 1.0], [30, 2.0]]
 
-  offset_range: 0.0       # deviazione per-grano ∈ [-offset_range, +offset_range]
+  offset_range: 0.0       # deviazione per-grano: banda larga offset_range
+                          # attorno a 0 (con range_anchor: min → da 0 in su,
+                          # cioè sempre in avanti).
                           # scalata sulla finestra di loop attiva e CONFINATA al
                           # suo interno (wrap modulare). Senza loop: scala e wrap
                           # sull'intero file.
@@ -491,11 +571,13 @@ Chiavi valide del blocco: le 6 unità più `range` e `value`. `value` è ammesso
 pitch:
   ratio: 1.0              # rapporto di trasposizione (default 1.0 = no trasposizione)
   ratio: [[0, 0.5], [30, 2.0]]
-  range: 0.1              # ±variazione random intorno a ratio
+  range: 0.1              # larghezza della banda di variazione random
+                          # (range_anchor: center → ±0.05 intorno a ratio)
 
   semitones: 0            # trasposizione in semitoni (intero o float)
   semitones: [[0, -12], [30, 12]]
-  range: 6                # ±variazione random in semitoni (intera)
+  range: 6                # larghezza della banda in semitoni, step interi
+                          # (range_anchor: min → da base a base+6 semitoni)
 
   quarter_tone: 3         # quarti di tono (24-EDO)
   eighth_tone: 6          # ottavi di tono (48-EDO)
@@ -515,7 +597,10 @@ pitch:
 ## Dephase (Variazione Stocastica)
 
 `dephase` controlla la probabilità di applicare variazioni stocastiche per-grano.
-Si applica a tutti i parametri che hanno un `_range` associato.
+Si applica a tutti i parametri che hanno un `_range` associato. Decide **se** la
+variazione avviene; la banda dentro cui il valore viene pescato la decidono
+`distribution_mode` e `range_anchor` (vedi
+[La banda dei `_range`](#la-banda-dei-_range-distribution_mode-e-range_anchor)).
 
 ```yaml
 # Disabilitato (default): range attivi solo se presenti

--- a/src/pge/core/stream_config.py
+++ b/src/pge/core/stream_config.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass,fields
 from typing import Optional, Union
 
 from pge.shared.constants import DEFAULT_OUTPUT_SR
+from pge.shared.distribution_strategy import ANCHOR_CENTER
 
 @dataclass(frozen=True)
 class StreamContext:
@@ -76,6 +77,13 @@ class StreamConfig:
     dephase: Optional[Union[dict, bool, int, float, list]] = False
     range_always_active: bool = False
     distribution_mode: str = 'uniform'
+    # Ancora dei `_range` dichiarati: 'center' (default, banda
+    # [base - range/2, base + range/2]) o 'min' (banda [base, base + range]).
+    # Asse ortogonale a distribution_mode: quella dice come la banda si
+    # riempie, questa dove cade `base` dentro la banda. Non tocca il jitter
+    # implicito, che resta centrato (non c'e' nessun range dichiarato da
+    # reinterpretare). Vedi shared/distribution_strategy.py.
+    range_anchor: str = ANCHOR_CENTER
     time_mode: str = 'absolute'
     time_scale: float = 1.0
     clip_strategy: str = 'overflow_margin'

--- a/src/pge/parameters/parameter.py
+++ b/src/pge/parameters/parameter.py
@@ -23,7 +23,11 @@ from pge.envelopes.envelope import Envelope
 from pge.parameters.parameter_definitions import ParameterBounds
 from pge.shared.logger import log_clip_warning
 from pge.shared.probability_gate import *
-from pge.shared.distribution_strategy import DistributionFactory, DistributionStrategy
+from pge.shared.distribution_strategy import (
+    ANCHOR_CENTER,
+    DistributionFactory,
+    DistributionStrategy,
+)
 from pge.strategies.variation_registry import VariationFactory
 
 ParamInput = Union[float, int, Envelope]
@@ -57,6 +61,7 @@ class Parameter:
         mod_range: Optional[ParamInput] = None,
         owner_id: str = "unknown",
         distribution_mode: str = 'uniform',
+        range_anchor: str = ANCHOR_CENTER,
         rng: Optional[random.Random] = None,
     ):
         self.name = name
@@ -67,8 +72,20 @@ class Parameter:
         self._mod_range = mod_range
         self._probability_gate = NeverGate()
 
+        # Ancora effettiva: `range_anchor` vale solo se un range è stato
+        # dichiarato. Senza range esplicito si applica il jitter implicito
+        # (bounds.default_jitter), che è un tremolio simmetrico attorno al
+        # valore e non una banda: non c'è nessun `range` scritto da
+        # reinterpretare, e ancorarlo al minimo lo trasformerebbe in un
+        # offset positivo sistematico su ogni grano. La scelta è costante per
+        # tutta la vita del Parameter (mod_range non cambia dopo l'init),
+        # quindi si risolve una volta qui invece che a ogni get_value.
+        effective_anchor = range_anchor if mod_range is not None else ANCHOR_CENTER
+
         # RNG locale del parametro (issue #154): None → random globale.
-        self._distribution = DistributionFactory.create(distribution_mode, rng=rng)
+        self._distribution = DistributionFactory.create(
+            distribution_mode, rng=rng, anchor=effective_anchor
+        )
         self._variation_strategy = VariationFactory.create(bounds.variation_mode)
         
     def set_probability_gate(self, gate: ProbabilityGate):

--- a/src/pge/parameters/parser.py
+++ b/src/pge/parameters/parser.py
@@ -16,8 +16,16 @@ from typing import Union, Optional, List, Any
 from pge.parameters.parameter import Parameter, ParamInput
 from pge.envelopes.envelope import Envelope, create_scaled_envelope
 from pge.parameters.parameter_definitions import get_parameter_definition
-from pge.shared.distribution_strategy import ANCHOR_CENTER, ANCHOR_MIN
-from pge.shared.exceptions import InvalidParameterError, ParameterBoundError
+from pge.shared.distribution_strategy import (
+    ANCHOR_CENTER,
+    ANCHOR_MIN,
+    validate_range_anchor,
+)
+from pge.shared.exceptions import (
+    InvalidFieldValueError,
+    InvalidParameterError,
+    ParameterBoundError,
+)
 from pge.shared.seeding import component_rng
 
 class GranularParser:
@@ -51,7 +59,12 @@ class GranularParser:
         self.distribution_mode = config.distribution_mode
         # Ancora dei range dichiarati (center | min). getattr difensivo come
         # per `seed`: i config parziali dei test possono non averla.
-        self.range_anchor = getattr(config, 'range_anchor', ANCHOR_CENTER)
+        # Validata qui e non solo a valle nella DistributionFactory: qui si
+        # conosce lo stream_id, quindi un typo dice QUALE stream lo contiene
+        # invece del solo valore incriminato.
+        self.range_anchor = self._validated_anchor(
+            getattr(config, 'range_anchor', ANCHOR_CENTER)
+        )
         # Seed effettivo del run (issue #154): deriva l'RNG per-parametro.
         # getattr difensivo: i config parziali dei test possono non averlo.
         self.seed = getattr(config, 'seed', None)
@@ -169,6 +182,14 @@ class GranularParser:
         err.stream_id = self.stream_id
         raise err
 
+    def _validated_anchor(self, anchor: str) -> str:
+        """Valida `range_anchor` attribuendo l'errore allo stream."""
+        try:
+            return validate_range_anchor(anchor)
+        except InvalidFieldValueError as err:
+            err.stream_id = self.stream_id
+            raise
+
     def _validate_band_ceiling(
         self,
         value: Optional[ParamInput],
@@ -191,7 +212,8 @@ class GranularParser:
         Solo il tetto: il pavimento della banda e' `base`, gia' validato
         contro min_val da _validate_and_clip.
 
-        Il controllo scatta solo quando il massimo della somma e' ESATTO:
+        Il controllo scatta solo quando il massimo della somma e' calcolabile
+        da un solo lato:
 
             base scalare + range scalare   -> base + range
             base envelope + range scalare  -> max(base) + range
@@ -201,6 +223,12 @@ class GranularParser:
         massimi (i due picchi possono cadere in istanti diversi): il controllo
         sarebbe conservativo e un falso positivo bloccherebbe un render valido.
         In quel caso resta il safety clamp.
+
+        Il picco di un envelope e' stimato dai suoi breakpoint. Con
+        interpolazione cubica la curva puo' superare i breakpoint, quindi la
+        stima puo' essere per difetto: il controllo puo' lasciar passare una
+        banda che sfora di poco, mai bloccarne una valida. Il residuo lo
+        prende il safety clamp — errore di sicurezza dalla parte giusta.
         """
         if self.range_anchor != ANCHOR_MIN:
             return

--- a/src/pge/parameters/parser.py
+++ b/src/pge/parameters/parser.py
@@ -16,6 +16,7 @@ from typing import Union, Optional, List, Any
 from pge.parameters.parameter import Parameter, ParamInput
 from pge.envelopes.envelope import Envelope, create_scaled_envelope
 from pge.parameters.parameter_definitions import get_parameter_definition
+from pge.shared.distribution_strategy import ANCHOR_CENTER
 from pge.shared.exceptions import InvalidParameterError, ParameterBoundError
 from pge.shared.seeding import component_rng
 
@@ -48,6 +49,9 @@ class GranularParser:
         self.output_sr = getattr(config.context, 'output_sr', None)
         self.time_mode = config.time_mode
         self.distribution_mode = config.distribution_mode
+        # Ancora dei range dichiarati (center | min). getattr difensivo come
+        # per `seed`: i config parziali dei test possono non averla.
+        self.range_anchor = getattr(config, 'range_anchor', ANCHOR_CENTER)
         # Seed effettivo del run (issue #154): deriva l'RNG per-parametro.
         # getattr difensivo: i config parziali dei test possono non averlo.
         self.seed = getattr(config, 'seed', None)
@@ -129,6 +133,7 @@ class GranularParser:
             mod_range=validated_range,
             owner_id=self.stream_id,
             distribution_mode=self.distribution_mode,
+            range_anchor=self.range_anchor,
             rng=component_rng(self.seed, self.rng_id, name),
         )
 

--- a/src/pge/parameters/parser.py
+++ b/src/pge/parameters/parser.py
@@ -16,7 +16,7 @@ from typing import Union, Optional, List, Any
 from pge.parameters.parameter import Parameter, ParamInput
 from pge.envelopes.envelope import Envelope, create_scaled_envelope
 from pge.parameters.parameter_definitions import get_parameter_definition
-from pge.shared.distribution_strategy import ANCHOR_CENTER
+from pge.shared.distribution_strategy import ANCHOR_CENTER, ANCHOR_MIN
 from pge.shared.exceptions import InvalidParameterError, ParameterBoundError
 from pge.shared.seeding import component_rng
 
@@ -120,6 +120,9 @@ class GranularParser:
             value_type='probability'
         ) if clean_prob is not None else None
 
+        # 3-bis. Tetto della banda sotto ancora `min` (vedi _validate_band_ceiling).
+        self._validate_band_ceiling(validated_value, validated_range, bounds, name)
+
         # 4. Assembla e restituisce l'oggetto Smart Parameter.
         # RNG per-componente (issue #154): ogni parametro pesca dal proprio
         # stream derivato da (seed, rng_id, nome) — i draw di un parametro
@@ -162,6 +165,68 @@ class GranularParser:
             param_name=context_info,
             value=raw_data,
             hint="atteso numero, lista di punti, o dict envelope",
+        )
+        err.stream_id = self.stream_id
+        raise err
+
+    def _validate_band_ceiling(
+        self,
+        value: Optional[ParamInput],
+        mod_range: Optional[ParamInput],
+        bounds: Any,
+        param_name: str,
+    ) -> None:
+        """Verifica che la banda `[base, base + range]` stia sotto max_val.
+
+        Si applica SOLO con `range_anchor: min`. Sotto l'ancora `center` la
+        banda arriva a `base + range/2` e resta gestita dal safety clamp a
+        valle: e' il comportamento storico e non si tocca.
+
+        Perche' al parse e non solo col clamp: la modalita' `min` promette una
+        banda esatta. Se la banda non e' realizzabile, il clamp la schiaccia
+        contro il tetto e produce un warning per grano — un sintomo rumoroso
+        ma facile da non leggere, che lascia l'utente convinto di avere la
+        banda che ha scritto. Meglio dirlo una volta, prima di renderizzare.
+
+        Solo il tetto: il pavimento della banda e' `base`, gia' validato
+        contro min_val da _validate_and_clip.
+
+        Il controllo scatta solo quando il massimo della somma e' ESATTO:
+
+            base scalare + range scalare   -> base + range
+            base envelope + range scalare  -> max(base) + range
+            base scalare + range envelope  -> base + max(range)
+
+        Con entrambi envelope il massimo della somma non e' la somma dei
+        massimi (i due picchi possono cadere in istanti diversi): il controllo
+        sarebbe conservativo e un falso positivo bloccherebbe un render valido.
+        In quel caso resta il safety clamp.
+        """
+        if self.range_anchor != ANCHOR_MIN:
+            return
+        if mod_range is None or bounds.max_val is None:
+            return
+
+        value_is_env = isinstance(value, Envelope)
+        range_is_env = isinstance(mod_range, Envelope)
+        if value_is_env and range_is_env:
+            return
+
+        peak_value = (max(y for _, y in value.breakpoints)
+                      if value_is_env else float(value))
+        peak_range = (max(y for _, y in mod_range.breakpoints)
+                      if range_is_env else float(mod_range))
+        ceiling = peak_value + peak_range
+
+        if ceiling <= bounds.max_val:
+            return
+
+        err = ParameterBoundError(
+            param_name=param_name,
+            value_type='base + range (range_anchor: min)',
+            value=ceiling,
+            min_bound=bounds.min_val,
+            max_bound=bounds.max_val,
         )
         err.stream_id = self.stream_id
         raise err

--- a/src/pge/rendering/stream_cache_manager.py
+++ b/src/pge/rendering/stream_cache_manager.py
@@ -32,6 +32,24 @@ from typing import Dict, List, Optional
 # nell'hash (divergenza nota e accettata rispetto al JS, PGE-ui #39).
 FINGERPRINT_IGNORE_KEYS = frozenset({"solo", "mute"})
 
+# Versione della semantica di variazione del motore.
+#
+# Il fingerprint di uno stem non puo' essere solo il testo YAML: se il MOTORE
+# cambia il significato di una chiave a YAML invariato, l'hash resta identico,
+# lo stem resta marcato 'clean' e si continua ad ascoltare l'audio vecchio
+# senza nessun errore. Il manifest su disco non porta traccia della versione
+# del motore, quindi la traccia va messa qui.
+#
+# Bumpare a ogni modifica che cambia i VALORI prodotti a parita' di YAML:
+# formule delle distribuzioni, delle VariationStrategy, derivazione degli RNG.
+# Un bump marca dirty ogni stream di ogni progetto: un re-render completo al
+# primo run, poi la cache incrementale riparte normalmente.
+#
+# 1 -> semantica storica (uniform ±range/2, gaussian con range = sigma)
+# 2 -> range e' sempre la larghezza della banda; gaussian troncata con
+#      sigma = larghezza/6; introdotta l'ancora range_anchor
+VARIATION_SEMANTICS_VERSION = 2
+
 
 class StreamCacheManager:
     """
@@ -58,6 +76,10 @@ class StreamCacheManager:
         Le chiavi in FINGERPRINT_IGNORE_KEYS (solo/mute) vengono escluse: non
         influenzano l'audio del singolo stem, solo quali stream renderizzare.
 
+        Nell'hash entra anche VARIATION_SEMANTICS_VERSION: lo stem dipende dal
+        testo YAML E dalla semantica con cui il motore lo interpreta, e la
+        seconda puo' cambiare a YAML fermo.
+
         Args:
             stream_dict: dict parametri dello stream dallo YAML
 
@@ -68,7 +90,11 @@ class StreamCacheManager:
             k: v for k, v in stream_dict.items()
             if k not in FINGERPRINT_IGNORE_KEYS
         }
-        serialized = json.dumps(filtered, sort_keys=True)
+        payload = {
+            'semantics': VARIATION_SEMANTICS_VERSION,
+            'stream': filtered,
+        }
+        serialized = json.dumps(payload, sort_keys=True)
         return hashlib.sha256(serialized.encode('utf-8')).hexdigest()
 
     # =========================================================================

--- a/src/pge/shared/distribution_strategy.py
+++ b/src/pge/shared/distribution_strategy.py
@@ -11,9 +11,46 @@ from abc import ABC, abstractmethod
 from typing import Tuple
 
 from pge.shared.exceptions import (
+    InvalidFieldValueError,
     InvalidStrategyConfigError,
     StrategyNotFoundError,
 )
+
+# =============================================================================
+# ANCORA DEL RANGE
+# =============================================================================
+# `spread` e' SEMPRE la larghezza della banda. L'ancora dice dove cade il
+# valore base dentro quella banda:
+#
+#   center (default) -> [base - spread/2, base + spread/2]
+#   min              -> [base,           base + spread]
+#
+# E' un asse ortogonale alla forma della distribuzione (`distribution_mode`),
+# non una sua variante: la stessa ancora vale per uniform, gaussian e per
+# qualunque distribuzione registrata in futuro.
+
+ANCHOR_CENTER = 'center'
+ANCHOR_MIN = 'min'
+
+#: Valori validi della chiave YAML per-stream `range_anchor`. Esposto come
+#: registry perche' PGE-ls e PGE-ui possano leggerlo dal vivo invece di
+#: duplicarne una copia statica (stesso ruolo di DistributionFactory.modes()).
+RANGE_ANCHORS = (ANCHOR_CENTER, ANCHOR_MIN)
+
+
+def validate_range_anchor(anchor: str) -> str:
+    """Valida il valore di `range_anchor`, restituendolo normalizzato.
+
+    Raises:
+        InvalidFieldValueError: se il valore non e' fra RANGE_ANCHORS.
+    """
+    if anchor not in RANGE_ANCHORS:
+        raise InvalidFieldValueError(
+            field='range_anchor',
+            value=anchor,
+            hint=f"valori ammessi: {' | '.join(RANGE_ANCHORS)}",
+        )
+    return anchor
 
 
 class DistributionStrategy(ABC):
@@ -27,15 +64,37 @@ class DistributionStrategy(ABC):
     iniettato; i sample pescano da quello, così ogni Parameter ha il proprio
     stream di draw isolato. Senza rng si usa il modulo `random` globale
     (comportamento legacy).
+
+    Ancora del range: il costruttore accetta `anchor` (ANCHOR_CENTER di
+    default). L'ancora e' stato dell'istanza, non un argomento di sample():
+    cosi' la firma `sample(center, spread)` resta invariata e i chiamanti
+    (VariationStrategy) non devono sapere che l'ancora esiste.
     """
 
-    def __init__(self, rng=None):
+    def __init__(self, rng=None, anchor: str = ANCHOR_CENTER):
         self._rng = rng if rng is not None else random
+        self._anchor = validate_range_anchor(anchor)
 
     @property
     def rng(self):
         """RNG locale della strategia (random.Random o modulo random)."""
         return self._rng
+
+    @property
+    def anchor(self) -> str:
+        """Ancora del range: ANCHOR_CENTER o ANCHOR_MIN."""
+        return self._anchor
+
+    def _band(self, center: float, spread: float) -> Tuple[float, float]:
+        """Banda [lo, hi] effettiva per (center, spread) sotto l'ancora attiva.
+
+        E' la fonte di verita' condivisa da sample() e get_bounds(): una sola
+        definizione della banda, nessuna possibilita' che le due divergano.
+        """
+        if self._anchor == ANCHOR_MIN:
+            return (center, center + spread)
+        half_spread = spread / 2
+        return (center - half_spread, center + half_spread)
 
     @abstractmethod
     def sample(self, center: float, spread: float) -> float:        # pragma: no cover
@@ -75,76 +134,94 @@ class UniformDistribution(DistributionStrategy):
     Distribuzione uniforme: tutti i valori nel range sono equiprobabili.
     
     Comportamento:
-    - center viene ignorato (uniform è simmetrico attorno a 0)
-    - spread definisce il range totale
-    - Output: center + uniform(-spread/2, +spread/2)
-    
+    - spread definisce la larghezza della banda
+    - ancora `center`: output in [center - spread/2, center + spread/2]
+    - ancora `min`:    output in [center, center + spread]
+
     Uso tipico: comportamento attuale del sistema.
     """
-    
+
     def sample(self, center: float, spread: float) -> float:
         """
-        Genera valore uniformemente distribuito.
+        Genera valore uniformemente distribuito nella banda.
 
-        Formula: center + rng.uniform(-0.5, 0.5) * spread
+        Ancora `center`: center + rng.uniform(-0.5, 0.5) * spread
+        Ancora `min`:    center + rng.uniform(0.0, 1.0) * spread
+
+        Il ramo `center` e' volutamente scritto come espressione letterale
+        invariata (non derivata da _band): e' il default storico e deve
+        restare identico bit per bit.
         """
         if spread <= 0:
             return center
 
+        if self._anchor == ANCHOR_MIN:
+            return center + self._rng.uniform(0.0, 1.0) * spread
+
         return center + self._rng.uniform(-0.5, 0.5) * spread
-    
+
     @property
     def name(self) -> str:
         return "uniform"
-    
+
     def get_bounds(self, center: float, spread: float) -> Tuple[float, float]:
-        """Bounds teorici: [center - spread/2, center + spread/2]"""
-        half_spread = spread / 2
-        return (center - half_spread, center + half_spread)
+        """Bounds della banda, secondo l'ancora attiva."""
+        return self._band(center, spread)
 
 
 class GaussianDistribution(DistributionStrategy):
     """
-    Distribuzione gaussiana (normale): valori concentrati attorno al centro.
-    
+    Distribuzione gaussiana troncata: campana dentro una banda chiusa.
+
     Comportamento:
-    - center = μ (media della gaussiana)
-    - spread = σ (deviazione standard)
-    - ~68% dei valori in [μ±σ]
-    - ~95% dei valori in [μ±2σ]
-    - ~99.7% dei valori in [μ±3σ]
-    
-    Uso tipico: texture "smooth", nuvole sonore, variazioni naturali.
-    
-    Note:
-    - La gaussiana è teoricamente illimitata, ma clamping ai bounds
-      del parametro viene fatto successivamente in Parameter._clamp()
+    - spread = LARGHEZZA della banda (non σ)
+    - σ = spread / 6, cioè i bordi della banda cadono a 3σ dalla media
+    - μ = centro della banda, che dipende dall'ancora:
+        `center` -> banda [center - spread/2, center + spread/2], μ = center
+        `min`    -> banda [center, center + spread],              μ = center + spread/2
+    - la coda oltre 3σ (~0.3%) viene clampata ai bordi, non lasciata uscire
+
+    Uso tipico: texture "smooth", nuvole sonore, variazioni naturali — dove
+    si vuole una banda dichiarata, con i valori addensati al centro invece che
+    distribuiti piatti.
+
+    Nota storica: fino alla v5.2.0 `spread` era σ e la campana era illimitata,
+    richiusa solo dal clamp ai bounds del parametro in Parameter._clamp(). Con
+    `range: 200` su `base: 300` i valori arrivavano grosso modo a 0..600 invece
+    che a 200..400. La semantica e' stata cambiata perche' `range` doveva
+    significare la stessa cosa in tutte le distribuzioni: la larghezza della
+    banda. È un cambio di comportamento voluto, non retrocompatibile.
     """
-    
+
+    #: Rapporto larghezza/σ: i bordi della banda cadono a 3σ dalla media.
+    SIGMA_DIVISOR = 6.0
+
     def sample(self, center: float, spread: float) -> float:
         """
-        Genera valore con distribuzione gaussiana.
+        Genera valore gaussiano dentro la banda, con clamp ai bordi.
 
-        Formula: rng.gauss(μ=center, σ=spread)
+        Formula: clamp(rng.gauss(μ=centro_banda, σ=spread/6), lo, hi)
         """
         if spread <= 0:
             return center
 
-        return self._rng.gauss(center, spread)
-    
+        lo, hi = self._band(center, spread)
+        mu = (lo + hi) / 2.0
+        sigma = spread / self.SIGMA_DIVISOR
+
+        return min(max(self._rng.gauss(mu, sigma), lo), hi)
+
     @property
     def name(self) -> str:
         return "gaussian"
-    
+
     def get_bounds(self, center: float, spread: float) -> Tuple[float, float]:
+        """Bounds della banda, secondo l'ancora attiva.
+
+        Sono bounds esatti, non piu' la stima 3σ: la distribuzione e' troncata,
+        quindi nessun campione cade fuori da qui.
         """
-        Bounds teorici: ~99.7% dei valori in [μ-3σ, μ+3σ]
-        
-        Nota: la gaussiana è teoricamente illimitata,
-        ma usiamo 3σ come bound pratico (3-sigma rule).
-        """
-        three_sigma = spread * 3
-        return (center - three_sigma, center + three_sigma)
+        return self._band(center, spread)
 
 
 class DistributionFactory:
@@ -160,7 +237,7 @@ class DistributionFactory:
     }
     
     @classmethod
-    def create(cls, mode: str, rng=None) -> DistributionStrategy:
+    def create(cls, mode: str, rng=None, anchor: str = ANCHOR_CENTER) -> DistributionStrategy:
         """
         Crea una strategia di distribuzione.
 
@@ -168,12 +245,14 @@ class DistributionFactory:
             mode: Nome della distribuzione ('uniform', 'gaussian')
             rng: random.Random locale da iniettare (issue #154);
                  None → modulo random globale (legacy)
+            anchor: ancora del range ('center' default, 'min')
 
         Returns:
             Istanza di DistributionStrategy
 
         Raises:
-            ValueError: Se mode non è riconosciuto
+            StrategyNotFoundError: Se mode non è riconosciuto
+            InvalidFieldValueError: Se anchor non è fra RANGE_ANCHORS
         """
         if mode not in cls._registry:
             raise StrategyNotFoundError(
@@ -183,8 +262,17 @@ class DistributionFactory:
             )
 
         strategy_class = cls._registry[mode]
-        return strategy_class(rng=rng)
-    
+        return strategy_class(rng=rng, anchor=validate_range_anchor(anchor))
+
+    @classmethod
+    def modes(cls) -> list:
+        """Nomi delle distribuzioni registrate.
+
+        Punto di lettura per i consumer esterni (PGE-ls legge di qui l'enum di
+        `distribution_mode`) invece di ispezionare `_registry`.
+        """
+        return list(cls._registry.keys())
+
     @classmethod
     def register(cls, name: str, strategy_class: type):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,10 @@ def mock_config():
     config.context = context
     config.time_mode = 'absolute'
     config.distribution_mode = 'uniform'
+    # Mock(spec=StreamConfig) espone i campi della dataclass, ma restituisce
+    # un Mock figlio invece del default: le stringhe di configurazione vanno
+    # valorizzate a mano o arrivano validate come Mock.
+    config.range_anchor = 'center'
     config.dephase = False
     config.range_always_active = False
     # issue #154: seed None → fallback legacy sul random globale

--- a/tests/core/test_stream_config.py
+++ b/tests/core/test_stream_config.py
@@ -319,16 +319,17 @@ class TestStreamConfigDefaults:
         assert config.context is None
 
     def test_field_count(self):
-        """StreamConfig ha esattamente 9 campi (issue #154: +seed)."""
-        assert len(fields(StreamConfig)) == 9
+        """StreamConfig ha esattamente 10 campi (issue #154: +seed;
+        range-anchor-mode: +range_anchor)."""
+        assert len(fields(StreamConfig)) == 10
 
     def test_field_names(self):
         """Nomi campi nell'ordine atteso."""
         names = [f.name for f in fields(StreamConfig)]
         expected = [
             'dephase', 'range_always_active', 'distribution_mode',
-            'time_mode', 'time_scale', 'clip_strategy', 'clip_margin',
-            'seed', 'context'
+            'range_anchor', 'time_mode', 'time_scale', 'clip_strategy',
+            'clip_margin', 'seed', 'context'
         ]
         assert names == expected
 

--- a/tests/engine/test_default_variation_identity.py
+++ b/tests/engine/test_default_variation_identity.py
@@ -1,0 +1,144 @@
+# tests/engine/test_default_variation_identity.py
+"""
+test_default_variation_identity.py
+
+Golden test dell'identita' bit-per-bit della variazione di default.
+
+`range_anchor` (issue range-anchor-mode) introduce una lettura alternativa dei
+`_range`: `base` diventa il minimo della banda invece del centro. Il default
+resta `center`, e il contratto e' che con il default NIENTE cambia — non "quasi
+niente", non "statisticamente equivalente": gli stessi identici float.
+
+Il test congela i grani prodotti da uno YAML che esercita tutti i `_range` che
+passano da `Parameter` (volume, pan, grain.duration, pointer.offset_range,
+pitch.range) piu' il jitter implicito sotto dephase, con `distribution_mode:
+uniform` e seed fisso. Il digest e' stato calcolato PRIMA dell'introduzione di
+`range_anchor` ed e' il riferimento immutabile.
+
+Nota di scope: il golden copre `uniform`, non `gaussian`. La gaussiana cambia
+semantica per decisione esplicita (`range` diventa la larghezza della banda
+invece della sigma), quindi un golden sulla gaussiana sarebbe un golden su un
+comportamento che stiamo deliberatamente sostituendo. La copertura della nuova
+gaussiana sta in tests/shared/test_distribution_strategy.py.
+
+Non richiede csound/sox ne' sample reali: la durata del sample e' mockata e i
+grani si confrontano simbolicamente.
+"""
+
+import hashlib
+import json
+
+import pytest
+import yaml
+from unittest.mock import patch
+
+from pge.engine.generator import Generator
+
+
+# =============================================================================
+# YAML DI RIFERIMENTO
+# =============================================================================
+
+def _golden_yaml():
+    """YAML che esercita ogni `_range` che passa da Parameter.
+
+    - stream `explicit`: tutti i range dichiarati esplicitamente, dephase off
+      (con `range_always_active` i range espliciti valgono al 100% dei grani).
+    - stream `implicit`: nessun range dichiarato + dephase attivo, cioe' il
+      path del jitter implicito (`ParameterBounds.default_jitter`) e del detune
+      implicito EDO.
+    """
+    return {
+        'seed': 20260729,
+        'streams': [
+            {
+                'stream_id': 'explicit',
+                'onset': 0.0,
+                'duration': 4.0,
+                'sample': 'test.wav',
+                'density': 12,
+                'distribution_mode': 'uniform',
+                'range_always_active': True,
+                'volume': -6.0,
+                'volume_range': 8.0,
+                'pan': 0.0,
+                'pan_range': 90.0,
+                'grain': {'duration': 0.05, 'duration_range': 0.02},
+                'pointer': {'start': 1.0, 'offset_range': 0.3},
+                'pitch': {'semitones': 3, 'range': 4},
+            },
+            {
+                'stream_id': 'implicit',
+                'onset': 0.0,
+                'duration': 4.0,
+                'sample': 'test.wav',
+                'density': 12,
+                'distribution_mode': 'uniform',
+                'dephase': True,
+                'volume': -6.0,
+                'pan': 0.0,
+                'grain': {'duration': 0.05},
+                'pointer': {'start': 1.0},
+                'pitch': {'semitones': 3},
+            },
+        ],
+    }
+
+
+def _materialize(tmp_path):
+    """Materializza i grani dello YAML golden. Ritorna la lista dei campi."""
+    cfg = tmp_path / "golden_variation.yml"
+    cfg.write_text(yaml.safe_dump(_golden_yaml()))
+    gen = Generator(str(cfg))
+    gen.load_yaml()
+    with patch('pge.core.stream.get_sample_duration', return_value=10.0):
+        gen.create_elements()
+        rows = [
+            [
+                s.stream_id,
+                repr(g.onset), repr(g.duration), repr(g.pointer_pos),
+                repr(g.pitch_ratio), repr(g.volume), repr(g.pan),
+            ]
+            for s in gen.streams for g in s.grains
+        ]
+    return rows
+
+
+def _digest(rows):
+    """SHA-256 stabile della materializzazione (repr float = esatto)."""
+    return hashlib.sha256(
+        json.dumps(rows, sort_keys=True).encode('utf-8')
+    ).hexdigest()
+
+
+# Digest congelato sul comportamento PRE range_anchor.
+# Se questo test diventa rosso, il default e' cambiato: e' un bug, non un
+# aggiornamento da fare al valore atteso.
+GOLDEN_DIGEST = "727d4c843e3a900724e5bf0021b5e186ca8e89082d754556c5bbfcc0f923473a"
+
+GOLDEN_GRAIN_COUNT = 96
+
+
+class TestDefaultVariationIdentity:
+    """Il default `range_anchor: center` non cambia un solo float."""
+
+    def test_golden_digest_unchanged(self, tmp_path):
+        """La materializzazione dei grani e' identica al riferimento."""
+        rows = _materialize(tmp_path)
+
+        assert _digest(rows) == GOLDEN_DIGEST, (
+            "Il comportamento di default e' cambiato. Il golden congela la "
+            "variazione stocastica con distribution_mode=uniform e "
+            "range_anchor=center (default): nessuna modifica deve alterarlo."
+        )
+
+    def test_golden_is_not_empty(self, tmp_path):
+        """Guardia: il golden deve esercitare grani veri, non una lista vuota."""
+        rows = _materialize(tmp_path)
+
+        assert len(rows) == GOLDEN_GRAIN_COUNT
+        assert GOLDEN_GRAIN_COUNT > 0
+
+    def test_materialization_is_deterministic(self, tmp_path):
+        """Due materializzazioni dello stesso YAML seedato coincidono."""
+        assert _materialize(tmp_path) == _materialize(tmp_path)

--- a/tests/parameters/test_parameter_range_anchor.py
+++ b/tests/parameters/test_parameter_range_anchor.py
@@ -1,0 +1,259 @@
+# tests/parameters/test_parameter_range_anchor.py
+"""
+test_parameter_range_anchor.py
+
+Cablaggio della chiave YAML per-stream `range_anchor` fino al Parameter.
+
+Catena: YAML stream dict -> StreamConfig.range_anchor -> GranularParser ->
+Parameter.__init__ -> DistributionStrategy(anchor=...).
+
+Regola non ovvia coperta qui: il **jitter implicito** resta sempre centrato.
+`ParameterBounds.default_jitter` si attiva quando l'utente NON ha dichiarato
+nessun range; non c'e' nessun `range` scritto da reinterpretare, e ancorarlo al
+minimo lo trasformerebbe da tremolio simmetrico in un offset positivo
+sistematico su ogni grano. L'ancora agisce solo dove un range esiste davvero.
+"""
+
+import random
+
+import pytest
+import yaml
+from unittest.mock import patch
+
+from pge.core.stream_config import StreamConfig, StreamContext
+from pge.engine.generator import Generator
+from pge.parameters.parameter import Parameter
+from pge.parameters.parameter_definitions import ParameterBounds
+from pge.shared.distribution_strategy import ANCHOR_CENTER, ANCHOR_MIN
+from pge.shared.exceptions import InvalidFieldValueError
+
+
+BASE = 10.0
+WIDTH = 4.0
+N = 500
+
+
+def _bounds(**kw):
+    defaults = dict(
+        min_val=-1000.0, max_val=1000.0,
+        min_range=0.0, max_range=100.0,
+        default_jitter=0.0, variation_mode='additive',
+    )
+    defaults.update(kw)
+    return ParameterBounds(**defaults)
+
+
+def _param(mod_range=WIDTH, anchor=ANCHOR_CENTER, bounds=None,
+           distribution_mode='uniform', value=BASE):
+    p = Parameter(
+        name='test',
+        value=value,
+        bounds=bounds if bounds is not None else _bounds(),
+        mod_range=mod_range,
+        distribution_mode=distribution_mode,
+        range_anchor=anchor,
+        rng=random.Random(20260729),
+    )
+    from pge.shared.probability_gate import AlwaysGate
+    p.set_probability_gate(AlwaysGate())
+    return p
+
+
+# =============================================================================
+# 1. STREAMCONFIG
+# =============================================================================
+
+class TestStreamConfigRangeAnchor:
+
+    def test_default_is_center(self):
+        assert StreamConfig().range_anchor == ANCHOR_CENTER
+
+    def test_read_from_yaml_stream_dict(self):
+        ctx = StreamContext(
+            stream_id='s1', onset=0.0, duration=4.0,
+            sample='x.wav', sample_dur_sec=10.0,
+        )
+        cfg = StreamConfig.from_yaml({'range_anchor': 'min'}, context=ctx)
+
+        assert cfg.range_anchor == ANCHOR_MIN
+
+    def test_absent_key_keeps_default(self):
+        ctx = StreamContext(
+            stream_id='s1', onset=0.0, duration=4.0,
+            sample='x.wav', sample_dur_sec=10.0,
+        )
+        cfg = StreamConfig.from_yaml({}, context=ctx)
+
+        assert cfg.range_anchor == ANCHOR_CENTER
+
+
+# =============================================================================
+# 2. PARAMETER — range esplicito
+# =============================================================================
+
+class TestExplicitRangeAnchoring:
+
+    def test_center_band_is_symmetric(self):
+        param = _param(anchor=ANCHOR_CENTER)
+
+        values = [param.get_value(0.0) for _ in range(N)]
+
+        assert min(values) >= BASE - WIDTH / 2
+        assert max(values) <= BASE + WIDTH / 2
+
+    def test_min_never_below_base(self):
+        param = _param(anchor=ANCHOR_MIN)
+
+        values = [param.get_value(0.0) for _ in range(N)]
+
+        assert min(values) >= BASE
+        assert max(values) <= BASE + WIDTH
+
+    def test_min_with_gaussian_never_below_base(self):
+        param = _param(anchor=ANCHOR_MIN, distribution_mode='gaussian')
+
+        values = [param.get_value(0.0) for _ in range(N)]
+
+        assert min(values) >= BASE
+        assert max(values) <= BASE + WIDTH
+
+    def test_range_zero_is_noop_in_both_anchors(self):
+        """`range: 0` esplicito: nessuna variazione, e nessun jitter implicito."""
+        for anchor in (ANCHOR_CENTER, ANCHOR_MIN):
+            param = _param(mod_range=0.0, anchor=anchor,
+                           bounds=_bounds(default_jitter=3.0))
+
+            assert {param.get_value(0.0) for _ in range(20)} == {BASE}
+
+    def test_envelope_range_is_anchored_too(self):
+        """L'ancora vale anche quando il range e' un envelope."""
+        from pge.envelopes.envelope import Envelope
+
+        param = _param(mod_range=Envelope([[0.0, 0.0], [10.0, WIDTH]]),
+                       anchor=ANCHOR_MIN)
+
+        values = [param.get_value(10.0) for _ in range(N)]
+
+        assert min(values) >= BASE
+        assert max(values) <= BASE + WIDTH
+
+
+# =============================================================================
+# 3. PARAMETER — jitter implicito: sempre centrato
+# =============================================================================
+
+class TestImplicitJitterStaysCentered:
+    """Senza range dichiarato l'ancora non si applica: non c'e' nulla da ancorare."""
+
+    def test_implicit_jitter_is_symmetric_under_min_anchor(self):
+        param = _param(mod_range=None, anchor=ANCHOR_MIN,
+                       bounds=_bounds(default_jitter=WIDTH))
+
+        values = [param.get_value(0.0) for _ in range(N)]
+
+        assert min(values) < BASE, "il jitter implicito deve poter scendere sotto base"
+        assert min(values) >= BASE - WIDTH / 2
+        assert max(values) <= BASE + WIDTH / 2
+
+    def test_implicit_jitter_mean_is_base(self):
+        param = _param(mod_range=None, anchor=ANCHOR_MIN,
+                       bounds=_bounds(default_jitter=WIDTH))
+
+        values = [param.get_value(0.0) for _ in range(N)]
+        mean = sum(values) / len(values)
+
+        assert abs(mean - BASE) < 0.1 * WIDTH
+
+    def test_has_explicit_range_drives_the_choice(self):
+        assert _param(mod_range=None).has_explicit_range is False
+        assert _param(mod_range=0.0).has_explicit_range is True
+
+
+# =============================================================================
+# 4. VARIAZIONE QUANTIZZATA (pitch EDO)
+# =============================================================================
+
+class TestQuantizedAnchoring:
+    """QuantizedVariation campiona attorno a 0 e somma: con ancora min
+    sample(0, r) cade in [0, r], quindi base + round(...) resta >= base."""
+
+    def test_quantized_min_never_below_base(self):
+        param = _param(anchor=ANCHOR_MIN, mod_range=6.0,
+                       bounds=_bounds(variation_mode='quantized'))
+
+        values = [param.get_value(0.0) for _ in range(N)]
+
+        assert min(values) >= BASE
+        assert max(values) <= BASE + 6.0
+
+    def test_quantized_center_is_symmetric(self):
+        param = _param(anchor=ANCHOR_CENTER, mod_range=6.0,
+                       bounds=_bounds(variation_mode='quantized'))
+
+        values = [param.get_value(0.0) for _ in range(N)]
+
+        assert min(values) < BASE
+        assert max(values) > BASE
+
+    def test_quantized_values_are_integer_steps(self):
+        param = _param(anchor=ANCHOR_MIN, mod_range=6.0,
+                       bounds=_bounds(variation_mode='quantized'))
+
+        values = {param.get_value(0.0) for _ in range(N)}
+
+        assert all(float(v).is_integer() for v in values)
+
+
+# =============================================================================
+# 5. VALIDAZIONE E END-TO-END
+# =============================================================================
+
+class TestYamlSurface:
+
+    def test_invalid_anchor_raises_config_error(self):
+        with pytest.raises(InvalidFieldValueError) as exc:
+            _param(anchor='minimo')
+
+        assert exc.value.field == 'range_anchor'
+
+    def _render(self, tmp_path, anchor):
+        data = {
+            'seed': 7,
+            'streams': [{
+                'stream_id': 's1',
+                'onset': 0.0,
+                'duration': 4.0,
+                'sample': 'test.wav',
+                'density': 30,
+                'range_always_active': True,
+                'grain': {'duration': 0.05, 'duration_range': 0.02},
+                **({'range_anchor': anchor} if anchor else {}),
+            }],
+        }
+        cfg = tmp_path / f"anchor_{anchor or 'default'}.yml"
+        cfg.write_text(yaml.safe_dump(data))
+        gen = Generator(str(cfg))
+        gen.load_yaml()
+        with patch('pge.core.stream.get_sample_duration', return_value=10.0):
+            gen.create_elements()
+            return [g.duration for s in gen.streams for g in s.grains]
+
+    def test_end_to_end_min_never_below_base(self, tmp_path):
+        durations = self._render(tmp_path, 'min')
+
+        assert min(durations) >= 0.05
+        assert max(durations) <= 0.05 + 0.02
+        assert max(durations) > 0.05, "la variazione deve essere attiva"
+
+    def test_end_to_end_center_straddles_base(self, tmp_path):
+        durations = self._render(tmp_path, 'center')
+
+        assert min(durations) < 0.05
+        assert max(durations) > 0.05
+
+    def test_end_to_end_default_equals_center(self, tmp_path):
+        assert self._render(tmp_path, None) == self._render(tmp_path, 'center')
+
+    def test_end_to_end_invalid_anchor_raises(self, tmp_path):
+        with pytest.raises(InvalidFieldValueError):
+            self._render(tmp_path, 'massimo')

--- a/tests/parameters/test_parameter_range_anchor.py
+++ b/tests/parameters/test_parameter_range_anchor.py
@@ -23,6 +23,7 @@ from unittest.mock import patch
 from pge.core.stream_config import StreamConfig, StreamContext
 from pge.engine.generator import Generator
 from pge.parameters.parameter import Parameter
+from pge.parameters.parser import GranularParser
 from pge.parameters.parameter_definitions import ParameterBounds
 from pge.shared.distribution_strategy import ANCHOR_CENTER, ANCHOR_MIN
 from pge.shared.exceptions import InvalidFieldValueError
@@ -215,6 +216,25 @@ class TestYamlSurface:
             _param(anchor='minimo')
 
         assert exc.value.field == 'range_anchor'
+
+    def test_invalid_anchor_names_the_stream(self):
+        """Un typo va attribuito allo stream che lo contiene.
+
+        Senza stream_id l'errore dice solo "valore invalido": in uno YAML con
+        decine di stream tocca all'utente cercare quale. Il parser conosce il
+        proprio stream_id, quindi valida l'ancora una volta all'init.
+        """
+        ctx = StreamContext(
+            stream_id='colpevole', onset=0.0, duration=10.0,
+            sample='x.wav', sample_dur_sec=30.0,
+        )
+        cfg = StreamConfig(range_anchor='minimo', context=ctx)
+
+        with pytest.raises(InvalidFieldValueError) as exc:
+            GranularParser(cfg)
+
+        assert exc.value.field == 'range_anchor'
+        assert exc.value.stream_id == 'colpevole'
 
     def _render(self, tmp_path, anchor):
         data = {

--- a/tests/parameters/test_range_anchor_bounds.py
+++ b/tests/parameters/test_range_anchor_bounds.py
@@ -1,0 +1,153 @@
+# tests/parameters/test_range_anchor_bounds.py
+"""
+test_range_anchor_bounds.py
+
+Validazione al parse del tetto della banda sotto `range_anchor: min`.
+
+Con l'ancora al minimo la banda dichiarata e' `[base, base + range]`: il tetto
+non e' piu' `base + range/2` ma `base + range`, quindi una coppia (base, range)
+che passava la validazione centrata puo' sfondare `max_val`. Senza controllo
+al parse il sintomo e' silenzioso a metà: la banda viene schiacciata dal safety
+clamp di Parameter._clamp e si accumula un warning per grano.
+
+La modalita' `min` promette una banda esatta. Se la banda non e' realizzabile
+lo si dice al parse, invece di prometterla e poi tagliarla.
+
+Il controllo vale SOLO per l'ancora `min` (`center` e' il default storico e non
+cambia) e solo quando il tetto e' calcolabile esattamente. Con base ed envelope
+di range entrambi variabili nel tempo il massimo della somma non e' la somma dei
+massimi, e un falso positivo che blocca il render sarebbe peggio del clamp.
+"""
+
+import pytest
+
+from pge.core.stream_config import StreamConfig, StreamContext
+from pge.parameters.parser import GranularParser
+from pge.shared.exceptions import ParameterBoundError
+
+
+def _parser(anchor='min'):
+    ctx = StreamContext(
+        stream_id='s1', onset=0.0, duration=10.0,
+        sample='x.wav', sample_dur_sec=30.0,
+    )
+    return GranularParser(StreamConfig(range_anchor=anchor, context=ctx))
+
+
+# 'volume': min_val=-120, max_val=12, max_range=24
+CEILING = 12.0
+
+
+class TestBandCeilingScalar:
+
+    def test_band_within_bounds_is_accepted(self):
+        param = _parser().parse_parameter('volume', value_raw=0.0, range_raw=6.0)
+
+        assert param is not None
+
+    def test_band_exactly_on_the_ceiling_is_accepted(self):
+        param = _parser().parse_parameter('volume', value_raw=6.0, range_raw=6.0)
+
+        assert param is not None
+
+    def test_band_above_the_ceiling_raises(self):
+        with pytest.raises(ParameterBoundError) as exc:
+            _parser().parse_parameter('volume', value_raw=0.0, range_raw=18.0)
+
+        assert exc.value.stream_id == 's1'
+
+    def test_error_names_the_parameter(self):
+        with pytest.raises(ParameterBoundError) as exc:
+            _parser().parse_parameter('volume', value_raw=0.0, range_raw=18.0)
+
+        assert 'volume' in str(exc.value)
+
+    def test_error_message_points_at_the_anchor(self):
+        """Il messaggio deve dire QUALE somma sfora e perche', altrimenti
+        l'utente vede solo un numero che nel suo YAML non compare."""
+        with pytest.raises(ParameterBoundError) as exc:
+            _parser().parse_parameter('volume', value_raw=0.0, range_raw=18.0)
+
+        message = exc.value.user_message()
+
+        assert 'range_anchor' in message
+        assert 'base + range' in message
+        assert '18' in message or '18.0' in message
+
+
+class TestCenterAnchorIsUntouched:
+    """Il default non guadagna nessuna validazione nuova: la sua banda arriva
+    a base + range/2 e resta gestita dal safety clamp, come da sempre."""
+
+    def test_center_accepts_what_min_rejects(self):
+        param = _parser(anchor='center').parse_parameter(
+            'volume', value_raw=0.0, range_raw=18.0
+        )
+
+        assert param is not None
+
+    def test_center_accepts_band_far_above_ceiling(self):
+        param = _parser(anchor='center').parse_parameter(
+            'volume', value_raw=10.0, range_raw=24.0
+        )
+
+        assert param is not None
+
+
+class TestBandCeilingWithEnvelopes:
+
+    def test_envelope_value_with_scalar_range_is_checked(self):
+        """max(base) + range e' un tetto esatto: si puo' validare."""
+        env = [[0.0, -20.0], [10.0, 8.0]]
+
+        with pytest.raises(ParameterBoundError):
+            _parser().parse_parameter('volume', value_raw=env, range_raw=10.0)
+
+    def test_envelope_value_within_bounds_is_accepted(self):
+        env = [[0.0, -20.0], [10.0, 2.0]]
+
+        param = _parser().parse_parameter('volume', value_raw=env, range_raw=10.0)
+
+        assert param is not None
+
+    def test_scalar_value_with_envelope_range_is_checked(self):
+        """base + max(range) e' un tetto esatto: si puo' validare."""
+        env = [[0.0, 0.0], [10.0, 20.0]]
+
+        with pytest.raises(ParameterBoundError):
+            _parser().parse_parameter('volume', value_raw=6.0, range_raw=env)
+
+    def test_two_envelopes_are_not_checked(self):
+        """max(base) + max(range) sarebbe conservativo, non esatto: i due
+        massimi possono cadere in istanti diversi. Meglio nessun controllo che
+        un falso positivo che blocca il render."""
+        base_env = [[0.0, 10.0], [10.0, -60.0]]
+        range_env = [[0.0, 0.0], [10.0, 20.0]]
+
+        param = _parser().parse_parameter(
+            'volume', value_raw=base_env, range_raw=range_env
+        )
+
+        assert param is not None
+
+
+class TestNoCeilingToCheck:
+
+    def test_missing_range_is_not_checked(self):
+        """Senza range dichiarato l'ancora non si applica: niente da validare."""
+        param = _parser().parse_parameter('volume', value_raw=12.0, range_raw=None)
+
+        assert param is not None
+
+    def test_open_ended_max_val_is_not_checked(self):
+        """loop_start ha max_val dinamico (None senza sample_dur_sec): non c'e'
+        nessun tetto contro cui validare."""
+        ctx = StreamContext(
+            stream_id='s1', onset=0.0, duration=10.0,
+            sample='x.wav', sample_dur_sec=None,
+        )
+        parser = GranularParser(StreamConfig(range_anchor='min', context=ctx))
+
+        param = parser.parse_parameter('loop_start', value_raw=1.0, range_raw=None)
+
+        assert param is not None

--- a/tests/rendering/test_stream_cache_manager.py
+++ b/tests/rendering/test_stream_cache_manager.py
@@ -25,6 +25,7 @@ import os
 import pytest
 from unittest.mock import patch
 
+from pge.rendering import stream_cache_manager as scm
 from pge.rendering.stream_cache_manager import StreamCacheManager
 
 
@@ -194,6 +195,50 @@ class TestFingerprintIgnoresMuteSolo:
         d1 = {'stream_id': 's1', 'volume': -6.0, 'rng_group': 'gruppo_a'}
         d2 = {'stream_id': 's1', 'volume': -6.0, 'rng_group': 'gruppo_b'}
         assert manager.compute_fingerprint(d1) != manager.compute_fingerprint(d2)
+
+    def test_range_anchor_changes_fingerprint(self, manager):
+        """range_anchor cambia la banda dei _range, quindi i valori pescati
+        e l'audio dello stem. Deve entrare nel fingerprint — mai aggiungerlo
+        a FINGERPRINT_IGNORE_KEYS."""
+        base = {'stream_id': 's1', 'volume': -6.0, 'volume_range': 8.0}
+        anchored = {**base, 'range_anchor': 'min'}
+        assert (
+            manager.compute_fingerprint(base)
+            != manager.compute_fingerprint(anchored)
+        )
+
+    def test_different_range_anchor_changes_fingerprint(self, manager):
+        d1 = {'stream_id': 's1', 'volume_range': 8.0, 'range_anchor': 'center'}
+        d2 = {'stream_id': 's1', 'volume_range': 8.0, 'range_anchor': 'min'}
+        assert manager.compute_fingerprint(d1) != manager.compute_fingerprint(d2)
+
+    def test_semantics_version_participates_in_fingerprint(self, manager):
+        """Il fingerprint copre anche la semantica del motore, non solo il testo
+        YAML. Senza, un cambio di significato a YAML invariato (es. `range` che
+        da sigma diventa larghezza della banda per la gaussiana) lascerebbe ogni
+        stem gia' renderizzato marcato 'clean': audio vecchio, nessun errore."""
+        d = {'stream_id': 's1', 'volume': -6.0}
+        before = manager.compute_fingerprint(d)
+
+        with patch.object(scm, 'VARIATION_SEMANTICS_VERSION',
+                          scm.VARIATION_SEMANTICS_VERSION + 1):
+            after = manager.compute_fingerprint(d)
+
+        assert before != after
+
+    def test_semantics_bump_marks_existing_stems_dirty(self, manager, tmp_path):
+        """End-to-end: un manifest scritto con la semantica precedente marca
+        dirty, anche con lo YAML identico e il .aif presente sul disco."""
+        aif = str(tmp_path / 's1.aif')
+        open(aif, 'w').close()
+        d = {'stream_id': 's1', 'volume': -6.0}
+        manager.save({'s1': manager.compute_fingerprint(d)})
+
+        assert manager.is_dirty(d, aif_path=aif) is False
+
+        with patch.object(scm, 'VARIATION_SEMANTICS_VERSION',
+                          scm.VARIATION_SEMANTICS_VERSION + 1):
+            assert manager.is_dirty(d, aif_path=aif) is True
 
     def test_toggling_mute_does_not_mark_stream_dirty(self, manager, tmp_path):
         """Dirty-check end-to-end: aggiungere mute non marca lo stem dirty se

--- a/tests/shared/test_distribution_strategy.py
+++ b/tests/shared/test_distribution_strategy.py
@@ -232,16 +232,20 @@ class TestGaussianDistribution:
         
         assert isinstance(result, float)
     
-    def test_get_bounds_uses_three_sigma(self):
-        """get_bounds usa regola 3-sigma."""
+    def test_get_bounds_is_the_band(self):
+        """get_bounds e' la banda esatta: spread e' la larghezza, non σ.
+
+        La distribuzione e' troncata ai bordi, quindi questi sono bounds
+        reali e non la stima 3σ di una campana illimitata.
+        """
         dist = GaussianDistribution()
-        
+
         center = 100.0
-        spread = 10.0  # σ
+        spread = 10.0  # larghezza della banda
         min_b, max_b = dist.get_bounds(center, spread)
-        
-        assert min_b == 70.0  # 100 - 3*10
-        assert max_b == 130.0  # 100 + 3*10
+
+        assert min_b == 95.0   # 100 - 10/2
+        assert max_b == 105.0  # 100 + 10/2
     
     def test_get_bounds_symmetric(self):
         """Bounds sono simmetrici rispetto al center."""
@@ -265,51 +269,57 @@ class TestGaussianDistribution:
         # Con 1000 campioni, media ±2%
         assert abs(mean - center) < center * 0.02
     
-    def test_statistical_std_close_to_spread(self):
-        """Deviazione standard dei campioni ~spread."""
+    def test_statistical_std_is_one_sixth_of_the_width(self):
+        """Deviazione standard dei campioni ~larghezza/6.
+
+        spread e' la larghezza della banda; σ = spread/6 mette i bordi a 3σ.
+        """
         dist = GaussianDistribution()
         center = 100.0
-        spread = 10.0  # σ target
-        
+        spread = 10.0  # larghezza
+        sigma = spread / 6.0
+
         samples = [dist.sample(center, spread) for _ in range(1000)]
         std = statistics.stdev(samples)
-        
+
         # Con 1000 campioni, σ ±20%
-        assert abs(std - spread) < spread * 0.2
-    
+        assert abs(std - sigma) < sigma * 0.2
+
     def test_statistical_68_percent_in_one_sigma(self):
-        """~68% dei campioni in [μ-σ, μ+σ]."""
+        """~68% dei campioni in [μ-σ, μ+σ], con σ = larghezza/6."""
         dist = GaussianDistribution()
         center = 100.0
         spread = 10.0
-        
+        sigma = spread / 6.0
+
         samples = [dist.sample(center, spread) for _ in range(1000)]
-        
+
         in_one_sigma = sum(
-            1 for s in samples 
-            if center - spread <= s <= center + spread
+            1 for s in samples
+            if center - sigma <= s <= center + sigma
         )
-        
+
         percentage = (in_one_sigma / 1000) * 100
-        
+
         # ~68% ±5%
         assert 63 <= percentage <= 73
-    
+
     def test_statistical_95_percent_in_two_sigma(self):
-        """~95% dei campioni in [μ-2σ, μ+2σ]."""
+        """~95% dei campioni in [μ-2σ, μ+2σ], con σ = larghezza/6."""
         dist = GaussianDistribution()
         center = 100.0
         spread = 10.0
-        
+        sigma = spread / 6.0
+
         samples = [dist.sample(center, spread) for _ in range(1000)]
-        
+
         in_two_sigma = sum(
-            1 for s in samples 
-            if center - 2*spread <= s <= center + 2*spread
+            1 for s in samples
+            if center - 2*sigma <= s <= center + 2*sigma
         )
-        
+
         percentage = (in_two_sigma / 1000) * 100
-        
+
         # ~95% ±3%
         assert 92 <= percentage <= 98
     
@@ -587,14 +597,15 @@ class TestDistributionStrategyParametrized:
     
     @pytest.mark.parametrize("spread", [1.0, 5.0, 10.0, 50.0])
     def test_gaussian_std_accurate_at_various_spreads(self, spread):
-        """GaussianDistribution ha σ accurata per vari spread."""
+        """GaussianDistribution ha σ = larghezza/6 per varie larghezze."""
         dist = GaussianDistribution()
-        
+        sigma = spread / 6.0
+
         samples = [dist.sample(center=100.0, spread=spread) for _ in range(500)]
         std = statistics.stdev(samples)
-        
+
         # ±25% tolleranza
-        assert abs(std - spread) < spread * 0.25
+        assert abs(std - sigma) < sigma * 0.25
     
     @pytest.mark.parametrize("invalid_mode", [
         'invalid',
@@ -618,70 +629,61 @@ class TestDistributionComparison:
     """Test comparativi tra distribuzioni diverse."""
     
     def test_uniform_vs_gaussian_spread(self):
-        """Uniform ha spread più ampio di gaussian per stessi parametri."""
+        """A parita' di banda, la gaussiana e' piu' stretta della piatta.
+
+        Le due distribuzioni riempiono la STESSA banda in modo diverso:
+        uniform ha σ = larghezza/sqrt(12) ≈ 2.89, gaussian σ = larghezza/6 ≈ 1.67.
+        La campana addensa al centro, la piatta no.
+        """
         uniform = UniformDistribution()
         gaussian = GaussianDistribution()
-        
+
         center = 100.0
         spread = 10.0
-        
+
         uniform_samples = [uniform.sample(center, spread) for _ in range(1000)]
         gaussian_samples = [gaussian.sample(center, spread) for _ in range(1000)]
-        
+
         uniform_std = statistics.stdev(uniform_samples)
         gaussian_std = statistics.stdev(gaussian_samples)
-        
-        # Uniform dovrebbe avere σ ~spread/sqrt(3) ≈ 5.77
-        # Gaussian dovrebbe avere σ ~spread = 10
-        # Quindi gaussian_std > uniform_std
-        assert gaussian_std > uniform_std
+
+        assert gaussian_std < uniform_std
     
     def test_gaussian_more_concentrated_than_uniform(self):
-        """Gaussian con σ piccolo concentra campioni più di uniform con spread largo."""
+        """Gaussian su banda stretta concentra più di uniform su banda larga."""
         uniform = UniformDistribution()
         gaussian = GaussianDistribution()
-        
+
         center = 50.0
-        
-        # Uniform con spread largo
+
+        # Uniform su banda larga 20 → [40, 60] piatta
         uniform_samples = [uniform.sample(center, spread=20.0) for _ in range(1000)]
-        
-        # Gaussian con σ piccolo (più concentrato)
+
+        # Gaussian su banda larga 5 → [47.5, 52.5], σ = 5/6 ≈ 0.83
         gaussian_samples = [gaussian.sample(center, spread=5.0) for _ in range(1000)]
-        
-        # Conta campioni in zona ±10
-        uniform_in_range = sum(1 for s in uniform_samples if 40 <= s <= 60)
-        gaussian_in_range = sum(1 for s in gaussian_samples if 40 <= s <= 60)
-        
-        # Uniform: spread=20 → bounds [40, 60] → tutti i campioni (100%)
-        # Gaussian: σ=5 → [40, 60] = μ±2σ → ~95% dei campioni
-        # 
-        # Quindi uniform ≈ gaussian per questa zona
-        
-        # Usiamo zona più stretta: ±5
+
+        # Zona centrale ±5
         uniform_narrow = sum(1 for s in uniform_samples if 45 <= s <= 55)
         gaussian_narrow = sum(1 for s in gaussian_samples if 45 <= s <= 55)
-        
+
         # Uniform: [45, 55] = 10 unità su 20 = 50% → ~500
-        # Gaussian: [45, 55] = μ±σ → ~68% → ~680
-        
-        # Gaussian ha più campioni in zona centrale
+        # Gaussian: la banda [47.5, 52.5] è tutta dentro [45, 55] → 100%
         assert gaussian_narrow > uniform_narrow
     
-    def test_bounds_different_between_distributions(self):
-        """Bounds teorici diversi tra uniform e gaussian."""
+    def test_bounds_identical_between_distributions(self):
+        """Stessa banda per tutte le distribuzioni: cambia solo come si riempie.
+
+        E' il contratto: `spread` e' la larghezza della banda, sempre. La forma
+        (`distribution_mode`) decide la densita' dentro la banda, non la banda.
+        """
         uniform = UniformDistribution()
         gaussian = GaussianDistribution()
-        
+
         center = 100.0
         spread = 10.0
-        
-        u_min, u_max = uniform.get_bounds(center, spread)
-        g_min, g_max = gaussian.get_bounds(center, spread)
-        
-        # Uniform: [95, 105] (spread/2)
-        # Gaussian: [70, 130] (3σ)
-        assert (u_max - u_min) < (g_max - g_min)
+
+        assert uniform.get_bounds(center, spread) == (95.0, 105.0)
+        assert gaussian.get_bounds(center, spread) == (95.0, 105.0)
 
 class TestDistributionStrategyABCCoverage:
     """Copre i pass nei metodi astratti tramite super()."""

--- a/tests/shared/test_range_anchor.py
+++ b/tests/shared/test_range_anchor.py
@@ -1,0 +1,276 @@
+# tests/shared/test_range_anchor.py
+"""
+test_range_anchor.py
+
+Semantica dell'ancora del range nelle distribuzioni.
+
+Contratto in tre frasi ortogonali:
+
+1. `range` (lo `spread` delle distribuzioni) e' SEMPRE la larghezza della banda.
+2. `distribution_mode` dice COME la banda viene riempita: `uniform` piatta,
+   `gaussian` a campana con i bordi a 3 sigma (sigma = larghezza/6) e clamp
+   ai bordi.
+3. `range_anchor` dice DOVE sta `base` dentro la banda: `center` (default,
+   banda `[base - range/2, base + range/2]`) o `min` (banda
+   `[base, base + range]`).
+
+Con `base = 300` e `range = 200`:
+
+    uniform  + center -> 200..400 piatta
+    uniform  + min    -> 300..500 piatta
+    gaussian + center -> 200..400, picco a 300
+    gaussian + min    -> 300..500, picco a 400
+"""
+
+import random
+
+import pytest
+
+from pge.shared.distribution_strategy import (
+    ANCHOR_CENTER,
+    ANCHOR_MIN,
+    RANGE_ANCHORS,
+    DistributionFactory,
+    DistributionStrategy,
+    GaussianDistribution,
+    UniformDistribution,
+)
+from pge.shared.exceptions import InvalidFieldValueError
+
+
+BASE = 300.0
+WIDTH = 200.0
+N = 2000
+
+
+def _rng():
+    return random.Random(20260729)
+
+
+# =============================================================================
+# 1. COSTANTI E VALIDAZIONE
+# =============================================================================
+
+class TestAnchorConstants:
+    """Le ancore disponibili sono un'enumerazione chiusa e scopribile."""
+
+    def test_anchor_values(self):
+        assert ANCHOR_CENTER == 'center'
+        assert ANCHOR_MIN == 'min'
+
+    def test_range_anchors_registry(self):
+        """RANGE_ANCHORS e' la lista che PGE-ls/PGE-ui possono leggere."""
+        assert tuple(RANGE_ANCHORS) == (ANCHOR_CENTER, ANCHOR_MIN)
+
+    def test_default_anchor_is_center(self):
+        """Senza ancora esplicita si resta sul comportamento storico."""
+        assert UniformDistribution().anchor == ANCHOR_CENTER
+        assert GaussianDistribution().anchor == ANCHOR_CENTER
+        assert DistributionFactory.create('uniform').anchor == ANCHOR_CENTER
+
+    def test_invalid_anchor_raises(self):
+        """Un'ancora sconosciuta e' un errore di configurazione YAML."""
+        with pytest.raises(InvalidFieldValueError) as exc:
+            UniformDistribution(anchor='massimo')
+
+        assert 'range_anchor' in str(exc.value.field)
+        assert 'massimo' in repr(exc.value.value)
+
+    def test_invalid_anchor_from_factory_raises(self):
+        with pytest.raises(InvalidFieldValueError):
+            DistributionFactory.create('gaussian', anchor='min_value')
+
+    def test_factory_propagates_anchor(self):
+        dist = DistributionFactory.create('uniform', anchor=ANCHOR_MIN)
+
+        assert dist.anchor == ANCHOR_MIN
+
+
+# =============================================================================
+# 2. BANDA — get_bounds e' la fonte di verita' della banda
+# =============================================================================
+
+class TestBandBounds:
+    """get_bounds descrive la banda effettiva, per ogni combinazione."""
+
+    def test_uniform_center_band(self):
+        assert UniformDistribution().get_bounds(BASE, WIDTH) == (200.0, 400.0)
+
+    def test_uniform_min_band(self):
+        dist = UniformDistribution(anchor=ANCHOR_MIN)
+
+        assert dist.get_bounds(BASE, WIDTH) == (300.0, 500.0)
+
+    def test_gaussian_center_band(self):
+        """La gaussiana non usa piu' la regola 3-sigma su `spread`: `spread`
+        E' la larghezza, e i bordi cadono a 3 sigma perche' sigma = width/6."""
+        assert GaussianDistribution().get_bounds(BASE, WIDTH) == (200.0, 400.0)
+
+    def test_gaussian_min_band(self):
+        dist = GaussianDistribution(anchor=ANCHOR_MIN)
+
+        assert dist.get_bounds(BASE, WIDTH) == (300.0, 500.0)
+
+    def test_zero_width_band_collapses_on_base(self):
+        """Larghezza nulla: la banda e' il punto `base`, in entrambe le ancore."""
+        for anchor in RANGE_ANCHORS:
+            for cls in (UniformDistribution, GaussianDistribution):
+                assert cls(anchor=anchor).get_bounds(BASE, 0.0) == (BASE, BASE)
+
+
+# =============================================================================
+# 3. UNIFORM
+# =============================================================================
+
+class TestUniformAnchor:
+
+    def test_center_is_bit_identical_to_legacy_formula(self):
+        """Il ramo default deve restare la stessa identica espressione."""
+        expected = [
+            BASE + random.Random(1).uniform(-0.5, 0.5) * WIDTH
+        ]
+        got = [UniformDistribution(rng=random.Random(1)).sample(BASE, WIDTH)]
+
+        assert got == expected
+
+    def test_min_never_below_base(self):
+        dist = UniformDistribution(rng=_rng(), anchor=ANCHOR_MIN)
+
+        samples = [dist.sample(BASE, WIDTH) for _ in range(N)]
+
+        assert min(samples) >= BASE
+        assert max(samples) <= BASE + WIDTH
+
+    def test_min_covers_the_whole_band(self):
+        """Piatta: dopo N draw deve avvicinarsi a entrambi i bordi."""
+        dist = UniformDistribution(rng=_rng(), anchor=ANCHOR_MIN)
+
+        samples = [dist.sample(BASE, WIDTH) for _ in range(N)]
+
+        assert min(samples) < BASE + 0.05 * WIDTH
+        assert max(samples) > BASE + 0.95 * WIDTH
+
+    def test_min_mean_is_band_center(self):
+        dist = UniformDistribution(rng=_rng(), anchor=ANCHOR_MIN)
+
+        samples = [dist.sample(BASE, WIDTH) for _ in range(N)]
+        mean = sum(samples) / len(samples)
+
+        assert abs(mean - (BASE + WIDTH / 2)) < 0.05 * WIDTH
+
+    def test_min_shifts_the_band_by_half_width(self):
+        """Stesso RNG, stessa sequenza: min = center + width/2, esattamente."""
+        centered = UniformDistribution(rng=random.Random(7))
+        anchored = UniformDistribution(rng=random.Random(7), anchor=ANCHOR_MIN)
+
+        for _ in range(50):
+            assert (anchored.sample(BASE, WIDTH)
+                    == pytest.approx(centered.sample(BASE, WIDTH) + WIDTH / 2))
+
+    def test_zero_width_returns_base_in_both_anchors(self):
+        for anchor in RANGE_ANCHORS:
+            dist = UniformDistribution(rng=_rng(), anchor=anchor)
+
+            assert dist.sample(BASE, 0.0) == BASE
+            assert dist.sample(BASE, -5.0) == BASE
+
+
+# =============================================================================
+# 4. GAUSSIAN — banda troncata, `range` e' la larghezza
+# =============================================================================
+
+class TestGaussianBand:
+
+    def test_center_stays_inside_the_band(self):
+        """Il cambio di semantica: con range 200 su base 300 la gaussiana non
+        esce piu' da 200..400 (prima sigma=200 la portava grosso modo 0..600)."""
+        dist = GaussianDistribution(rng=_rng())
+
+        samples = [dist.sample(BASE, WIDTH) for _ in range(N)]
+
+        assert min(samples) >= BASE - WIDTH / 2
+        assert max(samples) <= BASE + WIDTH / 2
+
+    def test_center_peaks_on_base(self):
+        """Campana centrata su `base`: la meta' centrale della banda raccoglie
+        la maggioranza netta dei campioni (~68% entro 1 sigma = width/6)."""
+        dist = GaussianDistribution(rng=_rng())
+
+        samples = [dist.sample(BASE, WIDTH) for _ in range(N)]
+        within_one_sigma = sum(
+            1 for s in samples if abs(s - BASE) <= WIDTH / 6
+        )
+
+        assert 0.60 < within_one_sigma / N < 0.76
+
+    def test_min_never_below_base(self):
+        dist = GaussianDistribution(rng=_rng(), anchor=ANCHOR_MIN)
+
+        samples = [dist.sample(BASE, WIDTH) for _ in range(N)]
+
+        assert min(samples) >= BASE
+        assert max(samples) <= BASE + WIDTH
+
+    def test_min_peaks_on_band_center(self):
+        dist = GaussianDistribution(rng=_rng(), anchor=ANCHOR_MIN)
+
+        samples = [dist.sample(BASE, WIDTH) for _ in range(N)]
+        mean = sum(samples) / len(samples)
+
+        assert abs(mean - (BASE + WIDTH / 2)) < 0.02 * WIDTH
+
+    def test_sigma_is_one_sixth_of_the_width(self):
+        """I bordi della banda cadono a 3 sigma: e' la definizione scelta."""
+        dist = GaussianDistribution(rng=_rng())
+
+        samples = [dist.sample(BASE, WIDTH) for _ in range(N)]
+        mean = sum(samples) / len(samples)
+        var = sum((s - mean) ** 2 for s in samples) / len(samples)
+
+        assert var ** 0.5 == pytest.approx(WIDTH / 6, rel=0.12)
+
+    def test_tails_are_clamped_not_dropped(self):
+        """La coda oltre 3 sigma si appiattisce sul bordo invece di uscire:
+        con una banda strettissima i bordi devono comparire davvero."""
+        dist = GaussianDistribution(rng=_rng(), anchor=ANCHOR_MIN)
+
+        samples = [dist.sample(0.0, 1.0) for _ in range(20000)]
+
+        assert min(samples) == 0.0 or max(samples) == 1.0
+
+    def test_zero_width_returns_base_in_both_anchors(self):
+        for anchor in RANGE_ANCHORS:
+            dist = GaussianDistribution(rng=_rng(), anchor=anchor)
+
+            assert dist.sample(BASE, 0.0) == BASE
+            assert dist.sample(BASE, -5.0) == BASE
+
+
+# =============================================================================
+# 5. ESTENSIBILITA' — le distribuzioni di terze parti non si rompono
+# =============================================================================
+
+class TestThirdPartyDistributions:
+    """`DistributionFactory.register` e' superficie pubblica: una distribuzione
+    esterna che non conosce l'ancora deve continuare a costruirsi."""
+
+    def test_registered_distribution_without_anchor_awareness(self):
+        class ConstantDistribution(DistributionStrategy):
+            def sample(self, center, spread):
+                return center
+
+            @property
+            def name(self):
+                return "constant"
+
+            def get_bounds(self, center, spread):
+                return (center, center)
+
+        DistributionFactory.register('constant_test', ConstantDistribution)
+        try:
+            dist = DistributionFactory.create('constant_test', anchor=ANCHOR_MIN)
+
+            assert dist.sample(BASE, WIDTH) == BASE
+            assert dist.anchor == ANCHOR_MIN
+        finally:
+            DistributionFactory._registry.pop('constant_test', None)


### PR DESCRIPTION
## Cosa

Un interruttore per-stream che fa funzionare i `_range` di PGE come in `granulation-studies`: `base` diventa il **minimo** della banda e `range` la forbice di apertura verso l'alto. Il comportamento storico resta il default.

```yaml
range_anchor: center   # default — banda [base - range/2, base + range/2]
range_anchor: min      # banda [base, base + range]: base è il MINIMO
```

Nasceva da un attrito reale: nello stesso `study.yml`, `axes.grain.duration: {base: 300, range: 200}` (granstudies) vuol dire `[300, 500]`, mentre `base.grain.duration_range: 200` su base 300 (PGE) vuol dire `[200, 400]`. Stessa parola, due semantiche, a poche righe di distanza.

## Il modello: tre concetti ortogonali

Il lavoro ha ripulito una confusione più profonda dell'ancora. Prima, `range` significava **due cose diverse** a seconda della distribuzione: larghezza con `uniform`, deviazione standard con `gaussian`. Ora sono tre assi separati:

| concetto | chiave | cosa decide |
|---|---|---|
| larghezza | il valore del `_range` | quanto è larga la banda |
| forma | `distribution_mode` | come la banda viene riempita |
| ancora | `range_anchor` | dove cade `base` dentro la banda |

Con `base: 300`, `range: 200`:

| forma | ancora | banda | picco |
|---|---|---|---|
| `uniform` | `center` (default) | 200…400 | — piatta |
| `uniform` | `min` | 300…500 | — piatta |
| `gaussian` | `center` | 200…400 | 300 |
| `gaussian` | `min` | 300…500 | 400 |

## Decisioni prese (le due aperte nel plan)

**Gaussiana in modalità `min`** → banda piena, come granstudies (μ = centro banda, σ = larghezza/6, clamp ai bordi). Ma la decisione è andata oltre `min`: **`range` è la larghezza della banda in ogni distribuzione e in ogni modalità**, anche in `gaussian: center`, dove prima era σ. Questo è un **cambio di comportamento non retrocompatibile del default per chi usa `gaussian`**, accettato consapevolmente dall'utente dopo averne visto il costo.

**Nome della chiave** → `range_anchor: center | min`. Una volta che `range` è sempre la larghezza, l'unica cosa che l'interruttore muove è dove cade `base`: è letteralmente un'ancora, e si estende a un terzo valore `max` senza rifare niente.

## Design (con due correzioni al plan)

L'ancora è **stato dell'istanza della distribuzione**, non un argomento di `sample()`. Il plan originale proponeva di non toccare le distribuzioni e risolvere l'ancora con una funzione pura `(base, range) → (center, spread)` in `Parameter.get_value`: incompatibile con la sua stessa raccomandazione sulla gaussiana (una coppia `(center, spread)` non può esprimere σ = larghezza/6 per la gaussiana e σ = larghezza per l'uniforme senza sapere quale distribuzione alimenta, né esprimere il clamp post-sample). Dettaglio completo nel plan spostato in `docs/plans/done/`.

Conseguenze del design scelto:
- la firma `sample(center, spread)` **non cambia** — nessun rosso gratuito;
- `VariationStrategy` **non cambia**: `QuantizedVariation` (pitch EDO) diventa corretto senza una riga, perché campiona attorno a 0 e somma (`base + round(sample(0, r))`, con `sample(0,r)` in `[0,r]` sotto `min`);
- `sample` e `get_bounds` condividono una sola definizione della banda (`_band`).

## Cosa `range_anchor` governa (e cosa no)

**Governa** tutti e soli i `_range` che passano da `Parameter`: `volume_range`, `pan_range`, `grain.duration_range`, `pointer.offset_range`, `pitch.range`, compreso il pitch quantizzato EDO.

**Non governa**, e resta simmetrico in ogni modalità: il jitter implicito (`default_jitter`), il detune implicito del pitch (±12 cents), lo spread delle voice strategy (`spread`, `pitch_range`, `pointer_range`). Non sono `_range` dichiarati con una `base` di cui essere il minimo.

## Vincoli del task, verificati (non asseriti)

- **Default identico bit per bit** per `uniform`: golden test `tests/engine/test_default_variation_identity.py`, digest congelato sul comportamento pre-modifica, stabile fra processi e `PYTHONHASHSEED`.
- **Cache stems**: `range_anchor` entra nel fingerprint per costruzione (chiave per-stream). Il rischio vero era un altro, che il plan non vedeva — il fingerprint copriva il *testo* YAML ma non la *semantica*: col cambio della gaussiana a YAML invariato ogni stem sarebbe rimasto `clean`. Risolto con `VARIATION_SEMANTICS_VERSION` dentro l'hash → **un re-render completo al primo run dopo il merge**, poi la cache incrementale riparte.
- **Bounds sotto `min`**: la banda arriva a `base + range` e può sforare `max_val`. Validato **al parse** con `ParameterBoundError`, non lasciato al solo safety clamp. Solo dove il massimo è esatto (scalare+scalare, envelope+scalare, scalare+envelope); con due envelope resta il clamp.
- **`make e2e-tests`**: non gira in ambiente pulito (corpus `refs/` non versionato). Un fallimento (`test_e2e_missing_context_fields`) è **pre-esistente** — verificato identico su `main`, non è una regressione di questa PR.

## Test

`make tests`: **5103 passed, 2 skipped**. Nuovi file: `test_range_anchor.py` (distribuzioni + ancora), `test_parameter_range_anchor.py` (cablaggio + jitter implicito centrato + quantizzato), `test_range_anchor_bounds.py` (validazione tetto banda), `test_default_variation_identity.py` (golden). Aggiornati i 10 test che asserivano la vecchia semantica σ della gaussiana.

## Migrazione

Chi usa `distribution_mode: gaussian` e vuole un'escursione paragonabile a prima deve **moltiplicare il proprio `range` per circa 6** (prima σ=range, ora σ=range/6). `uniform` non cambia.

## Fuori scope, dichiarato

`granulation-studies` **non è toccato**. Adottare la modalità lì è lavoro a parte e comporta rileggere i valori esistenti: es. `stack_300-1000ms/study.yml` ha `duration_range` fino a 350 su base 300 → oggi `[125, 475]`, con `min` diventa `[300, 650]`. Annotato, non fatto.

---

## Analisi d'impatto cross-repo

**PGE-ls** — impatto **sì**. Issue già esistente: DMGiulioRomano/PGE-ls#37 (aperta col plan). Allineata all'implementazione finale con [un commento](https://github.com/DMGiulioRomano/PGE-ls/issues/37#issuecomment-5127677921), perché il body descriveva ancora la vecchia semantica della gaussiana e i bounds come warning. In sintesi: nuova chiave `range_anchor` (enum `center | min`) per completamento/hover/diagnostica; la diagnostica dei bounds sotto `min` è un **errore** (`ParameterBoundError`), non un warning; `distribution_mode` è già gestito.

**PGE-ui** — impatto **sì**. Issue già esistente: DMGiulioRomano/PGE-ui#115 (aperta col plan). Allineata con [un commento](https://github.com/DMGiulioRomano/PGE-ui/issues/115#issuecomment-5127679795). In sintesi: `primitives.jsx:271` renderizza `±{range/2}` che sotto `min` mente; serve il controllo per la nuova chiave; la gaussiana cambia il disegno della dispersione anche in `center`; e la label `"reserved — not yet used by the engine"` su `distribution_mode` (`Inspector.jsx:615`) è falsa.

**score_visualizer** — impatto **nullo**, verificato: non disegna nessuna banda `base ± range/2`; emette `<param>_range` come curva a sé con la larghezza grezza, scalata data-driven (issue #114).

**Paper CIM 2026** — nessun bump del submodule proposto: gli esempi `exN.yml` non usano `distribution_mode: gaussian` né `range_anchor` (valutazione del plan), quindi il loro audio non cambia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUVgmrvJYK4EvLpHX21NW8