### PR TITLE
fix(rendering): i rilievi della review della #174

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,41 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Corretto
 
+- **Il tetto della cache delle silhouette non era il tetto vero.**
+  `window_silhouette` ha un limite di 64 voci, ma leggeva da un
+  `NumpyWindowRegistry` tenuto in una variabile di modulo — che ha una cache
+  propria, **senza eviction**, e che il refactor aveva promosso da attributo
+  d'istanza a globale di processo. Il caso per cui il tetto esiste — chi
+  rigenera le figure variando `window_shape_resolution` — continuava quindi ad
+  accumulare un livello più giù, dove per giunta stanno gli array e non le
+  chiavi, e non veniva più liberato con il visualizer che l'aveva riempito.
+  Il registry ora si costruisce per singolo miss e muore lì: chi arriva a
+  generare una finestra è già un miss della memoizzazione, quindi la cache del
+  registry non serviva a nessuno, e `__init__` è un dizionario vuoto. Il
+  globale sparisce, e con esso la sua corsa fra thread.
+
+- **Un valore fuori dominio dentro un `Parameter` faceva cadere l'intera
+  estrazione.** `Parameter.__init__` non valida il proprio valore; leggerne le
+  facce come `ParameterCurve` ha reso un `TypeError` quello che prima era una
+  curva semplicemente saltata, e un solo parametro malformato si portava via
+  tutte le altre curve dello stream — cioè la partitura, o la sessione Sonic
+  Visualiser. `envelope_extractor` torna a dichiararla `absent`.
+  `ParameterCurve.classify` resta stretta: il dominio lo dichiara il value
+  object, la tolleranza è di chi legge.
+
+- **`config` non-dizionario dava un messaggio che descriveva un altro
+  problema.** `ScoreVisualizer(gen, config='page_duration')` iterava la stringa
+  carattere per carattere e li riportava come chiavi sconosciute
+  (`_, a, d, e, g, i, n, o, p, r, t, u`). Ora è un `TypeError` che nomina il
+  tipo ricevuto.
+
+- **La copia della config dipendeva dal tipo di parentesi.** `_as_plain`
+  copiava dict, list e set: `magnify_targets` passato come tupla di dizionari
+  restava condiviso con il chiamante, mentre la stessa cosa scritta come lista
+  veniva copiata in profondità — senza nessun segnale della differenza. La
+  copia comprende ora anche `tuple` e `frozenset`; un oggetto `Colormap`
+  continua a viaggiare per riferimento, che è quello che deve fare.
+
 - **Override parziale di un gruppo di config annidato**: passare
   `config={'envelope_display': {'pad_ratio': 0.1}}` a `ScoreVisualizer`
   cancellava gli altri campi del gruppo, e il primo che li leggeva sollevava
@@ -117,6 +152,29 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   e `total_duration` restano interni al visualizer), ma sono attributi
   pubblici e chi li leggesse da fuori va adeguato.
 
+- **BREAKING — gli array di `window_silhouette` sono di sola lettura.** La
+  cache è di modulo e quindi condivisa fra visualizer: un chiamante che
+  mutasse la curva la avvelenerebbe per tutti, e adesso fallisce subito invece
+  di propagarsi. Riguarda anche la delega `ScoreVisualizer._window_silhouette`,
+  che prima restituiva array scrivibili. Nessun consumatore in-repo ci scrive:
+  `window_vertices` costruisce comunque un array nuovo.
+
+- **BREAKING — i campi-sequenza dei record di layout sono tuple**:
+  `PageLayout.streams` e `EnvelopeLane.env_types`. `frozen` blocca il
+  riassegnamento del campo, non la scrittura dentro il campo, e una lista
+  lasciava aperta proprio la strada che il record dichiara chiusa.
+  `PageLayout.slots` resta un dict: per un mapping è il tipo giusto, e la sola
+  alternativa di sola lettura in stdlib non è né copiabile né serializzabile —
+  lì l'immutabilità è una convenzione dichiarata nella docstring.
+
+- **`envelope_extractor.get_voice_offset_envelopes` rimossa.** Il criterio
+  applicato alle nove deleghe del visualizer vale anche un livello più giù:
+  questa estrazione le ha portato via entrambi i chiamanti — 
+  `get_stream_envelopes` campiona direttamente da `VoiceManager`, e la delega
+  che la usava è fra le nove — e restava viva per un import nella sua suite che
+  non la chiamava. Le stesse curve arrivano da
+  `get_stream_envelopes(show_voice_offsets=True)`.
+
 - **Costanti appiattite: i valori dei breakpoint sono ora `float`.** Con
   `show_static_params` una costante diventa una curva piatta, e il suo valore
   passa da `ParameterCurve`, che normalizza a `float`: un `reverse: 0` che
@@ -148,7 +206,7 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 - I test dell'estrazione (dieci classi, ~500 righe) non costruiscono più un
   `ScoreVisualizer` per interrogare l'estrattore:
-  `tests/rendering/test_envelope_extractor.py` passa da 11 a 67 test,
+  `tests/rendering/test_envelope_extractor.py` passa da 11 a 75 test,
   `test_score_visualizer.py` da 181 a 129 (resta il disegno).
 
 ---

--- a/docs/explanation/parameter-curve.md
+++ b/docs/explanation/parameter-curve.md
@@ -9,7 +9,7 @@ sources:
   - src/pge/controllers/voice_manager.py
   - src/pge/shared/probability_gate.py
   - src/pge/rendering/envelope_extractor.py
-last_synced_commit: 676b011
+last_synced_commit: 4413fef
 ---
 
 # ParameterCurve: come si legge il comportamento nel tempo di un parametro
@@ -188,6 +188,15 @@ il modulo dei parametri.
 
 - `Parameter` espone le tre facce come `ParameterCurve` (`value_curve`,
   `range_curve`, `probability_curve`); `value` resta per retro-compatibilità.
+- **Il dominio lo dichiara il value object, la tolleranza è di chi legge.**
+  `ParameterCurve.classify` rifiuta ciò che non è un `Envelope`, un numero o
+  `None`, con un errore che nomina il tipo. Ma `Parameter.__init__` non valida
+  il proprio valore, quindi un `Parameter` costruito a mano può contenerne uno
+  qualunque — e per una faccia così `envelope_extractor` risponde `absent`,
+  come faceva prima del refactor, invece di lasciar cadere l'intera estrazione.
+  Le curve di uno stream sono decine: un parametro malformato non deve
+  portarsi via anche le altre, cioè la partitura intera o l'intera sessione
+  Sonic Visualiser.
 - `envelope_extractor` è passato da 394 a 287 righe: i sei blocchi duplicati e
   i tre meccanismi di accesso sono una tabella sola, con **un unico punto di
   appiattimento** — l'unico che ha bisogno di `stream.duration`.
@@ -211,8 +220,13 @@ il modulo dei parametri.
   nomi dei layer SV, né su PGE-ls / PGE-ui.
 - **Test.** Dieci classi (~500 righe) verificavano l'estrattore costruendo un
   `ScoreVisualizer` intero per chiamarne `_get_stream_envelopes`: ora
-  interrogano la funzione. `test_envelope_extractor.py` è passato da 11 a 63
+  interrogano la funzione. `test_envelope_extractor.py` è passato da 11 a 75
   test, `test_score_visualizer.py` da 181 a 129 (resta il disegno).
+- `get_voice_offset_envelopes` è stata rimossa: questa estrazione le ha portato
+  via entrambi i chiamanti (`get_stream_envelopes` campiona direttamente da
+  `VoiceManager`, e la delega del visualizer che la usava è fra le nove
+  rimosse), e restava viva per un import nella sua suite che non la chiamava.
+  Le stesse curve arrivano da `get_stream_envelopes(show_voice_offsets=True)`.
 - Nessun impatto sulla sintassi YAML: `ParameterCurve` è interno alla lettura
   della IR, non alla superficie di input.
 

--- a/docs/explanation/score-visualizer-layout.md
+++ b/docs/explanation/score-visualizer-layout.md
@@ -9,7 +9,7 @@ sources:
   - src/pge/rendering/envelope_display.py
   - src/pge/rendering/magnifier_targets.py
   - src/pge/rendering/score_visualizer.py
-last_synced_commit: 917c7dd
+last_synced_commit: 4413fef
 ---
 
 # Il layout della partitura: separare i numeri dal disegno
@@ -115,7 +115,7 @@ disegna possa raggiungerne l'asse matplotlib.
 | Quattro moduli invece di uno | Ogni modulo ha una domanda sola | Quattro import invece di uno |
 | Quattro moduli invece di collaboratori per feature | Il seam è testabile: si asseriscono numeri | Non riduce la lunghezza di `render_page` |
 | Config come keyword argument | I moduli non conoscono il dict | Le firme sono più lunghe |
