### PR TITLE
feat(stream): duration opzionale, default = durata del sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ## [Unreleased]
 
+### Aggiunto
+
+- **`duration` opzionale nello stream: senza dichiarazione vale la durata del
+  sample.** A riposo lo stream risintetizza il file audio, quindi l'unica
+  durata non arbitraria è quella del file: ogni altro valore è una scelta
+  compositiva, e le scelte compositive stanno meglio come override espliciti.
+  Le condizioni di esistenza di uno stream passano da quattro a tre —
+  `stream_id`, `onset`, `sample`. `onset` resta obbligatorio: la posizione in
+  timeline non è deducibile da nulla.
+
+  La risoluzione vive in un punto solo, `resolve_stream_duration` in
+  `core/stream_config.py`, perché i siti che scrivono la durata sono due e
+  devono dire la stessa cosa: `StreamContext.from_yaml` (che la risolve prima
+  di costruire il dataclass — `duration` è dichiarato prima di `sample` e
+  `sample_dur_sec`, quindi un default lì costringerebbe anche loro ad averne
+  uno) e `Stream._init_stream_context`, che assegnava `self.duration`
+  iterando sui campi obbligatori e senza la stessa regola lascerebbe
+  l'attributo inesistente fino all'AttributeError alla prima generazione di
+  grani.
+
+  Il default scatta su `is None`, non sulla truthiness: `duration: null` vale
+  come chiave assente, mentre `duration: 0` resta zero e produce uno stream
+  senza grani invece di ereditare silenziosamente la lunghezza del sample.
+  Con `time_mode: normalized` l'asse `0.0`–`1.0` è mappato sulla durata
+  risolta, quindi senza `duration` copre l'intero sample.
+
+  Nessuno YAML valido cambia comportamento: se `duration` c'è, vince come
+  prima. Cambia solo il verdetto su input che prima erano rifiutati.
+
 ---
 
 ## [v7.0.0] — "Deviation Probability" — 2026-08-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,15 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   Nessuno YAML valido cambia comportamento: se `duration` c'è, vince come
   prima. Cambia solo il verdetto su input che prima erano rifiutati.
 
+  **Cache incrementale.** Per gli stream senza `duration` il fingerprint dello
+  stem include ora la durata risolta del sample: la lunghezza dello stem
+  dipende dal file audio, e il file non è mai entrato nell'hash — sostituirlo
+  con uno di durata diversa, a YAML fermo, avrebbe lasciato montato uno stem
+  della lunghezza vecchia. Entra la sola durata, non il contenuto: hashare i
+  campioni costerebbe quanto rirenderizzare. Uno stream che dichiara
+  `duration` produce un fingerprint identico a prima, quindi nessuno stem già
+  renderizzato viene invalidato.
+
 ---
 
 ## [v7.0.0] — "Deviation Probability" — 2026-08-12

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -11,7 +11,7 @@ sources:
   - src/pge/envelopes/
   - src/pge/shared/seeding.py
   - src/pge/shared/distribution_strategy.py
-last_synced_commit: dd43e1e
+last_synced_commit: 0e23016
 entry_for: [yaml-syntax, envelope-syntax]
 ---
 
@@ -204,9 +204,42 @@ Qualsiasi parametro numerico accetta le seguenti forme:
 streams:
   - stream_id: "nome_univoco"   # stringa identificativa
     onset: 0.0                  # tempo di inizio in secondi (assoluto)
-    duration: 30.0              # durata dello stream in secondi
     sample: "file.wav"          # nome file (cercato in Media/)
 ```
+
+Le condizioni di esistenza di uno stream sono tre. `onset` resta obbligatorio:
+la posizione in timeline non è deducibile da nulla.
+
+### `duration` opzionale
+
+`duration` è un campo **opzionale**: se assente vale la durata del file audio
+dichiarato in `sample`.
+
+```yaml
+streams:
+  - stream_id: "risintesi"      # dura quanto il sample
+    onset: 0.0
+    sample: "file.wav"
+
+  - stream_id: "scelta"         # override compositivo esplicito
+    onset: 0.0
+    duration: 30.0
+    sample: "file.wav"
+```
+
+A riposo lo stream risintetizza il sample, quindi l'unica durata non arbitraria
+è quella del file: ogni altro valore è una scelta compositiva, e le scelte
+compositive stanno bene come override espliciti.
+
+| Dichiarazione | Durata dello stream |
+|---------------|---------------------|
+| chiave assente | durata del sample |
+| `duration: null` | durata del sample (come chiave assente) |
+| `duration: 30.0` | 30.0 s (l'esplicito vince sempre) |
+| `duration: 0` | 0 s — nessun grano generato, il default **non** scatta |
+
+Con `time_mode: normalized` l'asse `0.0`–`1.0` degli envelope è mappato sulla
+durata risolta: senza `duration`, copre l'intero sample.
 
 ---
 

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -11,7 +11,7 @@ sources:
   - src/pge/envelopes/
   - src/pge/shared/seeding.py
   - src/pge/shared/distribution_strategy.py
-last_synced_commit: 0e23016
+last_synced_commit: 6d4bd0b
 entry_for: [yaml-syntax, envelope-syntax]
 ---
 
@@ -37,7 +37,9 @@ Sezioni rilevanti in questo doc:
 - [Seed (Riproducibilità)](#seed-riproducibilità) — render NumPy riproducibili;
   `rng_group` per condividere la sequenza fra stream
 - [Parameter Syntax](#parameter-syntax) — scalari, tuple, dict, envelope
-- [Campi Obbligatori di Stream](#campi-obbligatori-di-stream)
+- [Campi Obbligatori di Stream](#campi-obbligatori-di-stream) — `stream_id`, `onset`, `sample`
+- [Durata dello Stream](#durata-dello-stream-duration-opzionale) — `duration` opzionale,
+  assente = durata del sample
 - [Configurazione Processo (StreamConfig)](#configurazione-processo-streamconfig)
 - [La banda dei `_range`](#la-banda-dei-_range-distribution_mode-e-range_anchor) —
   larghezza, forma (`distribution_mode`), ancora (`range_anchor`)
@@ -208,9 +210,12 @@ streams:
 ```
 
 Le condizioni di esistenza di uno stream sono tre. `onset` resta obbligatorio:
