### PR TITLE
fix(rendering): la superficie di lettura di Stream diventa un contratto verificato, e la densità reale arriva sulla partitura

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,16 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   come i loop, il pointer no. La reference ora dice che `start` è scalare, e
   mantiene separata la semantica di unità, che invece condivide.
 
+- **`pointer.start` con un envelope ora viene rifiutato, non più a valle.**
+  Chi ci scriveva un envelope — seguendo la reference, che fino a ieri glielo
+  prometteva — vedeva lo `Stream` costruirsi senza un lamento e poi morire
+  dentro la generazione dei grani con `TypeError: can only concatenate list
+  (not "float") to list`: un messaggio che non nomina il campo e non dice cosa
+  correggere. `PointerController` ora lo ferma in inizializzazione con un
+  `InvalidFieldValueError` su `pointer.start`, con lo stream_id e un hint che
+  indica le due strade vere per far variare la posizione di lettura nel tempo
+  (`pointer.speed_ratio`, o un loop mobile con `loop_start` come envelope).
+
 - **Il tetto della cache delle silhouette non era il tetto vero.**
   `window_silhouette` ha un limite di 64 voci, ma leggeva da un
   `NumpyWindowRegistry` tenuto in una variabile di modulo — che ha una cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,25 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Corretto
 
+- **`pointer_speed_ratio` prometteva una curva che nessuno ha mai visto.**
+  Chi legge uno `Stream` per disegnarlo — partitura, export Sonic Visualiser,
+  `--plot-envelopes` — lo interroga per nome a runtime, con
+  `getattr(stream, name, None)`. Il default `None` fa sì che un nome
+  inesistente non sollevi ma produca una curva assente, indistinguibile da un
+  parametro non configurato: una curva può sparire dall'insieme pubblicato, o
+  entrarci, senza che niente fallisca. Costruendo `Stream` reali su tre
+  configurazioni che coprono ogni gruppo esclusivo, 25 chiavi pubblicate su 28
+  risolvono. `pointer_speed_ratio` è il nome di schema di una curva già
+  pubblicata come `pointer_speed`: una seconda chiave che `getattr` non ha mai
+  potuto risolvere, ora esclusa esplicitamente. Le altre due che non risolvono
+  — `pointer_start` ed `effective_density` — restano dichiarate nella guardia
+  con il loro motivo, perché pubblicarle richiede una decisione di dominio
+  (issue #199). La guardia è
+  `tests/rendering/test_envelope_extractor.py::TestPublishedSurfaceResolves`:
+  verifica l'uguaglianza nei due sensi, quindi né una chiave viva può morire
+  in silenzio né una dichiarata morta può restare nella lista dopo essere
+  tornata viva.
+
 - **Il tetto della cache delle silhouette non era il tetto vero.**
   `window_silhouette` ha un limite di 64 voci, ma leggeva da un
   `NumpyWindowRegistry` tenuto in una variabile di modulo — che ha una cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Aggiunto
 
+- **La densità reale arriva sulla partitura.** `fill_factor` da solo non dice
+  quanti grani al secondo si stanno ascoltando: la densità vera è
+  `fill_factor(t) / grain_duration(t)`, un quoziente che il motore calcolava a
+  ogni onset senza conservarlo da nessuna parte. `effective_density` esisteva
+  già come nome — con il suo colore in `ENVELOPE_COLORS`, la sua etichetta in
+  `page_layout` e il suo range Y in `visualizer_config` — ma nessuno la
+  calcolava, quindi la curva non arrivava mai e `--plot-envelopes
+  effective_density` era un filtro che non produceva niente. Ora
+  `DensityController.density_curve()` la campiona, sul modello di
+  `VoiceManager.offset_curves()`: il campionamento sta accanto alla strategy
+  che possiede formula e clamp, non nel visualizer. È la densità della **voce
+  0**, quella che definisce il `sync_iot` in `generate_grains`; `num_voices`
+  resta una riga a parte della legenda. Appare solo in modalità `fill_factor`:
+  in modalità `density` sarebbe la copia esatta della curva `density`.
+  La curva legge la faccia **valore** dei parametri, non `get_value`, che
+  passa dal gate e dalla variation strategy e quindi pesca: disegnare la
+  partitura non consuma l'RNG del render, e due letture danno lo stesso
+  disegno. La griglia è più fitta di quella degli offset per-voce
+  (`DEFAULT_DENSITY_SAMPLES = 129` contro 33) perché fra due breakpoint gli
+  input sono lineari ma il loro quoziente è un'iperbole.
+
 - **`ParameterCurve`**: value object che risponde alla domanda "come varia nel
   tempo questa faccia di un `Parameter`?" — `kind` in `varying` / `constant` /
   `absent`, più il payload. Dà una casa al riconoscimento della **costante

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,16 +81,30 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   parametro non configurato: una curva può sparire dall'insieme pubblicato, o
   entrarci, senza che niente fallisca. Costruendo `Stream` reali su tre
   configurazioni che coprono ogni gruppo esclusivo, 25 chiavi pubblicate su 28
-  risolvono. `pointer_speed_ratio` è il nome di schema di una curva già
-  pubblicata come `pointer_speed`: una seconda chiave che `getattr` non ha mai
-  potuto risolvere, ora esclusa esplicitamente. Le altre due che non risolvono
-  — `pointer_start` ed `effective_density` — restano dichiarate nella guardia
-  con il loro motivo, perché pubblicarle richiede una decisione di dominio
+  risolvono. Due delle tre morte sono nomi che non dovevano essere pubblicati e
+  ora sono esclusi esplicitamente: `pointer_speed_ratio`, nome di schema di una
+  curva già pubblicata come `pointer_speed`, e `pointer_start`, che non è una
+  curva e non può esserlo — la spec lo dichiara `is_smart=False` e il pointer
+  lo somma come scalare. La terza, `effective_density`, resta dichiarata nella
+  guardia con il motivo, perché pubblicarla richiede una decisione di dominio
   (issue #199). La guardia è
   `tests/rendering/test_envelope_extractor.py::TestPublishedSurfaceResolves`:
   verifica l'uguaglianza nei due sensi, quindi né una chiave viva può morire
   in silenzio né una dichiarata morta può restare nella lista dopo essere
   tornata viva.
+
+- **La reference prometteva envelope su `pointer.start`, che non li accetta.**
+  `docs/reference/yaml.md` elencava `pointer.start` fra i parametri numerici
+  che accettano envelope, e la sezione 10.1 lo affiancava a `loop_start` /
+  `loop_end` / `loop_dur`. Ma il pointer usa `start` come scalare
+  (`self.start + sample_position`): scrivendo un envelope lì lo `Stream` si
+  costruisce senza protestare e la generazione dei grani muore con
+  `TypeError: can only concatenate list (not "float") to list`. La confusione
+  aveva una radice — `_pre_normalize_loop_params` scala davvero anche `start`
+  insieme ai parametri di loop quando `loop_unit: normalized`, e lo fa con un
+  helper che gli envelope li gestisce: la macchina delle unità tratta `start`
+  come i loop, il pointer no. La reference ora dice che `start` è scalare, e
+  mantiene separata la semantica di unità, che invece condivide.
 
 - **Il tetto della cache delle silhouette non era il tetto vero.**
   `window_silhouette` ha un limite di 64 voci, ma leggeva da un

--- a/docs/plans/2026-08-03-001-refactor-stream-read-surface-plan.md
+++ b/docs/plans/2026-08-03-001-refactor-stream-read-surface-plan.md
@@ -128,15 +128,45 @@ elencava `pointer.start` fra i parametri che accettano envelope, e la sezione
 `loop_unit: normalized`, con un helper che gli envelope li gestisce: la
 macchina delle unità tratta `start` come i loop, il pointer no.
 
-### S1.4 `effective_density` resta dichiarata morta
+### S1.4 `effective_density` diventa la curva che doveva essere
 
-Richiede una decisione di dominio che non si prende di passaggio in un
-refactor: prima va deciso se è una curva o uno scalare interno. Pubblicare un
-float costante quando `density` è un envelope disegnerebbe una riga piatta che
-mente.
+Era nata come calcolo interno da trasformare in parametro visualizzabile, e la
+trasformazione non era mai stata finita: il nome aveva già colore, etichetta di
+legenda e range Y, ma nessuno calcolava la curva.
 
-Resta nella lista dichiarata con il rimando alla issue. La differenza rispetto
-a oggi è che è **scritta**: prima era invisibile.
+La decisione di dominio, presa: si disegna la densità della **voce 0**, quella
+che definisce il `sync_iot` in `generate_grains`. Non la somma su tutte le voci
+— `num_voices` è una riga a parte, e chi guarda la partitura moltiplica se
+vuole il totale.
+
+Forma, calcata su `VoiceManager.offset_curves`:
+
+- la **strategy** guadagna `nominal_density()`, la versione disegnabile di
+  `calculate_density()`. Vive lì perché formula e clamp li possiede lei;
+- `DensityController.density_curve(duration, *, grain_duration_at, samples)`
+  campiona. `grain_duration_at` è iniettata perché `grain_duration` vive sullo
+  `Stream`;
+- `Stream.effective_density_curve` la espone, `envelope_extractor` la pubblica
+  da una riga esplicita — il segnaposto di schema va in `_SCHEMA_EXCLUDED`.
+
+Due vincoli che il codice non poteva ignorare:
+
+- **nominale, non `get_value`**. `Parameter.get_value` passa dal probability
+  gate e dalla variation strategy, quindi *pesca* quando c'è un range.
+  Campionare con quello darebbe una linea tremolante, non riproducibile, e
+  consumerebbe l'RNG: guardare la partitura cambierebbe il render. Si legge la
+  faccia valore, quella che `value_curve` pubblica;
+- **griglia fitta**. Fra due breakpoint `fill_factor` e `grain_duration` sono
+  lineari, ma il loro quoziente è un'iperbole: i soli breakpoint direbbero la
+  cosa sbagliata a metà segmento. `DEFAULT_DENSITY_SAMPLES = 129` contro i 33
+  degli offset per-voce.
+
+In modalità `density` la curva è `None`: lì sarebbe la copia esatta del
+parametro `density`, già disegnato sotto il suo nome.
+
+Resta aperto un dettaglio non toccato qui: `GRANULAR_PARAMETERS['effective_density']`
+dichiara `min=1` ma il clamp reale usa i bounds di `density` (`min=0.01`), e
+nessuno legge i primi. Vanno allineati o rimossi.
 
 ---
 

--- a/docs/plans/2026-08-03-001-refactor-stream-read-surface-plan.md
+++ b/docs/plans/2026-08-03-001-refactor-stream-read-surface-plan.md
@@ -50,7 +50,7 @@ tre non risolvono mai**:
 
 | Chiave | Diagnosi |
 |---|---|
-| `pointer_start` | `pointer_start` non è in `GRANULAR_PARAMETERS`, quindi l'orchestratore non ne fa un `Parameter` e `PointerController.start` resta il valore YAML grezzo, che `_readable` scarta. Chi scrive `pointer: {start: <envelope>}` non vede mai quella curva. |
+| `pointer_start` | Non è una curva e non può esserlo: la spec lo dichiara `is_smart=False`, quindi l'orchestratore non ne fa un `Parameter`, e il pointer lo usa come scalare (`self.start + sample_position`). Un envelope lì non è una curva che nessuno disegna: è un `TypeError` alla generazione dei grani. |
 | `pointer_speed_ratio` | Nome di schema; la stessa cosa è già pubblicata come `pointer_speed`, che risolve. Chiave morta duplicata. |
 | `effective_density` | `yaml_path` `_internal_calc_`; il valore vive come float in `DensityController._loaded_params` e non è esposto. |
 
@@ -102,29 +102,41 @@ insiemi:
 L'uguaglianza è in entrambe le direzioni (R3): una chiave che comincia a
 risolvere deve uscire dalla lista dichiarata, non restarci.
 
-### S1.3 `pointer_speed_ratio` esce dall'insieme pubblicato
+### S1.3 `pointer_speed_ratio` e `pointer_start` escono dall'insieme pubblicato
 
-È un duplicato: `pointer_speed` pubblica la stessa curva e risolve. Va in
-`_SCHEMA_EXCLUDED`, dove già sta `pointer_deviation`, con il commento del
-perché. Zero rischio: la chiave non ha mai prodotto una curva, quindi nessun
-consumatore può averla vista.
+Nessuna delle due doveva starci, per due motivi diversi.
 
-### S1.4 `pointer_start` e `effective_density` restano dichiarate morte
+`pointer_speed_ratio` è un duplicato: `pointer_speed` pubblica la stessa curva
+e risolve. Un solo parametro con tre nomi lungo la catena — `speed_ratio` nello
+YAML, `pointer_speed_ratio` nello schema e nel controller, `pointer_speed`
+sulla property dello `Stream` — e il ciclo sugli schemi pubblicava il secondo
+mentre solo il terzo risolve.
 
-Entrambe richiedono una decisione di dominio che non si prende di passaggio in
-un refactor:
+`pointer_start` non è una curva. La spec lo dichiara `is_smart=False`, quindi
+non diventa mai un `Parameter`, e `PointerController.calculate` lo usa come
+scalare: `self.start + sample_position`. Scriverci un envelope non produce una
+curva invisibile, produce un `TypeError` alla generazione dei grani.
 
-- `pointer_start` — pubblicarla vuol dire darle bounds in
-  `GRANULAR_PARAMETERS` e far diventare `PointerController.start` un
-  `Parameter`. Tocca cosa quell'attributo contiene, quindi il comportamento del
-  pointer, e interagisce con `time_mode: normalized`. È una feature, non un
-  collegamento mancante.
-- `effective_density` — prima va deciso se è una curva o uno scalare interno.
-  Pubblicare un float costante quando `density` è un envelope disegnerebbe una
-  riga piatta che mente.
+Entrambe vanno in `_SCHEMA_EXCLUDED`, dove già sta `pointer_deviation`, con il
+commento del perché. Zero rischio: nessuna delle due ha mai prodotto una curva,
+quindi nessun consumatore può averle viste.
 
-Restano nella lista dichiarata con il rimando alla issue. La differenza
-rispetto a oggi è che sono **scritte**: prima erano invisibili.
+Da qui esce anche una correzione alla reference: `docs/reference/yaml.md`
+elencava `pointer.start` fra i parametri che accettano envelope, e la sezione
+10.1 lo affiancava ai parametri di loop. La radice della confusione è che
+`_pre_normalize_loop_params` **scala davvero anche `start`** quando
+`loop_unit: normalized`, con un helper che gli envelope li gestisce: la
+macchina delle unità tratta `start` come i loop, il pointer no.
+
+### S1.4 `effective_density` resta dichiarata morta
+
+Richiede una decisione di dominio che non si prende di passaggio in un
+refactor: prima va deciso se è una curva o uno scalare interno. Pubblicare un
+float costante quando `density` è un envelope disegnerebbe una riga piatta che
+mente.
+
+Resta nella lista dichiarata con il rimando alla issue. La differenza rispetto
+a oggi è che è **scritta**: prima era invisibile.
 
 ---
 
@@ -172,6 +184,15 @@ make tests
 ## Impatto cross-repo
 
 Nessuno. Non cambiano sintassi YAML, bounds, nomi di strategy o finestre,
-gerarchia errori, CLI, formati di output. L'unica chiave che sparisce
-dall'insieme pubblicato (`pointer_speed_ratio`) non ha mai prodotto una curva,
-quindi non è mai stata osservabile da `PGE-ls` né da `PGE-ui`.
+gerarchia errori, CLI, formati di output. Le due chiavi che spariscono
+dall'insieme pubblicato non hanno mai prodotto una curva, quindi non sono mai
+state osservabili da `PGE-ls` né da `PGE-ui`.
+
+La correzione della reference su `pointer.start` non genera issue a valle per
+la stessa ragione del caso `triangle`: entrambi i repo erano già allineati, era
+la reference di PGE a non esserlo. `PGE-ls` documenta `start` come «Valore raw:
+NON accetta envelope» (`granular_ls/providers/completion_provider.py`) e lo
+tiene fra i `_POINTER_SCALAR_PARAMS` del diagnostic provider; `PGE-ui` lo
+serializza come scalare secco (`start: ptr.start ?? undefined` in
+`yaml-bridge.js`), senza la coppia valore/envelope che usa per
+`speed_ratio`, `loop_start`, `loop_end`, `loop_dur` e `offset_range`.

--- a/docs/plans/2026-08-03-001-refactor-stream-read-surface-plan.md
+++ b/docs/plans/2026-08-03-001-refactor-stream-read-surface-plan.md
@@ -1,0 +1,177 @@
+---
+title: "refactor: la superficie di lettura di Stream diventa un contratto verificato"
+type: refactor
+status: active
+date: 2026-08-03
+issue: 199
+---
+
+# refactor: la superficie di lettura di Stream diventa un contratto verificato
+
+## Overview
+
+Chi legge uno `Stream` per disegnarlo — `ScoreVisualizer`, `SVExporter`,
+`--plot-envelopes` — non lo interroga per attributi noti: lo interroga **per
+nome, a runtime**, con `getattr(stream, name, None)`. I nomi vengono dagli
+schema parametri; il default `None` fa sì che un nome inesistente non produca un
+errore ma una curva assente. Nulla dichiara quella superficie e nulla la
+verifica.
+
+Il piano la rende dichiarata e verificata, in tre stadi. Questo plan copre lo
+**stadio 1**; gli stadi 2 e 3 restano descritti qui perché la decisione di
+fermarsi allo stadio 1 è deliberata, non una dimenticanza.
+
+---
+
+## Problem Frame
+
+`envelope_extractor._attr` è tutta la storia:
+
+```python
+def _attr(name):
+    return lambda stream: getattr(stream, name, None)
+```
+
+Due direzioni, entrambe silenziose:
+
+- **una curva esce** — si rinomina un attributo di `Stream` e la curva
+  corrispondente smette di essere disegnata, senza che niente fallisca;
+- **una curva entra** — si aggiunge una property a `Stream` per un motivo
+  qualsiasi e un nome di schema comincia a risolvere. È successo davvero: il
+  commento su `_SCHEMA_EXCLUDED` racconta che `pointer_deviation` non veniva
+  pubblicato «per un accidente», e che quando `Stream` ha cominciato a esporlo
+  l'esclusione è dovuta diventare esplicita.
+
+La conseguenza è misurabile. Costruendo `Stream` reali su tre configurazioni che
+coprono ogni gruppo esclusivo (`density` / `fill_factor`, loop con `loop_end` /
+con `loop_dur`, `pointer.start` e `pointer.speed_ratio` espliciti, voices,
+scatter, range e gate su volume e pan), **25 chiavi pubblicate su 28 risolvono;
+tre non risolvono mai**:
+
+| Chiave | Diagnosi |
+|---|---|
+| `pointer_start` | `pointer_start` non è in `GRANULAR_PARAMETERS`, quindi l'orchestratore non ne fa un `Parameter` e `PointerController.start` resta il valore YAML grezzo, che `_readable` scarta. Chi scrive `pointer: {start: <envelope>}` non vede mai quella curva. |
+| `pointer_speed_ratio` | Nome di schema; la stessa cosa è già pubblicata come `pointer_speed`, che risolve. Chiave morta duplicata. |
+| `effective_density` | `yaml_path` `_internal_calc_`; il valore vive come float in `DensityController._loaded_params` e non è esposto. |
+
+Il motivo per cui nessuno se n'è accorto è che **non si può costruire uno
+`Stream` nei test**: due file usano `object.__new__(Stream)` (20 occorrenze) per
+aggirare `__init__`, e il codice di produzione porta la cicatrice —
+`getattr(self, 'samples_dir', None)` in `_init_stream_context`, con il commento
+che spiega che serve alle istanze costruite col bypass.
+
+---
+
+## Requirements Trace
+
+- **R1.** Esiste un modo di costruire uno `Stream` vero nei test, attraverso
+  `__init__`, senza dipendere da un sample versionato nel repo e senza skip.
+- **R2.** Ogni chiave pubblicata da `_curve_sources()` risolve su almeno una
+  configurazione reale, oppure è dichiarata non pubblicabile con il motivo.
+- **R3.** La guardia fallisce se una chiave viva smette di risolvere o se una
+  chiave dichiarata morta comincia a risolvere: la lista dichiarata non può
+  diventare un tappeto sotto cui nascondere.
+- **R4.** Nessun cambiamento di comportamento a runtime: la partitura, l'export
+  SV e `--plot-envelopes` producono esattamente quello che producevano.
+
+---
+
+## Stadio 1 — questo lavoro
+
+### S1.1 Costruire uno `Stream` vero nei test
+
+Fixture in `tests/conftest.py`: scrive un wav minimo in `tmp_path` con
+`soundfile` (già dipendenza) e costruisce lo `Stream` passando `samples_dir`.
+Nessuna modifica al codice di produzione: la strada per costruire uno `Stream`
+senza toccare il repo esisteva già, mancava solo il fixture che la usa.
+
+Non usa `refs/`: quella directory è vuota in un checkout pulito — due test già
+oggi si skippano con «nessun sample disponibile» — e una guardia che si skippa
+non è una guardia.
+
+### S1.2 La guardia
+
+Test che, per ogni `CurveSource` prodotta da `_curve_sources()`, verifica su
+un ventaglio di configurazioni reali che la chiave risolva. Confronta due
+insiemi:
+
+- **vive** — le chiavi che risolvono su almeno una configurazione;
+- **dichiarate morte** — una costante nel test, con il motivo di ciascuna e il
+  riferimento alla issue.
+
+L'uguaglianza è in entrambe le direzioni (R3): una chiave che comincia a
+risolvere deve uscire dalla lista dichiarata, non restarci.
+
+### S1.3 `pointer_speed_ratio` esce dall'insieme pubblicato
+
+È un duplicato: `pointer_speed` pubblica la stessa curva e risolve. Va in
+`_SCHEMA_EXCLUDED`, dove già sta `pointer_deviation`, con il commento del
+perché. Zero rischio: la chiave non ha mai prodotto una curva, quindi nessun
+consumatore può averla vista.
+
+### S1.4 `pointer_start` e `effective_density` restano dichiarate morte
+
+Entrambe richiedono una decisione di dominio che non si prende di passaggio in
+un refactor:
+
+- `pointer_start` — pubblicarla vuol dire darle bounds in
+  `GRANULAR_PARAMETERS` e far diventare `PointerController.start` un
+  `Parameter`. Tocca cosa quell'attributo contiene, quindi il comportamento del
+  pointer, e interagisce con `time_mode: normalized`. È una feature, non un
+  collegamento mancante.
+- `effective_density` — prima va deciso se è una curva o uno scalare interno.
+  Pubblicare un float costante quando `density` è un envelope disegnerebbe una
+  riga piatta che mente.
+
+Restano nella lista dichiarata con il rimando alla issue. La differenza
+rispetto a oggi è che sono **scritte**: prima erano invisibili.
+
+---
+
+## Stadi successivi — non in questo lavoro
+
+### Stadio 2 — l'interfaccia torna a essere la superficie di test
+
+Rimuovere le 20 occorrenze di `object.__new__(Stream)` in
+`tests/core/test_stream.py` e `tests/core/test_stream_multivoice.py`, e con
+esse il `getattr(self, 'samples_dir', None)` di `_init_stream_context`.
+
+Non è meccanico: quei test esercitano metodi privati (`_init_stream_context`,
+`_init_grain_reverse`) su un oggetto mezzo costruito, quindi riscriverli
+significa decidere quale comportamento pubblico stavano davvero verificando.
+Ha bisogno del suo giro di TDD.
+
+Da fare insieme: `get_sample_duration` è chiamata **due volte** per stream, in
+`__init__` e di nuovo in `_init_stream_context`. Due letture di header per
+stream, per lo stesso file.
+
+### Stadio 3 — il read-model prende un nome
+
+Le quindici property di pass-through di `Stream` la cui docstring dice «Espone X
+per ScoreVisualizer» sono un read-model implicito, cresciuto di un accessore
+per volta al bisogno del consumatore. Sette di esse non hanno nessun call site
+per attributo in `src/`: il loro unico lettore è il `getattr` per nome di
+`envelope_extractor`.
+
+Darle un nome — un'interfaccia dichiarata fra il lato composizione e il lato
+lettura — è il lavoro grosso, e va discusso prima di essere scritto.
+
+---
+
+## Test da aggiornare
+
+- `tests/conftest.py` — fixture dello `Stream` reale
+- `tests/rendering/test_envelope_extractor.py` — la guardia
+
+## Verifica
+
+```bash
+make tests
+```
+
+## Impatto cross-repo
+
+Nessuno. Non cambiano sintassi YAML, bounds, nomi di strategy o finestre,
+gerarchia errori, CLI, formati di output. L'unica chiave che sparisce
+dall'insieme pubblicato (`pointer_speed_ratio`) non ha mai prodotto una curva,
+quindi non è mai stata osservabile da `PGE-ls` né da `PGE-ui`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -6,7 +6,7 @@ tags: [cli, flags, make, rendering, export]
 sources:
   - src/main.py
   - make/build.mk
-last_synced_commit: 9de1079
+last_synced_commit: 95fd483
 entry_for: [cli-flags, build-flags]
 ---
 
@@ -119,6 +119,12 @@ Vincoli tra flag e comportamento nelle combinazioni non valide:
   statico elencato nel filtro appare solo se c'è anche `--show-static`.
   Nomi validi = chiavi di `ENVELOPE_COLORS`
   (`src/pge/rendering/score_visualizer.py`, costante `PLOT_ENVELOPE_KEYS`).
+  Non tutti i nomi sono parametri scrivibili nello YAML: `effective_density`
+  è **derivato**, la densità reale in grani/secondo della voce 0
+  (`fill_factor(t) / grain_duration(t)`), campionata da
+  `DensityController.density_curve`. Appare solo in modalità `fill_factor`:
+  in modalità `density` sarebbe la copia della curva `density`, già disegnata
+  sotto il suo nome.
 - **`--magnify` / `--magnify-at`** hanno effetto solo insieme a
   `--visualize` (come `--show-static`); la validazione di `--magnify-at`
   avviene comunque (SPEC malformato → exit 1 anche senza `--visualize`). Le

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -11,7 +11,7 @@ sources:
   - src/pge/envelopes/
   - src/pge/shared/seeding.py
   - src/pge/shared/distribution_strategy.py
-last_synced_commit: 41a469c
+last_synced_commit: dd43e1e
 entry_for: [yaml-syntax, envelope-syntax]
 ---
 
@@ -492,6 +492,8 @@ Controlla la posizione di lettura nel sample sorgente.
 ```yaml
 pointer:
   start: 0.0              # posizione iniziale in secondi (default 0.0)
+                          # SCALARE: non accetta envelope — il pointer lo somma
+                          # alla posizione calcolata, non lo valuta nel tempo
   speed_ratio: 1.0        # velocità di lettura (default 1.0)
                           # 1.0 = velocità normale, -1.0 = indietro, 2.0 = doppia
                           # supporta envelope: [[0, 1.0], [30, 2.0]]
@@ -1089,7 +1091,7 @@ envelope tramite `Envelope.is_envelope_like(value)`:
 Tutti i parametri numerici dei seguenti blocchi accettano envelope:
 `density`, `fill_factor`, `distribution`, `volume`, `pan`, `grain.duration`,
 `grain.duration_range`, `pitch.ratio`, `pitch.semitones`, `pitch.range`,
-`pointer.start`, `pointer.speed_ratio`, `pointer.offset_range`,
+`pointer.speed_ratio`, `pointer.offset_range`,
 `pointer.loop_start`, `pointer.loop_end`, `pointer.loop_dur`, `dephase` (globale
 o per chiave), `voices.num_voices`, `voices.scatter`, i parametri scalari di
 ciascuna voice strategy (`step`, `pitch_range`, `pointer_range`,
@@ -1336,9 +1338,10 @@ density:
 
 **(c) Solo per i parametri loop del pointer: `loop_unit`**
 
-I parametri `loop_start`, `loop_end`, `loop_dur` (e `start`) hanno una semantica
-aggiuntiva: `loop_unit: normalized` scala i **valori** (asse Y) da `[0, 1]` a
-`[0, sample_dur_sec]`. Non agisce sull'asse X. È documentato nella sezione 10.
+I parametri `loop_start`, `loop_end`, `loop_dur` (e `start`, che è scalare ma
+segue la stessa unità) hanno una semantica aggiuntiva: `loop_unit: normalized`
+scala i **valori** (asse Y) da `[0, 1]` a `[0, sample_dur_sec]`. Non agisce
+sull'asse X. È documentato nella sezione 10.
 
 #### 3.3 Scaling del formato compatto
 
@@ -1792,8 +1795,9 @@ che diventa parte del breakpoint. Non è quindi modulabile dinamicamente.
 
 #### 10.1 Loop pointer e `loop_unit`
 
-`loop_start`, `loop_end`, `loop_dur`, e `start` accettano envelope. In più,
-hanno una semantica di unità separata controllata da `loop_unit`:
+`loop_start`, `loop_end`, `loop_dur` accettano envelope. `start` **no**: è un
+valore scalare (vedi § Blocco Pointer). Condivide però con i tre parametri di
+loop la semantica di unità controllata da `loop_unit`:
 
 ```yaml
 pointer:

--- a/src/pge/controllers/density_controller.py
+++ b/src/pge/controllers/density_controller.py
@@ -14,6 +14,11 @@ from pge.core.stream_config import StreamConfig
 from pge.parameters.parameter_orchestrator import ParameterOrchestrator
 from pge.shared.seeding import component_rng
 
+# Griglia di campionamento della curva di densita' reale. Piu' fitta dei 33
+# punti di DEFAULT_OFFSET_SAMPLES perche' qui la forma e' un'iperbole, non una
+# spezzata: i breakpoint degli input non ne descrivono la curvatura.
+DEFAULT_DENSITY_SAMPLES = 129
+
 class DensityController:
     """
     Controlla la densità granulare e la distribuzione temporale.
@@ -132,6 +137,55 @@ class DensityController:
             return (1.0 - dist_val) * avg_iot + dist_val * async_iot
     
     
+    def density_curve(
+        self,
+        duration: float,
+        *,
+        grain_duration_at,
+        samples: int = DEFAULT_DENSITY_SAMPLES,
+    ):
+        """La densita' reale della voce 0 in grani/secondo, campionata.
+
+        E' il quoziente `fill_factor(t) / grain_duration(t)`: il motore lo
+        calcola a ogni onset e non lo conserva, quindi l'unico modo di
+        disegnarlo e' campionarlo. Il campionamento sta qui, e non nel
+        visualizer, per lo stesso motivo di `VoiceManager.offset_curves`:
+        la formula e il clamp li conosce la strategy.
+
+        Args:
+            duration: estensione temporale su cui campionare.
+            grain_duration_at: callable t -> durata nominale del grano. E'
+                iniettata perche' grain_duration vive sullo Stream, non qui.
+            samples: densita' della griglia. Serve fitta: fra due breakpoint
+                gli input sono lineari ma il loro quoziente e' un'iperbole,
+                quindi i soli breakpoint non basterebbero.
+
+        Returns:
+            Envelope, oppure None se la curva non ha niente da aggiungere —
+            in modalita' `density` sarebbe la copia esatta del parametro
+            `density`, gia' pubblicato sotto il suo nome.
+        """
+        from pge.envelopes.envelope import Envelope
+
+        if self.mode != 'fill_factor':
+            return None
+        if duration <= 0 or samples < 2:
+            return None
+
+        step = duration / (samples - 1)
+        points = []
+        for i in range(samples):
+            time = i * step
+            grain_duration = grain_duration_at(time)
+            if not grain_duration:
+                return None
+            value = self._strategy.nominal_density(
+                time, grain_duration=grain_duration)
+            if value is None:
+                return None
+            points.append([time, value])
+        return Envelope(points)
+
     @property
     def mode(self) -> str:
         return self._strategy.name

--- a/src/pge/controllers/pointer_controller.py
+++ b/src/pge/controllers/pointer_controller.py
@@ -87,6 +87,8 @@ class PointerController:
                 hint=(
                     "pointer.start e' un valore scalare — la posizione di "
                     "partenza nel sample — e non accetta envelope.\n"
+                    "  Se non ti serve, ometti la chiave: il default e' 0.0 "
+                    "(o loop_start, con un loop attivo).\n"
                     "  Per far variare nel tempo la posizione di lettura usa "
                     "pointer.speed_ratio, oppure un loop mobile con "
                     "loop_start come envelope."

--- a/src/pge/controllers/pointer_controller.py
+++ b/src/pge/controllers/pointer_controller.py
@@ -74,6 +74,27 @@ class PointerController:
             attr_name = name.replace('pointer_', '')
             setattr(self, attr_name, param_obj)
 
+        # 3b. `start` e' un valore, non una curva: `calculate` lo somma alla
+        # posizione (`self.start + sample_position`), e la spec lo dichiara
+        # is_smart=False, quindi qui arriva grezzo dallo YAML. Se e' un
+        # envelope va fermato adesso, mentre il campo ha ancora un nome: piu'
+        # avanti diventa un TypeError dentro la generazione dei grani, quando
+        # non c'e' piu' modo di dire all'utente cosa ha scritto.
+        if not isinstance(self.start, (int, float)):
+            err = InvalidFieldValueError(
+                field='pointer.start',
+                value=self.start,
+                hint=(
+                    "pointer.start e' un valore scalare — la posizione di "
+                    "partenza nel sample — e non accetta envelope.\n"
+                    "  Per far variare nel tempo la posizione di lettura usa "
+                    "pointer.speed_ratio, oppure un loop mobile con "
+                    "loop_start come envelope."
+                ),
+            )
+            err.stream_id = self._config.context.stream_id
+            raise err
+
         # 4. has_loop dipende solo dalla presenza di loop_start
         self.has_loop = 'loop_start' in params
         # Se loop_start è presente ma start non è esplicito nello YAML,

--- a/src/pge/core/stream.py
+++ b/src/pge/core/stream.py
@@ -42,6 +42,7 @@ from pge.strategies.voice_onset_strategy import VoiceOnsetStrategyFactory
 from pge.strategies.voice_pointer_strategy import VoicePointerStrategyFactory
 from pge.strategies.voice_pan_strategy import VoicePanStrategyFactory
 from pge.strategies.grain_clip_strategy import GrainClipStrategyFactory, OverflowMarginClipStrategy
+from pge.strategies.strategie import nominal_value
 from dataclasses import fields, MISSING as dataclass_MISSING
 
 
@@ -805,6 +806,27 @@ class Stream:
         (stream._pointer.deviation).
         """
         return getattr(self._pointer, 'deviation', None)
+
+    @property
+    def effective_density_curve(self):
+        """La densita' reale della voce 0 in grani/secondo, come curva.
+
+        `fill_factor` da solo non dice quanti grani al secondo si ascoltano:
+        la densita' vera e' `fill_factor(t) / grain_duration(t)`, che il
+        motore calcola a ogni onset (`generate_grains` -> voce 0 ->
+        `calculate_inter_onset`) e non conserva. Qui viene campionata.
+
+        Voce 0, la voce di riferimento: e' lei a definire il `sync_iot`. Con
+        piu' voci i grani totali sono di piu' — `num_voices` e' una riga a
+        parte della partitura.
+
+        None in modalita' `density`: li' sarebbe la copia esatta del
+        parametro `density`, gia' disegnato sotto il suo nome.
+        """
+        return self._density.density_curve(
+            self.duration,
+            grain_duration_at=lambda t: nominal_value(self.grain_duration, t),
+        )
 
     @property
     def voice_manager(self):

--- a/src/pge/rendering/envelope_extractor.py
+++ b/src/pge/rendering/envelope_extractor.py
@@ -113,7 +113,12 @@ def _attr(name):
 # schemi per un accidente — hasattr(stream,'pointer_deviation') era False
 # perche' il Parameter viveva solo dentro PointerController. Ora che lo Stream
 # lo espone, l'esclusione va dichiarata invece che subita.
-_SCHEMA_EXCLUDED = frozenset({'pointer_deviation'})
+# pointer_speed_ratio e' il nome di schema di una curva gia' pubblicata piu'
+# sotto come 'pointer_speed', che e' il nome che lo Stream espone e che i
+# consumatori usano (layer SV, --plot-envelopes). Dal ciclo sugli schemi
+# usciva una seconda chiave che getattr non ha mai potuto risolvere: prometteva
+# una curva e ne consegnava zero. Esclusa qui invece che lasciata morta.
+_SCHEMA_EXCLUDED = frozenset({'pointer_deviation', 'pointer_speed_ratio'})
 
 
 def _curve_sources():

--- a/src/pge/rendering/envelope_extractor.py
+++ b/src/pge/rendering/envelope_extractor.py
@@ -118,7 +118,14 @@ def _attr(name):
 # consumatori usano (layer SV, --plot-envelopes). Dal ciclo sugli schemi
 # usciva una seconda chiave che getattr non ha mai potuto risolvere: prometteva
 # una curva e ne consegnava zero. Esclusa qui invece che lasciata morta.
-_SCHEMA_EXCLUDED = frozenset({'pointer_deviation', 'pointer_speed_ratio'})
+#
+# pointer_start non e' una curva e non puo' esserlo: la spec lo dichiara
+# is_smart=False, quindi l'orchestratore non ne fa un Parameter, e il pointer
+# lo usa come scalare (`self.start + sample_position` in
+# PointerController.calculate). Un envelope li' non e' una curva che nessuno
+# disegna: e' un TypeError alla generazione dei grani.
+_SCHEMA_EXCLUDED = frozenset({
+    'pointer_deviation', 'pointer_speed_ratio', 'pointer_start'})
 
 
 def _curve_sources():

--- a/src/pge/rendering/envelope_extractor.py
+++ b/src/pge/rendering/envelope_extractor.py
@@ -124,8 +124,13 @@ def _attr(name):
 # lo usa come scalare (`self.start + sample_position` in
 # PointerController.calculate). Un envelope li' non e' una curva che nessuno
 # disegna: e' un TypeError alla generazione dei grani.
+# effective_density e' un segnaposto nello schema (yaml_path '_internal_calc_',
+# is_smart=False): il valore vero non e' un Parameter da leggere ma un
+# quoziente che il motore calcola a ogni onset. Viene pubblicato piu' sotto
+# dalla curva campionata, non da qui.
 _SCHEMA_EXCLUDED = frozenset({
-    'pointer_deviation', 'pointer_speed_ratio', 'pointer_start'})
+    'pointer_deviation', 'pointer_speed_ratio', 'pointer_start',
+    'effective_density'})
 
 
 def _curve_sources():