-| Cache delle silhouette come `lru_cache` di modulo | È memoizzazione, non stato d'istanza | Condivisa fra visualizer: gli array vanno resi read-only |
+| Cache delle silhouette come `lru_cache` di modulo | È memoizzazione, non stato d'istanza | Condivisa fra visualizer: gli array vanno resi read-only, e il tetto deve valere per tutto ciò che il modulo trattiene |
 | Dataclass al posto dei dict | I campi sono dichiarati | Tocca i consumatori esistenti |
 
 **Il contro principale, detto per intero: questo taglio ha un solo consumatore
@@ -146,12 +146,27 @@ fatto diventare rosso niente. Sono state rimosse: `_find_active_streams`,
 `_auto_y_at`, `_get_voice_offset_envelopes`. Il criterio è quello: una delega
 si tiene se qualcuno la chiama.
 
-La suite passa da 5106 a 5283 test.
+Lo stesso criterio vale un livello più giù, e applicarlo fino in fondo ne ha
+tolta una decima: `envelope_extractor.get_voice_offset_envelopes`. Non era una
+delega del visualizer ma una funzione di modulo, e questa estrazione le ha
+portato via entrambi i chiamanti — `get_stream_envelopes` ora campiona
+direttamente da `VoiceManager`, e la delega del visualizer che la usava è fra
+le nove. Restava viva per un import nella sua suite, che non la chiamava.
+Le stesse curve si ottengono da `get_stream_envelopes(show_voice_offsets=True)`,
+che è il path che il disegno percorre davvero.
+
+La suite passa da 5106 a 5309 test.
 
 Alcune cose sono cambiate di comportamento osservabile solo nel tipo:
 
 - `viz.page_layouts` è una lista di `PageLayout`, non di dict. Sette test
-  esistenti sono stati adeguati.
+  esistenti sono stati adeguati. I campi-sequenza dei record (`PageLayout.streams`,
+  `EnvelopeLane.env_types`) sono tuple: `frozen` blocca il riassegnamento del
+  campo e non la scrittura dentro il campo, e una lista lascerebbe aperta la
+  strada che il record dichiara chiusa. `PageLayout.slots` resta un dict —
+  per un mapping è il tipo giusto, e l'unica alternativa di sola lettura in
+  stdlib non è né copiabile né serializzabile — quindi lì l'immutabilità è
+  una convenzione dichiarata, non una garanzia.
 - `_resolve_magnify_targets` restituisce `MagnifyTarget`.
 - `_compute_env_legend_layout` restituisce `EnvelopeLane`.
 
@@ -185,6 +200,29 @@ Cinque fatti che il codice non diceva, ora scritti dove servono:
 5. **Il commento `gap_ratio = 0.02  # coerente con render_page` era stantio.**
    Dal fix #113 `render_page` consuma le corsie calcolate qui, non le ricalcola.
 
+Una seconda passata, fatta perturbando i moduli estratti uno per uno, ne ha
+aggiunti tre — tutti della stessa famiglia: codice difensivo la cui condizione
+non si può raggiungere, che quindi nessun test può tenere fermo.
+
+6. **In `paginate`, `max(simultanei, corsie)` non sceglie mai.** `assign_slots`
+   è il greedy per onset crescente, che su intervalli usa esattamente tante
+   corsie quanti sono gli stream mutuamente sovrapposti; e due stream entrambi
+   attivi in pagina che si sovrappongono continuano a sovrapporsi anche tagliati
+   sulla finestra, quindi quel grumo lo conta pure la sweep line. Una ricerca su
+   400 000 configurazioni casuali non trova un controesempio. Il massimo resta
+   scritto perché l'uguaglianza dipende da come `paginate` chiama `assign_slots`,
+   non da una proprietà delle due funzioni: a essere tenuta ferma da un test è
+   l'invariante che conta, cioè che l'altezza riservata basti alle corsie.
+7. **In `auto_target`, la guardia sul bin vuoto è irraggiungibile.** Il
+   ricontrollo dei grani nel bin è inclusivo su entrambi gli estremi, quindi più
+   largo del binning di numpy: un punto che l'istogramma ha contato ci ricade
+   dentro per forza. Resta perché l'indice del bin viene dall'aritmetica di
+   numpy e il ricontrollo è nostro, e fra i due, nel caso peggiore, c'è un ULP.
+8. **Le due uscite di `auto_target` si coprono a vicenda.** Quando l'istogramma
+   non conta niente, anche il ricontrollo trova la lista vuota: a test si
+   osserva solo il risultato comune, cioè che lo stream viene saltato, e non
+   quale delle due guardie l'ha deciso.
+
 ### Il metodo: rete di caratterizzazione, poi perturbazione
 
 Il refactor è stato coperto da una rete temporanea che congelava i **numeri** —
@@ -204,8 +242,17 @@ lasco (la distribuzione delle voci di legenda, che verificava l'ordine ma non gl
 estremi).
 
 A estrazione completata la rete è stata cancellata: la copertura definitiva sono
-`test_page_layout.py`, `test_grain_visuals.py`, `test_envelope_display.py` e
-`test_magnifier_targets.py`.
+`test_page_layout.py` (35), `test_grain_visuals.py` (36),
+`test_envelope_display.py` (26) e `test_magnifier_targets.py` (30).
+
+La rete è stata poi **ricostruita da fuori** in sede di review, e allargata: i
+numeri su tutte e ventisette le config del repository per quattro varianti di
+config del visualizer, più un confronto a livello di **figura** — gli artisti
+matplotlib di ventotto pagine renderizzate davvero, che copre i call site del
+disegno che la rete numerica salta. Contro `main`, il residuo è zero oltre alle
+differenze dichiarate qui sopra. Una seconda passata di perturbazione, questa
+volta su ogni modulo estratto, ha prodotto i tre fatti aggiunti alla lista
+sopra e i test che mancavano.
 
 ## Vedi anche
 

--- a/src/pge/rendering/envelope_extractor.py
+++ b/src/pge/rendering/envelope_extractor.py
@@ -183,11 +183,22 @@ def _curve_of(source, stream):
     if obj is None:
         return ParameterCurve(kind='absent')
     if isinstance(obj, Parameter):
