### PR TITLE
fix(rendering): il catalogo delle finestre è uno, non due

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,24 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Corretto
 
+- **`grain: {envelope: triangle}` passava la validazione e poi esplodeva al
+  render.** Il catalogo delle finestre esisteva due volte: `WindowRegistry`,
+  che decide quali nomi lo YAML può scrivere (alias compresi), e
+  `NumpyWindowRegistry`, che teneva un proprio elenco indipendente di nomi
+  generabili. I due erano già divergenti su `triangle` — alias documentato di
+  `bartlett` in [docs/reference/yaml.md](docs/reference/yaml.md) — che il
+  renderer Csound accettava e quello NumPy, cioè il default, rifiutava con
+  `InvalidWindowError`. Stesso buco sulla partitura: la silhouette del grano
+  con `grain_shape='window'` passa dallo stesso registry. Ora il catalogo è
+  uno solo: `WindowRegistry.canonical()` risolve gli alias, e
+  `NumpyWindowRegistry` è l'adapter che materializza in array il nome
+  canonico, senza tenere un secondo elenco di cosa sia valido. Alias e nome
+  canonico condividono la voce di cache invece di duplicare l'array, e
+  `available_windows()` — la lista che finisce nel messaggio d'errore — elenca
+  ciò che l'utente può davvero scrivere. La divergenza non può tornare senza
+  far fallire il parity test in
+  `tests/rendering/test_numpy_window_registry.py::TestCatalogueParity`.
+
 - **Il tetto della cache delle silhouette non era il tetto vero.**
   `window_silhouette` ha un limite di 64 voci, ma leggeva da un
   `NumpyWindowRegistry` tenuto in una variabile di modulo — che ha una cache

--- a/docs/how-to/add-window-function.md
+++ b/docs/how-to/add-window-function.md
@@ -5,7 +5,8 @@ status: stable
 tags: [window, grain, extension]
 sources:
   - src/pge/controllers/window_registry.py
-last_synced_commit: 8c896d8
+  - src/pge/rendering/numpy_window_registry.py
+last_synced_commit: 5b3ab25
 entry_for: [add-window-function]
 ---
 
@@ -18,32 +19,53 @@ Vuoi aggiungere una nuova forma di finestra grain (es. tukey, kaiser custom, exp
 ## Prerequisiti
 
 - Funzione numpy `f(N) -> np.ndarray` di lunghezza N, valori in `[0, 1]`
-- Verificare che il nome non collida con quelli già registrati (vedi `WindowRegistry.WINDOW_FUNCTIONS`)
+- Verificare che il nome non collida con quelli già registrati (vedi `WindowRegistry.WINDOWS` e `WindowRegistry.ALIASES`)
 - Conoscenza Window Registry pre-registrato a Stream init (vedi nota implementazione in `CLAUDE.md`)
 
 ## Prerequisiti aggiuntivi (Csound)
 
 Se la finestra deve essere usata dal renderer Csound: la `FtableManager` numera le ftable in base all'ordine del registro — non lazy-registrare.
 
+## Il catalogo è uno, gli adapter sono due
+
+`WindowRegistry` è il **catalogo**: decide quali nomi lo YAML può scrivere
+(canonici in `WINDOWS`, alias in `ALIASES`) e qual è il nome canonico di
+ciascuno. Chi materializza la finestra è un adapter del catalogo:
+
+| Adapter | Cosa produce | Dove |
+|---------|--------------|------|
+| Csound | statement `f` (GEN16/GEN20) | `WindowRegistry.generate_ftable_statement` |
+| NumPy | array `np.ndarray` di lunghezza N | `NumpyWindowRegistry._generate` |
+
+Aggiungere una finestra al solo catalogo la rende **accettata dalla
+validazione YAML e non renderizzabile** dal renderer NumPy, che è il default:
+il nome esplode a render time con `InvalidWindowError`. È quello che è successo
+all'alias `triangle`. Il parity test citato sotto è la guardia che lo impedisce
+— eseguilo, non fidarti della lettura.
+
 ## Passi
 
-1. Definisci la funzione in `src/pge/controllers/window_registry.py`
-2. Aggiungi entry a `WindowRegistry.WINDOW_FUNCTIONS` (chiave = nome usato in YAML)
+1. Definisci la `WindowSpec` in `src/pge/controllers/window_registry.py` e aggiungi la entry a `WindowRegistry.WINDOWS` (chiave = nome usato in YAML); se serve un sinonimo, aggiungilo a `WindowRegistry.ALIASES`
+2. Aggiungi il generatore NumPy in `src/pge/rendering/numpy_window_registry.py`: la entry nel dict giusto (`_NUMPY_WINDOWS`, `_GEN16_WINDOWS`) oppure un ramo in `_generate` con il suo metodo statico
 3. Aggiungi test unit verificando shape, range, simmetria (se attesa)
-4. Aggiorna [[yaml]] § Finestre Disponibili con il nuovo nome
+4. Verifica la parità catalogo/adapter (vedi § Test da aggiornare): il nome nuovo dev'essere generabile, non solo valido
+5. Aggiorna [[yaml]] § Finestre Disponibili con il nuovo nome
 
 ## File toccati
 
 | Path | Tipo |
 |------|------|
-| `src/pge/controllers/window_registry.py` | aggiunta funzione + entry registry |
-| `tests/controllers/test_window_registry.py` | nuovi test |
+| `src/pge/controllers/window_registry.py` | nuova `WindowSpec` + entry catalogo (ed eventuale alias) |
+| `src/pge/rendering/numpy_window_registry.py` | generatore dell'array per il renderer NumPy |
+| `tests/controllers/test_window_registry.py` | nuovi test catalogo |
+| `tests/rendering/test_numpy_window_registry.py` | nuovi test forma array |
 | `docs/reference/yaml.md` | elenco finestre aggiornato |
 
 ## Test da aggiornare
 
 - Test forma window (lunghezza, range, simmetria)
 - Test integrazione con `grain: {envelope: <nome>}`
+- `tests/rendering/test_numpy_window_registry.py::TestCatalogueParity` — parità fra catalogo e adapter NumPy: passa da sé se hai fatto il passo 2, fallisce se hai toccato solo il catalogo
 
 ## Verifica
 

--- a/src/pge/controllers/window_registry.py
+++ b/src/pge/controllers/window_registry.py
@@ -158,10 +158,23 @@ class WindowRegistry:
     }
     
     @classmethod