-la posizione in timeline non è deducibile da nulla.
+la posizione in timeline non è deducibile da nulla. Per `duration`, che
+obbligatoria non è, vedi [Durata dello Stream](#durata-dello-stream-duration-opzionale).
 
-### `duration` opzionale
+---
+
+## Durata dello Stream (`duration` opzionale)
 
 `duration` è un campo **opzionale**: se assente vale la durata del file audio
 dichiarato in `sample`.

--- a/src/pge/api.py
+++ b/src/pge/api.py
@@ -127,12 +127,19 @@ def _with_trailing_sep(samples_dir):
     return samples_dir
 
 
-def _make_cache_manager(cache_manifest_path: Optional[str]):
-    """StreamCacheManager sul manifest esplicito; None = cache disattiva."""
+def _make_cache_manager(cache_manifest_path: Optional[str],
+                        samples_dir: Optional[str] = None):
+    """StreamCacheManager sul manifest esplicito; None = cache disattiva.
+
+    `samples_dir` serve al fingerprint degli stream senza `duration` (#205),
+    che risolve la durata dal file audio: senza, la risoluzione userebbe
+    PATHSAMPLES anche quando i sample stanno altrove.
+    """
     if cache_manifest_path is None:
         return None
     from pge.rendering.stream_cache_manager import StreamCacheManager
-    return StreamCacheManager(cache_path=cache_manifest_path)
+    return StreamCacheManager(cache_path=cache_manifest_path,
+                              samples_dir=samples_dir)
 
 
 def build_renderer(
@@ -178,7 +185,7 @@ def build_renderer(
             window_registry=window_reg,
             table_map=table_map,
             output_sr=output_sr,
-            cache_manager=_make_cache_manager(cache_manifest_path),
+            cache_manager=_make_cache_manager(cache_manifest_path, samples_dir),
             stream_data_map=generator.stream_data_map,
             audio_format=audio_format,
             jobs=jobs,
@@ -209,7 +216,7 @@ def build_renderer(
             'csound',
             score_writer=generator.score_writer,
             csound_config=csound_config,
-            cache_manager=_make_cache_manager(cache_manifest_path),
+            cache_manager=_make_cache_manager(cache_manifest_path, samples_dir),
             stream_data_map=generator.stream_data_map,
             sco_dir=opts.sco_dir,
         )

--- a/src/pge/core/stream.py
+++ b/src/pge/core/stream.py
@@ -34,7 +34,7 @@ from pge.shared.exceptions import (
 )
 from pge.parameters.parameter_schema import STREAM_PARAMETER_SCHEMA
 from pge.parameters.parameter_orchestrator import ParameterOrchestrator
-from pge.core.stream_config import StreamConfig, StreamContext
+from pge.core.stream_config import StreamConfig, StreamContext, resolve_stream_duration
 from pge.controllers.voice_manager import VoiceManager, VoiceConfig
 from pge.parameters.pitch_unit import make_pitch_unit
 from pge.strategies.voice_pitch_strategy import VoicePitchStrategyFactory, SEMITONE_LOCKED
@@ -169,11 +169,16 @@ class Stream:
 
     @staticmethod
     def _required_context_fields() -> set:
-        """Campi StreamContext che il YAML deve fornire: quelli senza default
-        (sample_dur_sec escluso: derivato dal file audio, mai dal YAML)."""
+        """Campi StreamContext che il YAML deve fornire: quelli senza default.
+
+        Esclusi, pur non avendo un default nel dataclass:
+        - sample_dur_sec: derivato dal file audio, mai dal YAML;
+        - duration: se assente vale la durata del sample (issue #205), risolta
+          da resolve_stream_duration invece che pretesa dallo YAML.
+        """
         return {
             field.name for field in fields(StreamContext)
-            if field.name != 'sample_dur_sec'
+            if field.name not in ('sample_dur_sec', 'duration')
             and field.default is dataclass_MISSING
             and field.default_factory is dataclass_MISSING
         }
@@ -195,6 +200,11 @@ class Stream:
         # con object.__new__ (bypass di __init__), dove samples_dir manca.
         self.sample_dur_sec = get_sample_duration(
             self.sample, base_path=getattr(self, 'samples_dir', None))
+        # duration e' fuori dai campi obbligatori (issue #205): il setattr sopra
+        # non la scrive piu', va risolta qui con la stessa regola di
+        # StreamContext.from_yaml. Senza questa riga self.duration non esiste e
+        # la prima generazione di grani solleva AttributeError.
+        self.duration = resolve_stream_duration(params, self.sample_dur_sec)
 
     def _init_stream_parameters(self, params: dict, config: StreamConfig) -> None:
         """

--- a/src/pge/core/stream_config.py
+++ b/src/pge/core/stream_config.py
@@ -7,6 +7,24 @@ from typing import Optional, Union
 from pge.shared.constants import DEFAULT_OUTPUT_SR
 from pge.shared.distribution_strategy import ANCHOR_CENTER
 
+
+def resolve_stream_duration(yaml_data: dict, sample_dur_sec: float) -> float:
+    """Durata dello stream: quella dichiarata, o la durata del sample (issue #205).
+
+    A riposo lo stream risintetizza il sample, quindi l'unica durata non
+    arbitraria e' quella del file: `duration` e' un override compositivo.
+
+    `is None` (non la truthiness, non `setdefault`) copre sia la chiave assente
+    sia `duration: null` esplicito, e lascia passare `duration: 0` invariata
+    invece di trasformarla silenziosamente nella lunghezza del sample.
+
+    Punto unico di risoluzione: la usano sia StreamContext.from_yaml sia
+    Stream._init_stream_context, che scrivono la stessa durata su due oggetti.
+    """
+    declared = yaml_data.get('duration')
+    return sample_dur_sec if declared is None else declared
+
+
 @dataclass(frozen=True)
 class StreamContext:
     stream_id: str
@@ -60,6 +78,11 @@ class StreamContext:
                 if name in yaml_data and yaml_data[name] is not None
             }
         kwargs['sample_dur_sec'] = sample_dur_sec
+        # duration assente o null -> durata del sample (issue #205). Risolta
+        # prima di cls(**kwargs): il dataclass non puo' avere un default,
+        # e' dichiarato prima di sample/sample_dur_sec che ne resterebbero
+        # obbligati ad averne uno.
+        kwargs['duration'] = resolve_stream_duration(kwargs, sample_dur_sec)
         return cls(**kwargs)
 
 

--- a/src/pge/core/stream_config.py
+++ b/src/pge/core/stream_config.py
@@ -8,21 +8,34 @@ from pge.shared.constants import DEFAULT_OUTPUT_SR
 from pge.shared.distribution_strategy import ANCHOR_CENTER
 
 
+def stream_duration_is_implicit(yaml_data: dict) -> bool:
+    """True quando lo stream non dichiara una durata propria (issue #205).
+
+    `is None` (non la truthiness, non `setdefault`) copre sia la chiave assente
+    sia `duration: null` esplicito, e lascia fuori `duration: 0`, che e' una
+    dichiarazione degenere ma pur sempre una dichiarazione.
+
+    Predicato condiviso, non solo dettaglio di resolve_stream_duration: lo usa
+    anche il fingerprint della cache (rendering/stream_cache_manager.py), che
+    deve registrare la durata del sample esattamente sugli stream su cui il
+    motore la eredita. Se le due letture divergessero, uno stream la cui durata
+    dipende dal file audio resterebbe clean al cambiare del file.
+    """
+    return yaml_data.get('duration') is None
+
+
 def resolve_stream_duration(yaml_data: dict, sample_dur_sec: float) -> float:
     """Durata dello stream: quella dichiarata, o la durata del sample (issue #205).
 
     A riposo lo stream risintetizza il sample, quindi l'unica durata non
     arbitraria e' quella del file: `duration` e' un override compositivo.
 
-    `is None` (non la truthiness, non `setdefault`) copre sia la chiave assente
-    sia `duration: null` esplicito, e lascia passare `duration: 0` invariata
-    invece di trasformarla silenziosamente nella lunghezza del sample.
-
     Punto unico di risoluzione: la usano sia StreamContext.from_yaml sia
     Stream._init_stream_context, che scrivono la stessa durata su due oggetti.
     """
-    declared = yaml_data.get('duration')
-    return sample_dur_sec if declared is None else declared
+    if stream_duration_is_implicit(yaml_data):
+        return sample_dur_sec
+    return yaml_data['duration']
 
 
 @dataclass(frozen=True)

--- a/src/pge/rendering/stream_cache_manager.py
+++ b/src/pge/rendering/stream_cache_manager.py
@@ -185,7 +185,7 @@ class StreamCacheManager:
         if stream_id not in manifest:
             return True
 
-        if manifest[stream_id] != self.compute_fingerprint(stream_dict):
+        if manifest[stream_id] != current_fp:
             return True
 
         if aif_path is not None and not os.path.exists(aif_path):

--- a/src/pge/rendering/stream_cache_manager.py
+++ b/src/pge/rendering/stream_cache_manager.py
@@ -23,6 +23,8 @@ import json
 import os
 from typing import Dict, List, Optional
 
+from pge.core.stream_config import stream_duration_is_implicit
+
 
 # Chiavi escluse dal fingerprint: cambiano QUALI stream vengono renderizzati
 # (vedi Generator._filter_solo_mute), non il contenuto audio del singolo stem.
@@ -120,10 +122,15 @@ class StreamCacheManager:
         # stem della lunghezza vecchia. Il contenuto resta fuori: hashare i
         # campioni costerebbe quanto rirenderizzare.
         #
+        # Il predicato e' quello del motore, importato e non riscritto: se il
+        # default cambiasse (es. anche `0` trattato come assente) le due letture
+        # divergerebbero, e uno stream con durata ereditata resterebbe clean al
+        # cambiare del sample.
+        #
         # La chiave si aggiunge SOLO quando `duration` manca: uno stream che la
         # dichiara produce il payload identico a prima, quindi nessuno stem gia'
         # renderizzato viene invalidato da questa modifica.
-        if stream_dict.get('duration') is None:
+        if stream_duration_is_implicit(stream_dict):
             sample_dur = self._sample_dur_sec(stream_dict.get('sample'))
             if sample_dur is not None:
                 payload['sample_dur_sec'] = sample_dur

--- a/src/pge/rendering/stream_cache_manager.py
+++ b/src/pge/rendering/stream_cache_manager.py
@@ -184,10 +184,6 @@ class StreamCacheManager:
         manifest = self.load()
         
         current_fp = self.compute_fingerprint(stream_dict)
-        saved_fp = manifest.get(stream_id, 'NON_PRESENTE')
-        #match = current_fp == saved_fp
-        #aif_exists = os.path.exists(aif_path) if aif_path is not None else 'N/A'
-        #print(f"[CACHE DEBUG] {stream_id}: match={match} aif_path={aif_path} aif_exists={aif_exists}", flush=True)
 
         if stream_id not in manifest:
             return True

--- a/src/pge/rendering/stream_cache_manager.py
+++ b/src/pge/rendering/stream_cache_manager.py
@@ -57,10 +57,29 @@ class StreamCacheManager:
 
     Args:
         cache_path: path del file manifest JSON su disco
+        samples_dir: directory dei sample audio, usata solo per risolvere la
+            durata di uno stream che non dichiara `duration` (issue #205).
+            None -> fallback su PATHSAMPLES, come nel resto del motore.
     """
 
-    def __init__(self, cache_path: str):
+    def __init__(self, cache_path: str, samples_dir: Optional[str] = None):
         self.cache_path = cache_path
+        self.samples_dir = samples_dir
+
+    def _sample_dur_sec(self, sample) -> Optional[float]:
+        """Durata del sample, o None se non risolvibile.
+
+        Non solleva: un sample introvabile fara' fallire il render con il suo
+        errore, e non e' compito del fingerprint anticiparlo — qui produrrebbe
+        solo un crash prima del messaggio giusto.
+        """
+        if not isinstance(sample, str) or not sample:
+            return None
+        from pge.shared.utils import get_sample_duration
+        try:
+            return get_sample_duration(sample, base_path=self.samples_dir)
+        except Exception:
+            return None
 
     # =========================================================================
     # FINGERPRINT
@@ -94,6 +113,20 @@ class StreamCacheManager:
             'semantics': VARIATION_SEMANTICS_VERSION,
             'stream': filtered,
         }
+        # `duration` omessa (issue #205): la lunghezza dello stem viene dal file
+        # audio, e il contenuto del file non e' mai stato nell'hash. Entra qui la
+        # sola durata risolta — l'unica dipendenza che il default introduce —
+        # cosi' sostituire il sample con uno piu' lungo non lascia montato uno
+        # stem della lunghezza vecchia. Il contenuto resta fuori: hashare i
+        # campioni costerebbe quanto rirenderizzare.
+        #
+        # La chiave si aggiunge SOLO quando `duration` manca: uno stream che la
+        # dichiara produce il payload identico a prima, quindi nessuno stem gia'
+        # renderizzato viene invalidato da questa modifica.
+        if stream_dict.get('duration') is None:
+            sample_dur = self._sample_dur_sec(stream_dict.get('sample'))
+            if sample_dur is not None:
+                payload['sample_dur_sec'] = sample_dur
         serialized = json.dumps(payload, sort_keys=True)
         return hashlib.sha256(serialized.encode('utf-8')).hexdigest()
 

--- a/tests/core/test_stream_duration_default.py
+++ b/tests/core/test_stream_duration_default.py
@@ -1,0 +1,142 @@
+# =============================================================================
+# tests/core/test_stream_duration_default.py
+# =============================================================================
+"""
+Test per `duration` opzionale nello stream (issue #205).
+
+A riposo lo stream risintetizza il sample: se `duration` non e' dichiarata,
+la durata dello stream e' quella del file audio in `sample`. Le condizioni
+di esistenza di uno stream passano da quattro a tre: stream_id, onset, sample.
+"""
+import numpy as np
+import pytest
+import soundfile as sf
+
+from pge.core.stream import Stream
+from pge.shared.exceptions import MissingFieldError
+
+
+SR = 48000
+
+
+def _write_wav(directory, name='tone.wav', seconds=2.0):
+    """Scrive un wav silenzioso di durata nota: la generazione dei grani e'
+    simbolica, conta solo la durata dichiarata dall'header."""
+    sf.write(str(directory / name),
+             np.zeros(int(SR * seconds), dtype='float32'), SR)
+    return name
+
+
+def _params(**overrides):
+    """Stream minimo SENZA `duration`: solo le tre condizioni di esistenza."""
+    params = {
+        'stream_id': 'test_stream',
+        'onset': 0.0,
+        'sample': 'tone.wav',
+        'grain': {'duration': 0.05, 'envelope': 'hanning'},
+    }
+    params.update(overrides)
+    return params
+
+
+def _build(tmp_path, **overrides):
+    """Stream vero attraverso __init__, pronto a generare grani.
+
+    I riferimenti Csound (`sample_table_num`, `window_table_map`) in produzione
+    li assegna il Generator: qui vanno iniettati a mano, come negli altri test
+    che generano grani da uno Stream costruito direttamente.
+    """
+    stream = Stream(_params(**overrides), samples_dir=str(tmp_path))
+    stream.sample_table_num = 1
+    stream.window_table_map = {'hanning': 2}
+    return stream
+
+
+class TestDurationDefaultsToSampleDuration:
+    """Senza `duration`, lo stream dura quanto il sample."""
+
+    def test_grains_span_the_sample_duration(self, tmp_path):
+        """Il default e' visibile sui grani, non solo sull'attributo: la
+        generazione e' lazy, quindi il test legge `.grains` (issue #205)."""
+        _write_wav(tmp_path, seconds=2.0)
+
+        stream = _build(tmp_path)
+
+        onsets = [g.onset for g in stream.grains]
+        assert onsets, "senza duration lo stream deve comunque generare grani"
+        assert max(onsets) < 2.0
+        assert max(onsets) > 1.0, (
+            "i grani devono coprire la durata del sample, non un default piu' corto")
+
+    def test_explicit_duration_still_wins(self, tmp_path):
+        """Nessuna regressione sugli YAML esistenti: la durata dichiarata
+        prevale sulla durata del sample."""
+        _write_wav(tmp_path, seconds=2.0)
+
+        stream = _build(tmp_path, duration=0.5)
+
+        assert stream.duration == pytest.approx(0.5)
+        assert max(g.onset for g in stream.grains) < 0.5
+
+    def test_explicit_null_behaves_as_absent_key(self, tmp_path):
+        """`duration: null` e' una dichiarazione vuota, non un valore: vale
+        la durata del sample come se la chiave non ci fosse."""
+        _write_wav(tmp_path, seconds=2.0)
+
+        stream = _build(tmp_path, duration=None)
+
+        assert stream.duration == pytest.approx(2.0)
+        assert max(g.onset for g in stream.grains) > 1.0
+
+    def test_zero_duration_is_not_replaced_by_the_sample(self, tmp_path):
+        """`duration: 0` resta zero: il default scatta sull'assenza, non sulla
+        truthiness. Uno stream vuoto e' un errore da segnalare all'autore, non
+        da riempire silenziosamente con la lunghezza del sample."""
+        _write_wav(tmp_path, seconds=2.0)
+
+        stream = _build(tmp_path, duration=0)
+
+        assert stream.duration == 0
+        assert stream.grains == []
+
+    def test_normalized_time_mode_maps_onto_the_resolved_duration(self, tmp_path):
+        """`time_mode: normalized` mappa 0.0-1.0 sulla duration risolta: senza
+        `duration`, l'asse normalizzato copre l'intero sample."""
+        _write_wav(tmp_path, seconds=2.0)
+
+        stream = _build(
+            tmp_path,
+            time_mode='normalized',
+            grain={'duration': [[0.0, 0.08], [1.0, 0.02]], 'envelope': 'hanning'},
+        )
+
+        # A meta' del sample l'envelope e' a meta' corsa. Se 0.0-1.0 fosse
+        # mappato su una duration diversa (1 s, o un default arbitrario), qui
+        # il valore sarebbe gia' saturo a 0.02.
+        midpoint = min(stream.grains, key=lambda g: abs(g.onset - 1.0))
+        assert midpoint.duration == pytest.approx(0.05, abs=1e-3)
+
+
+class TestStreamExistenceConditions:
+    """Le condizioni di esistenza di uno stream sono tre: stream_id, onset,
+    sample. `duration` non e' piu' fra queste."""
+
+    def test_missing_onset_still_fails_and_does_not_name_duration(self, tmp_path):
+        _write_wav(tmp_path)
+        params = {'stream_id': 'test_stream', 'sample': 'tone.wav'}
+
+        with pytest.raises(MissingFieldError) as exc_info:
+            Stream(params, samples_dir=str(tmp_path))
+
+        err = exc_info.value
+        assert err.fields == ['onset']
+        assert err.stream_id == 'test_stream'
+
+    def test_missing_stream_id_still_fails(self, tmp_path):
+        _write_wav(tmp_path)
+        params = {'onset': 0.0, 'sample': 'tone.wav'}
+
+        with pytest.raises(MissingFieldError) as exc_info:
+            Stream(params, samples_dir=str(tmp_path))
+
+        assert exc_info.value.fields == ['stream_id']

--- a/tests/core/test_stream_duration_default.py
+++ b/tests/core/test_stream_duration_default.py
@@ -140,3 +140,33 @@ class TestStreamExistenceConditions:
             Stream(params, samples_dir=str(tmp_path))
 
         assert exc_info.value.fields == ['stream_id']
+
+
+class TestRenderWithoutDuration:
+    """La pipeline completa YAML -> audio con uno stream senza `duration`."""
+
+    def test_yaml_without_duration_renders_for_the_sample_duration(self, tmp_path):
+        from pge import api
+
+        _write_wav(tmp_path, seconds=2.0)
+        yaml_path = tmp_path / 'senza_duration.yml'
+        yaml_path.write_text(
+            "composition:\n"
+            "  title: \"duration default\"\n"
+            "\n"
+            "streams:\n"
+            "  - stream_id: \"s1\"\n"
+            "    onset: 0.0\n"
+            "    sample: \"tone.wav\"\n"
+        )
+        output_path = tmp_path / 'out.wav'
+
+        generator = api.load_generator(str(yaml_path), samples_dir=str(tmp_path))
+        result = api.render(
+            generator, str(output_path),
+            renderer='numpy', samples_dir=str(tmp_path),
+        )
+
+        assert result.audio_paths
+        rendered = sf.info(result.audio_paths[0])
+        assert rendered.duration == pytest.approx(2.0, abs=0.2)

--- a/tests/e2e/test_engine_errors_e2e.py
+++ b/tests/e2e/test_engine_errors_e2e.py
@@ -41,12 +41,30 @@ streams:
       duration_range: 0.01
 """
 
+# Manca `onset`. `duration` e' opzionale (issue #205): ometterla non e' un
+# errore, quindi qui il campo mancante e' uno solo -> messaggio singolare.
 YAML_MISSING_CONTEXT = """\
 composition:
   title: "test missing context"
 streams:
   - stream_id: "stream_no_ctx"
     sample: "pino.wav"
+    distribution_mode: 'gaussian'
+    density: 5
+    distribution: [[0,1],[1,1]]
+    pointer:
+      speed_ratio: 1.0
+    grain:
+      duration: 0.05
+      duration_range: 0.01
+"""
+
+# Mancano `stream_id` e `onset`: due campi obbligatori -> messaggio plurale.
+YAML_MISSING_TWO_CONTEXT = """\
+composition:
+  title: "test missing two context fields"
+streams:
+  - sample: "pino.wav"
     distribution_mode: 'gaussian'
     density: 5
     distribution: [[0,1],[1,1]]
@@ -245,11 +263,27 @@ def test_e2e_missing_context_fields(tmp_path, cleanup_log):
     cleanup_log.append(_log_path_for(yaml_abs))
     result = _run(yaml_abs)
     _assert_clean_user_output(result)
-    assert "Campi obbligatori mancanti" in result.stdout
-    assert "'duration'" in result.stdout
+    assert "Campo obbligatorio mancante" in result.stdout
     assert "'onset'" in result.stdout
+    # duration omessa non e' un errore (issue #205): non deve comparire
+    # fra i campi mancanti.
+    assert "'duration'" not in result.stdout
     assert "stream_no_ctx" in result.stdout
-    _assert_log_contains(yaml_abs, "MissingFieldError", ["duration", "onset"])
+    _assert_log_contains(yaml_abs, "MissingFieldError", ["onset"])
+
+
+@pytest.mark.e2e
+def test_e2e_missing_two_context_fields(tmp_path, cleanup_log):
+    """Con piu' campi mancanti il messaggio e' plurale e li elenca tutti."""
+    yaml_abs = _write_yaml(tmp_path, '02b_missing_two_context.yml',
+                           YAML_MISSING_TWO_CONTEXT)
+    cleanup_log.append(_log_path_for(yaml_abs))
+    result = _run(yaml_abs)
+    _assert_clean_user_output(result)
+    assert "Campi obbligatori mancanti" in result.stdout
+    assert "'onset'" in result.stdout
+    assert "'stream_id'" in result.stdout
+    _assert_log_contains(yaml_abs, "MissingFieldError", ["onset", "stream_id"])
 
 
 @pytest.mark.e2e

--- a/tests/rendering/test_stream_cache_manager.py
+++ b/tests/rendering/test_stream_cache_manager.py
@@ -328,6 +328,41 @@ class TestFingerprintImplicitDuration:
 
         assert isinstance(fp, str) and len(fp) == 64
 
+    def test_is_dirty_computes_the_fingerprint_once(self, cache_path, tmp_path):
+        """Il fingerprint di uno stream senza `duration` legge l'header del
+        sample: calcolarlo due volte per ogni is_dirty raddoppia l'I/O senza
+        cambiare la risposta."""
+        d = {'stream_id': 's1', 'onset': 0.0, 'sample': 'tono.wav'}
+        self._write_wav(tmp_path, 'tono.wav', 2.0)
+        mgr = self._manager(cache_path, tmp_path)
+        mgr.update_after_build([d])
+
+        calls = []
+        real = mgr.compute_fingerprint
+
+        def counting(stream_dict):
+            calls.append(stream_dict)
+            return real(stream_dict)
+
+        mgr.compute_fingerprint = counting
+        mgr.is_dirty(d, aif_path=None)
+
+        assert len(calls) == 1
+
+    def test_null_duration_counts_as_absent(self, cache_path, tmp_path):
+        """`duration: null` e' la chiave assente anche per il fingerprint:
+        stessa regola di resolve_stream_duration, o il motore userebbe la
+        durata del sample mentre l'hash non la registra."""
+        implicit = {'stream_id': 's1', 'onset': 0.0, 'sample': 'tono.wav'}
+        explicit_null = {**implicit, 'duration': None}
+
+        self._write_wav(tmp_path, 'tono.wav', 2.0)
+        before = self._manager(cache_path, tmp_path).compute_fingerprint(explicit_null)
+        self._write_wav(tmp_path, 'tono.wav', 5.0)
+        after = self._manager(cache_path, tmp_path).compute_fingerprint(explicit_null)
+
+        assert before != after
+
     def test_without_samples_dir_the_fingerprint_still_works(self, manager):
         """Manager costruito senza samples_dir (cache disattiva sul path di
         default): nessuna risoluzione, nessun crash."""

--- a/tests/rendering/test_stream_cache_manager.py
+++ b/tests/rendering/test_stream_cache_manager.py
@@ -254,6 +254,90 @@ class TestFingerprintIgnoresMuteSolo:
         assert manager.is_dirty(toggled, aif_path=aif) is False
 
 
+class TestFingerprintImplicitDuration:
+    """Con `duration` omessa (issue #205) la lunghezza dello stem viene dal file
+    audio, che il fingerprint non osserva: sostituire il sample con uno di
+    durata diversa, a YAML fermo, lascerebbe montato uno stem lungo un'altra
+    cosa. Entra nell'hash la durata risolta del sample — non il suo contenuto,
+    che resta fuori come e' sempre stato."""
+
+    @staticmethod
+    def _write_wav(directory, name, seconds):
+        import numpy as np
+        import soundfile as sf
+        sf.write(str(directory / name),
+                 np.zeros(int(48000 * seconds), dtype='float32'), 48000)
+
+    def _manager(self, cache_path, samples_dir):
+        return StreamCacheManager(cache_path=cache_path, samples_dir=str(samples_dir))
+
+    def test_sample_length_change_marks_the_stem_dirty(self, cache_path, tmp_path):
+        d = {'stream_id': 's1', 'onset': 0.0, 'sample': 'tono.wav'}
+
+        self._write_wav(tmp_path, 'tono.wav', 2.0)
+        before = self._manager(cache_path, tmp_path).compute_fingerprint(d)
+
+        # stesso YAML, altro file audio sotto lo stesso nome
+        self._write_wav(tmp_path, 'tono.wav', 5.0)
+        after = self._manager(cache_path, tmp_path).compute_fingerprint(d)
+
+        assert before != after
+
+    def test_same_sample_length_keeps_the_fingerprint(self, cache_path, tmp_path):
+        d = {'stream_id': 's1', 'onset': 0.0, 'sample': 'tono.wav'}
+        self._write_wav(tmp_path, 'tono.wav', 2.0)
+        mgr = self._manager(cache_path, tmp_path)
+
+        assert mgr.compute_fingerprint(d) == mgr.compute_fingerprint(d)
+
+    def test_explicit_duration_ignores_the_sample_length(self, cache_path, tmp_path):
+        """Con `duration` dichiarata la durata del sample non c'entra nulla:
+        cambiarla non deve marcare dirty uno stem che suona identico."""
+        d = {'stream_id': 's1', 'onset': 0.0, 'duration': 3.0, 'sample': 'tono.wav'}
+
+        self._write_wav(tmp_path, 'tono.wav', 2.0)
+        before = self._manager(cache_path, tmp_path).compute_fingerprint(d)
+        self._write_wav(tmp_path, 'tono.wav', 5.0)
+        after = self._manager(cache_path, tmp_path).compute_fingerprint(d)
+
+        assert before == after
+
+    def test_explicit_duration_payload_is_unchanged(self, cache_path, tmp_path):
+        """Il payload di uno stream con `duration` esplicita e' identico a
+        quello di prima di #205: qualunque variazione invaliderebbe la cache di
+        ogni stem gia' renderizzato."""
+        import hashlib
+        d = {'stream_id': 's1', 'onset': 0.0, 'duration': 3.0, 'sample': 'tono.wav'}
+        self._write_wav(tmp_path, 'tono.wav', 2.0)
+
+        legacy_payload = {
+            'semantics': scm.VARIATION_SEMANTICS_VERSION,
+            'stream': d,
+        }
+        legacy = hashlib.sha256(
+            json.dumps(legacy_payload, sort_keys=True).encode('utf-8')).hexdigest()
+
+        assert self._manager(cache_path, tmp_path).compute_fingerprint(d) == legacy
+
+    def test_unresolvable_sample_does_not_raise(self, cache_path, tmp_path):
+        """Un sample introvabile non deve far esplodere il fingerprint: il
+        render fallira' da solo, con il suo errore, piu' avanti."""
+        d = {'stream_id': 's1', 'onset': 0.0, 'sample': 'inesistente.wav'}
+
+        fp = self._manager(cache_path, tmp_path).compute_fingerprint(d)
+
+        assert isinstance(fp, str) and len(fp) == 64
+
+    def test_without_samples_dir_the_fingerprint_still_works(self, manager):
+        """Manager costruito senza samples_dir (cache disattiva sul path di
+        default): nessuna risoluzione, nessun crash."""
+        d = {'stream_id': 's1', 'onset': 0.0, 'sample': 'tono.wav'}
+
+        fp = manager.compute_fingerprint(d)
+
+        assert isinstance(fp, str) and len(fp) == 64
+
+
 # =============================================================================
 # 2. CACHE PERSISTENCE
 # =============================================================================

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -171,7 +171,7 @@ class TestBuildRendererCache:
             api_mocks['api'].build_renderer(
                 'numpy', gen, cache_manifest_path='cache/x.json')
 
-        scm_cls.assert_called_once_with(cache_path='cache/x.json')
+        scm_cls.assert_called_once_with(cache_path='cache/x.json', samples_dir=None)
         kwargs = api_mocks['RendererFactory'].create.call_args.kwargs
         assert kwargs['cache_manager'] is scm_instance
         assert capsys.readouterr().out == ''
@@ -185,10 +185,28 @@ class TestBuildRendererCache:
             api_mocks['api'].build_renderer(
                 'csound', gen, cache_manifest_path='cache/y.json')
 
-        scm_cls.assert_called_once_with(cache_path='cache/y.json')
+        scm_cls.assert_called_once_with(cache_path='cache/y.json', samples_dir=None)
         kwargs = api_mocks['RendererFactory'].create.call_args.kwargs
         assert kwargs['cache_manager'] is scm_instance
         assert capsys.readouterr().out == ''
+
+
+    def test_samples_dir_reaches_the_cache_manager(self, api_mocks):
+        """Il fingerprint di uno stream senza `duration` (#205) risolve la
+        durata dal file audio: senza samples_dir cercherebbe in PATHSAMPLES
+        anche quando i sample stanno altrove, e la risoluzione fallirebbe in
+        silenzio."""
+        scm_mod, scm_cls, _ = _make_scm_module()
+        gen = api_mocks['generator_instance']
+
+        with patch.dict(sys.modules,
+                        {'pge.rendering.stream_cache_manager': scm_mod}):
+            api_mocks['api'].build_renderer(
+                'csound', gen, cache_manifest_path='cache/y.json',
+                samples_dir='/media/wavs')
+
+        scm_cls.assert_called_once_with(cache_path='cache/y.json',
+                                        samples_dir='/media/wavs')
 
 
 class TestBuildRendererUnknownType:


### PR DESCRIPTION
Closes #205

## Cosa cambia

`duration` diventa un campo opzionale dello stream: se assente, la durata dello stream è quella del file audio dichiarato in `sample`. Le condizioni di esistenza passano da quattro a tre — `stream_id`, `onset`, `sample`.

| Dichiarazione | Durata risolta |
|---|---|
| chiave assente | durata del sample |
| `duration: null` | durata del sample |
| `duration: 30.0` | 30.0 s (l'esplicito vince) |
| `duration: 0` | 0 s, il default non scatta |

## Come

La regola vive in `core/stream_config.py`, in due funzioni che si chiamano fra loro: `stream_duration_is_implicit` decide *se* la durata è ereditata, `resolve_stream_duration` decide *quale* sia. Tre siti la consumano, nessuno la riscrive:

1. `StreamContext.from_yaml` — risolve prima di `cls(**kwargs)`. Il dataclass non può avere un default su `duration`: è dichiarato prima di `sample` e `sample_dur_sec`, che ne resterebbero obbligati ad averne uno. `duration` è quindi escluso da `_required_context_fields()` come già `sample_dur_sec`.
2. `Stream._init_stream_context` — assegnava `self.duration` iterando sui campi obbligatori. Tolta `duration` da quel set, l'attributo non veniva più scritto e la prima generazione di grani sollevava AttributeError; ora usa la stessa funzione di risoluzione.
3. `StreamCacheManager.compute_fingerprint` — importa il predicato per sapere su quali stream registrare la durata del sample (sotto).

Il default scatta su `is None`, non sulla truthiness: copre sia la chiave assente sia `duration: null`, e lascia `duration: 0` invariata.

## Cache: la durata del sample entra nel fingerprint

Con `duration` omessa la lunghezza dello stem diventa funzione di un file che l'hash non osservava: sostituire il sample con uno di durata diversa, a YAML fermo, lasciava lo stem clean e montato alla lunghezza vecchia.

`compute_fingerprint` aggiunge al payload la **sola durata risolta** del sample, e **solo quando `duration` manca** — deciso da `stream_duration_is_implicit`, lo stesso predicato del motore, così un domani un default più largo si propaga ai due siti insieme invece di lasciarli divergere. Due conseguenze volute:

- il contenuto audio resta fuori dall'hash, come è sempre stato — il buco pre-esistente non viene chiuso qui, viene chiusa la sola dipendenza che questa PR introduce;
- uno stream che dichiara `duration` produce un payload bit-identico a prima, quindi **nessuno stem già renderizzato viene invalidato**. È pinnato da un test golden che ricalcola l'hash legacy a mano.

La risoluzione la fa il manager stesso via `get_sample_duration`, con `samples_dir` iniettata da `api.build_renderer`; un sample introvabile non solleva, il render fallirà più avanti con il suo errore. `is_dirty` calcola il fingerprint una volta sola: adesso che comporta una lettura di header, farlo due volte è I/O sprecato.

## TDD

Il primo test è rosso per il motivo giusto (`MissingFieldError: 'duration'` in costruzione) e legge `.grains`: la generazione è lazy, quindi costruire uno Stream senza `duration` non farebbe emergere l'AttributeError. Otto test in `tests/core/test_stream_duration_default.py`, dal default sui grani al render completo YAML → NumPy → audio; otto in `tests/rendering/test_stream_cache_manager.py` per il fingerprint (incluso `duration: null` e il conteggio delle chiamate dentro `is_dirty`).

## Copertura dei test — cosa esercita cosa

`pytest.ini` ha `addopts = -m "not e2e"`, quindi **`make tests` da solo non esegue** le asserzioni e2e che questa PR modifica in `tests/e2e/test_engine_errors_e2e.py`. Servono entrambi i comandi, ed entrambi sono verdi:

- `make tests` → **5358 passed**, 78 deselected (i deselected sono gli e2e).
- `make e2e-tests` (con `refs/` popolata) → **62 passed, 15 skipped**. I 15 skip sono i test che richiedono csound, non installato in locale: in CI il job e2e installa csound e sox, genera `refs/pino.wav` e li esegue tutti — è quel job a coprire `test_cache_e2e.py`, cioè proprio la superficie toccata dal fix del fingerprint.

Nota per chi rilancia in locale: con `refs/` vuota gli e2e falliscono per `SampleNotFoundError`, perché in `Stream.__init__` `get_sample_duration` gira prima di `_check_required_context_fields`. È comportamento pre-esistente e resta invariato.

## Scostamento dalla issue

Un criterio di accettazione non è verificabile come scritto: «`duration: 0` resta un errore di validazione». Contro il codice, `duration: 0` **non** è un errore di validazione né prima né dopo questa PR — non esiste alcun bound su `duration` di stream, e uno stream a durata zero produce semplicemente zero grani (comportamento già fissato da `test_zero_duration_no_grains` in `tests/core/test_stream.py`).

L'invariante che conta è comunque coperto, e il test lo asserisce così: con `duration: 0` la durata **non** diventa la lunghezza del sample. Introdurre una validazione `duration > 0` sarebbe una restrizione nuova della superficie YAML, fuori dallo scope di questa issue e non additiva — quindi non l'ho fatto.

## Versionamento

Target **v7.1.0** (MINOR), come da issue: nessuno YAML valido cambia comportamento, cambia solo il verdetto su input prima rifiutati.

## Impatto cross-repo

Come da `.claude/rules/cross-repo-impact.md`, e già tracciato nel commento della issue:

- PGE-ls: DMGiulioRomano/PGE-ls#41 → PR DMGiulioRomano/PGE-ls#42
- PGE-ui: DMGiulioRomano/PGE-ui#117 → PR DMGiulioRomano/PGE-ui#118

Submodule del paper CIM 2026: nessun bump necessario. La modifica è retrocompatibile e gli esempi `exN.yml` dichiarano tutti `duration` esplicitamente, quindi il rendering degli esempi non cambia.

## Documentazione

- `docs/reference/yaml.md`: `duration` esce dai campi obbligatori e ha una sezione propria di pari livello — «Durata dello Stream» — con la tabella dei quattro casi e la nota su `time_mode: normalized`; TOC aggiornata. `make docs-lint` OK (19 docs).
- CHANGELOG sotto Unreleased / Aggiunto, con il paragrafo sulla cache incrementale.