-        return {
-            'value': obj.value_curve,
-            'range': obj.range_curve,
-            'probability': obj.probability_curve,
+        face = {
+            'value': lambda p: p.value_curve,
+            'range': lambda p: p.range_curve,
+            'probability': lambda p: p.probability_curve,
         }[source.face]
+        try:
+            return face(obj)
+        except TypeError:
+            # Dentro un Parameter puo' esserci un valore fuori dal dominio di
+            # ParameterCurve: Parameter non valida al costruttore. Qui non e'
+            # una curva e non se ne pubblica nessuna — ma saltarla e' l'unica
+            # reazione proporzionata, perche' far cadere questa faccia vuol
+            # dire far cadere tutte le altre curve dello stream, cioe' la
+            # partitura intera. Il value object resta stretto: e' il lettore a
+            # essere tollerante, come lo era prima del refactor.
+            return ParameterCurve(kind='absent')
     # Sorgente grezza (pitch_value): ha solo il valore, niente range ne' gate.
     if source.face != 'value':
         return ParameterCurve(kind='absent')
@@ -277,14 +288,3 @@ def get_stream_envelopes(stream, show_static=False, show_voice_offsets=False,
         }
 
     return envelopes
-
-
-def get_voice_offset_envelopes(stream):
-    """Curve degli offset per-voce come dict {chiave: Envelope}.
-
-    Il campionamento vive in VoiceManager.offset_curves (issue #90 lo faceva
-    qui, frugando in vm._pitch_strategy / vm._pointer_strategy): questa resta
-    come vista a dizionario per chi vuole le sole curve per-voce senza il
-    resto — get_stream_envelopes le prende dalla stessa sorgente, non da qui.
-    """
-    return dict(_voice_curves(stream))

--- a/src/pge/rendering/grain_visuals.py
+++ b/src/pge/rendering/grain_visuals.py
@@ -19,25 +19,25 @@ from functools import lru_cache
 
 import numpy as np
 
-_WINDOW_REGISTRY = None
 
+def _generate_window(name, resolution):
+    """La finestra grezza, da un registry usa-e-getta.
 
-def _window_registry():
-    """Registry NumPy delle finestre, istanziato al primo uso.
+    Il registry ha una cache propria, e qui non serve a niente: chi arriva fin
+    qui e' gia' un miss di `window_silhouette`, che memoizza sulla stessa
+    chiave. Tenerlo vivo fra una chiamata e l'altra vorrebbe dire conservare
+    due volte gli stessi array, e conservarli SENZA tetto — la cache del
+    registry non ha eviction — sotto un tetto che li conta una volta sola.
+    Costruirlo per-miss non costa niente (`__init__` e' un dict vuoto, le
+    tabelle delle finestre sono attributi di classe) e rende vero il limite
+    dichiarato sopra.
 
-    Lazy perche' serve solo con grain_shape='window': chi disegna frecce non
-    deve pagarne la costruzione.
-
-    Il controllo e l'assegnazione non sono atomici, e non serve che lo siano:
-    due chiamanti concorrenti costruirebbero due registry identici e il
-    secondo vincerebbe: si spreca una costruzione, non si corrompe niente,
-    perche' il registry non ha stato che dipenda da chi lo usa.
+    L'import resta locale: serve solo con grain_shape='window', e chi disegna
+    frecce non deve pagarlo.
     """
-    global _WINDOW_REGISTRY
-    if _WINDOW_REGISTRY is None:
-        from pge.rendering.numpy_window_registry import NumpyWindowRegistry
-        _WINDOW_REGISTRY = NumpyWindowRegistry()
-    return _WINDOW_REGISTRY
+    from pge.rendering.numpy_window_registry import NumpyWindowRegistry
+
+    return NumpyWindowRegistry().get(name, resolution)
 
 
 # Quante silhouette tenere in cache. Una partitura ne usa quante sono le
@@ -45,7 +45,9 @@ def _window_registry():
 # serve al caso opposto — chi rigenera le figure variando
 # `window_shape_resolution` — perche' la cache e' di modulo e senza limite non
 # verrebbe liberata mai, essendo la sua vita quella del processo e non quella
-# del visualizer che l'ha riempita.
+# del visualizer che l'ha riempita. E' il tetto di TUTTO cio' che il modulo
+# trattiene: sotto non resta nessun altro strato che accumuli (vedi
+# _generate_window).
 WINDOW_SILHOUETTE_CACHE_SIZE = 64
 
 
@@ -62,7 +64,7 @@ def window_silhouette(name, resolution):
     nient'altro che dai due argomenti — e per la stessa ragione ha un tetto,
     invece di crescere per tutta la vita del processo.
     """
-    w = _window_registry().get(name, resolution)
+    w = _generate_window(name, resolution)
     w = np.clip(np.asarray(w, dtype=float), 0.0, None)
     peak = float(w.max())
     if peak > 0:

--- a/src/pge/rendering/magnifier_targets.py
+++ b/src/pge/rendering/magnifier_targets.py
@@ -18,6 +18,7 @@ proiettare — gli e' opaco e viaggia intatto fino a chi disegna.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Optional
 
 import numpy as np
 
@@ -78,7 +79,13 @@ class MagnifyTarget:
     y: float
     zoom: float
     out: float
-    src: float | None
+    # Optional e non `float | None`: il progetto dichiara Python >= 3.9, dove
+    # l'unione con | non e' valutabile. Qui `from __future__ import
+    # annotations` la salverebbe finche' nessuno risolve le annotazioni, ma
+    # basta un typing.get_type_hints — un serializzatore, un generatore di
+    # doc — perche' torni a essere un errore, e il resto del modulo usa gia'
+    # Optional.
+    src: Optional[float]
     corner: str
 
 
@@ -145,6 +152,14 @@ def auto_target(entries, t_start, t_end, *, hist_bins, defaults):
             range=[[t_start, t_end], [0.0, y_max]])
         i, j = np.unravel_index(int(np.argmax(histogram)), histogram.shape)
         count = histogram[i, j]
+        # Nessun grano dentro l'istogramma: argmax su una matrice di zeri
+        # restituisce comunque (0,0), e senza questa uscita la lente si
+        # punterebbe sul primo bin in alto a sinistra, cioe' sul vuoto.
+        # Il caso e' coperto da TestAutoTargetCountsNothing, che pero' non
+        # distingue questa uscita da quella su `in_bin` piu' sotto: quando il
+        # conteggio e' nullo anche il ricontrollo trova la lista vuota, quindi
+        # le due guardie si coprono a vicenda e a test si osserva solo il
+        # risultato comune, cioe' che lo stream viene saltato.
         if count <= 0:
             continue
 
@@ -154,7 +169,14 @@ def auto_target(entries, t_start, t_end, *, hist_bins, defaults):
         in_bin = [(t, y) for t, y in points
                   if t_edges[i] <= t <= t_edges[i + 1]
                   and y_edges[j] <= y <= y_edges[j + 1]]