+    def canonical(cls, name: str) -> Optional[str]:
+        """Nome canonico di `name`, risolti gli alias. None se il catalogo
+        non conosce il nome.
+
+        E' il punto in cui un alias smette di essere tale: chi materializza
+        una finestra (statement Csound, array NumPy) passa di qui e lavora
+        sempre sul nome canonico, cosi' i due adapter non possono divergere
+        su quali nomi lo YAML puo' scrivere.
+        """
+        resolved_name = cls.ALIASES.get(name, name)
+        return resolved_name if resolved_name in cls.WINDOWS else None
+
+    @classmethod
     def get(cls, name: str) -> Optional[WindowSpec]:
         """Ottieni specifica envelope (gestisce alias)."""
-        resolved_name = cls.ALIASES.get(name, name)
-        return cls.WINDOWS.get(resolved_name)
+        resolved_name = cls.canonical(name)
+        return cls.WINDOWS.get(resolved_name) if resolved_name else None
     
     @classmethod
     def all_names(cls) -> List[str]:

--- a/src/pge/rendering/numpy_window_registry.py
+++ b/src/pge/rendering/numpy_window_registry.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 import numpy as np
 from typing import Dict, List, Tuple
 
+from pge.controllers.window_registry import WindowRegistry
+
 
 class NumpyWindowRegistry:
     """
@@ -82,25 +84,33 @@ class NumpyWindowRegistry:
             from pge.shared.exceptions import InvalidWindowError
             raise InvalidWindowError(param="n", value=n)
 
-        key = (name, n)
+        # Il catalogo (WindowRegistry) decide quali nomi lo YAML puo' scrivere
+        # e quale sia il nome canonico di ciascuno: qui si generano array, non
+        # si tiene un secondo elenco di nomi validi. Canonicalizzare prima
+        # della cache fa condividere l'array fra alias e nome canonico.
+        canonical = WindowRegistry.canonical(name)
+        if canonical is None:
+            from pge.shared.exceptions import InvalidWindowError
+            raise InvalidWindowError(name=name, available=self.available_windows())
+
+        key = (canonical, n)
         if key in self._cache:
             return self._cache[key]
 
-        window = self._generate(name, n)
+        window = self._generate(canonical, n)
         self._cache[key] = window
         return window
 
     def available_windows(self) -> List[str]:
-        """Lista dei nomi di finestra disponibili."""
-        names = list(self._NUMPY_WINDOWS.keys())
-        names.append('kaiser')
-        names.append('gaussian')
-        names.append('blackman_harris')
-        names.extend(self._GEN16_WINDOWS.keys())
-        names.append('half_sine')
-        names.append('rectangle')
-        names.append('sinc')
-        return names
+        """Nomi di finestra scrivibili nello YAML, alias compresi.
+
+        Viene dal catalogo, non da un elenco locale: e' la lista che finisce
+        nel messaggio d'errore quando un nome non esiste, e deve dire cosa
+        l'utente puo' scrivere. Che il catalogo sia integralmente
+        materializzabile in array e' garantito dal parity test in
+        tests/rendering/test_numpy_window_registry.py.
+        """
+        return WindowRegistry.all_names()
 
     def __len__(self) -> int:
         """Numero di entry attualmente in cache."""

--- a/tests/rendering/test_grain_visuals.py
+++ b/tests/rendering/test_grain_visuals.py
@@ -129,6 +129,15 @@ class TestWindowSilhouette:
         assert w.max() == pytest.approx(1.0)
         assert w.min() >= 0.0
 
+    def test_alias_name_has_a_silhouette(self):
+        """La partitura disegna la finestra col nome scritto nello YAML: se
+        quello e' un alias (`triangle`), la silhouette deve esistere lo stesso.
+        Secondo consumatore del catalogo dopo il renderer numpy."""
+        xs_alias, w_alias = window_silhouette('triangle', 64)
+        xs_canon, w_canon = window_silhouette('bartlett', 64)
+        assert len(w_alias) == 64
+        assert list(w_alias) == list(w_canon)
+
     def test_same_shape_is_computed_once(self):
         """Stesso nome e stessa risoluzione: stessa curva, senza ricalcolarla."""
         a = window_silhouette('hanning', 32)

--- a/tests/rendering/test_numpy_window_registry.py
+++ b/tests/rendering/test_numpy_window_registry.py
@@ -530,3 +530,46 @@ class TestSmallWindows:
         registry = NumpyWindowRegistry()
         for n in (1, 2, 3):
             assert np.all(registry.get('rectangle', n) == 1.0)
+
+
+# =============================================================================
+# PARITA' COL CATALOGO (WindowRegistry)
+# =============================================================================
+
+class TestCatalogueParity:
+    """Il catalogo delle finestre e' uno solo: WindowRegistry dice quali nomi
+    lo YAML puo' scrivere, questo registry e' l'adapter che li materializza in
+    array. Se i due divergono, un nome accettato dalla validazione esplode al
+    momento del render."""
+
+    def test_triangle_alias_renders_as_bartlett(self, registry):
+        """`triangle` e' l'alias documentato di `bartlett`: il renderer numpy
+        deve produrre la stessa finestra, non un errore."""
+        assert np.array_equal(registry.get('triangle', 64),
+                              registry.get('bartlett', 64))
+
+    def test_every_catalogue_name_is_renderable(self, registry):
+        """Guardia anti-drift: ogni nome che la validazione YAML accetta deve
+        produrre un array. Finche' i due elenchi erano indipendenti, `triangle`
+        passava la validazione e poi esplodeva al render con RENDERER=numpy."""
+        from pge.controllers.window_registry import WindowRegistry
+
+        for name in WindowRegistry.all_names():
+            window = registry.get(name, 128)
+            assert len(window) == 128, name
+            assert np.all(np.isfinite(window)), name
+
+    def test_alias_and_canonical_share_one_cache_entry(self, registry):
+        """`triangle` e `bartlett` sono la stessa finestra: una sola voce in
+        cache, non due array identici."""
+        registry.get('bartlett', 64)
+        registry.get('triangle', 64)
+        assert len(registry) == 1
+
+    def test_available_windows_are_the_catalogue_names(self, registry):
+        """`available_windows()` e' cio' che finisce nel messaggio d'errore di
+        un nome sbagliato: deve elencare i nomi scrivibili nello YAML, alias
+        compresi, non l'elenco privato dei generatori."""
+        from pge.controllers.window_registry import WindowRegistry
+
+        assert set(registry.available_windows()) == set(WindowRegistry.all_names())