@@ -154,6 +159,14 @@ def _curve_sources():
     # valore base gia' risolto (Envelope o scalare), non un Parameter: e' una
     # riga normale con una sorgente diversa, non un caso a parte.
     sources.append(CurveSource('pitch', _attr('pitch_value'), 'value'))
+
+    # La densita' reale della voce 0: fill_factor(t)/grain_duration(t), che il
+    # motore calcola a ogni onset e non conserva. Lo Stream la espone gia'
+    # campionata come Envelope (effective_density_curve), None in modalita'
+    # density — li' sarebbe il doppione della curva `density`. Subito dopo il
+    # blocco density, per tenere la famiglia vicina in legenda.
+    sources.append(
+        CurveSource('effective_density', _attr('effective_density_curve'), 'value'))
 
     # Parametri fuori da ogni schema: num_voices/scatter sono privati dello
     # Stream, pointer_speed e' esposto con un nome diverso da quello di schema

--- a/src/pge/strategies/strategie.py
+++ b/src/pge/strategies/strategie.py
@@ -90,20 +90,51 @@ class UnitPitchStrategy(PitchStrategy):
 # STRATEGIE DENSITY
 # =============================================================================
 
+def nominal_value(param, time: float):
+    """Valore base di un Parameter al tempo dato, senza estrazioni casuali.
+
+    `Parameter.get_value` passa dal probability gate e dalla variation
+    strategy, quindi PESCA quando c'e' un range: va benissimo per generare un
+    grano, non per disegnare una curva. Userebbe l'RNG, e guardare la
+    partitura cambierebbe il render.
+
+    Qui si legge la faccia valore — la stessa che `value_curve` pubblica — e
+    la si valuta al tempo. None se quella faccia non c'e'.
+    """
+    from pge.parameters.parameter_curve import VARYING, CONSTANT
+
+    curve = param.value_curve
+    if curve.kind == VARYING:
+        return curve.envelope.evaluate(time)
+    if curve.kind == CONSTANT:
+        return curve.value
+    return None
+
+
 class DensityStrategy(ABC):
     """Interfaccia base per calcolare la densità."""