-        if not in_bin:
+        # Praticamente irraggiungibile: il confronto qui sopra e' inclusivo su
+        # entrambi gli estremi, quindi e' piu' largo del binning di numpy, e un
+        # punto che il bin ha contato lo ricade dentro per forza. Resta perche'
+        # l'indice del bin viene dall'aritmetica di numpy e il ricontrollo e'
+        # nostra: a separarli, nel caso peggiore, c'e' un ULP — e centrare la
+        # lente su una media di lista vuota darebbe nan, che si propaga fino
+        # alle coordinate del disegno senza dire da dove viene.
+        if not in_bin:  # pragma: no cover
             continue
         if best is None or count > best[0]:
             best = (count, candidate,

--- a/src/pge/rendering/page_layout.py
+++ b/src/pge/rendering/page_layout.py
@@ -101,11 +101,18 @@ class PageLayout:
 
     Sostituisce il dict a cinque chiavi che analyze costruiva. `slots` mappa
     stream_id -> corsia verticale.
+
+    `streams` e' una tuple: `frozen` blocca il riassegnamento del campo, non
+    la scrittura dentro cio' che il campo contiene, e una lista lascerebbe
+    aperta proprio la strada che il record dichiara chiusa. `slots` resta un
+    dict — un mapping e' il tipo giusto per un mapping, e la sola alternativa
+    di sola lettura in stdlib non e' ne' copiabile ne' serializzabile — quindi
+    li' l'immutabilita' e' una convenzione, non una garanzia.
     """
     index: int
     t_start: float
     t_end: float
-    streams: list
+    streams: tuple
     max_concurrent: int
     slots: dict
 
@@ -135,16 +142,27 @@ def paginate(streams, page_duration):
         on_page = active_streams(streams, t_start, t_end)
 
         if not on_page:
-            pages.append(PageLayout(index, t_start, t_end, [], 0, {}))
+            pages.append(PageLayout(index, t_start, t_end, (), 0, {}))
             continue
 
         slots = assign_slots(on_page)
-        # Il picco di simultanei e il numero di corsie possono divergere: le
-        # corsie si assegnano sull'intera estensione degli stream, i simultanei
-        # si contano tagliati sulla pagina. La pagina riserva il maggiore dei
-        # due, o due stream finirebbero disegnati nella stessa corsia.
+        # La pagina riserva il maggiore fra il picco di simultanei e il numero
+        # di corsie, o due stream finirebbero disegnati nella stessa corsia.
+        #
+        # Con gli stream di QUESTA pagina il massimo cade sempre sul primo dei
+        # due, e il `max` non sceglie mai davvero: `assign_slots` e' il greedy
+        # per onset crescente, che su intervalli usa esattamente tante corsie
+        # quanti sono gli stream mutuamente sovrapposti; e due stream entrambi
+        # attivi in pagina che si sovrappongono continuano a sovrapporsi anche
+        # tagliati sulla finestra, quindi quel grumo lo conta pure la sweep
+        # line. Resta scritto come un massimo perche' l'uguaglianza vale per
+        # come `paginate` chiama `assign_slots`, non per una proprieta' delle
+        # due funzioni: una strategia di corsie meno stretta la romperebbe, e
+        # il disegno non deve dipendere da quella dimostrazione. Il test
+        # `test_lanes_never_exceed_the_reserved_height` tiene ferma l'unica
+        # cosa che conta, cioe' che la pagina basti.
         pages.append(PageLayout(
-            index, t_start, t_end, on_page,
+            index, t_start, t_end, tuple(on_page),
             max(max_concurrent(on_page, t_start, t_end),
                 len(set(slots.values()))),
             slots))
@@ -161,12 +179,17 @@ LEGEND_TOP, LEGEND_BOTTOM = 0.85, 0.15
 
 @dataclass(frozen=True)
 class EnvelopeLane:
-    """Una corsia envelope: quale stream, dove sta, che curve ci vanno."""
+    """Una corsia envelope: quale stream, dove sta, che curve ci vanno.
+
+    `env_types` e' una tuple per la stessa ragione di `PageLayout.streams`:
+    in un record frozen un campo lista sarebbe scrivibile nonostante il
+    frozen.
+    """
     stream: object
     stream_id: str
     y_base: float
     y_height: float
-    env_types: list
+    env_types: tuple
 
 
 def envelope_lanes(streams_with_envelopes):
@@ -199,8 +222,8 @@ def envelope_lanes(streams_with_envelopes):
         # Le curve per-voce '__vN' collassano a una sola voce per parametro
         # base: N tracce, una etichetta. La colonna e' stretta, e ripetere lo
         # stesso nome non aggiunge niente.
-        env_types = sorted(
-            dict.fromkeys(base_param_name(k) for k in envelopes))
+        env_types = tuple(sorted(
+            dict.fromkeys(base_param_name(k) for k in envelopes)))
 
         lanes.append(EnvelopeLane(
             stream=stream, stream_id=stream.stream_id,

--- a/src/pge/rendering/visualizer_config.py
+++ b/src/pge/rendering/visualizer_config.py
@@ -25,6 +25,7 @@ sbagliato, che si vede al primo giro.
 """
 from __future__ import annotations
 
+from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import (
     MISSING, dataclass, field, fields, is_dataclass, replace)
@@ -208,8 +209,12 @@ class VisualizerConfig:
     # =========================================================================
 
     @classmethod
-    def _default_of(cls, field):
+    def _default_of(cls, spec):
         """Il valore di default di un campo, comunque sia dichiarato.
+
+        `spec` e' il descrittore restituito da `fields()`. Non si chiama
+        `field` per non ombreggiare `dataclasses.field`, che questo stesso
+        modulo importa e usa nelle dichiarazioni qui sopra.
 
         Non si legge dall'attributo di classe: per un campo con
         `default_factory` quell'attributo NON esiste — dataclasses lo cancella
@@ -217,10 +222,10 @@ class VisualizerConfig:
         dizionari-dato (`envelope_ranges`, `envelope_colors`) sono dichiarati
         cosi', quindi un merge scritto su getattr li salterebbe in silenzio.
         """
-        if field.default is not MISSING:
-            return field.default
-        if field.default_factory is not MISSING:
-            return field.default_factory()
+        if spec.default is not MISSING:
+            return spec.default
+        if spec.default_factory is not MISSING:
+            return spec.default_factory()
         return None
 
     @classmethod
@@ -232,6 +237,15 @@ class VisualizerConfig:
         e' quello che fa dict.update — il primo che leggesse un campo non
         ridichiarato solleverebbe KeyError.
         """
+        if overrides is not None and not isinstance(overrides, Mapping):
+            # Senza questa guardia una stringa verrebbe iterata carattere per
+            # carattere e riportata come un elenco di chiavi sconosciute:
+            # un messaggio che descrive un problema inesistente e nasconde
+            # quello vero.
+            raise TypeError(
+                "config di ScoreVisualizer deve essere un dizionario di "
+                f"chiavi note (o None); ricevuto {type(overrides).__name__}")
+
         by_name = {f.name: f for f in fields(cls)}
         unknown = sorted(set(overrides or {}) - set(by_name))
         if unknown:
@@ -286,24 +300,35 @@ def _merge_group(group_name, default, overrides):
     return replace(default, **overrides)
 
 
+# Contenitori che si copiano invece di attraversare per riferimento. Sono i
+# tipi in cui default e override arrivano davvero, e la lista include le due
+# forme immutabili (tuple, frozenset) perche' l'immutabilita' del contenitore
+# non dice niente di quella del contenuto: una tuple di dict e' scrivibile
+# quanto una lista di dict, e `magnify_targets` accetta entrambe. Senza,
+# la stessa configurazione sarebbe protetta o no a seconda delle parentesi
+# che il chiamante ha scritto.
+_COPIED_CONTAINERS = (dict, list, set, tuple, frozenset)
+
+
 def _as_plain(value):
-    """Un gruppo dichiarato torna dict; i contenitori mutabili si copiano.
+    """Un gruppo dichiarato torna dict; i contenitori si copiano.
 
-    Si copiano solo dict, list e set: sono quelli che i consumatori mutano, e
-    sono i tipi in cui i default e gli override arrivano davvero. Tutto il
-    resto passa per riferimento — in particolare un oggetto Colormap passato
-    dall'utente, che deve restare LO STESSO oggetto: copiarlo sarebbe sprecato
-    e sorprendente.
+    Tutto cio' che non e' un contenitore passa per riferimento — in
+    particolare un oggetto Colormap passato dall'utente, che deve restare LO
+    STESSO oggetto: copiarlo sarebbe sprecato e sorprendente.
 
-    Il limite e' voluto ma va detto: un contenitore mutabile di un tipo
-    diverso (una tuple di dict passata come `magnify_targets`, un ndarray
-    passato come range) attraversa per riferimento. Oggi non fa danni perche'
-    ogni consumatore di quei campi e' in sola lettura; se un domani qualcuno
-    ci scrivesse, la copia andrebbe estesa a quel tipo invece che data per
-    scontata.
+    Il limite resta, ed e' bene dirlo: un contenitore di un tipo ancora
+    diverso (un ndarray passato come range, una collezione utente) attraversa
+    per riferimento. Oggi non fa danni perche' ogni consumatore di quei campi
+    e' in sola lettura; se un domani qualcuno ci scrivesse, la copia va estesa
+    a quel tipo invece che data per scontata.
+
+    Nota: `deepcopy` di una tuple di soli valori atomici restituisce la tuple
+    stessa, quindi i campi-range (`page_size`, `pitch_range`, ...) non pagano
+    niente per essere entrati nella lista.
     """
     if is_dataclass(value) and not isinstance(value, type):
         return {f.name: _as_plain(getattr(value, f.name)) for f in fields(value)}
-    if isinstance(value, (dict, list, set)):
+    if isinstance(value, _COPIED_CONTAINERS):
         return deepcopy(value)
     return value

--- a/tests/rendering/test_envelope_display.py
+++ b/tests/rendering/test_envelope_display.py
@@ -57,6 +57,29 @@ class TestDisplayRanges:
             pad_ratio=PAD, samples=SAMPLES)
         assert 'pan' not in ranges
 