### PR DESCRIPTION
## Il difetto

`grain: {envelope: triangle}` passava la validazione e poi esplodeva al render.

`triangle` è l'alias documentato di `bartlett` (`docs/reference/yaml.md` § Finestre Disponibili). La catena:

1. `WindowController.parse_window_list` valida contro `WindowRegistry.all_names()`, che include gli alias → il nome passa;
2. `FtableManager.register_window` risolve l'alias per validare ma memorizza il nome **grezzo** nel `table_map`;
3. il renderer NumPy lo rilegge da lì (`numpy_audio_renderer._resolve_window_name`) e lo passa a `NumpyWindowRegistry.get`, che teneva un proprio elenco indipendente di nomi generabili — senza `triangle`.

Risultato: `InvalidWindowError: Finestra 'triangle' non trovata` con `RENDERER=numpy`, che è il default. Con Csound funzionava. Stesso buco sulla partitura: `grain_visuals.window_silhouette` passa dallo stesso registry, quindi con `grain_shape='window'` la silhouette di uno stream su `triangle` faceva cadere il disegno.

La causa non è il nome mancante: è che il catalogo delle finestre esisteva **due volte**, con due elenchi liberi di divergere. E infatti avevano già divergiuto.

## La modifica

Un catalogo, due adapter.