-    
+
     @abstractmethod
     def calculate_density(self, elapsed_time: float, **context) -> float:
         """
         Calcola la densità in grani/secondo.
-        
+
         Args:
             elapsed_time: tempo corrente nello stream
             **context: dati contestuali (es. grain_duration per fill_factor)
         """
         pass
-    
+
+    @abstractmethod
+    def nominal_density(self, elapsed_time: float, **context) -> float:
+        """La stessa densita' di `calculate_density`, ma sui valori base.
+
+        E' la versione disegnabile: deterministica, riproducibile, senza
+        toccare l'RNG. Vive qui e non nel visualizer perche' la formula e il
+        clamp li conosce la strategy, e due copie divergerebbero.
+        """
+        pass
+
     @property
     @abstractmethod
     def name(self) -> str:
@@ -132,8 +163,18 @@ class FillFactorStrategy(DensityStrategy):
         fill_factor = self._fill_factor.get_value(elapsed_time)
         grain_duration = context['grain_duration']
         raw_density = fill_factor / grain_duration
-        return max(self._density_bounds.min_val,min(self._density_bounds.max_val, raw_density))
-        
+        return self._clamp(raw_density)
+
+    def nominal_density(self, elapsed_time: float, **context) -> float:
+        if 'grain_duration' not in context:
+            raise ValueError(f"{self.__class__.__name__} requires 'grain_duration' in context")
+        fill_factor = nominal_value(self._fill_factor, elapsed_time)
+        return self._clamp(fill_factor / context['grain_duration'])
+
+    def _clamp(self, raw_density: float) -> float:
+        return max(self._density_bounds.min_val,
+                   min(self._density_bounds.max_val, raw_density))
+
     @property
     def name(self) -> str:
         return "fill_factor"