+    def test_a_per_voice_pan_is_excluded_too(self):
+        """L'esclusione si decide sul nome BASE, come la normalizzazione.
+
+        Una curva per-voce eredita la natura del parametro da cui viene: se
+        qui il confronto fosse sul nome pieno, `pan__v1` riceverebbe un range
+        data-driven mentre `normalize` continuerebbe a trattarlo da ciclico —
+        e la curva verrebbe disegnata su una scala diversa da quella con cui
+        e' stata misurata.
+        """
+        envelopes = {'pan__v1': Envelope([[0, -10.0], [10, 10.0]])}
+        ranges = display_ranges(
+            envelopes, stream_start=0.0, t_start=0.0, t_end=10.0,
+            pad_ratio=PAD, samples=SAMPLES)
+        assert 'pan__v1' not in ranges
+
+    def test_the_two_sides_agree_on_a_per_voice_pan(self):
+        """La controprova della stessa regola dall'altro lato: `normalize`
+        tratta `pan__v1` da ciclico, cioe' non cerca il suo range fra quelli
+        di display. Le due funzioni devono dire la stessa cosa, o la curva
+        finirebbe fuori corsia."""
+        assert normalize('pan__v1', 180.0, {}, pan_range=(-180, 180)) == \
+            normalize('pan', 180.0, {}, pan_range=(-180, 180))
+
     def test_constant_envelope_gets_a_range_around_its_value(self):
         """Escursione nulla: il pad si calcola sul valore, non sullo span, e il
         range resta non degenere. Un range collassato renderebbe la

--- a/tests/rendering/test_envelope_extractor.py
+++ b/tests/rendering/test_envelope_extractor.py
@@ -23,7 +23,6 @@ from pge.parameters.parameter import Parameter
 from pge.parameters.parameter_definitions import GRANULAR_PARAMETERS
 from pge.rendering.envelope_extractor import (
     get_stream_envelopes,
-    get_voice_offset_envelopes,
     base_param_name,
 )
 
@@ -695,3 +694,104 @@ class TestEnvelopeFilter:
 # =============================================================================
 # GROUP - Pitch color auto-zoom (colormap divergente pitch_div + range dinamico per-subplot)
 # =============================================================================
+
+
+# =============================================================================
+# Robustezza della lettura delle facce
+# =============================================================================
+
+class TestValueOutsideTheDomain:
+    """Un Parameter puo' contenere un valore che non e' ne' un numero ne' un
+    Envelope: `Parameter.__init__` non valida, e chi lo costruisce a mano puo'
+    metterci dentro qualunque cosa.
+
+    Il valore non e' una curva, e infatti non se ne pubblica nessuna. Ma la
+    reazione giusta e' saltarlo, non far cadere l'estrazione: le curve dello
+    stream sono decine, e un parametro malformato non deve portarsi via anche
+    le altre — cioe' l'intera partitura, o l'intera sessione Sonic Visualiser.
+    """
+
+    def _stream_with(self, value):
+        s = make_stream('s1', onset=0.0, duration=10.0)
+        s.volume = Parameter('volume', value, GRANULAR_PARAMETERS['volume'])
+        s.pan = _param('pan', Envelope([[0, -90.0], [10, 90.0]]))
+        return s
+
+    def test_a_bogus_value_is_skipped_not_raised(self):
+        """La faccia non classificabile sparisce dal risultato."""
+        keys = get_stream_envelopes(self._stream_with('rumore'), show_static=True)
+        assert 'volume' not in keys
+
+    def test_the_other_curves_survive_it(self):
+        """E' il punto: le curve buone dello stesso stream restano."""
+        keys = get_stream_envelopes(self._stream_with('rumore'), show_static=True)
+        assert 'pan' in keys
+
+    def test_the_value_object_itself_stays_strict(self):
+        """La tolleranza sta in chi legge, non nel value object: ParameterCurve
+        continua a dichiarare il proprio dominio e a farlo rispettare, cosi'
+        chi lo usa altrove ha un errore che nomina il tipo invece di un
+        `float()` nudo che parla di stringhe."""
+        from pge.parameters.parameter_curve import ParameterCurve
+        with pytest.raises(TypeError):
+            ParameterCurve.classify('rumore')
+
+
+class TestFlattenSpansTheStream:
+    """La costante appiattita copre l'estensione dello stream.
+
+    E' l'unico punto dell'estrattore che ha bisogno di `stream.duration` — la
+    ragione per cui ParameterCurve, che dice solo *cos'e'* il dato, non la
+    conosce. Senza un test l'ancoraggio non e' tenuto fermo da niente: si puo'
+    appiattire su una durata qualunque e la suite resta verde.
+    """
+
+    def _flat(self, duration, value=-6.0):
+        s = make_stream('s1', onset=0.0, duration=duration)
+        s.volume = _param('volume', value)
+        return get_stream_envelopes(s, show_static=True)['volume']
+
+    def test_the_flat_curve_runs_from_zero_to_the_stream_duration(self):
+        env = self._flat(duration=7.5)
+        assert [bp[0] for bp in env.breakpoints] == [0, pytest.approx(7.5)]
+
+    def test_a_different_duration_moves_the_end(self):
+        """Due stream di durata diversa danno due curve piatte diverse: la
+        durata e' letta, non costante."""
+        assert self._flat(duration=3.0).breakpoints[-1][0] == pytest.approx(3.0)
+        assert self._flat(duration=42.0).breakpoints[-1][0] == pytest.approx(42.0)
+
+    def test_the_value_is_the_constant_on_both_ends(self):
+        env = self._flat(duration=7.5, value=-12.0)
+        assert [bp[1] for bp in env.breakpoints] == [
+            pytest.approx(-12.0), pytest.approx(-12.0)]
+
+
+class TestRawSourcesHaveOnlyAValue:
+    """Le sorgenti che non sono un Parameter portano un valore e basta: niente
+    range, niente gate.
+
+    `grain_envelope` e' dichiarata `is_smart=False`, quindi lo Stream la espone
+    grezza; di solito e' una stringa e non e' leggibile come curva. Ma un
+    numero lo sarebbe, e senza la guardia la riga `grain_envelope_prob` —
+    che esiste perche' la spec ha un `dephase_key` — pubblicherebbe come
+    probabilita' il valore base. Sarebbe per giunta una chiave fuori da
+    ENVELOPE_COLORS, cioe' fuori dall'universo dei nomi plottabili.
+    """
+
+    def _stream_with_numeric_grain_envelope(self):
+        s = make_stream('s1', onset=0.0, duration=10.0)
+        s.grain_envelope = 3
+        return s
+
+    def test_no_probability_key_from_a_raw_numeric_source(self):
+        keys = get_stream_envelopes(
+            self._stream_with_numeric_grain_envelope(), show_static=True)
+        assert 'grain_envelope_prob' not in keys
+
+    def test_the_value_face_still_reads_it(self):
+        """La guardia riguarda solo le facce che una sorgente grezza non ha:
+        il valore si legge."""
+        keys = get_stream_envelopes(
+            self._stream_with_numeric_grain_envelope(), show_static=True)
+        assert 'grain_envelope' in keys

--- a/tests/rendering/test_grain_visuals.py
+++ b/tests/rendering/test_grain_visuals.py
@@ -12,6 +12,7 @@ colormap e costruire il Polygon resta dell'adapter, perche' e' li' che comincia
 matplotlib.
 """
 
+import gc
 from types import SimpleNamespace
 
 import pytest
@@ -38,6 +39,20 @@ def grain(onset=0.0, duration=1.0, pointer_pos=0.0, pitch_ratio=1.0,
         envelope_table=envelope_table)
 
 
+@pytest.fixture
+def clean_silhouette_cache():
+    """Cache delle silhouette vuota all'entrata e all'uscita.
+
+    La cache e' di modulo, quindi la sua vita e' quella del processo: un test
+    che la riempie di proposito la lascerebbe piena per tutti quelli dopo. E'
+    l'unico stato globale che questa suite tocca, e la pulizia va in entrambe
+    le direzioni perche' i test che la riempiono contano le voci.
+    """
+    window_silhouette.cache_clear()
+    yield
+    window_silhouette.cache_clear()
+
+
 class TestArrowVertices:
     """La forma storica del grano: un rettangolo con la punta triangolare che
     indica il verso di lettura del sample."""
@@ -55,6 +70,26 @@ class TestArrowVertices:
         assert verts[3] == (0.5, 1.0)   # punta: meta' larghezza, in cima
         assert verts[0] == (0.0, 0.0)   # base sinistra, sul pointer
         assert verts[1] == (1.0, 0.0)   # base destra, sul pointer
+
+    def test_the_head_takes_half_the_length(self):
+        """Le spalle stanno a meta' altezza del grano: la testa triangolare ne
+        occupa la meta', il fusto l'altra meta'.
+
+        E' la proporzione che rende la freccia leggibile a colpo d'occhio, ed
+        e' l'unico numero della forma che non discende da onset/durata: senza
+        un test, cambiarlo non farebbe rumore.
+        """
+        verts = arrow_vertices(grain(onset=0.0, duration=2.0, pointer_pos=0.0,
+                                     pitch_ratio=1.0))
+        shoulders = [verts[2][1], verts[4][1]]
+        assert shoulders == [pytest.approx(1.0), pytest.approx(1.0)]
+
+    def test_the_head_takes_half_the_length_when_reverse(self):
+        """Ribaltata, la proporzione e' la stessa: la testa resta meta'."""
+        verts = arrow_vertices(grain(onset=0.0, duration=2.0, pointer_pos=0.0,
+                                     pitch_ratio=-1.0))
+        shoulders = [verts[2][1], verts[4][1]]
+        assert shoulders == [pytest.approx(-1.0), pytest.approx(-1.0)]
 
     def test_arrow_points_down_when_reverse(self):
         """pitch_ratio negativo: la lettura torna indietro, e la freccia si
@@ -126,14 +161,39 @@ class TestWindowSilhouette:
         assert info.maxsize == WINDOW_SILHOUETTE_CACHE_SIZE
         assert info.maxsize is not None
 
-    def test_entries_beyond_the_ceiling_are_evicted(self):
+    def test_entries_beyond_the_ceiling_are_evicted(self, clean_silhouette_cache):
         """Il tetto e' vero, non decorativo: oltre la capienza le voci vecchie
         escono, e la cache non supera mai la sua dimensione dichiarata."""
-        window_silhouette.cache_clear()
         for resolution in range(8, 8 + WINDOW_SILHOUETTE_CACHE_SIZE + 10):
             window_silhouette('hanning', resolution)
         assert (window_silhouette.cache_info().currsize
                 == WINDOW_SILHOUETTE_CACHE_SIZE)