- `WindowRegistry` resta il catalogo: decide quali nomi lo YAML può scrivere e qual è il nome canonico di ciascuno. Nuovo `canonical(name)`, che è il punto in cui un alias smette di essere tale; `get()` ci passa attraverso.
- `NumpyWindowRegistry` diventa l'adapter che materializza in array il nome canonico, e smette di avere opinioni proprie su cosa sia valido. `available_windows()` viene dal catalogo — è la lista che finisce nel messaggio d'errore di un nome sbagliato, e deve dire cosa l'utente può davvero scrivere.
- Canonicalizzare prima della cache fa condividere la voce fra alias e nome canonico, invece di tenere due array identici.

Non ho toccato `FtableManager`: canonicalizzare anche lì cambierebbe il contenuto del `table_map`, che è struttura osservabile, e non serve al fix. Conseguenza nota e lasciata com'era: `triangle` e `bartlett` citati nello stesso YAML allocano due ftable Csound identiche.

## Test

Cinque test nuovi, tutti verificati rossi senza il fix e verdi con:

- `TestCatalogueParity::test_triangle_alias_renders_as_bartlett` — il comportamento richiesto;
- `TestCatalogueParity::test_every_catalogue_name_is_renderable` — **la guardia**: ogni nome che la validazione accetta deve produrre un array. È il test che avrebbe intercettato questa divergenza il giorno in cui è nata;
- `TestCatalogueParity::test_alias_and_canonical_share_one_cache_entry`;
- `TestCatalogueParity::test_available_windows_are_the_catalogue_names`;
- `TestWindowSilhouette::test_alias_name_has_a_silhouette` — il secondo consumatore, la partitura.

`TestSmallWindows::test_all_windows_small_n`, che itera `available_windows()`, ora copre da sé anche gli alias a n ∈ {1,2,3}.

Suite completa: **5326 passed, 2 skipped, 77 deselected** (i 2 skip sono preesistenti, `refs/` vuota in questo checkout; i deselected sono i marker `e2e` che richiedono csound). Baseline prima della modifica: 5321 passed.

## Documentazione

`docs/how-to/add-window-function.md` elencava fra i "File toccati" il solo `window_registry.py`: chi seguiva la procedura aggiungeva una finestra che il renderer di default non sapeva disegnare. È il modo in cui questa divergenza è potuta nascere, quindi il how-to è parte del fix, non un contorno. Ora dichiara la forma vera — un catalogo, due adapter — e chiede esplicitamente il generatore NumPy e il parity test.

Corretto anche `WindowRegistry.WINDOW_FUNCTIONS`, attributo citato dal doc e inesistente nel codice: il catalogo sta in `WINDOWS` e `ALIASES`.

`docs/reference/yaml.md` non cambia: diceva già la cosa giusta, che dopo questa PR è vera su entrambi i renderer.

## Impatto cross-repo

Nessuna issue aperta: **PGE-ls e PGE-ui erano già allineati, era PGE a non esserlo.**

- `PGE-ls` mirrora `triangle` fra i `grain.envelope` validi (`granular_ls/schema_bridge.py`, con commento che rimanda a `WindowRegistry.ALIASES`), e il suo `tests/test_pge_parity.py` legge `all_names()` dal sorgente PGE reale. Questa PR non cambia `all_names()`, quindi quel test resta verde.
- `PGE-ui` offre `triangle` nell'`EnvelopeSelector`, con tanto di curva di anteprima.

Entrambi, cioè, proponevano all'utente un nome che il renderer di default rifiutava. Nessuna chiave YAML nuova, nessun bound cambiato, nessuna classe d'errore nuova.

## Paper CIM 2026

Nessun bump del submodule proposto: la modifica non è osservabile dagli esempi. Un esempio che oggi renderizza non usa `triangle` (sarebbe fallito), quindi il suo output resta byte-identico; la PR trasforma un errore in un render, non cambia un render esistente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGbVnYdq91hHKRnN6x6ehs

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGbVnYdq91hHKRnN6x6ehs)_