@@ -146,7 +187,10 @@ class DirectDensityStrategy(DensityStrategy):
     
     def calculate_density(self, elapsed_time: float, **context) -> float:
         return self._density.get_value(elapsed_time)
-    
+
+    def nominal_density(self, elapsed_time: float, **context) -> float:
+        return nominal_value(self._density, elapsed_time)
+
     @property
     def name(self) -> str:
         return "density"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,42 @@ def mock_config():
 
 
 
+@pytest.fixture
+def build_stream(tmp_path):
+    """Costruisce Stream VERI, attraverso `__init__`.
+
+    Serve a chi deve verificare qualcosa della superficie dello Stream: un
+    MagicMock ha ogni attributo e quindi non puo' dire se un attributo esiste
+    davvero, e `object.__new__(Stream)` salta proprio l'inizializzazione che
+    la superficie la costruisce.
+
+    Il sample e' un wav di silenzio scritto in `tmp_path`: non dipende da
+    `refs/`, che in un checkout pulito e' vuota (due test si skippano gia'
+    con "nessun sample disponibile"), e un test che si skippa non verifica
+    niente.
+    """
+    import numpy as np
+    import soundfile as sf
+
+    sample_name = 'silence.wav'
+    sf.write(str(tmp_path / sample_name),
+             np.zeros(48000, dtype='float32'), 48000)
+
+    def build(**params):
+        from pge.core.stream import Stream
+        yaml_params = {
+            'stream_id': 'test_stream',
+            'onset': 0.0,
+            'duration': 2.0,
+            'sample': sample_name,
+            'grain': {'duration': 0.05, 'envelope': 'hanning'},
+        }
+        yaml_params.update(params)
+        return Stream(yaml_params, samples_dir=str(tmp_path))
+
+    return build
+
+
 def make_mock_stream_for_generator(stream_id='stream_01', sample='test.wav'):
     """
     Mock Stream con attributi necessari per Generator.

--- a/tests/controllers/test_density_controller.py
+++ b/tests/controllers/test_density_controller.py
@@ -744,3 +744,62 @@ class TestRealisticSequence:
         # Media vicina a avg_iot
         mean_interval = sum(intervals) / len(intervals)
         assert mean_interval == pytest.approx(0.025, rel=0.1)
+
+# =============================================================================
+# LA CURVA DELLA DENSITA' REALE (issue #199)
+# =============================================================================
+
+class TestEffectiveDensityCurve:
+    """`fill_factor` da solo non dice quanti grani al secondo stai ascoltando:
+    la densita' vera e' `fill_factor(t) / grain_duration(t)`, un quoziente che
+    il motore calcola a ogni onset e non conserva da nessuna parte.
+
+    La curva e' quella della **voce 0**, la voce di riferimento: e' lei a
+    definire il `sync_iot` in `generate_grains`. Con piu' voci i grani totali
+    sono di piu', ma il ritmo di riferimento e' questo.
+    """
+
+    def test_the_curve_is_the_quotient_at_the_endpoints(self, build_stream):
+        """grain_duration che raddoppia -> densita' che dimezza."""
+        stream = build_stream(
+            fill_factor=0.5,
+            grain={'duration': [[0, 0.05], [2.0, 0.1]], 'envelope': 'hanning'},
+        )
+        curve = stream.effective_density_curve
+        assert curve.evaluate(0.0) == pytest.approx(10.0)    # 0.5 / 0.05
+        assert curve.evaluate(2.0) == pytest.approx(5.0)     # 0.5 / 0.10
+
+    def test_no_curve_in_density_mode(self, build_stream):
+        """In modalita' `density` la curva sarebbe la copia esatta del
+        parametro density, gia' disegnato sotto il suo nome: due righe
+        sovrapposte non aggiungono niente."""
+        stream = build_stream(density=[[0, 5], [2.0, 20]])
+        assert stream.effective_density_curve is None
+
+    def test_between_two_breakpoints_it_curves(self, build_stream):
+        """Il quoziente di due segmenti lineari non e' un segmento: e' un
+        iperbole. A meta' strada fra 10 e 5 g/s non c'e' 7.5 ma 6.67, e una
+        curva campionata sui soli breakpoint direbbe la cosa sbagliata."""
+        stream = build_stream(
+            fill_factor=0.5,
+            grain={'duration': [[0, 0.05], [2.0, 0.1]], 'envelope': 'hanning'},
+        )
+        curve = stream.effective_density_curve
+        # a t=1.0 grain_duration = 0.075 -> 0.5 / 0.075 = 6.666...
+        assert curve.evaluate(1.0) == pytest.approx(6.667, abs=0.05)
+        assert curve.evaluate(1.0) < 7.0, "sta interpolando linearmente"
+
+    def test_the_curve_is_nominal_not_a_dice_roll(self, build_stream):
+        """`grain.duration_range` fa pescare a ogni grano una durata diversa.
+        La curva legge la faccia valore, non `get_value`: due letture danno lo
+        stesso disegno, e guardare la partitura non consuma l'RNG del render.
+        """
+        stream = build_stream(
+            fill_factor=0.5,
+            grain={'duration': 0.05, 'duration_range': 0.02,
+                   'envelope': 'hanning'},
+        )
+        first = stream.effective_density_curve
+        second = stream.effective_density_curve
+        assert first.evaluate(1.0) == pytest.approx(second.evaluate(1.0))
+        assert first.evaluate(1.0) == pytest.approx(10.0)  # 0.5 / 0.05 base