+
+    def test_nothing_survives_the_call_beyond_the_cache(
+            self, clean_silhouette_cache):
+        """Il tetto della lru e' il tetto VERO: dietro non resta un registry
+        che accumula gli array senza limite.
+
+        E' il caso che il tetto esiste per chiudere — chi rigenera le figure
+        variando window_shape_resolution — e un tetto sul solo strato di sopra
+        non lo chiude: la memoria si accumulerebbe un livello piu' giu', dove
+        per giunta stanno gli array veri e non le chiavi.
+        """
+        from pge.rendering.numpy_window_registry import NumpyWindowRegistry
+
+        def retained():
+            gc.collect()
+            return sum(len(obj._cache) for obj in gc.get_objects()
+                       if isinstance(obj, NumpyWindowRegistry))
+
+        # Risoluzioni che nessun altro test tocca: se si sovrapponessero, un
+        # registry gia' popolato le troverebbe in cache e il conteggio non
+        # crescerebbe — il test passerebbe per l'ordine, non per la regola.
+        base = 1000
+        before = retained()
+        for resolution in range(base, base + WINDOW_SILHOUETTE_CACHE_SIZE + 40):
+            window_silhouette('hanning', resolution)
+        assert retained() - before <= WINDOW_SILHOUETTE_CACHE_SIZE
 
 
 class TestWindowVertices:
@@ -302,9 +362,22 @@ class TestPitchPosition:
     def test_non_positive_ratio_uses_the_fixed_range(self):
         """Ratio non positivo non ha un valore in cent: anche con l'autozoom
         attivo si ricade sul range fisso, invece di prendere il logaritmo di
-        zero."""
-        assert 0.0 <= pitch_position(
-            0.0, (0.0, 1200.0), pitch_range=(0.5, 2.0)) <= 1.0
+        zero.
+
+        Il range fisso e' scelto simmetrico apposta: su 0.5-2.0 il ramo giusto
+        e quello sbagliato darebbero entrambi 0.0 dopo il clamp — uno perche'
+        misura sotto il minimo, l'altro perche' log2(0) e' -inf — e il test
+        passerebbe qualunque cosa faccia il codice. Su -2.0..2.0 lo zero cade
+        a meta', e i due rami si distinguono.
+        """
+        assert pitch_position(
+            0.0, (0.0, 1200.0), pitch_range=(-2.0, 2.0)) == pytest.approx(0.5)
+
+    def test_zero_ratio_does_not_take_a_logarithm(self, recwarn):
+        """Il ramo in cent non viene nemmeno sfiorato: niente log2(0), quindi
+        nessun -inf e nessun RuntimeWarning di divisione invalida."""
+        pitch_position(0.0, (0.0, 1200.0), pitch_range=(-2.0, 2.0))
+        assert [w for w in recwarn if issubclass(w.category, RuntimeWarning)] == []
 
 
 class TestVolumeAlpha:

--- a/tests/rendering/test_magnifier_targets.py
+++ b/tests/rendering/test_magnifier_targets.py
@@ -251,3 +251,82 @@ class TestResolve:
                        hist_bins=(40, 16), defaults=DEFAULTS) == []
         assert resolve([], 0.0, 10.0, auto=True, specs=[{'t': 5.0}],
                        hist_bins=(40, 16), defaults=DEFAULTS) == []
+
+
+class TestAutoTargetTieBreak:
+    """Fra due stream ugualmente affollati la lente ne sceglie uno solo, e la
+    scelta non puo' dipendere dall'ordine in cui capitano."""
+
+    def _twins(self):
+        """Due entry con lo stesso identico grumo: il conteggio pareggia."""
+        grains = [grain(onset=1.0 + i * 0.01, pointer_pos=0.5) for i in range(6)]
+        return [entry('primo', grains=grains), entry('secondo', grains=grains)]
+
+    def test_the_first_wins_a_tie(self):
+        """A parita' vince chi arriva prima: il confronto e' stretto, quindi
+        un pari non spodesta il campione in carica. Con un confronto largo
+        vincerebbe l'ultimo, e l'ordine di stream_entries — che e' l'ordine
+        degli stream nel file — sposterebbe la lente."""
+        target = auto_target(self._twins(), 0.0, 10.0,
+                             hist_bins=(40, 16), defaults=DEFAULTS)
+        assert target.entry['stream'].stream_id == 'primo'
+
+    def test_the_tie_is_broken_the_same_way_reversed(self):
+        """La regola e' 'il primo della lista', non 'quello che si chiama
+        primo': invertendo la lista vince l'altro, e nulla resta ambiguo."""
+        target = auto_target(list(reversed(self._twins())), 0.0, 10.0,
+                             hist_bins=(40, 16), defaults=DEFAULTS)
+        assert target.entry['stream'].stream_id == 'secondo'
+
+
+class TestAutoTargetDegenerateSample:
+    """L'istogramma ha bisogno di un'altezza: la posizione di lettura si
+    distribuisce su [0, durata del sample]."""
+
+    def test_a_zero_length_sample_does_not_break_the_histogram(self):
+        """Un sample di durata nulla darebbe un range verticale degenere, e
+        np.histogram2d su un range vuoto non produce il bin che serve. Il
+        floor tiene in piedi il conto invece di far sparire la lente."""
+        only = entry('s1', sample_duration=0.0,
+                     grains=[grain(onset=2.0, pointer_pos=0.0)])
+        target = auto_target([only], 0.0, 10.0,
+                             hist_bins=(40, 16), defaults=DEFAULTS)
+        assert target is not None
+        assert target.t == pytest.approx(2.0)
+
+    def test_a_negative_sample_duration_is_survived_too(self):
+        """Stessa guardia, dal lato assurdo: una durata negativa non deve
+        propagarsi dentro numpy come un range invertito."""
+        only = entry('s1', sample_duration=-1.0,
+                     grains=[grain(onset=2.0, pointer_pos=0.0)])
+        assert auto_target([only], 0.0, 10.0,
+                           hist_bins=(40, 16), defaults=DEFAULTS) is not None
+
+
+class TestAutoTargetCountsNothing:
+    """Il centro della lente e' il centroide dei grani del bin piu' popolato,
+    non il centro geometrico del bin: la finestra e' stretta per via dello
+    zoom, e centrata sui grani veri contiene davvero qualcosa.
+
+    Quando invece NESSUN grano finisce dentro l'istogramma, non c'e' un bin
+    su cui centrare e lo stream va saltato: `argmax` su una matrice di zeri
+    restituisce comunque un indice, e senza la guardia sul conteggio la lente
+    si punterebbe sul primo bin in alto a sinistra, cioe' sul vuoto.
+    """
+
+    def test_a_stream_whose_grains_fall_outside_the_range_is_skipped(self):
+        """I grani sopra l'altezza del sample cadono fuori dal range
+        dell'istogramma: nessun bin li conta."""
+        fuori = entry('fuori', sample_duration=1.0,
+                      grains=[grain(onset=2.0, pointer_pos=50.0)])
+        assert auto_target([fuori], 0.0, 10.0,
+                           hist_bins=(40, 16), defaults=DEFAULTS) is None
+
+    def test_a_stream_with_grains_in_range_still_wins(self):
+        """Controprova: con i grani dentro il range la lente si punta."""
+        dentro = entry('dentro', sample_duration=1.0,
+                       grains=[grain(onset=2.0, pointer_pos=0.5)])
+        target = auto_target([dentro], 0.0, 10.0,
+                             hist_bins=(40, 16), defaults=DEFAULTS)
+        assert target is not None
+        assert target.y == pytest.approx(0.5)

--- a/tests/rendering/test_page_layout.py
+++ b/tests/rendering/test_page_layout.py
@@ -154,26 +154,54 @@ class TestPaginate:
             [stream('a', 0.0, 10.0), stream('b', 95.0, 5.0)],
             page_duration=30.0)
         assert len(pages) == 4
-        assert pages[2].streams == []
+        assert pages[2].streams == ()
         assert pages[2].max_concurrent == 0
         assert pages[2].slots == {}
 
     def test_page_carries_its_streams_and_layout(self):
         a, b = stream('a', 0.0, 10.0), stream('b', 5.0, 10.0)
         page = paginate([a, b], page_duration=30.0)[0]
-        assert page.streams == [a, b]
+        assert page.streams == (a, b)
         assert page.max_concurrent == 2
         assert page.slots == {'a': 0, 'b': 1}
 
