### PR TITLE
refactor(parameters): rimuove _get_caller, codice morto in parameter_factory.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,10 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   `tests/rendering/test_envelope_extractor.py` passa da 11 a 75 test,
   `test_score_visualizer.py` da 181 a 129 (resta il disegno).
 
+- Rimosso `ParameterFactory._get_caller`: diagnostica di sviluppo che
+  ricostruiva il chiamante con `inspect` e che nessuno invocava. Con lei se ne
+  va l'import `inspect`, che nel modulo serviva solo a questo.
+
 ---
 
 ## [v6.0.0] — "Range Anchor" — 2026-07-30

--- a/src/pge/parameters/parameter_factory.py
+++ b/src/pge/parameters/parameter_factory.py
@@ -18,7 +18,6 @@ from typing import Any
 from pge.parameters.parameter import Parameter
 from pge.parameters.parser import GranularParser
 from pge.parameters.parameter_schema import ParameterSpec
-import inspect
 
 class ParameterFactory:
     """
@@ -144,12 +143,6 @@ class ParameterFactory:
                 return default
         
         return current
-
-    def _get_caller(self):   
-        frame = inspect.currentframe().f_back
-        caller_info = inspect.getframeinfo(frame)
-        return f"{caller_info.function}:{caller_info.lineno}"
-    
 
     def __repr__(self) -> str:
         return f"ParameterFactory(stream_id='{self._stream_id}')"


### PR DESCRIPTION
Closes #176

## Cosa cambia

`ParameterFactory._get_caller` ricostruiva il chiamante con `inspect` e lo restituiva come `"funzione:riga"`. Era diagnostica di sviluppo: `grep -rn "_get_caller"` su tutto il repo (sorgenti, test, docs) trova solo la definizione, nessuna chiamata. Rimosso insieme all'import `inspect`, che nel modulo serviva unicamente a questo.

`parameter_factory.py`: 155 -> 148 righe.

## Verifica

`make tests`: 5313 passed, 2 skipped, 77 deselected — stesso conteggio del baseline su `main`, nessun test toccava il metodo.

## Impatto cross-repo

Nessuno. Il metodo era privato, senza chiamanti, e non compare in nessuna superficie osservabile da PGE-ls o PGE-ui (YAML, bounds, errori, CLI, formati). Nessuna issue aperta nei repo a valle.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbCXo7dFoikbhZTrrWWu5t)_