--- a/tests/controllers/test_pointer_controller.py
+++ b/tests/controllers/test_pointer_controller.py
@@ -2677,6 +2677,16 @@ class TestStartMustBeScalar:
         stream = build_stream(pointer={'start': 0.3})
         assert stream._pointer.start == pytest.approx(0.3)
 
+    def test_empty_start_is_rejected_too(self, build_stream):
+        """`start:` scritto e lasciato vuoto e' None, e None non e' una
+        posizione: prima diventava `None + sample_position` a valle. Non lo si
+        fa passare in silenzio ricadendo sul default — l'utente ha scritto la
+        chiave, e va detto che cosi' non vale."""
+        with pytest.raises(InvalidFieldValueError) as exc_info:
+            build_stream(pointer={'start': None})
+        assert exc_info.value.field == 'pointer.start'
+        assert 'ometti la chiave' in exc_info.value.user_message().lower()
+
     def test_absent_start_still_builds(self, build_stream):
         """`start` assente resta legittimo: il default e' 0.0, e con un loop
         il pointer parte da loop_start."""

--- a/tests/controllers/test_pointer_controller.py
+++ b/tests/controllers/test_pointer_controller.py
@@ -2649,3 +2649,36 @@ class TestLoopBoundsValidation:
                 {'loop_start': [[0.0, 5.0], [1.0, 1.0]], 'loop_end': 3.0}, mock_config
             )
             assert pointer.has_loop is True