-    def test_concurrency_is_at_least_the_slots_used(self):
-        """Il numero di corsie e il picco di simultanei possono divergere: le
-        corsie si assegnano sull'intera estensione degli stream, i simultanei
-        si contano tagliati sulla pagina. La pagina deve riservare il maggiore
-        dei due, o due stream finirebbero disegnati nella stessa corsia."""
-        a = stream('a', 25.0, 10.0)    # 25-35, entra nella pagina 0
-        b = stream('b', 28.0, 10.0)    # 28-38, si sovrappone ad 'a'
-        page = paginate([a, b], page_duration=30.0)[1]
-        assert page.max_concurrent >= len(set(page.slots.values()))
+    def test_lanes_never_exceed_the_reserved_height(self):
+        """L'altezza riservata dalla pagina basta sempre alle corsie che le
+        servono. E' la sola cosa che il disegno chiede: se una corsia cadesse
+        fuori, due stream finirebbero sovrapposti.
+
+        Il conto tiene su una batteria di forme diverse — stream a cavallo dei
+        confini, catene che si toccano, grumi, pagine parziali — perche' le
+        corsie si assegnano sull'estensione intera e i simultanei si contano
+        tagliati sulla finestra: sono due misure diverse, e l'invariante lega
+        proprio loro due.
+        """
+        shapes = [
+            [('a', 0.0, 10.0), ('b', 5.0, 10.0)],
+            [('a', 25.0, 10.0), ('b', 28.0, 10.0)],            # a cavallo
+            [('a', 0.0, 10.0), ('b', 10.0, 10.0), ('c', 20.0, 10.0)],  # catena
+            [('a', 0.0, 40.0), ('b', 29.0, 3.0), ('c', 31.0, 3.0)],
+            [('a', 0.0, 5.0), ('b', 0.0, 5.0), ('c', 0.0, 5.0)],       # grumo
+            [('a', 55.0, 20.0), ('b', 58.0, 2.0), ('c', 59.0, 30.0)],
+        ]
+        for shape in shapes:
+            pages = paginate([stream(*s) for s in shape], page_duration=30.0)
+            for page in pages:
+                assert page.max_concurrent >= len(set(page.slots.values())), shape
+
+    def test_the_page_is_a_frozen_record(self):
+        """La pagina e' un record: chi la riceve la legge, non la ritocca.
+
+        `frozen` da solo blocca il riassegnamento del campo e non la scrittura
+        dentro il campo, quindi la sequenza degli stream e' una tuple: senza,
+        il record prometterebbe un'immutabilita' che non ha.
+        """
+        page = paginate([stream('a', 0.0, 10.0)], page_duration=30.0)[0]
+        assert isinstance(page.streams, tuple)
+        with pytest.raises(Exception):
+            page.streams = ()
+        with pytest.raises(AttributeError):
+            page.streams.append(stream('b'))
 
     def test_no_streams_is_an_error(self):
         """Impaginare il nulla non ha senso: meglio dirlo che produrre zero
@@ -216,7 +244,7 @@ class TestEnvelopeLanes:
         non aggiunge niente."""
         envelopes = {f'voice_pitch_offset__v{i}': object() for i in (1, 2, 3)}
         lanes, entries = envelope_lanes([(stream('s'), envelopes)])
-        assert lanes[0].env_types == ['voice_pitch_offset']
+        assert lanes[0].env_types == ('voice_pitch_offset',)
         assert [name for name, _, _ in entries] == ['voice_pitch_offset']
 
     def test_single_entry_sits_in_the_middle(self):
