### PR TITLE
docs(architecture): il conteggio dei test diventa il comando che lo produce

### DIFF
--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -193,6 +193,13 @@ Gli altri file sotto `tests/e2e/` coprono export e pulizia REAPER
 (`test_engine_errors_e2e.py`) e il sidecar JSON dei grani
 (`test_grain_json_e2e.py`).
 
+Un test `e2e` sta fuori da quella cartella, ed è il motivo per cui il comando di
+conteggio dà un numero più alto dei file elencati qui: è
+`test_editable_install_in_clean_venv` in `tests/test_package_layout.py`, che
+crea un venv pulito, ci installa il pacchetto in editable e importa `pge` da
+fuori dal repo. Il marker segue quello che il test fa, non la cartella in cui
+sta.
+
 **Note semantica onset:**
 - Csound/NumPy STEMS: onset relativi allo stream (onset=0 nel file)
 - Csound/NumPy MIX: onset assoluti, stream posizionati nel tempo

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -6,7 +6,7 @@ tags: [architecture, rendering, ocp]
 sources:
   - src/pge/rendering/
   - src/main.py
-last_synced_commit: d750ba6
+last_synced_commit: 1aba65c
 ---
 
 # Architettura Renderer
@@ -169,14 +169,29 @@ Sequenza e invarianti:
 
 ### Copertura test
 
-| Layer | Strumento | Conteggio |
-|-------|-----------|-----------|
-| Unit (mock) | `pytest` / `make tests` | 4149 test |
-| E2E | `pytest -m e2e` / `make e2e-tests` | 24 test |
+| Layer | Come si lancia | Come si conta |
+|-------|----------------|---------------|
+| Unit (mock) | `make tests` | riga finale di `make tests` |
+| E2E | `make e2e-tests` | `pytest -m e2e --collect-only -q` |
 
-**E2E Csound** (`tests/e2e/test_cache_e2e.py`, 15 test): pipeline `make → Python → Csound → filesystem` in `STEMS=true CACHE=true`. Copre first build, incremental, partial rebuild, garbage collection.
+Qui non c'è un numero: il conteggio dei test cambia a ogni PR e `make docs-lint`
+non può verificarlo, quindi un numero scritto a mano è drift garantito (è
+esattamente come è nata l'issue #179). I due comandi della colonna destra danno
+la cifra aggiornata in un secondo.
 
-**E2E NumPy** (`tests/e2e/test_numpy_renderer_e2e.py`, 9 test): pipeline `make → Python → NumPy → filesystem`, no Csound. Copre stems, mix, rendering multi-processo (`JOBS`) intra-stream e a livello di stream (stem byte-identici a `JOBS=1`, cache clean).
+Il marker `e2e` è deselezionato di default (`addopts = -m "not e2e"` in
+`pytest.ini`): `make tests` esegue il layer unit e riporta gli e2e come
+`deselected`.
+
+**E2E Csound** (`tests/e2e/test_cache_e2e.py`): pipeline `make → Python → Csound → filesystem` in `STEMS=true CACHE=true`. Copre first build, incremental, partial rebuild, garbage collection.
+
+**E2E NumPy** (`tests/e2e/test_numpy_renderer_e2e.py`): pipeline `make → Python → NumPy → filesystem`, no Csound. Copre stems, mix, rendering multi-processo (`JOBS`) intra-stream e a livello di stream (stem byte-identici a `JOBS=1`, cache clean).
+
+Gli altri file sotto `tests/e2e/` coprono export e pulizia REAPER
+(`test_reaper_export_e2e.py`, `test_reaper_makefile_e2e.py`,
+`test_clean_rpp_e2e.py`), gli errori dell'engine end-to-end
+(`test_engine_errors_e2e.py`) e il sidecar JSON dei grani
+(`test_grain_json_e2e.py`).
 
 **Note semantica onset:**
 - Csound/NumPy STEMS: onset relativi allo stream (onset=0 nel file)


### PR DESCRIPTION
Closes #179

## La scelta

L'issue lasciava aperta la domanda: correggere il numero o sostituirlo con il comando. Ho scelto **il comando**. Un numero che `make docs-lint` non sa verificare e che cambia a ogni PR e' drift garantito: correggerlo da 4149 a 5313 vuol dire solo riaprire la stessa issue fra qualche settimana.

## Cosa cambia

`docs/explanation/architecture.md`, sezione "Copertura test":

- la colonna `Conteggio` diventa `Come si conta` — riga finale di `make tests` per il layer unit, `pytest -m e2e --collect-only -q` per gli e2e;
- una nota spiega perche' li' non c'e' un numero, citando questa issue come precedente;
- aggiunta la nota che `pytest.ini` ha `addopts = -m "not e2e"`, quindi `make tests` riporta gli e2e come `deselected` (oggi 77) invece di eseguirli.

Tolti anche i conteggi per-file nella prosa, che avevano lo stesso difetto: `test_numpy_renderer_e2e.py` era dichiarato "9 test", ne ha 17. E aggiunta una riga sugli altri cinque file sotto `tests/e2e/` (export e pulizia REAPER, errori engine, sidecar JSON dei grani), che il documento non nominava affatto.

`last_synced_commit`: `d750ba6` -> `1aba65c`.

## Numeri verificati (per il record, non nel doc)

| Layer | Valore dichiarato prima | Valore reale |
|-------|------------------------|--------------|
| Unit | 4149 | 5313 passed, 2 skipped |
| E2E | 24 | 77 |
| `test_numpy_renderer_e2e.py` | 9 | 17 |
| `test_cache_e2e.py` | 15 | 15 (l'unico ancora giusto) |

## Verifica

- `make docs-lint`: `docs-lint: OK (19 docs)`
- `make docs-index`: nessuna modifica a `INDEX.md` (le chiavi indicizzate non cambiano)
- `make tests`: 5313 passed, 2 skipped, 77 deselected

## Fuori scope, ma rilevato

Nello stesso file, "Platform notes" dichiara `Python: 3.12+`, mentre `pyproject.toml` ha `requires-python = ">=3.9"` e `make/test.mk` cerca da 3.9 in su. Non l'ho toccato perche' l'issue nomina due punti verificati e questo non e' fra quelli; vale una issue separata se lo si vuole allineare.

## Impatto cross-repo

Nessuno. Modifica di sola documentazione interna: nessuna superficie YAML, bounds, errori, CLI o formati cambia, quindi niente da aggiornare in PGE-ls o PGE-ui. Nessuna issue aperta nei repo a valle.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbCXo7dFoikbhZTrrWWu5t)_