+
+class TestStartMustBeScalar:
+    """`pointer.start` e' la posizione di partenza: un numero, non una curva.
+
+    Il pointer la somma alla posizione calcolata (`self.start + sample_position`
+    in `calculate`), non la valuta nel tempo — e la spec la dichiara
+    `is_smart=False`, quindi non diventa mai un Parameter. Un envelope li' non
+    produce una curva che nessuno disegna: produce un TypeError alla
+    generazione dei grani, dopo che lo Stream si e' costruito senza protestare.
+    Va rifiutato dove l'utente puo' ancora capire cosa ha sbagliato (#199).
+    """
+
+    def test_envelope_start_is_rejected(self, build_stream):
+        with pytest.raises(InvalidFieldValueError) as exc_info:
+            build_stream(pointer={'start': [[0, 0.0], [2.0, 0.5]]})
+        assert exc_info.value.field == 'pointer.start'
+
+    def test_the_error_says_what_to_write_instead(self, build_stream):
+        with pytest.raises(InvalidFieldValueError) as exc_info:
+            build_stream(pointer={'start': [[0, 0.0], [2.0, 0.5]]})
+        msg = exc_info.value.user_message()
+        assert 'scalare' in msg.lower()
+
+    def test_scalar_start_still_builds(self, build_stream):
+        """La controprova: il caso valido non deve essere toccato."""
+        stream = build_stream(pointer={'start': 0.3})
+        assert stream._pointer.start == pytest.approx(0.3)
+
+    def test_absent_start_still_builds(self, build_stream):
+        """`start` assente resta legittimo: il default e' 0.0, e con un loop
+        il pointer parte da loop_start."""
+        stream = build_stream(pointer={'speed_ratio': 1.0})
+        assert stream._pointer.start == pytest.approx(0.0)

--- a/tests/rendering/test_envelope_extractor.py
+++ b/tests/rendering/test_envelope_extractor.py
@@ -621,11 +621,18 @@ class TestSchemaExclusion:
         assert keys.index('pointer_deviation') > keys.index('volume')
 
     def test_the_exclusion_is_declared_and_not_incidental(self):
-        """L'esclusione e' scritta, e riguarda solo pointer_deviation: se
-        crescesse in silenzio, ogni nome aggiunto sparirebbe dalla partitura
-        senza che niente lo dica."""
+        """L'esclusione e' scritta: se crescesse in silenzio, ogni nome
+        aggiunto sparirebbe dalla partitura senza che niente lo dica.
+
+        Due nomi, per due motivi diversi. `pointer_deviation` e' pubblicato
+        dalle righe dedicate piu' sotto, col range al posto del valore base.
+        `pointer_speed_ratio` e' il nome di schema di una curva gia'
+        pubblicata come `pointer_speed`: dal ciclo usciva una chiave che
+        `getattr` non ha mai potuto risolvere (issue #199).
+        """
         from pge.rendering.envelope_extractor import _SCHEMA_EXCLUDED
-        assert _SCHEMA_EXCLUDED == frozenset({'pointer_deviation'})
+        assert _SCHEMA_EXCLUDED == frozenset({
+            'pointer_deviation', 'pointer_speed_ratio'})
 
 
 class TestEnvelopeFilter:
@@ -795,3 +802,100 @@ class TestRawSourcesHaveOnlyAValue:
         keys = get_stream_envelopes(
             self._stream_with_numeric_grain_envelope(), show_static=True)
         assert 'grain_envelope' in keys
+
+
+# =============================================================================
+# LA SUPERFICIE PUBBLICATA E' UN CONTRATTO (issue #199)
+# =============================================================================
+
+class TestPublishedSurfaceResolves:
+    """Ogni nome che il modulo pubblica deve corrispondere a qualcosa che
+    esiste davvero sullo Stream.
+
+    La risoluzione e' `getattr(stream, name, None)`: un nome che non esiste
+    non solleva, produce una curva assente. Indistinguibile da un parametro
+    che l'utente non ha configurato — quindi una curva puo' sparire dalla
+    partitura, o entrarci, senza che niente fallisca.
+
+    Qui si costruiscono Stream VERI (il MagicMock ha ogni attributo, e non
+    saprebbe rispondere alla domanda) su un ventaglio di configurazioni che
+    copre ogni gruppo esclusivo, e si confronta l'insieme pubblicato con
+    quello che risolve.
+
+    `_curve_sources` e' privata ma e' il catalogo: il lavoro di questo test e'
+    esattamente confrontare il catalogo con la realta'.
+    """
+
+    # Chiavi pubblicate che oggi non risolvono in nessuna configurazione, con
+    # il motivo. Non e' un tappeto: il test verifica l'uguaglianza nei due
+    # sensi, quindi una chiave che tornasse a risolvere andrebbe tolta da qui.
+    DICHIARATE_MORTE = {
+        # pointer_start non e' in GRANULAR_PARAMETERS: l'orchestratore non ne
+        # fa un Parameter e PointerController.start resta il valore YAML
+        # grezzo, che _readable scarta. Pubblicarla vuol dire darle bounds e
+        # cambiare cosa contiene quell'attributo: e' una feature, non un
+        # collegamento mancante. Issue #199.
+        'pointer_start',
+        # effective_density ha yaml_path '_internal_calc_' e vive come float
+        # dentro DensityController._loaded_params. Prima di pubblicarla va
+        # deciso se e' una curva o uno scalare interno: una riga piatta
+        # accanto a una density che varia mentirebbe. Issue #199.
+        'effective_density',
+    }
+
+    def _configurazioni(self, build_stream):
+        """Un ventaglio che copre i gruppi esclusivi: density contro
+        fill_factor, loop_end contro loop_dur, pointer e voci espliciti."""
+        return [
+            build_stream(
+                stream_id='A',
+                density=[[0, 5], [2.0, 20]],
+                volume=-6, volume_range=3,
+                pan=0, pan_range=20,
+                dephase=10,
+                scatter=0.2,
+                pitch={'semitones': [[0, 0], [2.0, 12]]},
+                pointer={'start': 0.0, 'speed_ratio': 1.0,
+                         'offset_range': 0.1},
+                voices={'num_voices': 3,
+                        'pitch': {'strategy': 'chord', 'chord': 'dom7'}},
+            ),
+            build_stream(
+                stream_id='B',
+                fill_factor=0.5,
+                pointer={'loop_start': 0.0, 'loop_end': 0.8},
+            ),
+            build_stream(
+                stream_id='C',
+                density=10,
+                pointer={'loop_start': 0.1, 'loop_dur': 0.5},
+            ),
+        ]
+
+    def _pubblicate_e_vive(self, build_stream):
+        from pge.rendering.envelope_extractor import (
+            _curve_sources, VoiceOffsetSource)
+
+        pubblicate, vive = set(), set()
+        for stream in self._configurazioni(build_stream):
+            for source in _curve_sources():
+                if isinstance(source, VoiceOffsetSource):
+                    continue
+                pubblicate.add(source.key)
+                if source.resolve(stream) is not None:
+                    vive.add(source.key)
+        return pubblicate, vive
+
+    def test_no_key_is_dead_without_being_declared(self, build_stream):
+        """Una chiave che non risolve mai promette una curva che nessuno
+        vedra': o si pubblica davvero, o si dichiara qui il perche'."""
+        pubblicate, vive = self._pubblicate_e_vive(build_stream)
+        morte = pubblicate - vive
+        assert morte == self.DICHIARATE_MORTE
+
+    def test_most_of_the_surface_actually_resolves(self, build_stream):
+        """Controprova che il ventaglio esercita davvero le configurazioni: se
+        risolvesse una manciata di chiavi, l'asserzione sopra passerebbe per
+        difetto di copertura invece che per correttezza."""
+        pubblicate, vive = self._pubblicate_e_vive(build_stream)
+        assert len(vive) >= len(pubblicate) - len(self.DICHIARATE_MORTE)