@@ -248,7 +276,7 @@ class TestEnvelopeLanes:
         legenda."""
         envelopes = {'volume': object(), 'density': object()}
         lanes, _ = envelope_lanes([(stream('s'), envelopes)])
-        assert lanes[0].env_types == ['density', 'volume']
+        assert lanes[0].env_types == ('density', 'volume')
 
 
 class TestLegendDisplayName:

--- a/tests/rendering/test_score_visualizer.py
+++ b/tests/rendering/test_score_visualizer.py
@@ -293,7 +293,7 @@ class TestGapPagePipeline:
         viz = make_viz(gap_scene(), config={'page_duration': 30.0})
         viz.analyze()
         # pagina centrale (30-60s) e' vuota
-        assert viz.page_layouts[1].streams == []
+        assert viz.page_layouts[1].streams == ()
 
     def test_gap_page_renders_without_error(self):
         viz = make_viz(gap_scene(), config={'page_duration': 30.0})

--- a/tests/rendering/test_visualizer_config.py
+++ b/tests/rendering/test_visualizer_config.py
@@ -182,3 +182,65 @@ class TestIsolation:
 
         targets[0]['t'] = 99.0
         assert published[0]['t'] == 1.0
+
+    def test_a_tuple_from_the_caller_is_not_aliased_either(self):
+        """La protezione non puo' dipendere dal contenitore che l'utente ha
+        scelto.
+
+        `magnify_targets` funziona anche come tupla — `resolve` ci itera
+        sopra — e se la copia si fermasse a dict/list/set, la stessa
+        configurazione sarebbe protetta o no a seconda che il chiamante abbia
+        scritto `[...]` o `(...)`, senza nessun segnale della differenza.
+        """
+        targets = ({'t': 1.0},)
+        published = VisualizerConfig.from_overrides(
+            {'magnify_targets': targets}).as_dict()['magnify_targets']
+
+        targets[0]['t'] = 99.0
+        assert published[0]['t'] == 1.0
+
+    def test_a_frozenset_filter_is_not_aliased_either(self):
+        """Stessa regola per `envelope_filter`, che accetta qualunque
+        collezione di nomi."""
+        published = VisualizerConfig.from_overrides(
+            {'envelope_filter': frozenset({'volume'})}).as_dict()
+        assert published['envelope_filter'] == frozenset({'volume'})
+
+    def test_a_colormap_object_still_travels_by_reference(self):
+        """Il limite della copia resta dove serve: un oggetto Colormap passato
+        dall'utente deve restare LO STESSO oggetto, perche' il visualizer lo
+        interroga e copiarlo sarebbe sprecato e sorprendente."""
+        sentinel = object()
+        published = VisualizerConfig.from_overrides(
+            {'grain_colormap': sentinel}).as_dict()
+        assert published['grain_colormap'] is sentinel
+
+
+class TestConfigMustBeAMapping:
+    """`config=` e' un parametro di un costruttore pubblico: quando non e' un
+    dizionario, l'errore deve dirlo.
+
+    Iterare una stringa da' i suoi caratteri, e un controllo di chiavi scritto
+    su `set(overrides)` li riporterebbe uno per uno come "chiavi sconosciute" —
+    un messaggio che descrive un problema che non esiste e nasconde quello che
+    c'e'.
+    """
+
+    def test_a_string_says_what_is_wrong(self):
+        with pytest.raises(TypeError) as excinfo:
+            VisualizerConfig.from_overrides('page_duration')
+        assert 'str' in str(excinfo.value)
+
+    def test_a_string_is_not_read_as_a_bag_of_characters(self):
+        with pytest.raises(TypeError) as excinfo:
+            VisualizerConfig.from_overrides('page_duration')
+        assert 'sconosciute' not in str(excinfo.value)
+
+    def test_a_list_says_what_is_wrong(self):
+        with pytest.raises(TypeError) as excinfo:
+            VisualizerConfig.from_overrides(['page_duration'])
+        assert 'list' in str(excinfo.value)
+
+    def test_none_is_still_the_empty_configuration(self):
+        """None resta il default: nessuno scarto, tutti i valori dichiarati."""
+        assert VisualizerConfig.from_overrides(None).as_dict()['page_duration'] == 30.0


### PR DESCRIPTION
Chiude i rilievi emersi dalla review della #174. Base sul branch della #174, non su `main`: tocca codice che esiste solo lì.

**Nessun cambiamento osservabile rispetto alla #174.** Verificato, non asserito: vedi in fondo.

---

## Quattro difetti

**Il tetto della cache delle silhouette non era il tetto vero.** `window_silhouette` ha un limite di 64 voci, ma leggeva da un `NumpyWindowRegistry` tenuto in una variabile di modulo — che ha una cache propria **senza eviction**, e che il refactor aveva promosso da attributo d'istanza a globale di processo. Il caso per cui il tetto esiste — chi rigenera le figure variando `window_shape_resolution` — continuava quindi ad accumulare un livello più giù, dove per giunta stanno gli array e non le chiavi, e non veniva più liberato con il visualizer che l'aveva riempito. Misurato: 200 risoluzioni distinte lasciano 200 array vivi, che sopravvivono al visualizer successivo.

Chi arriva a generare una finestra è già un miss della memoizzazione, quindi la cache del registry non serviva a nessuno: si costruisce per singolo miss e muore lì (`__init__` è un dizionario vuoto, le tabelle sono attributi di classe). Con il globale sparisce anche la sua corsa fra thread.

**Un valore fuori dominio dentro un `Parameter` faceva cadere l'intera estrazione.** `Parameter.__init__` non valida il proprio valore; leggerne le facce come `ParameterCurve` ha reso un `TypeError` quello che prima era una curva semplicemente saltata, e un solo parametro malformato si portava via tutte le altre curve dello stream — cioè la partitura, o la sessione Sonic Visualiser. Torna a essere dichiarata `absent`. `ParameterCurve.classify` resta stretta: **il dominio lo dichiara il value object, la tolleranza è di chi legge.** Dal YAML non ci si arriva (il factory rifiuta prima), ma `Parameter` è API pubblica.

**`config` non-dizionario dava un messaggio che descriveva un altro problema.** `ScoreVisualizer(gen, config='page_duration')` iterava la stringa carattere per carattere: `chiavi di configurazione sconosciute: _, a, d, e, g, i, n, o, p, r, t, u`. Ora è un `TypeError` che nomina il tipo.

**La copia della config dipendeva dal tipo di parentesi.** `_as_plain` copiava dict, list e set: `magnify_targets` passato come tupla di dizionari restava condiviso con il chiamante, la stessa cosa come lista veniva copiata — senza segnale della differenza. La copia comprende ora anche `tuple` e `frozenset`; un `Colormap` continua a viaggiare per riferimento.

## Codice morto, per lo stesso criterio delle nove

`envelope_extractor.get_voice_offset_envelopes` rimossa. Il criterio della #174 — «una delega si tiene se qualcuno la chiama» — vale un livello più giù: questa estrazione le ha portato via entrambi i chiamanti (`get_stream_envelopes` campiona direttamente da `VoiceManager`, e la delega del visualizer che la usava è fra le nove). Restava viva per **un import nella sua suite che non la chiamava**. Le stesse curve arrivano da `get_stream_envelopes(show_voice_offsets=True)`.

## Due rotture che mancavano nel CHANGELOG

- **Gli array di `window_silhouette` sono di sola lettura**, anche per la delega `ScoreVisualizer._window_silhouette` che prima ne restituiva di scrivibili. Nessun consumatore in-repo ci scrive.
- **I campi-sequenza dei record di layout sono tuple** (`PageLayout.streams`, `EnvelopeLane.env_types`): `frozen` blocca il riassegnamento del campo, non la scrittura dentro il campo. `PageLayout.slots` resta un dict — per un mapping è il tipo giusto, e l'unica alternativa di sola lettura in stdlib non è né copiabile né serializzabile — quindi lì l'immutabilità è una convenzione dichiarata nella docstring.

## I test che mancavano

Sette regole centrali non erano tenute ferme da niente: perturbarle lasciava la suite verde. Ognuna ora ha un test, e ogni test è stato validato **rimettendo la mutazione** e verificando che diventi rosso.

| Regola | Dove |
|---|---|
| La costante appiattita copre `[0, stream.duration]` | l'unico punto che ha bisogno della durata, e la ragione per cui `ParameterCurve` non la conosce |
| Una sorgente grezza numerica non pubblica una chiave di probabilità che non ha | `grain_envelope: 3` produrrebbe `grain_envelope_prob`, fuori da `ENVELOPE_COLORS` |
| La testa della freccia occupa metà della lunghezza | l'unico numero della forma che non discende da onset/durata |
| Il ramo in cent non si sfiora con ratio zero | il test esistente passava per la ragione sbagliata: su `0.5-2.0` entrambi i rami danno `0.0` dopo il clamp |
| A parità di grani vince il primo stream | con un confronto largo l'ordine degli stream nel file sposterebbe la lente |
| Il floor sull'altezza del sample | una durata nulla o negativa non deve propagarsi dentro numpy |
| `display_ranges` esclude `pan` sul nome **base** | senza, `pan__v1` avrebbe un range data-driven mentre `normalize` lo tratta da ciclico: curva disegnata su una scala diversa da quella con cui è stata misurata |

## Tre cose che la review aveva inquadrato male

Vale la pena dirlo perché due erano segnalate come buchi di copertura, e non lo sono: sono **codice difensivo la cui condizione non si può raggiungere**, quindi nessun test le può tenere ferme. Documentate dove stanno, come la #174 fa già per il ramo "range degenere".

1. **`max(simultanei, corsie)` in `paginate` non sceglie mai.** `assign_slots` è il greedy per onset crescente, che su intervalli usa esattamente tante corsie quanti sono gli stream mutuamente sovrapposti; e due stream entrambi attivi in pagina che si sovrappongono continuano a sovrapporsi anche tagliati sulla finestra, quindi quel grumo lo conta pure la sweep line. Ricerca su 400.000 configurazioni casuali: nessun controesempio. Il massimo resta scritto perché l'uguaglianza dipende da come `paginate` chiama `assign_slots`, non da una proprietà delle due funzioni. Il commento diceva che le due misure "possono divergere": corretto. Al suo posto il test pina l'invariante che conta — che l'altezza riservata basti alle corsie — su una batteria di forme.
2. **La guardia sul bin vuoto in `auto_target` è irraggiungibile.** Il ricontrollo dei grani nel bin è inclusivo su entrambi gli estremi, quindi più largo del binning di numpy: un punto contato ci ricade dentro per forza. Resta per l'ULP fra l'aritmetica di numpy e la nostra.
3. **Le due uscite di `auto_target` si coprono a vicenda.** Quando l'istogramma non conta niente anche il ricontrollo trova la lista vuota: a test si osserva solo il risultato comune, cioè che lo stream viene saltato.

## Minori

`float | None` → `Optional[float]` in `magnifier_targets`: il progetto dichiara Python >= 3.9, dove l'unione con `|` non è valutabile, e lì la salvava solo il `__future__` import finché nessuno risolve le annotazioni — `typing.get_type_hints` la romperebbe, e 3.9 è nella matrice CI. Rinominato il parametro di `_default_of`, che ombreggiava `dataclasses.field`. La cache globale delle silhouette ora si ripulisce con una fixture in entrambe le direzioni: era l'unico stato di processo che quella suite lasciava sporco.

---

## Verifica

La rete di caratterizzazione della #174 era stata cancellata prima dell'apertura. Ne è stata ricostruita una da fuori, in due strati, e usata qui:

- **numerica** — `Generator` reale su tutte e 27 le config di `configs/`, sample silenziosi in tmpdir, seed fisso, `PYTHONHASHSEED=0`, 4 varianti di config del visualizer = 108 run per ramo. Cattura `page_layouts`, corsie e legenda coi nomi visualizzati, `display_ranges`, la normalizzazione sondata su 7 punti per curva, i vertici di freccia e silhouette, colore RGBA e alpha per grano, `cents_range`, i `MagnifyTarget` risolti su 6 spec incluse quelle sui confini, e `get_stream_envelopes` in 5 varianti con **ordine delle chiavi** e tipo Python di ogni breakpoint;
- **figura** — 28 pagine renderizzate davvero, con gli artisti matplotlib serializzati (patch, linee, collection, testi, limiti e posizione di ogni asse), incluse `magnify_auto` con target espliciti e `font_scale`.

Controllo di determinismo: due processi separati sullo stesso commit danno un diff a zero byte.

| Confronto | Risultato |
|---|---|
| questo branch vs **#174** | **0 differenze**, su entrambi gli strati |
| questo branch vs **`main`** | identico alla #174: residuo **0** oltre alle tre categorie già dichiarate lì (tipo `int`→`float` delle costanti appiattite, merge profondo di `pitch_color_autozoom`) |

`make tests`: **5309 passed, 2 skipped** (da 5281). `docs-lint`: verde. Le tre `TestSamplesDirConfig` che falliscono lanciando `test_score_visualizer.py` da solo sono la #182, invariate rispetto a `main`; nessuna nuova dipendenza d'ordine — verificata la matrice completa di ogni suite nuova prima, dopo e senza `test_score_visualizer.py`.

## Cosa resta aperto

- **Il bump del submodule nel repo del paper CIM 2026** e la verifica del rifiuto delle chiavi sconosciute su `paper/examples/render_example.py`: quel repository non è in questa sessione. Resta la precondizione già dichiarata dalla #174.
- **`[Unreleased]` deve diventare un major**: le rotture dichiarate sono ora quattro, e v6.0.0 è appena uscita.
- **Range degeneri** (`volume_range` con estremi uguali → `ZeroDivisionError` in `volume_alpha`; `cents_range` degenere → `RuntimeWarning` in `pitch_position`): comportamento **identico a `main`**, quindi non introdotto dalla #174 e lasciato fuori per non aggiungere una divergenza a una PR che ne ha zero.

## Impatto cross-repo

**Nessuno su PGE-ls e PGE-ui.** Non cambiano sintassi YAML, bounds, nomi di strategy/window/renderer, gerarchia errori, flag CLI né formati di output. Le chiavi pubblicate dall'estrattore sono bit-identiche, verificate sulle 27 config. Niente issue da aprire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UJqoGmQNSLnf1woTUDE8F


---
_Generated by [Claude Code](https://claude.ai/code/session_013UJqoGmQNSLnf1woTUDE8F)_