--- a/tests/rendering/test_envelope_extractor.py
+++ b/tests/rendering/test_envelope_extractor.py
@@ -624,15 +624,17 @@ class TestSchemaExclusion:
         """L'esclusione e' scritta: se crescesse in silenzio, ogni nome
         aggiunto sparirebbe dalla partitura senza che niente lo dica.
 
-        Due nomi, per due motivi diversi. `pointer_deviation` e' pubblicato
+        Tre nomi, per tre motivi diversi. `pointer_deviation` e' pubblicato
         dalle righe dedicate piu' sotto, col range al posto del valore base.
         `pointer_speed_ratio` e' il nome di schema di una curva gia'
         pubblicata come `pointer_speed`: dal ciclo usciva una chiave che
-        `getattr` non ha mai potuto risolvere (issue #199).
+        `getattr` non ha mai potuto risolvere. `pointer_start` non e' una
+        curva e non puo' esserlo: is_smart=False, e il pointer lo somma come
+        scalare (issue #199).
         """
         from pge.rendering.envelope_extractor import _SCHEMA_EXCLUDED
         assert _SCHEMA_EXCLUDED == frozenset({
-            'pointer_deviation', 'pointer_speed_ratio'})
+            'pointer_deviation', 'pointer_speed_ratio', 'pointer_start'})
 
 
 class TestEnvelopeFilter:
@@ -830,12 +832,6 @@ class TestPublishedSurfaceResolves:
     # il motivo. Non e' un tappeto: il test verifica l'uguaglianza nei due
     # sensi, quindi una chiave che tornasse a risolvere andrebbe tolta da qui.
     DICHIARATE_MORTE = {
-        # pointer_start non e' in GRANULAR_PARAMETERS: l'orchestratore non ne
-        # fa un Parameter e PointerController.start resta il valore YAML
-        # grezzo, che _readable scarta. Pubblicarla vuol dire darle bounds e
-        # cambiare cosa contiene quell'attributo: e' una feature, non un
-        # collegamento mancante. Issue #199.
-        'pointer_start',
         # effective_density ha yaml_path '_internal_calc_' e vive come float
         # dentro DensityController._loaded_params. Prima di pubblicarla va
         # deciso se e' una curva o uno scalare interno: una riga piatta

--- a/tests/rendering/test_envelope_extractor.py
+++ b/tests/rendering/test_envelope_extractor.py
@@ -624,17 +624,19 @@ class TestSchemaExclusion:
         """L'esclusione e' scritta: se crescesse in silenzio, ogni nome
         aggiunto sparirebbe dalla partitura senza che niente lo dica.
 
-        Tre nomi, per tre motivi diversi. `pointer_deviation` e' pubblicato
-        dalle righe dedicate piu' sotto, col range al posto del valore base.
-        `pointer_speed_ratio` e' il nome di schema di una curva gia'
-        pubblicata come `pointer_speed`: dal ciclo usciva una chiave che
-        `getattr` non ha mai potuto risolvere. `pointer_start` non e' una
-        curva e non puo' esserlo: is_smart=False, e il pointer lo somma come
-        scalare (issue #199).
+        Quattro nomi, per quattro motivi diversi. `pointer_deviation` e
+        `effective_density` sono pubblicati dalle righe dedicate piu' sotto —
+        il primo col range al posto del valore base, la seconda come curva
+        campionata invece che come segnaposto di schema. `pointer_speed_ratio`
+        e' il nome di schema di una curva gia' pubblicata come
+        `pointer_speed`: dal ciclo usciva una chiave che `getattr` non ha mai
+        potuto risolvere. `pointer_start` non e' una curva e non puo' esserlo:
+        is_smart=False, e il pointer lo somma come scalare (issue #199).
         """
         from pge.rendering.envelope_extractor import _SCHEMA_EXCLUDED
         assert _SCHEMA_EXCLUDED == frozenset({
-            'pointer_deviation', 'pointer_speed_ratio', 'pointer_start'})
+            'pointer_deviation', 'pointer_speed_ratio', 'pointer_start',
+            'effective_density'})
 
 
 class TestEnvelopeFilter:
@@ -831,13 +833,11 @@ class TestPublishedSurfaceResolves:
     # Chiavi pubblicate che oggi non risolvono in nessuna configurazione, con
     # il motivo. Non e' un tappeto: il test verifica l'uguaglianza nei due
     # sensi, quindi una chiave che tornasse a risolvere andrebbe tolta da qui.
-    DICHIARATE_MORTE = {
-        # effective_density ha yaml_path '_internal_calc_' e vive come float
-        # dentro DensityController._loaded_params. Prima di pubblicarla va
-        # deciso se e' una curva o uno scalare interno: una riga piatta
-        # accanto a una density che varia mentirebbe. Issue #199.
-        'effective_density',
-    }
+    # Vuota: ogni chiave che il modulo pubblica risolve su almeno una delle
+    # configurazioni qui sotto. Se ne aggiungi una che non risolve, o la
+    # colleghi o la dichiari qui con il motivo — non c'e' una terza strada che
+    # passi il test.
+    DICHIARATE_MORTE = set()
 
     def _configurazioni(self, build_stream):
         """Un ventaglio che copre i gruppi esclusivi: density contro
@@ -895,3 +895,28 @@ class TestPublishedSurfaceResolves:
         difetto di copertura invece che per correttezza."""
         pubblicate, vive = self._pubblicate_e_vive(build_stream)
         assert len(vive) >= len(pubblicate) - len(self.DICHIARATE_MORTE)
+
+
+class TestEffectiveDensityIsPublished:
+    """La densita' reale della voce 0 arriva alla partitura (issue #199).
+
+    Colore, etichetta di legenda e range Y erano gia' configurati in
+    ENVELOPE_COLORS, page_layout e visualizer_config: mancava solo chi la
+    calcolasse.
+    """
+
+    def test_fill_factor_stream_publishes_the_curve(self, build_stream):
+        stream = build_stream(
+            fill_factor=0.5,
+            grain={'duration': [[0, 0.05], [2.0, 0.1]], 'envelope': 'hanning'},
+        )
+        envelopes = get_stream_envelopes(stream)
+        assert 'effective_density' in envelopes
+        assert envelopes['effective_density'].evaluate(0.0) == pytest.approx(10.0)
+
+    def test_density_stream_does_not(self, build_stream):
+        """In modalita' density sarebbe il doppione della curva `density`."""
+        stream = build_stream(density=[[0, 5], [2.0, 20]])
+        envelopes = get_stream_envelopes(stream)
+        assert 'effective_density' not in envelopes
+        assert 'density' in envelopes

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -1258,6 +1258,8 @@ class TestAbstractMethodBodies:
         class _Concrete(DensityStrategy):
             def calculate_density(self, elapsed_time: float, **context) -> float:
                 return super().calculate_density(elapsed_time, **context)
+            def nominal_density(self, elapsed_time: float, **context) -> float:
+                return 1.0
             @property
             def name(self) -> str:
                 return "test"
@@ -1272,6 +1274,8 @@ class TestAbstractMethodBodies:
 
         class _Concrete(DensityStrategy):
             def calculate_density(self, elapsed_time: float, **context) -> float:
+                return 1.0
+            def nominal_density(self, elapsed_time: float, **context) -> float:
                 return 1.0
             @property
             def name(self) -> str:


### PR DESCRIPTION
Chiude #199. Plan: `docs/plans/2026-08-03-001-refactor-stream-read-surface-plan.md`.

> **Correzione in corso di revisione.** La prima stesura classificava `pointer_start` come una curva persa in attesa di una decisione di dominio. Era sbagliato: `pointer.start` non può essere un envelope, quindi non c'è nessuna curva da perdere. Commit `dd43e1e`, `ead5fa9`, `46be056`.

## Il problema

Chi legge uno `Stream` per disegnarlo — partitura, export Sonic Visualiser, `--plot-envelopes` — non lo interroga per attributi noti. Lo interroga **per nome, a runtime**:

```python
def _attr(name):
    return lambda stream: getattr(stream, name, None)
```

Il default `None` fa sì che un nome che non esiste sullo `Stream` non sollevi, ma produca una `ParameterCurve(kind='absent')`: **indistinguibile da un parametro che l'utente non ha configurato**. Nessuno dichiara quella superficie e nessuno la verifica, quindi una curva può uscire dall'insieme pubblicato (si rinomina un attributo) o entrarci (si aggiunge una property per altri motivi) senza che niente fallisca.

Il codice lo racconta già di sé, nel commento su `_SCHEMA_EXCLUDED`: `pointer_deviation` non veniva pubblicato «per un accidente», e quando `Stream` ha cominciato a esporlo l'esclusione è dovuta diventare esplicita.

## La misura

Costruendo `Stream` **reali** su tre configurazioni che coprono ogni gruppo esclusivo: **25 chiavi pubblicate su 28 risolvono, tre non risolvono mai.** Tre diagnosi diverse, tre esiti diversi.

| Chiave | Diagnosi | Esito |
|---|---|---|
| `pointer_speed_ratio` | Duplicato morto. Un parametro, tre nomi lungo la catena: `speed_ratio` nello YAML, `pointer_speed_ratio` nello schema e nel controller, `pointer_speed` sulla property dello `Stream`. Il ciclo pubblicava il secondo, solo il terzo risolve. | **Esce** dall'insieme pubblicato |
| `pointer_start` | **Non è una curva e non può esserlo.** `is_smart=False`, quindi non diventa mai un `Parameter`, e `PointerController.calculate` lo somma come scalare: `return self.start + sample_position`. | **Esce**, e un envelope lì viene ora **rifiutato** |
| `effective_density` | Era un calcolo interno che doveva diventare un parametro visualizzabile, e la trasformazione non era mai stata finita. | **Collegata**: ora la curva esiste davvero |

## La densità reale arriva sulla partitura

`fill_factor` da solo non dice quanti grani al secondo stai ascoltando. La densità vera è `fill_factor(t) / grain_duration(t)`, un quoziente che il motore calcola a ogni onset e non conserva da nessuna parte. Il nome `effective_density` era già **completamente apparecchiato** — il suo colore in `ENVELOPE_COLORS`, la sua etichetta in `page_layout`, il suo range Y in `visualizer_config` — ma nessuno lo calcolava: la curva non arrivava mai, e `--plot-envelopes effective_density` era un filtro accettato che non produceva niente.

La forma è calcata su `VoiceManager.offset_curves`, per la stessa ragione che quella porta scritta in docstring — il campionamento sta accanto a chi conosce la semantica, non nel visualizer:

- **`DensityStrategy.nominal_density()`** è la versione disegnabile di `calculate_density()`. Vive nella strategy perché formula e clamp li possiede lei, e due copie divergerebbero.
- **`DensityController.density_curve(duration, *, grain_duration_at, samples)`** campiona. `grain_duration_at` è iniettata perché `grain_duration` vive sullo `Stream`, non nel controller — stessa forma di `active_voices` in `offset_curves`.
- **`Stream.effective_density_curve`** la espone; `envelope_extractor` la pubblica da una riga esplicita, e il segnaposto di schema (`yaml_path: '_internal_calc_'`, `is_smart=False`) va in `_SCHEMA_EXCLUDED`.

È la densità della **voce 0**, quella che definisce il `sync_iot` in `generate_grains`. `num_voices` resta una riga a parte della legenda: chi guarda moltiplica se vuole il totale.

Due vincoli che il codice non poteva ignorare:

- **Nominale, non `get_value`.** `Parameter.get_value` passa dal probability gate e dalla variation strategy, quindi **pesca** quando c'è un range: campionare con quello darebbe una linea tremolante e non riproducibile, e consumerebbe l'RNG — *guardare la partitura cambierebbe il render*. Si legge la faccia valore, quella che `value_curve` già pubblica.
- **Griglia fitta.** Fra due breakpoint `fill_factor` e `grain_duration` sono lineari, ma il loro quoziente è un'**iperbole**: a metà strada fra 10 e 5 g/s non c'è 7.5 ma 6.67. `DEFAULT_DENSITY_SAMPLES = 129` contro i 33 degli offset per-voce, e un test lo verifica.

`None` in modalità `density`: lì sarebbe la copia esatta della curva `density`, già disegnata sotto il suo nome.

## Il resto

**Un fixture che costruisce `Stream` veri** (`tests/conftest.py`). Un `MagicMock` ha ogni attributo, quindi non sa rispondere a «questo attributo esiste?», e `object.__new__(Stream)` salta proprio l'inizializzazione che la superficie la costruisce. Il sample è un wav di silenzio in `tmp_path`, non `refs/` — che in un checkout pulito è vuota, dove due test si skippano già. Una guardia che si skippa non è una guardia.

**La guardia** (`TestPublishedSurfaceResolves`). Confronta l'insieme pubblicato con quello che risolve, **nei due sensi**. Con `effective_density` collegata, la lista delle chiavi dichiarate morte **si svuota**: ogni nome che il modulo pubblica adesso risolve.

**`pointer.start` con un envelope viene rifiutato dove il campo ha ancora un nome.** Prima moriva a valle con `TypeError: can only concatenate list (not "float") to list`, dentro `calculate`. Ora `InvalidFieldValueError` in inizializzazione, con `stream_id` e un hint che indica le due strade vere. Le espressioni matematiche continuano a funzionare (`_eval_math_expressions` è ricorsiva: `start: (10/2)` arriva già come `5.0` — verificato).

**La reference era sbagliata.** `docs/reference/yaml.md` elencava `pointer.start` fra i parametri che accettano envelope. La confusione aveva una radice reale: `_pre_normalize_loop_params` **scala davvero anche `start`** insieme ai parametri di loop con `loop_unit: normalized`. La macchina delle unità tratta `start` come i loop, il pointer no — ora il doc separa le due cose.

Aggiornati tre test che pinnavano contratti cambiati deliberatamente: `test_the_exclusion_is_declared_and_not_incidental` (l'insieme cresce a quattro nomi, ciascuno col suo motivo) e i due `TestAbstractMethodBodies` di `DensityStrategy`, i cui doppioni devono implementare il nuovo metodo dell'interfaccia.

## Verifica

Ogni test nuovo verificato rosso senza il fix corrispondente. Suite completa: **5333 passed, 2 skipped, 77 deselected**. Baseline su `main`: 5321. I due skip sono preesistenti (`refs/` vuota), i deselected sono i marker `e2e`.

Sull'audio non cambia niente. Sulla partitura sì, ed è il punto: gli stream in modalità `fill_factor` guadagnano una curva che prima non c'era.

## Cosa resta fuori

- **Stadio 2** — le 20 occorrenze di `object.__new__(Stream)` e la cicatrice che il bypass ha lasciato in produzione (`getattr(self, 'samples_dir', None)`). Quei test esercitano metodi privati su un oggetto mezzo costruito: riscriverli vuol dire decidere quale comportamento pubblico stavano verificando. Insieme: `get_sample_duration` è chiamata due volte per stream.
- **Stadio 3** — dare un nome al read-model: le quindici property di pass-through «Espone X per ScoreVisualizer».
- **I bounds di `effective_density`** — `GRANULAR_PARAMETERS` dichiara `min=1` ma il clamp reale usa quelli di `density` (`min=0.01`), e nessuno legge i primi. Vanno allineati o rimossi; non l'ho fatto qui perché tocca due test che pinnano il minimo a 1 di proposito.

## Impatto cross-repo

**`PGE-ls`: issue aperta** — [PGE-ls#39](https://github.com/DMGiulioRomano/PGE-ls/issues/39). Il suo `_check_pointer_param_bounds` ignora esplicitamente i valori envelope anche su `start`: giusto per i tre parametri di loop, sbagliato per `start`, e ora l'editor tace su una cosa che il motore rifiuta. L'hover del LS è invece già corretto.

**`PGE-ui`: nessuna issue.** Serializza `start` come scalare secco, quindi un envelope lì non lo produce. E `effective_density` era già fra le chiavi di `ENVELOPE_COLORS` che la UI legge via `/envelope-keys`: l'elenco dei nomi non cambia, cambia solo che ora uno di essi produce davvero una curva.

Per il resto non cambiano sintassi YAML, bounds, nomi di strategy o finestre, gerarchia errori (`InvalidFieldValueError` esisteva già), CLI, formati di output.

## Paper CIM 2026

**Questa PR è osservabile dagli esempi del paper**, a differenza delle precedenti: gli stream in modalità `fill_factor` guadagnano una curva in partitura. Il bump del submodule va deciso a valle del merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGbVnYdq91hHKRnN6x6ehs