### PR TITLE
feat(yaml): grain.read_direction — il verso di lettura del grano diventa dichiarativo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,52 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ## [Unreleased]
 
+### Aggiunto
+
+- **`grain.read_direction`: il verso di lettura del grano diventa
+  dichiarativo.** Dominio `[-1, +1]` — `-1` legge all'indietro, `+1` in avanti
+  — scalare o envelope, indipendente dal segno di `pointer.speed_ratio`. Il
+  caso più ovvio (testina che percorre il buffer all'indietro, grani letti in
+  avanti) si otteneva saturando un gate stocastico a 100; ora si scrive.
+
+  L'interpolazione è `step`, ma non come opzione: è la natura della chiave.
+  L'envelope si scrive come una spezzata qualsiasi e il gradino lo impone la
+  chiave (`type: step` esplicito è ridondanza accettata); qualunque altro
+  interp — `linear`, `cubic`, in forma dict, per-punto o BP group — solleva
+  `InvalidFieldValueError` invece di essere accettato o corretto in silenzio.
+  Il verso ha due stati, non una rampa fra i due. Per la stessa ragione i
+  valori dichiarati devono stare in `{-1, +1}`: con `step` imposto l'envelope
+  emette solo i valori scritti ai breakpoint, quindi arrotondare al segno
+  significherebbe renderizzare una cosa diversa da quella scritta, e lo `0`
+  non ha un segno.
+
+  `grain.reverse` **resta identica**: nessun breaking change, e con entrambe le
+  chiavi assenti il comportamento è l'attuale modalità `auto` (il verso segue
+  `pointer.speed_ratio`). Le due chiavi insieme sono un **errore esplicito** e
+  non una priorità come in `loop_end`/`loop_dur`: governano la stessa grandezza
+  con semantiche opposte, e sceglierne una in silenzio nasconderebbe l'errore
+  invece di segnalarlo.
+
+  Il verso stocastico ha una chiave propria, `deviation_probability.read_direction`,
+  come ogni altro parametro dello schema: probabilità per-grano di ribaltare il
+  verso dichiarato. `deviation_probability.reverse` resta legata a
+  `grain.reverse` e non tocca la chiave nuova, così un vecchio `reverse: 100`
+  rimasto nello YAML non ribalta in silenzio un verso appena scritto. Il
+  default è quindi deterministico, che era il punto.
+
+  Nuovo `variation_mode='negate'` (`NegateVariation`): su un dominio con segno
+  il flip per-grano è un cambio di segno, mentre `'invert'` (`1 - base`)
+  produrrebbe `2` e `0`. Con il flip dentro il `Parameter`, il verso del grano
+  si legge in una riga — `read_direction.get_value(t) < 0` — e il ramo morto
+  che gestiva un `Envelope` su `grain.reverse` (irraggiungibile: la chiave non
+  accetta valori) è stato rimosso.
+
+  La map non cambia: il verso della testa del grano è già disegnato dal solo
+  segno di `pitch_ratio`, e il colore usa `abs(pitch_ratio)`. Il blocco `pitch`
+  non è toccato: resta interfaccia per la sola altezza percepita, con bounds
+  positivi per costruzione. Le curve `read_direction` e `read_direction_prob`
+  sono registrate fra gli envelope plottabili (`--plot-envelopes`, export SV).
+
 ---
 
 ## [v7.1.0] — "Sample Duration" — 2026-08-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,15 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   come ogni altro parametro dello schema: probabilità per-grano di ribaltare il
   verso dichiarato. `deviation_probability.reverse` resta legata a
   `grain.reverse` e non tocca la chiave nuova, così un vecchio `reverse: 100`
-  rimasto nello YAML non ribalta in silenzio un verso appena scritto. Il
-  default è quindi deterministico, che era il punto.
+  rimasto nello YAML non ribalta in silenzio un verso appena scritto. Con
+  `deviation_probability` **omesso** — o con `read_direction: null` dentro di
+  esso — il gate è `NeverGate` e il verso dichiarato è quello che si ascolta,
+  che era il punto. Attenzione al caso `deviation_probability:` scritto e
+  lasciato **vuoto**: quello non è "assente" ma la modalità implicita
+  (`IMPLICIT_JITTER_PROB`), che applica il jitter di default a ogni chiave
+  dello schema, questa compresa (misurato: ~1% dei grani ribaltato). Vale per
+  `read_direction` come per ogni altro parametro, non è un'eccezione
+  introdotta qui.
 
   Nuovo `variation_mode='negate'` (`NegateVariation`): su un dominio con segno
   il flip per-grano è un cambio di segno, mentre `'invert'` (`1 - base`)

--- a/docs/plans/2026-08-14-001-feat-read-direction-plan.md
+++ b/docs/plans/2026-08-14-001-feat-read-direction-plan.md
@@ -1,0 +1,203 @@
+---
+title: "feat(yaml): grain.read_direction — il verso di lettura del grano diventa dichiarativo"
+type: feature
+status: active
+date: 2026-08-14
+issue: 207
+---
+
+# feat(yaml): `grain.read_direction`
+
+## Overview
+
+Il verso di lettura **interno al grano** oggi ha una sola superficie
+dichiarativa, `grain.reverse`: una chiave che deve essere presente e vuota, ha
+due soli stati (`auto` / sempre indietro) e non è esprimibile come funzione del
+tempo. Il caso deterministico più ovvio — testina che percorre il buffer
+all'indietro, grani letti in avanti — si ottiene oggi saturando un gate
+stocastico (`deviation_probability: {reverse: 100}`).
+
+Questo plan introduce `grain.read_direction`: dominio `[-1, +1]`, scalare o
+envelope, interpolazione `step` imposta, in exclusivity group con
+`grain.reverse`. Nessun breaking change: `grain.reverse` resta identica e con
+entrambe le chiavi assenti il comportamento resta `'auto'`.
+
+---
+
+## Problem Frame
+
+Quattro varianti minime dello stesso YAML (issue #207), osservate sul segno di
+`Grain.pitch_ratio` — l'unica grandezza che decide il verso di lettura interno:
+
+| YAML | percorrenza buffer | lettura nel grano |
+|---|---|---|
+| `speed_ratio: -1`, `reverse` assente | indietro | indietro |
+| `speed_ratio: -1` + `reverse:` | indietro | indietro (la dichiarazione non cambia nulla) |
+| `speed_ratio: +1` + `reverse:` | avanti | indietro |
+| `speed_ratio: -1` + `reverse:` + `deviation_probability: {reverse: 100}` | indietro | avanti |
+
+La riga 4 è il difetto che genera la issue: un comportamento deterministico
+ottenuto saturando un meccanismo stocastico.
+
+Tre grandezze da non confondere, e che questo plan tiene separate:
+
+- `pointer.speed_ratio` — verso della **testina** sul buffer;
+- il blocco `pitch` — **altezza percepita**, bounds positivi per costruzione,
+  fuori da questa modifica;
+- `Grain.pitch_ratio` — incremento di fasore interno, porta modulo **e** segno.
+  Non è una chiave YAML e non viene rinominato.
+
+---
+
+## Design
+
+### La chiave
+
+```yaml
+grain:
+  read_direction: 1                       # scalare: +1 avanti, -1 indietro
+  read_direction: [[0, 1], [12, -1]]      # envelope: il verso cambia a t=12
+```
+
+- dominio `[-1, +1]`, `-1` indietro, `+1` avanti — allineato alla convenzione
+  del progetto, dove il negativo significa già "indietro" ovunque;
+- scalare o envelope, come ogni altro parametro;
+- `step` è **la natura della chiave**, non un'opzione: il verso è discreto, un
+  valore intermedio fra -1 e +1 non significa nulla.
+
+### Decisione 1 — interazione con `deviation_probability`
+
+**Scelta: chiave dedicata `deviation_probability.read_direction`.**
+
+`deviation_probability.reverse` continua a governare **solo** `grain.reverse`,
+esattamente com'è oggi. La nuova chiave ha la propria voce nel blocco
+`deviation_probability`, come ogni altro parametro dello schema:
+
+```yaml
+grain:
+  read_direction: 1        # base: avanti
+deviation_probability:
+  read_direction: 30       # il 30% dei grani legge all'indietro
+```
+
+Perché non le altre due opzioni:
+
+- *far flippare `deviation_probability.reverse` anche il valore dichiarato*
+  lascerebbe una chiave chiamata `reverse` a governare un parametro chiamato
+  `read_direction`, e un vecchio `reverse: 100` rimasto nello YAML
+  ribalterebbe in silenzio il verso appena dichiarato;
+- *ignorare il gate quando la chiave è presente* toglierebbe il verso
+  stocastico a chi lo vuole, senza dargli una via dichiarativa.
+
+Con la chiave dedicata il default è **deterministico** (chiave assente dal
+dict → `NeverGate`), che è il punto della issue, e lo stocastico resta
+raggiungibile con la sintassi che tutti gli altri parametri già usano.
+Il comportamento sotto `deviation_probability` **globale** (numero o envelope
+per tutte le chiavi) resta quello di ogni parametro dello schema, `reverse`
+compresa: nessuna eccezione inventata per questa chiave.
+
+Implementazione: `variation_mode='negate'` (nuova `NegateVariation`,
+`base → -base`). Così il flip per-grano è dentro `Parameter.get_value()` e non
+serve rubare il gate dall'esterno: `is_reverse = read_direction.get_value(t) < 0`
+è tutta la lettura. `InvertVariation` (`1.0 - base`) non è riusabile: su un
+dominio `-1/+1` produrrebbe `0` e `2`.
+
+### Decisione 2 — valori fuori da `{-1, +1}`
+
+**Scelta: rifiuto esplicito a parse-time, `y = 0` compreso.**
+
+Con `step` imposto l'envelope emette solo i valori scritti ai breakpoint,
+quindi arrotondare al segno significherebbe accettare una scrittura
+(`read_direction: 0.3`) e renderizzarne un'altra (`+1`). Lo `0` non ha un segno
+e non ha una risposta non arbitraria: rifiutarlo è l'unica lettura onesta.
+Coerente con il rifiuto degli interp non-`step`: la chiave ha due stati, e li
+pretende scritti.
+
+Il rifiuto avviene **prima** del clamp dei bounds, così `read_direction: 0.5`
+dà un errore che parla del dominio a due valori invece di passare silenziosamente
+il clamp `[-1, 1]`.
+
+### Dove vive la validazione
+
+Nuovo modulo `src/pge/parameters/read_direction.py`, unico punto che legge il
+valore grezzo di `grain.read_direction`. Precedente diretto:
+`Stream._pre_normalize_grain_params` per `duration_unit` — un meta-parametro che
+governa l'interpretazione degli altri, letto una volta sul dizionario grezzo.
+
+Due responsabilità:
+
+1. **rifiutare** ogni interp diverso da `step` in tutte le forme (dict `type`,
+   3-tuple per-punto, BP group, formato compatto) e ogni `y` fuori da
+   `{-1, +1}`;
+2. **normalizzare** in `{'type': 'step', 'points': <raw>}`, così l'envelope
+   costruito a valle è `step` senza che l'utente debba scriverlo.
+
+Il wrapping preserva la semantica temporale: `create_scaled_envelope` sul dict
+legge `time_unit` con fallback su `time_mode`, cioè esattamente quello che fa
+sulla lista nuda.
+
+### Exclusivity group
+
+`grain.reverse` e `grain.read_direction` entrambe presenti → `InvalidFieldValueError`
+esplicito, sollevato in `Stream._init_grain_reverse` prima che l'orchestratore
+costruisca i parametri. Divergenza voluta dal precedente `loop_end`/`loop_dur`,
+che risolve per priorità: qui le due chiavi hanno semantiche opposte e una
+priorità silenziosa nasconderebbe l'errore invece di segnalarlo.
+
+Nello schema le due spec condividono `exclusive_group='grain_direction'`: serve
+a garantire che esattamente **uno** dei due `Parameter` esista (l'altro è
+`None`), così il discriminante a valle è `self.read_direction is not None`. Il
+tie-break per priorità del selettore resta irraggiungibile per questo gruppo —
+va commentato, non subito.
+
+### Codice morto
+
+In `_calculate_grain_reverse` il ramo forzato legge `self.reverse._value` e
+gestisce un `Envelope` con `hasattr(val, 'evaluate')`. È morto: `_init_grain_reverse`
+rifiuta ogni valore non-`None`, quindi in quel ramo `_value` è sempre `None` e
+`is_reverse_base` è sempre `True`. Con `read_direction` il ramo non diventa
+raggiungibile — la chiave nuova ha un ramo proprio — quindi si elimina, e il
+ramo forzato diventa `is_reverse_base = True`. Due test che lo pinnavano
+(`test_forced_mode_with_envelope`, `test_forced_mode_envelope_below_threshold`)
+vengono sostituiti da un test che verifica l'irraggiungibilità alla fonte.
+
+---
+
+## Steps
+
+| # | Passo | Test rossi prima |
+|---|---|---|
+| 1 | `read_direction.py`: validazione + normalizzazione | `tests/parameters/test_read_direction.py` |
+| 2 | Bounds + `NegateVariation` + registry | `test_parameter_definitions.py`, `test_variation_registry.py`, `test_variation_strategy.py` |
+| 3 | `ParameterSpec` + exclusive group | `test_parameter_schema.py` |
+| 4 | Wiring in `Stream` (init, exclusivity, `_calculate_grain_reverse`) | `tests/core/test_stream_read_direction.py`, `test_stream.py` |
+| 5 | Colori envelope + range visualizer | `test_envelope_extractor.py` |
+| 6 | Docs (`docs/reference/yaml.md`), `make docs-index`, `make docs-lint` | — |
+| 7 | CHANGELOG `Unreleased / Aggiunto` | — |
+
+## Copertura test richiesta
+
+- i quattro casi della tabella restano invariati (regressione su `grain.reverse`);
+- `read_direction` scalare `-1` / `+1` con `speed_ratio` concorde e discorde;
+- `read_direction` envelope: il verso cambia ai breakpoint e **solo** lì;
+- interp diverso da `step` nelle tre forme (dict, per-punto, BP group) → errore
+  con hint leggibile;
+- `grain.reverse` + `read_direction` insieme → errore di exclusivity;
+- `deviation_probability.read_direction` flippa; `deviation_probability.reverse`
+  non tocca `read_direction`;
+- `y` fuori da `{-1, +1}`, `y = 0` e chiave vuota → errore.
+
+Osservabile: il segno di `Grain.pitch_ratio`.
+
+## Fuori scope
+
+- Rinominare `Grain.pitch_ratio` o toccare il blocco `pitch`.
+- Modificare la map: `grain_visuals.arrow_vertices` / `window_vertices`
+  decidono il verso sul solo `sign(pitch_ratio)` — verificato, non riscritto.
+- Cambiare `grain.reverse` o la modalità `'auto'`.
+
+## Impatto cross-repo
+
+Superficie YAML pubblica: issue su `PGE-ls` (autocomplete, dominio, exclusivity,
+rifiuto interp, hover/snippet) e su `PGE-ui` (controllo a due stati, envelope,
+default).

--- a/docs/plans/done/2026-08-14-001-feat-read-direction-plan.md
+++ b/docs/plans/done/2026-08-14-001-feat-read-direction-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat(yaml): grain.read_direction — il verso di lettura del grano diventa dichiarativo"
 type: feature
-status: active
+status: done
 date: 2026-08-14
 issue: 207
 ---

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -11,7 +11,7 @@ sources:
   - src/pge/envelopes/
   - src/pge/shared/seeding.py
   - src/pge/shared/distribution_strategy.py
-last_synced_commit: d7753a5
+last_synced_commit: 39602b1
 entry_for: [yaml-syntax, envelope-syntax]
 ---
 
@@ -2014,6 +2014,12 @@ parser, e ogni interp dichiarato diverso da `step` solleva
 grain:
   read_direction: [[0, 1], [12, -1], [20, 1]]   # step, senza doverlo scrivere
 ```
+
+Le **forme** dell'envelope restano tutte quelle documentate qui — lista di
+breakpoint, dict `{points: ...}`, BP group, formato compatto, lista mista — e
+valgono identiche nei due modi di scriverle: quello che è accettato come lista
+nuda è accettato dentro `points`, e viceversa. A essere imposta è
+l'interpolazione, non la sintassi.
 
 Il rifiuto copre tutte le forme in cui un interp è dichiarabile: dict
 (`type:`), tag per-punto `[t, v, type]`, BP group `[points, interp]` e formato

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -11,7 +11,7 @@ sources:
   - src/pge/envelopes/
   - src/pge/shared/seeding.py
   - src/pge/shared/distribution_strategy.py
-last_synced_commit: 6d4bd0b
+last_synced_commit: d7753a5
 entry_for: [yaml-syntax, envelope-syntax]
 ---
 
@@ -490,6 +490,73 @@ grain:
   #          chiave presente vuota = reverse forzato
   reverse:          # forza reverse per tutti i grani
   # ERRORE: reverse: true / reverse: false / reverse: auto
+
+  # Verso di lettura INTERNO al grano, dichiarativo (alternativa a reverse).
+  # -1 = lettura all'indietro, +1 = lettura in avanti. Indipendente dal segno
+  # di pointer.speed_ratio: la testina puo' percorrere il buffer all'indietro
+  # mentre i grani leggono in avanti.
+  read_direction: 1
+
+  # Accetta envelope: il verso cambia nel tempo, a gradino
+  read_direction: [[0, 1], [12, -1], [20, 1]]
+  # ERRORE: read_direction insieme a reverse (gruppo esclusivo)
+  # ERRORE: read_direction: 0 / 0.5 (solo -1 e +1)
+  # ERRORE: interpolazione diversa da step
+```
+
+### `grain.read_direction` — il verso di lettura del grano
+
+Tre grandezze diverse, che è bene non confondere:
+
+| grandezza | governa | segno |
+|---|---|---|
+| `pointer.speed_ratio` | la velocità e il verso con cui la **testina** percorre il buffer | negativo = percorrenza all'indietro |
+| `grain.read_direction` | il verso con cui il **grano** legge il materiale | `-1` indietro, `+1` avanti |
+| blocco `pitch` | l'**altezza percepita** (trasposizione) | sempre positivo, per costruzione |
+
+`read_direction` è alternativa a `reverse`, non un suo complemento: **le due
+chiavi insieme sono un errore** (`InvalidFieldValueError`), non una priorità.
+Governano la stessa grandezza con semantiche opposte, e sceglierne una in
+silenzio nasconderebbe l'errore invece di segnalarlo. Con **entrambe assenti**
+il comportamento è quello di sempre: modalità `auto`, il verso segue il segno
+di `pointer.speed_ratio`.
+
+Il caso che con `reverse` richiede un gate stocastico saturato:
+
+```yaml
+# Prima: gate al 100% per un comportamento che di stocastico non ha nulla
+pointer: {speed_ratio: -1}
+grain: {reverse:}
+deviation_probability: {reverse: 100}
+
+# Adesso: dichiarato
+pointer: {speed_ratio: -1}
+grain: {read_direction: 1}
+```
+
+**L'interpolazione è `step`, implicita e obbligatoria.** L'envelope si scrive
+come una spezzata qualsiasi e il gradino lo impone la chiave; `type: step`
+esplicito è ridondanza accettata. Qualunque altro interp — `linear`, `cubic`,
+in forma dict, per-punto (`[t, v, type]`) o BP group (`[points, interp]`) — è
+un **errore esplicito**, mai un avviso e mai una correzione silenziosa: il
+verso di lettura ha due stati, non una rampa fra i due.
+
+**I valori dichiarati stanno in `{-1, +1}`.** Con `step` imposto l'envelope
+emette solo i valori scritti ai breakpoint, quindi il problema non è
+l'interpolazione ma la dichiarazione: `0.3` non è un verso e `0` non ha un
+segno. Ogni altro valore è rifiutato al parse, senza arrotondamento al segno.
+
+Verso stocastico: si dichiara con la chiave `read_direction` del blocco
+`deviation_probability`, che è la probabilità per-grano di **ribaltare** il
+verso dichiarato (vedi [DeviationProbability](#deviation_probability-variazione-stocastica)).
+`deviation_probability: {reverse: N}` resta legata a `grain.reverse` e non
+tocca `read_direction`.
+
+```yaml
+grain:
+  read_direction: 1        # base: in avanti
+deviation_probability:
+  read_direction: 30       # il 30% dei grani legge all'indietro
 ```
 
 Con qualunque `duration_unit` diverso da `seconds` la `grain.duration` va
@@ -662,7 +729,8 @@ deviation_probability:
   duration: 20        # 20% probabilità di applicare duration_range
   pitch: 10           # 10% per pitch range
   pointer: 40         # 40% per pointer offset_range
-  reverse: 5          # 5% probabilità di flip reverse
+  reverse: 5          # 5% probabilità di flip reverse (solo per grain.reverse)
+  read_direction: 5   # 5% probabilità di ribaltare grain.read_direction
   envelope: 15        # 15% probabilità di cambiare finestra (se lista)
 
 # Valore specifico come envelope
@@ -1486,6 +1554,10 @@ density:
 Utile per cambi discontinui di sezione, automazioni "a quantità fisse",
 modulazioni di parametri categorici (es. numero di voci).
 
+Su `grain.read_direction` non è una scelta ma la natura della chiave: è
+imposto, e ogni altro interp è un errore (vedi
+[§10.5](#105-grainread_direction-step-imposto)).
+
 #### 4.4 Discontinuità con formato compatto
 
 Quando si concatenano cicli, il `BUILDER` inserisce automaticamente un offset
@@ -1930,7 +2002,32 @@ voices:
     spread: [[0, 0], [30, 120]]      # tutte centrate → spread ampio
 ```
 
-#### 10.5 `num_voices` come envelope
+#### 10.5 `grain.read_direction`: `step` imposto
+
+`read_direction` (vedi [Blocco Grain](#grainread_direction--il-verso-di-lettura-del-grano))
+è l'unico parametro con un'interpolazione **imposta** invece che scelta: il
+valore grezzo viene avvolto in `{type: step, points: <scritto>}` prima del
+parser, e ogni interp dichiarato diverso da `step` solleva
+`InvalidFieldValueError` invece di essere accettato o corretto in silenzio.
+
+```yaml
+grain:
+  read_direction: [[0, 1], [12, -1], [20, 1]]   # step, senza doverlo scrivere
+```
+
+Il rifiuto copre tutte le forme in cui un interp è dichiarabile: dict
+(`type:`), tag per-punto `[t, v, type]`, BP group `[points, interp]` e formato
+compatto (quarto elemento). Così cade anche il caso del segmento **di confine**
+fra due macrozone, che l'interp di gruppo non governa (vedi
+[BP group](#4-tipi-di-interpolazione)): con `step` ovunque non esiste un
+segmento che possa produrre valori intermedi.
+
+Conseguenza sui valori: l'envelope emette solo i valori scritti ai breakpoint,
+che devono stare in `{-1, +1}`. La validazione è a parse-time e precede il
+clamp dei bounds, così `read_direction: 0.5` produce un errore sul dominio a
+due valori invece di passare silenziosamente il clamp `[-1, 1]`.
+
+#### 10.6 `num_voices` come envelope
 
 `num_voices` è un caso particolare: viene parsato come `Parameter` che ammette
 envelope, ma il `VoiceManager` pre-alloca `max_voices` pari al picco massimo dei
@@ -2062,6 +2159,7 @@ un envelope dal YAML al runtime è:
 | `pan` | -3600 | 3600 | 0.0 | gradi |
 | `pitch_ratio` | 0.001 | 8 | 1.0 | ratio diretto |
 | `pitch_semitones` | -36 | 36 | 0 | ±3 ottave |
+| `read_direction` | -1 | +1 | — | solo `-1` e `+1`; assente = modalità `auto` |
 | `pointer_speed_ratio` | -100 | 100 | 1.0 | negativo = indietro |
 | `pointer_deviation` | -1 | 1 | 0.0 | offset per-grano |
 | `loop_start` | 0 | sample_dur | — | secondi |

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -11,7 +11,7 @@ sources:
   - src/pge/envelopes/
   - src/pge/shared/seeding.py
   - src/pge/shared/distribution_strategy.py
-last_synced_commit: d76883d
+last_synced_commit: efbf8c6
 entry_for: [yaml-syntax, envelope-syntax]
 ---
 
@@ -1798,6 +1798,11 @@ volume: [[[0, -12], [50, 0], [100, -12]], 30, 10, 'cubic', {type: power, exponen
 - `exponential.rate <= 0` → `ValueError`
 - `logarithmic.base <= 1` → `ValueError`
 - `geometric.ratio <= 0` → `ValueError`
+- `power.exponent` non numerico → `InvalidFieldValueError`
+
+I primi cinque scattano alla costruzione della distribuzione; `power` era
+l'unico a non validare il proprio parametro, e falliva più tardi con un
+`TypeError` dentro `calculate_distribution`.
 
 ---
 
@@ -2033,15 +2038,31 @@ che devono stare in `{-1, +1}`. La validazione è a parse-time e precede il
 clamp dei bounds, così `read_direction: 0.5` produce un errore sul dominio a
 due valori invece di passare silenziosamente il clamp `[-1, 1]`.
 
-Su questa chiave alcune condizioni che altrove risalgono come `ValueError`
-nudo (vedi [§5](#5-formato-compatto-cicli-ripetuti)) sono invece
-`InvalidFieldValueError`, quindi portano il campo e lo `stream_id`: BP group
-con meno di 2 punti, `n_reps < 1`, `pattern_points` vuoto, punto del pattern
-non piatto, e distribuzione temporale non costruibile (nome ignoto o parametri
-non validi — la costruisce `TimeDistributionFactory`, i vincoli restano i
-suoi). Restano al builder, e quindi `ValueError`, `end_time <= time_offset` —
-che dipende dall'offset accumulato dagli elementi precedenti — e le
-distribuzioni che validano i propri parametri solo quando vengono usate.
+Su questa chiave un gruppo di condizioni che altrove risalgono come
+`ValueError` nudo (vedi [§5](#5-formato-compatto-cicli-ripetuti)) — o non
+risalgono affatto — sono invece `InvalidFieldValueError`, quindi portano il
+campo `grain.read_direction` e lo `stream_id`:
+
+| Condizione | Altrove |
+|---|---|
+| BP group con meno di 2 punti | `ValueError` |
+| `pattern_points` vuoto | `ValueError` |
+| `n_reps < 1`, e `n_reps: true` | `ValueError` / accettato in silenzio |
+| `end_time <= 0`, e `end_time: true` | `ValueError` / accettato in silenzio |
+| `x` del pattern fuori da `[0, 100]`, o che torna indietro | accettato in silenzio |
+| punto del pattern non piatto | `TypeError` |
+| breakpoint `{t, v}` con `t` non numerico | `ValueError` |
+| distribuzione temporale: nome ignoto o parametri non validi | `ValueError` / `AttributeError` |
+
+I nomi validi della distribuzione temporale sono quelli di
+[§6.2](#62-distribuzioni-disponibili); i vincoli sui loro parametri restano di
+`TimeDistributionFactory`, che li applica costruendola.
+
+Resta al builder, e quindi `ValueError`, la sola condizione che dipende da
+quanto il builder ha già percorso: `end_time <= time_offset`, dove
+`time_offset` è l'istante accumulato dagli elementi che precedono il ciclo in
+una lista mista. Qui se ne verifica il segno — decidibile, perché quell'istante
+non è mai negativo — non il confronto.
 
 #### 10.6 `num_voices` come envelope
 

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -11,7 +11,7 @@ sources:
   - src/pge/envelopes/
   - src/pge/shared/seeding.py
   - src/pge/shared/distribution_strategy.py
-last_synced_commit: efbf8c6
+last_synced_commit: 3ffcf1c
 entry_for: [yaml-syntax, envelope-syntax]
 ---
 
@@ -1803,8 +1803,17 @@ volume: [[[0, -12], [50, 0], [100, -12]], 30, 10, 'cubic', {type: power, exponen
 Tutti scattano alla costruzione della distribuzione; `power` era l'unico a non
 validare il proprio parametro, e falliva più tardi con un `TypeError` dentro
 `calculate_distribution`. Il controllo su `exponent` è sul **tipo** (non è un
-numero) e non sui bound: qualunque reale è un esponente legittimo. Come negli
-altri quattro, un booleano passa valendo `0`/`1`.
+numero) e non sui bound: qualunque reale è un esponente legittimo.
+
+Nessuna delle cinque rifiuta i booleani in quanto tali — sono numeri — ma i
+bound qui sopra li trattano diversamente, perché non sono la stessa condizione:
+
+| | `true` (vale 1) | `false` (vale 0) |
+|---|---|---|
+| `power.exponent` (nessun bound) | passa | passa |
+| `exponential.rate > 0` | passa | errore |
+| `geometric.ratio > 0` | passa | errore |
+| `logarithmic.base > 1` | **errore** | errore |
 
 ---
 

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -1800,9 +1800,11 @@ volume: [[[0, -12], [50, 0], [100, -12]], 30, 10, 'cubic', {type: power, exponen
 - `geometric.ratio <= 0` → `ValueError`
 - `power.exponent` non numerico → `InvalidFieldValueError`
 
-I primi cinque scattano alla costruzione della distribuzione; `power` era
-l'unico a non validare il proprio parametro, e falliva più tardi con un
-`TypeError` dentro `calculate_distribution`.
+Tutti scattano alla costruzione della distribuzione; `power` era l'unico a non
+validare il proprio parametro, e falliva più tardi con un `TypeError` dentro
+`calculate_distribution`. Il controllo su `exponent` è sul **tipo** (non è un
+numero) e non sui bound: qualunque reale è un esponente legittimo. Come negli
+altri quattro, un booleano passa valendo `0`/`1`.
 
 ---
 

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -11,7 +11,7 @@ sources:
   - src/pge/envelopes/
   - src/pge/shared/seeding.py
   - src/pge/shared/distribution_strategy.py
-last_synced_commit: 39602b1
+last_synced_commit: d76883d
 entry_for: [yaml-syntax, envelope-syntax]
 ---
 
@@ -2032,6 +2032,16 @@ Conseguenza sui valori: l'envelope emette solo i valori scritti ai breakpoint,
 che devono stare in `{-1, +1}`. La validazione è a parse-time e precede il
 clamp dei bounds, così `read_direction: 0.5` produce un errore sul dominio a
 due valori invece di passare silenziosamente il clamp `[-1, 1]`.
+
+Su questa chiave alcune condizioni che altrove risalgono come `ValueError`
+nudo (vedi [§5](#5-formato-compatto-cicli-ripetuti)) sono invece
+`InvalidFieldValueError`, quindi portano il campo e lo `stream_id`: BP group
+con meno di 2 punti, `n_reps < 1`, `pattern_points` vuoto, punto del pattern
+non piatto, e distribuzione temporale non costruibile (nome ignoto o parametri
+non validi — la costruisce `TimeDistributionFactory`, i vincoli restano i
+suoi). Restano al builder, e quindi `ValueError`, `end_time <= time_offset` —
+che dipende dall'offset accumulato dagli elementi precedenti — e le
+distribuzioni che validano i propri parametri solo quando vengono usate.
 
 #### 10.6 `num_voices` come envelope
 

--- a/src/pge/core/stream.py
+++ b/src/pge/core/stream.py
@@ -34,6 +34,10 @@ from pge.shared.exceptions import (
 )
 from pge.parameters.parameter_schema import STREAM_PARAMETER_SCHEMA
 from pge.parameters.parameter_orchestrator import ParameterOrchestrator
+from pge.parameters.read_direction import (
+    READ_DIRECTION_FIELD,
+    normalize_read_direction,
+)
 from pge.core.stream_config import StreamConfig, StreamContext, resolve_stream_duration
 from pge.controllers.voice_manager import VoiceManager, VoiceConfig
 from pge.parameters.pitch_unit import make_pitch_unit
@@ -143,6 +147,9 @@ class Stream:
         params = self._pre_normalize_grain_params(params, config.context.output_sr)
         # === 4. PARAMETRI SPECIALI ===
         self._init_grain_reverse(params)
+        # Da qui in poi grain.read_direction, se dichiarata, e' gia' validata e
+        # normalizzata a interpolazione 'step'.
+        params = self._normalize_read_direction(params)
         # === 5. PARAMETRI DIRETTI (riceve config) ===
         self._init_stream_parameters(params, config)
         # === 6. CONTROLLER (riceve config) ===
@@ -493,27 +500,53 @@ class Stream:
     def _init_grain_reverse(self, params: dict) -> None:
         """
         Inizializza parametri reverse del grano.
-        
+
         Semantica YAML RISTRETTA:
         - Chiave ASSENTE → 'auto' (segue pointer_speed)
         - Chiave PRESENTE (reverse:) → DEVE essere vuota, significa True (forzato reverse)
         - reverse: true/false/auto → ERRORE! Non accettati
-        
+
         Examples YAML validi:
             grain:
             # reverse assente → auto mode
-            
+
             grain:
                 reverse:  # ← Unico modo per forzare reverse
-        
+
         Examples YAML INVALIDI:
             grain:
                 reverse: true    # x ERRORE
                 reverse: false   # x ERRORE
                 reverse: 'auto'  # x ERRORE
+
+        Qui vive anche il rifiuto della coppia `reverse` + `read_direction`
+        (issue #207): le due chiavi governano la stessa grandezza con
+        semantiche opposte.
         """
-        grain_params = params.get('grain', {})
-        
+        grain_params = params.get('grain', {}) or {}
+
+        # Exclusivity group 'grain_direction': entrambe presenti e' ERRORE, non
+        # una priorita'. Il precedente vicino (loop_end / loop_dur) risolve per
+        # priorita', ma li' le due chiavi dicono la stessa cosa in due modi;
+        # qui dicono cose diverse, e scegliere in silenzio nasconderebbe
+        # l'errore dell'utente invece di segnalarlo. Prima di ogni altra
+        # validazione: e' il problema da risolvere per primo.
+        if 'reverse' in grain_params and 'read_direction' in grain_params:
+            err = InvalidFieldValueError(
+                field=READ_DIRECTION_FIELD,
+                value=grain_params['read_direction'],
+                hint=(
+                    "grain.read_direction e grain.reverse governano la stessa "
+                    "grandezza — il verso di lettura del grano — con semantiche "
+                    "opposte, e non possono coesistere.\n"
+                    "  Tieni grain.read_direction (-1 indietro, +1 avanti, "
+                    "anche come envelope) oppure grain.reverse (chiave vuota = "
+                    "sempre indietro), non entrambe."
+                ),
+            )
+            err.stream_id = self.stream_id
+            raise err
+
         if 'reverse' in grain_params:
             # Validazione: se la chiave è presente, DEVE essere None (vuota)
             value = grain_params['reverse']
@@ -537,6 +570,35 @@ class Stream:
         else:
             # Chiave assente → auto mode (segue speed)
             self.grain_reverse_mode = 'auto'
+
+    def _normalize_read_direction(self, params: dict) -> dict:
+        """
+        Valida `grain.read_direction` e le impone l'interpolazione `step`.
+
+        Stesso modello di `_pre_normalize_grain_params`: legge il valore grezzo
+        dal dizionario, lo riscrive per il parser a valle e non muta l'originale
+        (fingerprint della cache e stream_data_map leggono i dati grezzi).
+
+        La regola sta in `parameters/read_direction.py`; qui si attribuisce
+        l'errore allo stream, cosi' un verso scritto male dice in quale stream
+        cercarlo.
+        """
+        grain = params.get('grain')
+        if not isinstance(grain, dict) or 'read_direction' not in grain:
+            return params
+
+        try:
+            value = normalize_read_direction(grain['read_direction'])
+        except InvalidFieldValueError as err:
+            err.stream_id = self.stream_id
+            raise
+
+        normalized_grain = dict(grain)
+        normalized_grain['read_direction'] = value
+
+        normalized_params = dict(params)
+        normalized_params['grain'] = normalized_grain
+        return normalized_params
 
     # =========================================================================
     # GENERAZIONE GRANI
@@ -711,35 +773,43 @@ class Stream:
     def _calculate_grain_reverse(self, elapsed_time: float) -> bool:
         """
         Calcola se il grano deve essere riprodotto al contrario.
-        
-        Usa evaluate_gated_stochastic con variation_mode='invert':
-        - 'auto': base_reverse segue pointer_speed
-        - grain_reverse_randomness: probabilità di flip (0-100)
-        - grain_reverse_randomness=None: nessun flip (mantiene base)
-        
+
+        Due superfici dichiarative, mutuamente esclusive (issue #207):
+
+        - `grain.read_direction`: il verso e' il valore dichiarato, -1 indietro
+          e +1 avanti, scalare o envelope. Il gate deviation_probability e il
+          flip per-grano vivono dentro il Parameter (variation_mode='negate'),
+          quindi qui basta leggerne il segno: `get_value()` e' gia' la
+          risposta completa.
+        - `grain.reverse`: il verso base e' 'auto' (segue pointer_speed) o
+          sempre indietro; il flip per-grano arriva dal gate del Parameter
+          'reverse'. L'asimmetria e' nella cosa, non nel codice: in 'auto' il
+          valore base non e' dichiarato ma dedotto dalla velocita' della
+          testina, quindi non c'e' un Parameter da cui leggerlo.
+
         Args:
             elapsed_time: tempo trascorso dall'inizio dello stream
-            
+
         Returns:
             bool: True se grano deve essere riprodotto al contrario
         """
-        # 1. Determina base value come float (0.0 o 1.0)
+        if self.read_direction is not None:
+            return self.read_direction.get_value(elapsed_time) < 0
+
+        # 1. Determina il verso base
         if self.grain_reverse_mode == 'auto':
             # Se la testina va indietro, il grano è reverse di base
             is_reverse_base = (self._pointer.get_speed(elapsed_time) < 0)
         else:
-            # Se forzato da YAML, usiamo il valore caricato nel parametro
-            # Nota: self.reverse._value può essere un numero o un Envelope
-            val = self.reverse._value
-            if hasattr(val, 'evaluate'):
-                val = val.evaluate(elapsed_time)
-            is_reverse_base = (val > 0.5) if val is not None else True
-        
+            # Chiave presente e vuota: _init_grain_reverse ha gia' rifiutato
+            # ogni valore, quindi qui il verso base e' sempre "indietro".
+            is_reverse_base = True
+
         # FASE 2: Controlliamo se dobbiamo FLIPPARE (DeviationProbability/Probabilità)
         # Usiamo il metodo interno del parametro per vedere se il "dado" vince
         # Nota: Qui stiamo "rubando" la logica probabilistica all'oggetto Parameter
         should_flip = self.reverse._probability_gate.should_apply(elapsed_time)
-        
+
         if should_flip:
             return not is_reverse_base
         return is_reverse_base

--- a/src/pge/envelopes/time_distribution.py
+++ b/src/pge/envelopes/time_distribution.py
@@ -276,8 +276,15 @@ class PowerDistribution(TimeDistributionStrategy):
                 `calculate_distribution`, dove `(i + 1) ** exponent` alza un
                 `TypeError` nudo — invisibile a chi valida una spec
                 costruendola.
+
+                Il `bool` passa, come nelle sorelle: qui si valida il tipo
+                dove le altre validano i bound (`rate <= 0`, `ratio <= 0`,
+                `base <= 1`), e un `bool` quei bound li supera valendo 0 o 1.
+                `exponent: true` non ha mai alzato niente — `True ** n` fa 1 —
+                e rifiutarlo qui soltanto renderebbe `power` un'eccezione nel
+                registro, rompendo YAML che oggi renderizzano.
         """
-        if not isinstance(exponent, (int, float)) or isinstance(exponent, bool):
+        if not isinstance(exponent, (int, float)):
             from pge.shared.exceptions import InvalidFieldValueError
             raise InvalidFieldValueError(
                 field="power.exponent",

--- a/src/pge/envelopes/time_distribution.py
+++ b/src/pge/envelopes/time_distribution.py
@@ -267,7 +267,25 @@ class PowerDistribution(TimeDistributionStrategy):
                      < 1: cicli crescenti rallentati
                      = 1: lineare
                      > 1: cicli crescenti accelerati
+
+        Raises:
+            InvalidFieldValueError: se `exponent` non e' un numero. Nessun
+                bound: qualunque reale e' un esponente legittimo. Ma senza
+                questo controllo era l'unico costruttore del registro che
+                assegnava senza guardare, e il valore restava buono fino a
+                `calculate_distribution`, dove `(i + 1) ** exponent` alza un
+                `TypeError` nudo — invisibile a chi valida una spec
+                costruendola.
         """
+        if not isinstance(exponent, (int, float)) or isinstance(exponent, bool):
+            from pge.shared.exceptions import InvalidFieldValueError
+            raise InvalidFieldValueError(
+                field="power.exponent",
+                value=exponent,
+                hint="l'esponente della power law e' un numero (qualunque "
+                     "reale): < 1 rallenta la crescita dei cicli, 1 la rende "
+                     "lineare, > 1 la accelera.",
+            )
         self.exponent = exponent
     
     def calculate_distribution(

--- a/src/pge/envelopes/time_distribution.py
+++ b/src/pge/envelopes/time_distribution.py
@@ -277,12 +277,18 @@ class PowerDistribution(TimeDistributionStrategy):
                 `TypeError` nudo — invisibile a chi valida una spec
                 costruendola.
 
-                Il `bool` passa, come nelle sorelle: qui si valida il tipo
-                dove le altre validano i bound (`rate <= 0`, `ratio <= 0`,
-                `base <= 1`), e un `bool` quei bound li supera valendo 0 o 1.
-                `exponent: true` non ha mai alzato niente — `True ** n` fa 1 —
-                e rifiutarlo qui soltanto renderebbe `power` un'eccezione nel
-                registro, rompendo YAML che oggi renderizzano.
+                Il `bool` passa questo guard, perche' e' un numero. Cosa gli
+                succeda poi non e' una regola comune del registro ma dipende
+                dai bound di ciascuna distribuzione, che non sono la stessa
+                condizione: `rate: false` e `ratio: false` valgono 0 e cadono
+                su `> 0`, mentre `base: true` vale esattamente 1 e cade su
+                `> 1`. Qui non ci sono bound — qualunque reale e' un esponente
+                — quindi non cade niente.
+
+                Il punto non e' che i bool siano ammessi ovunque, ma che
+                `exponent: true` non ha mai alzato niente (`True ** n` fa 1):
+                rifiutarlo qui aggiungerebbe un controllo di tipo che nessuna
+                sorella fa, rompendo YAML che oggi rendono.
         """
         if not isinstance(exponent, (int, float)):
             from pge.shared.exceptions import InvalidFieldValueError

--- a/src/pge/parameters/parameter_definitions.py
+++ b/src/pge/parameters/parameter_definitions.py
@@ -101,6 +101,18 @@ GRANULAR_PARAMETERS: Dict[str, ParameterBounds] = {
         variation_mode='invert'  # <--- NOTA: (Boolean Flip)
     ),
 
+    # Verso di lettura interno al grano (issue #207): -1 indietro, +1 avanti.
+    # Alternativa dichiarativa a 'reverse', in exclusive group con essa.
+    # variation_mode='negate' perche' il dominio ha segno: il flip per-grano
+    # e' un cambio di segno, non il `1 - base` di 'invert'.
+    'read_direction': ParameterBounds(
+        min_val=-1,
+        max_val=1,
+        min_range=0,
+        max_range=0,
+        variation_mode='negate'
+    ),
+
     'grain_envelope': ParameterBounds(
         min_val=0,      # Non usato per choice
         max_val=0,      # Non usato per choice

--- a/src/pge/parameters/parameter_schema.py
+++ b/src/pge/parameters/parameter_schema.py
@@ -95,15 +95,47 @@ STREAM_PARAMETER_SCHEMA: List[ParameterSpec] = [
         is_smart=False
     ),    
     # =========================================================================
-    # REVERSE (caso speciale: variation_mode='invert')
+    # VERSO DI LETTURA DEL GRANO (gruppo esclusivo 'grain_direction')
     # =========================================================================
+    # Due chiavi per la stessa grandezza, con semantiche opposte:
+    # - 'reverse' (storica): presente-e-vuota = sempre indietro, assente =
+    #   'auto' (segue il segno di pointer.speed_ratio). Due stati, non
+    #   esprimibile nel tempo.
+    # - 'read_direction' (issue #207): -1 indietro / +1 avanti, scalare o
+    #   envelope, indipendente dal segno della velocita' della testina.
+    #
+    # Entrambe presenti e' un ERRORE, sollevato da Stream._init_grain_reverse
+    # prima che l'orchestratore arrivi qui: divergenza voluta dal precedente
+    # loop_end/loop_dur, che risolve per priorita'. Le due chiavi dicono cose
+    # opposte e una priorita' silenziosa nasconderebbe l'errore dell'utente
+    # invece di segnalarlo. Il gruppo serve a garantire che esattamente UNO dei
+    # due Parameter esista (l'altro e' None), cosi' il discriminante a valle e'
+    # `stream.read_direction is not None`; il suo tie-break per priorita' resta
+    # irraggiungibile, per costruzione.
     ParameterSpec(
         name='reverse',
         yaml_path='grain.reverse',
         default=0,  # 0 = forward, 1 = reverse
-        deviation_probability_key='reverse'
+        deviation_probability_key='reverse',
+        exclusive_group='grain_direction',
+        # Priorita' piu' alta + default non-None: con entrambe le chiavi
+        # assenti vince 'reverse', cioe' il comportamento 'auto' di sempre.
+        group_priority=1
         # Nota: 'reverse' usa variation_mode='invert', quindi
         # il deviation_probability_key controlla la PROBABILITÀ di flip, non un range
+    ),
+    ParameterSpec(
+        name='read_direction',
+        yaml_path='grain.read_direction',
+        default=None,  # None = chiave non dichiarata
+        # Chiave deviation_probability propria: il verso stocastico si dichiara
+        # dove si dichiara il verso. 'reverse' resta legata alla sua chiave,
+        # quindi un vecchio `deviation_probability: {reverse: N}` non ribalta
+        # in silenzio un read_direction appena scritto.
+        deviation_probability_key='read_direction',
+        exclusive_group='grain_direction',
+        group_priority=2
+        # Nota: usa variation_mode='negate' (dominio con segno), non 'invert'.
     ),
 ]
 

--- a/src/pge/parameters/read_direction.py
+++ b/src/pge/parameters/read_direction.py
@@ -27,6 +27,12 @@ come errore esplicito e mai come correzione silenziosa:
    accettare una scrittura e renderizzarne un'altra; `0` poi non ha un segno e
    non ha una risposta non arbitraria.
 
+A queste si aggiungono alcuni **guard di arita'** sulle macro-forme (quanti
+punti ha un gruppo, quanti cicli un formato compatto). Non sono una seconda
+validazione del builder: sono li' perche' quelle stesse condizioni, lasciate al
+builder, risalgono come `ValueError` nudi — fuori dalla gerarchia `EngineError`,
+senza campo e senza stream_id.
+
 La normalizzazione avvolge il valore in `{'type': 'step', 'points': <raw>}`.
 Il wrapping preserva la semantica temporale: `create_scaled_envelope` sul dict
 legge `time_unit` con fallback su `time_mode`, cioe' esattamente cio' che fa
@@ -69,6 +75,24 @@ _FORM_HINT = (
     "{points: [...]}, BP group o formato compatto."
 )
 
+# Guard di arita'. Sollevati qui e non lasciati al builder perche' di la'
+# risalgono come ValueError nudi, fuori dalla gerarchia EngineError: senza
+# campo, senza stream_id, e con un messaggio che PGE-ls non puo' attribuire.
+
+_GROUP_ARITY_HINT = (
+    "un BP group di grain.read_direction richiede almeno 2 punti: con meno "
+    "non ha segmenti interni, quindi non c'e' nessuna zona a cui applicare "
+    "l'interpolazione. Per un verso costante basta lo scalare (-1 o +1)."
+)
+
+_REPS_ARITY_HINT = (
+    "il numero di ripetizioni del formato compatto e' un intero >= 1: con "
+    "zero o meno cicli non c'e' nessun breakpoint da generare. Il resto della "
+    "coerenza temporale del ciclo (end_time contro l'istante da cui parte) "
+    "resta al builder, che e' l'unico a conoscere l'offset accumulato dagli "
+    "elementi precedenti."
+)
+
 
 def _is_number(value: Any) -> bool:
     """Numero vero: `bool` e' sottoclasse di `int`, ma `true` non e' `+1`."""
@@ -108,12 +132,18 @@ def _check_envelope_body(body: Any) -> None:
     fra le forme valide proprio quella appena scartata.
 
     Le macro-forme sono riconosciute qui in cima e, da `_check_item`, come
-    elementi di una lista mista — le stesse due posizioni in cui le riconosce
-    `EnvelopeBuilder.parse`. Piu' in fondo non serve guardarle: dentro un BP
-    group o dentro il pattern di un ciclo i punti devono essere `[t, v]` piatti
-    perche' la forma sia riconosciuta come tale, quindi una macro-forma
-    annidata li' non e' un caso da rifiutare — e' una cosa che non arriva mai
-    a chiamarsi cosi'.
+    elementi di una lista mista: le stesse due posizioni in cui le riconosce
+    `EnvelopeBuilder.parse`. Piu' in fondo non sono ammesse, ma per due ragioni
+    diverse, che vale la pena non confondere:
+
+    - dentro un BP group basta il riconoscimento della forma: `_is_bp_group`
+      pretende che ogni punto sia `[num, num]` o `[num, num, str]`, quindi un
+      annidamento fa fallire il riconoscimento e il valore non arriva mai a
+      chiamarsi gruppo;
+    - dentro il pattern di un ciclo no: `_is_compact_format` filtra i punti
+      sulla sola lunghezza (2 o 3), e un BP group e' lungo 2. Li' il rifiuto lo
+      fa `_check_pattern_point`, altrimenti il valore passa di qui e muore nel
+      builder con un TypeError nudo.
     """
     if EnvelopeBuilder._is_compact_format(body):
         _check_compact(body)
@@ -167,16 +197,42 @@ def _check_bp_group(group: list) -> None:
     """BP group (issue #64): `[points, interp]`, interp della macrozona."""
     points, interp = group
     _check_interp(interp)
+    # Solo l'arita': che `points` sia una lista di breakpoint piatti lo
+    # garantisce gia' `_is_bp_group`, che qui e' sempre passato.
+    if len(points) < 2:
+        _reject(points, _GROUP_ARITY_HINT)
     _check_points(points)
 
 
 def _check_compact(compact: list) -> None:
     """Formato compatto: l'interp e' il quarto elemento, i valori stanno nel
-    pattern. `end_time` e `n_reps` non sono versi e non si validano."""
+    pattern. `end_time` non e' un verso e non si valida qui (vedi
+    `_REPS_ARITY_HINT`)."""
     pattern = compact[0]
+    n_reps = compact[2]
     interp = compact[3] if len(compact) >= 4 else None
     _check_interp(interp)
-    _check_points(pattern)
+    if n_reps < 1:
+        _reject(n_reps, _REPS_ARITY_HINT)
+    if not pattern:
+        _reject(pattern, _FORM_HINT)
+    for point in pattern:
+        _check_pattern_point(point)
+
+
+def _check_pattern_point(point: list) -> None:
+    """Un punto del pattern di un ciclo: `[x%, y]` o `[x%, y, type]`, piatto.
+
+    Non passa da `_check_item` perche' li' le macro-forme sono ammesse, e qui
+    non lo sono: `_is_compact_format` filtra i punti del pattern sulla sola
+    lunghezza (2 o 3) e un BP group e' lungo 2, quindi ci si infila: il builder
+    poi fa `x_pct / 100.0` sul primo elemento e solleva un TypeError nudo.
+    """
+    if not _is_number(point[0]):
+        _reject(point, _FORM_HINT)
+    if len(point) == 3:
+        _check_interp(point[2])
+    _check_direction_value(point[1])
 
 
 def normalize_read_direction(raw: Any) -> Union[float, dict]:

--- a/src/pge/parameters/read_direction.py
+++ b/src/pge/parameters/read_direction.py
@@ -226,7 +226,12 @@ def _check_compact(compact: list) -> None:
     interp = compact[3] if len(compact) >= 4 else None
     time_dist = compact[4] if len(compact) >= 5 else None
     _check_interp(interp)
-    if n_reps < 1:
+    # Solo la natura di `n_reps`: che sia un `int` lo garantisce gia'
+    # `_is_compact_format`. Resta fuori il solo `bool`, che li' passa per
+    # sottoclasse e qui no, per la stessa ragione per cui `true` non e' `+1`:
+    # senza questo `True < 1` e' falso, il guard non scatta e `range(True)`
+    # rende un ciclo in silenzio.
+    if not _is_number(n_reps) or n_reps < 1:
         _reject(n_reps, _REPS_ARITY_HINT)
     if not pattern:
         _reject(pattern, _FORM_HINT)

--- a/src/pge/parameters/read_direction.py
+++ b/src/pge/parameters/read_direction.py
@@ -1,0 +1,196 @@
+"""
+read_direction.py
+
+Validazione e normalizzazione del valore grezzo di `grain.read_direction`
+(issue #207): il verso di lettura INTERNO al grano, dichiarato come funzione
+del tempo.
+
+Unico punto del sistema che legge il valore grezzo di questa chiave, per lo
+stesso motivo per cui `Stream._pre_normalize_grain_params` e' l'unico a leggere
+`grain.duration_unit`: qui non si sintetizza un valore, si decide come vanno
+interpretati quelli scritti.
+
+La chiave ha due stati — `-1` lettura all'indietro, `+1` lettura in avanti — e
+da questa natura discendono le due regole che il modulo fa rispettare, sempre
+come errore esplicito e mai come correzione silenziosa:
+
+1. **`step` e' l'interpolazione, non un'opzione.** E' il default implicito
+   (l'envelope si scrive come una spezzata qualsiasi) ed e' l'unico interp
+   ammesso: dichiarare `linear` o `cubic` — in forma dict, per-punto (issue
+   #54) o BP group (issue #64) — solleva `InvalidFieldValueError`. Un valore
+   intermedio fra -1 e +1 non e' un verso, quindi una rampa fra i due non ha
+   niente da produrre.
+
+2. **I valori dichiarati stanno in {-1, +1}.** Con `step` imposto l'envelope
+   emette solo i valori scritti ai breakpoint: il problema non e' piu'
+   l'interpolazione ma la dichiarazione. Arrotondare al segno significherebbe
+   accettare una scrittura e renderizzarne un'altra; `0` poi non ha un segno e
+   non ha una risposta non arbitraria.
+
+La normalizzazione avvolge il valore in `{'type': 'step', 'points': <raw>}`.
+Il wrapping preserva la semantica temporale: `create_scaled_envelope` sul dict
+legge `time_unit` con fallback su `time_mode`, cioe' esattamente cio' che fa
+sulla lista nuda.
+"""
+from __future__ import annotations
+
+from typing import Any, Union
+
+from pge.envelopes.envelope_builder import EnvelopeBuilder
+from pge.shared.exceptions import InvalidFieldValueError
+
+# Il nome della chiave nello YAML: identita' del campo in ogni errore.
+READ_DIRECTION_FIELD = 'grain.read_direction'
+
+# I due soli valori dichiarabili.
+READ_DIRECTION_VALUES = (-1.0, 1.0)
+
+# L'unica interpolazione ammessa, e quella imposta.
+REQUIRED_INTERP = 'step'
+
+_INTERP_HINT = (
+    "grain.read_direction ammette solo l'interpolazione 'step', che e' gia' "
+    "implicita: il verso di lettura ha due stati, non una rampa fra i due, e "
+    "un valore intermedio fra -1 e +1 non e' un verso. Togli il tipo "
+    "dichiarato (l'envelope si scrive come una spezzata qualsiasi) oppure "
+    "scrivi 'step', che e' ridondante ma valido."
+)
+
+_VALUE_HINT = (
+    "grain.read_direction ammette solo -1 (lettura all'indietro) e +1 "
+    "(lettura in avanti). Il verso non ha valori intermedi e lo 0 non ha un "
+    "segno: non c'e' arrotondamento che non sia arbitrario. Per il verso che "
+    "segue la testina, ometti la chiave (modalita' 'auto')."
+)
+
+_FORM_HINT = (
+    "grain.read_direction accetta uno scalare (-1 o +1) oppure un envelope "
+    "nelle forme note: lista di breakpoint [[t, v], ...], dict "
+    "{points: [...]}, BP group o formato compatto."
+)
+
+
+def _is_number(value: Any) -> bool:
+    """Numero vero: `bool` e' sottoclasse di `int`, ma `true` non e' `+1`."""
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _reject(value: Any, hint: str) -> None:
+    raise InvalidFieldValueError(
+        field=READ_DIRECTION_FIELD,
+        value=value,
+        hint=hint,
+    )
+
+
+def _check_direction_value(value: Any) -> None:
+    """Un valore dichiarato — scalare o Y di un breakpoint — vale -1 o +1."""
+    if not _is_number(value) or float(value) not in READ_DIRECTION_VALUES:
+        _reject(value, _VALUE_HINT)
+
+
+def _check_interp(interp: Any) -> None:
+    """Un interp dichiarato — dovunque sia dichiarato — vale 'step'."""
+    if interp is None:
+        return
+    if interp != REQUIRED_INTERP:
+        _reject(interp, _INTERP_HINT)
+
+
+def _check_points(points: Any) -> None:
+    """Percorre una lista di elementi envelope, qualunque forma abbiano."""
+    if not isinstance(points, list) or not points:
+        _reject(points, _FORM_HINT)
+
+    for item in points:
+        _check_item(item)
+
+
+def _check_item(item: Any) -> None:
+    """Un elemento della lista: breakpoint, gruppo, ciclo compatto o dict."""
+    if EnvelopeBuilder._is_compact_format(item):
+        _check_compact(item)
+        return
+
+    if EnvelopeBuilder._is_bp_group(item):
+        _check_bp_group(item)
+        return
+
+    if EnvelopeBuilder._is_3tuple_breakpoint(item):
+        # Tag per-punto (issue #54): il type governa il segmento uscente.
+        _check_interp(item[2])
+        _check_direction_value(item[1])
+        return
+
+    if isinstance(item, dict) and 't' in item and 'v' in item:
+        _check_interp(item.get('type'))
+        _check_direction_value(item['v'])
+        return
+
+    if isinstance(item, list) and len(item) == 2 and _is_number(item[0]):
+        _check_direction_value(item[1])
+        return
+
+    _reject(item, _FORM_HINT)
+
+
+def _check_bp_group(group: list) -> None:
+    """BP group (issue #64): `[points, interp]`, interp della macrozona."""
+    points, interp = group
+    _check_interp(interp)
+    _check_points(points)
+
+
+def _check_compact(compact: list) -> None:
+    """Formato compatto: l'interp e' il quarto elemento, i valori stanno nel
+    pattern. `end_time` e `n_reps` non sono versi e non si validano."""
+    pattern = compact[0]
+    interp = compact[3] if len(compact) >= 4 else None
+    _check_interp(interp)
+    _check_points(pattern)
+
+
+def normalize_read_direction(raw: Any) -> Union[float, dict]:
+    """
+    Valida il valore grezzo di `grain.read_direction` e lo normalizza a `step`.
+
+    Args:
+        raw: valore letto dallo YAML — scalare o envelope in una delle forme
+            note (lista di breakpoint, dict, BP group, formato compatto).
+
+    Returns:
+        float: se il valore e' scalare (-1.0 o +1.0);
+        dict: `{'type': 'step', 'points': <raw>}` per ogni forma envelope, con
+        le eventuali altre chiavi del dict originale (es. `time_unit`)
+        preservate.
+
+    Raises:
+        InvalidFieldValueError: chiave vuota, forma non riconosciuta, interp
+            diverso da `step` o valore fuori da {-1, +1}.
+    """
+    if raw is None:
+        _reject(raw, _VALUE_HINT)
+
+    if _is_number(raw):
+        _check_direction_value(raw)
+        return float(raw)
+
+    if isinstance(raw, dict):
+        if 'points' not in raw:
+            _reject(raw, _FORM_HINT)
+        _check_interp(raw.get('type'))
+        _check_points(raw['points'])
+        return {**raw, 'type': REQUIRED_INTERP}
+
+    if isinstance(raw, list):
+        if not raw:
+            _reject(raw, _FORM_HINT)
+        if EnvelopeBuilder._is_compact_format(raw):
+            _check_compact(raw)
+        elif EnvelopeBuilder._is_bp_group(raw):
+            _check_bp_group(raw)
+        else:
+            _check_points(raw)
+        return {'type': REQUIRED_INTERP, 'points': raw}
+
+    _reject(raw, _FORM_HINT)

--- a/src/pge/parameters/read_direction.py
+++ b/src/pge/parameters/read_direction.py
@@ -28,10 +28,16 @@ come errore esplicito e mai come correzione silenziosa:
    non ha una risposta non arbitraria.
 
 A queste si aggiungono alcuni **guard di arita'** sulle macro-forme (quanti
-punti ha un gruppo, quanti cicli un formato compatto). Non sono una seconda
-validazione del builder: sono li' perche' quelle stesse condizioni, lasciate al
-builder, risalgono come `ValueError` nudi — fuori dalla gerarchia `EngineError`,
-senza campo e senza stream_id.
+punti ha un gruppo, quanti cicli un formato compatto) e la costruzione anticipata
+della distribuzione temporale. Non sono una seconda validazione del builder:
+sono li' perche' quelle stesse condizioni, lasciate al builder, risalgono come
+`ValueError` nudi — fuori dalla gerarchia `EngineError`, senza campo e senza
+stream_id.
+
+La copertura non e' totale e non va dichiarata tale: restano al builder le
+condizioni che dipendono da quanto ha gia' percorso (`end_time` contro l'offset
+accumulato dagli elementi precedenti) e le distribuzioni che validano i propri
+parametri solo all'uso.
 
 La normalizzazione avvolge il valore in `{'type': 'step', 'points': <raw>}`.
 Il wrapping preserva la semantica temporale: `create_scaled_envelope` sul dict
@@ -43,7 +49,8 @@ from __future__ import annotations
 from typing import Any, Union
 
 from pge.envelopes.envelope_builder import EnvelopeBuilder
-from pge.shared.exceptions import InvalidFieldValueError
+from pge.envelopes.time_distribution import TimeDistributionFactory
+from pge.shared.exceptions import EngineError, InvalidFieldValueError
 
 # Il nome della chiave nello YAML: identita' del campo in ogni errore.
 READ_DIRECTION_FIELD = 'grain.read_direction'
@@ -91,6 +98,12 @@ _REPS_ARITY_HINT = (
     "coerenza temporale del ciclo (end_time contro l'istante da cui parte) "
     "resta al builder, che e' l'unico a conoscere l'offset accumulato dagli "
     "elementi precedenti."
+)
+
+_DIST_HINT = (
+    "la distribuzione temporale del formato compatto non e' costruibile: {err}. "
+    "Il verso di lettura non ha una distribuzione propria — e' quella "
+    "dell'envelope, e le forme valide sono quelle di sempre."
 )
 
 
@@ -211,6 +224,7 @@ def _check_compact(compact: list) -> None:
     pattern = compact[0]
     n_reps = compact[2]
     interp = compact[3] if len(compact) >= 4 else None
+    time_dist = compact[4] if len(compact) >= 5 else None
     _check_interp(interp)
     if n_reps < 1:
         _reject(n_reps, _REPS_ARITY_HINT)
@@ -218,6 +232,39 @@ def _check_compact(compact: list) -> None:
         _reject(pattern, _FORM_HINT)
     for point in pattern:
         _check_pattern_point(point)
+    _check_time_dist(time_dist)
+
+
+def _check_time_dist(spec: Any) -> None:
+    """La distribuzione temporale del ciclo: la valida il factory, costruendola.
+
+    Qui non c'e' niente da decidere — il verso di lettura non ha una
+    distribuzione propria, e' quella dell'envelope. Ma `_is_compact_format`
+    accetta in quella posizione qualunque `str` o `dict`, e cio' che ne esce
+    fallisce dentro `TimeDistributionFactory` con errori fuori dalla gerarchia
+    `EngineError`. Costruirla adesso li fa risalire dove hanno un campo.
+
+    E' delega, non duplicazione: il registro delle distribuzioni e i vincoli
+    sui loro parametri restano uno solo, e questo guard resta allineato da se'
+    se cambiano. I costruttori sono puri (validano e assegnano), quindi il
+    costo e' un oggetto buttato via.
+
+    Resta scoperta una distribuzione che accetti tutto nel costruttore e
+    fallisca all'uso: oggi `power`, che non valida `exponent` e sbaglia dentro
+    `calculate_distribution`, con un `total_time` che dipende dall'offset
+    accumulato e che di qui non si conosce. E' lo stesso confine di `end_time`.
+    """
+    try:
+        TimeDistributionFactory.create(spec)
+    except EngineError:
+        # Gia' dentro la gerarchia: ha campo, hint e prende lo stream_id.
+        # Riavvolgerla perderebbe il bound che ha appena nominato.
+        raise
+    except Exception as err:
+        # Largo di proposito: qualunque modo in cui il factory rifiuta questo
+        # dato e' un rifiuto di cio' che l'utente ha scritto, non un caso da
+        # enumerare a mano. Il messaggio originale finisce nell'hint.
+        _reject(spec, _DIST_HINT.format(err=err))
 
 
 def _check_pattern_point(point: list) -> None:

--- a/src/pge/parameters/read_direction.py
+++ b/src/pge/parameters/read_direction.py
@@ -223,6 +223,11 @@ def _check_item(item: Any) -> None:
         return
 
     if isinstance(item, dict) and 't' in item and 'v' in item:
+        # Il tempo si pretende numerico come nella forma lista: e' la stessa
+        # grandezza scritta in un altro modo, e senza questo il valore va a
+        # morire nel builder con un ValueError nudo.
+        if not _is_number(item['t']):
+            _reject(item, _FORM_HINT)
         _check_interp(item.get('type'))
         _check_direction_value(item['v'])
         return

--- a/src/pge/parameters/read_direction.py
+++ b/src/pge/parameters/read_direction.py
@@ -97,6 +97,35 @@ def _check_interp(interp: Any) -> None:
         _reject(interp, _INTERP_HINT)
 
 
+def _check_envelope_body(body: Any) -> None:
+    """Il corpo di un envelope: una macro-forma, oppure una lista di elementi.
+
+    Punto unico della grammatica dei due ingressi — `{points: ...}` e lista
+    nuda. Tenerne uno solo evita che divergano: `Envelope` costruisce entrambe
+    le forme (un formato compatto dentro `points` e' l'esempio nel suo
+    docstring), quindi un ingresso piu' stretto dell'altro rifiuterebbe uno
+    YAML che il motore renderizza — e lo rifiuterebbe con un hint che elenca
+    fra le forme valide proprio quella appena scartata.
+
+    Le macro-forme sono riconosciute qui in cima e, da `_check_item`, come
+    elementi di una lista mista — le stesse due posizioni in cui le riconosce
+    `EnvelopeBuilder.parse`. Piu' in fondo non serve guardarle: dentro un BP
+    group o dentro il pattern di un ciclo i punti devono essere `[t, v]` piatti
+    perche' la forma sia riconosciuta come tale, quindi una macro-forma
+    annidata li' non e' un caso da rifiutare — e' una cosa che non arriva mai
+    a chiamarsi cosi'.
+    """
+    if EnvelopeBuilder._is_compact_format(body):
+        _check_compact(body)
+        return
+
+    if EnvelopeBuilder._is_bp_group(body):
+        _check_bp_group(body)
+        return
+
+    _check_points(body)
+
+
 def _check_points(points: Any) -> None:
     """Percorre una lista di elementi envelope, qualunque forma abbiano."""
     if not isinstance(points, list) or not points:
@@ -179,18 +208,11 @@ def normalize_read_direction(raw: Any) -> Union[float, dict]:
         if 'points' not in raw:
             _reject(raw, _FORM_HINT)
         _check_interp(raw.get('type'))
-        _check_points(raw['points'])
+        _check_envelope_body(raw['points'])
         return {**raw, 'type': REQUIRED_INTERP}
 
     if isinstance(raw, list):
-        if not raw:
-            _reject(raw, _FORM_HINT)
-        if EnvelopeBuilder._is_compact_format(raw):
-            _check_compact(raw)
-        elif EnvelopeBuilder._is_bp_group(raw):
-            _check_bp_group(raw)
-        else:
-            _check_points(raw)
+        _check_envelope_body(raw)
         return {'type': REQUIRED_INTERP, 'points': raw}
 
     _reject(raw, _FORM_HINT)

--- a/src/pge/parameters/read_direction.py
+++ b/src/pge/parameters/read_direction.py
@@ -27,17 +27,19 @@ come errore esplicito e mai come correzione silenziosa:
    accettare una scrittura e renderizzarne un'altra; `0` poi non ha un segno e
    non ha una risposta non arbitraria.
 
-A queste si aggiungono alcuni **guard di arita'** sulle macro-forme (quanti
-punti ha un gruppo, quanti cicli un formato compatto) e la costruzione anticipata
-della distribuzione temporale. Non sono una seconda validazione del builder:
-sono li' perche' quelle stesse condizioni, lasciate al builder, risalgono come
-`ValueError` nudi — fuori dalla gerarchia `EngineError`, senza campo e senza
-stream_id.
+A queste si aggiungono alcuni **guard** sulle macro-forme: quanti punti ha un
+gruppo, quanti cicli e fino a quando dura un formato compatto, dove cadono le
+percentuali del suo pattern, e la costruzione anticipata della distribuzione
+temporale. Non sono una seconda validazione del builder: sono li' perche' quelle
+stesse condizioni, lasciate al builder, risalgono come `ValueError` nudi — fuori
+dalla gerarchia `EngineError`, senza campo e senza stream_id — o non risalgono
+affatto e si renderizzano in silenzio.
 
-La copertura non e' totale e non va dichiarata tale: restano al builder le
-condizioni che dipendono da quanto ha gia' percorso (`end_time` contro l'offset
-accumulato dagli elementi precedenti) e le distribuzioni che validano i propri
-parametri solo all'uso.
+La copertura non e' totale e non va dichiarata tale. Resta al builder l'unica
+condizione che dipende da quanto ha gia' percorso: `end_time` contro l'istante
+in cui il ciclo comincia, che in una lista mista e' l'offset accumulato dagli
+elementi precedenti. Qui se ne verifica il segno, che e' decidibile perche'
+quell'istante non e' mai negativo, non il confronto.
 
 La normalizzazione avvolge il valore in `{'type': 'step', 'points': <raw>}`.
 Il wrapping preserva la semantica temporale: `create_scaled_envelope` sul dict
@@ -94,10 +96,15 @@ _GROUP_ARITY_HINT = (
 
 _REPS_ARITY_HINT = (
     "il numero di ripetizioni del formato compatto e' un intero >= 1: con "
-    "zero o meno cicli non c'e' nessun breakpoint da generare. Il resto della "
-    "coerenza temporale del ciclo (end_time contro l'istante da cui parte) "
-    "resta al builder, che e' l'unico a conoscere l'offset accumulato dagli "
-    "elementi precedenti."
+    "zero o meno cicli non c'e' nessun breakpoint da generare."
+)
+
+_END_TIME_HINT = (
+    "il secondo elemento del formato compatto e' l'istante assoluto in cui il "
+    "ciclo finisce, e deve superare quello in cui comincia: dev'essere un "
+    "numero positivo (`true` non e' `1`). Che superi davvero l'istante di "
+    "partenza lo verifica il builder, l'unico a conoscere l'offset accumulato "
+    "dagli elementi che precedono in una lista mista."
 )
 
 _PATTERN_X_HINT = (
@@ -240,13 +247,19 @@ def _check_bp_group(group: list) -> None:
 
 def _check_compact(compact: list) -> None:
     """Formato compatto: l'interp e' il quarto elemento, i valori stanno nel
-    pattern. `end_time` non e' un verso e non si valida qui (vedi
-    `_REPS_ARITY_HINT`)."""
+    pattern. Di `end_time` si verifica il segno, che e' decidibile qui, non il
+    confronto con l'istante di partenza (vedi `_END_TIME_HINT`)."""
     pattern = compact[0]
+    end_time = compact[1]
     n_reps = compact[2]
     interp = compact[3] if len(compact) >= 4 else None
     time_dist = compact[4] if len(compact) >= 5 else None
     _check_interp(interp)
+    # `end_time` deve superare l'istante da cui il ciclo parte, che non e' mai
+    # negativo: il segno e' quindi decidibile qui, il confronto no. E il
+    # `bool` va escluso a mano per la stessa ragione di `n_reps`.
+    if not _is_number(end_time) or end_time <= 0:
+        _reject(end_time, _END_TIME_HINT)
     # Solo la natura di `n_reps`: che sia un `int` lo garantisce gia'
     # `_is_compact_format`. Resta fuori il solo `bool`, che li' passa per
     # sottoclasse e qui no, per la stessa ragione per cui `true` non e' `+1`:

--- a/src/pge/parameters/read_direction.py
+++ b/src/pge/parameters/read_direction.py
@@ -52,7 +52,7 @@ from typing import Any, Union
 
 from pge.envelopes.envelope_builder import EnvelopeBuilder
 from pge.envelopes.time_distribution import TimeDistributionFactory
-from pge.shared.exceptions import EngineError, InvalidFieldValueError
+from pge.shared.exceptions import InvalidFieldValueError
 
 # Il nome della chiave nello YAML: identita' del campo in ogni errore.
 READ_DIRECTION_FIELD = 'grain.read_direction'
@@ -122,10 +122,22 @@ _PATTERN_ORDER_HINT = (
     "e' la discontinuita'."
 )
 
-_DIST_HINT = (
-    "la distribuzione temporale del formato compatto non e' costruibile: {err}. "
-    "Il verso di lettura non ha una distribuzione propria — e' quella "
-    "dell'envelope, e le forme valide sono quelle di sempre."
+_DIST_NAME_HINT = (
+    "il quinto elemento del formato compatto e' la distribuzione temporale "
+    "dei cicli, e ne esiste un elenco chiuso: {disponibili}. Si scrive come "
+    "nome ('exponential') o come dict con i suoi parametri "
+    "({{type: geometric, ratio: 1.5}}); omettendola i cicli durano uguale."
+)
+
+_DIST_PARAM_HINT = (
+    "i parametri della distribuzione '{nome}' non sono validi.{nota} Il verso "
+    "di lettura non ha una distribuzione propria: e' quella dell'envelope, e i "
+    "vincoli sui suoi parametri sono documentati con lei."
+)
+
+_DIST_TIPO_IMPLICITO = (
+    " Senza la chiave `type` la distribuzione e' `linear`, che non prende "
+    "parametri: se ne volevi un'altra, dichiarane il nome."
 )
 
 
@@ -258,7 +270,6 @@ def _check_compact(compact: list) -> None:
     end_time = compact[1]
     n_reps = compact[2]
     interp = compact[3] if len(compact) >= 4 else None
-    time_dist = compact[4] if len(compact) >= 5 else None
     _check_interp(interp)
     # `end_time` deve superare l'istante da cui il ciclo parte, che non e' mai
     # negativo: il segno e' quindi decidibile qui, il confronto no. E il
@@ -278,7 +289,10 @@ def _check_compact(compact: list) -> None:
     for point in pattern:
         _check_pattern_point(point, precedente)
         precedente = point[0]
-    _check_time_dist(time_dist)
+    # Solo se dichiarata: senza questo, ogni elemento compatto costruirebbe e
+    # butterebbe via una LinearDistribution per non dire niente.
+    if len(compact) >= 5:
+        _check_time_dist(compact[4])
 
 
 def _check_time_dist(spec: Any) -> None:
@@ -287,30 +301,48 @@ def _check_time_dist(spec: Any) -> None:
     Qui non c'e' niente da decidere — il verso di lettura non ha una
     distribuzione propria, e' quella dell'envelope. Ma `_is_compact_format`
     accetta in quella posizione qualunque `str` o `dict`, e cio' che ne esce
-    fallisce dentro `TimeDistributionFactory` con errori fuori dalla gerarchia
-    `EngineError`. Costruirla adesso li fa risalire dove hanno un campo.
+    fallisce dentro `TimeDistributionFactory` con errori che non portano ne'
+    il campo ne' lo stream_id — `ParameterBoundError` compreso, che sta nella
+    gerarchia ma nomina il proprio bound, non questa chiave.
 
-    E' delega, non duplicazione: il registro delle distribuzioni e i vincoli
-    sui loro parametri restano uno solo, e questo guard resta allineato da se'
-    se cambiano. I costruttori sono puri (validano e assegnano), quindi il
-    costo e' un oggetto buttato via.
+    Due passaggi, per due ragioni diverse:
 
-    Resta scoperta una distribuzione che accetti tutto nel costruttore e
-    fallisca all'uso: oggi `power`, che non valida `exponent` e sbaglia dentro
-    `calculate_distribution`, con un `total_time` che dipende dall'offset
-    accumulato e che di qui non si conosce. E' lo stesso confine di `end_time`.
+    1. **Il nome si legge dal registro.** Non e' duplicazione: e' la stessa
+       lista che il factory consulta, e leggerla qui evita che `{'type': 5}`
+       arrivi a `spec.get('type').lower()` e risalga come `AttributeError`.
+       In cambio l'hint puo' elencare i nomi validi, che e' l'errore piu'
+       frequente.
+    2. **I parametri li valida il costruttore**, costruendo. Quelli sono
+       vincoli delle singole distribuzioni e replicarli qui sarebbe codice
+       destinato a divergere; i costruttori sono puri (validano e assegnano),
+       quindi il costo e' un oggetto buttato via.
+
+    Il catch e' stretto a `ValueError`/`TypeError` — i due modi in cui il
+    registro dice "questo dato non va" — cosi' `MemoryError`, `RecursionError`
+    e ogni altro guasto che non parla dello YAML restano visibili per quello
+    che sono. E l'hint non riversa `str(exc)`: quelle stringhe sono in parte
+    generate da CPython (`LinearDistribution() takes no arguments`), quindi
+    instabili fra versioni, e PGE-ls le parsa.
     """
+    disponibili = TimeDistributionFactory.list_available()
+    nome = spec.get('type', 'linear') if isinstance(spec, dict) else spec
+    if nome is None:
+        nome = 'linear'
+    if not isinstance(nome, str) or nome.lower() not in disponibili:
+        _reject(spec, _DIST_NAME_HINT.format(disponibili=', '.join(disponibili)))
+
     try:
         TimeDistributionFactory.create(spec)
-    except EngineError:
-        # Gia' dentro la gerarchia: ha campo, hint e prende lo stream_id.
-        # Riavvolgerla perderebbe il bound che ha appena nominato.
-        raise
-    except Exception as err:
-        # Largo di proposito: qualunque modo in cui il factory rifiuta questo
-        # dato e' un rifiuto di cio' che l'utente ha scritto, non un caso da
-        # enumerare a mano. Il messaggio originale finisce nell'hint.
-        _reject(spec, _DIST_HINT.format(err=err))
+    except (ValueError, TypeError):
+        # `EngineError` eredita da `ValueError`, quindi il ramo copre anche
+        # `ParameterBoundError`: e' voluto. Quello nomina 'rate', non questa
+        # chiave, e Stream attribuisce lo stream_id al solo
+        # InvalidFieldValueError — cosi' tutte le famiglie rispondono uguale.
+        senza_tipo = isinstance(spec, dict) and 'type' not in spec
+        _reject(spec, _DIST_PARAM_HINT.format(
+            nome=nome,
+            nota=_DIST_TIPO_IMPLICITO if senza_tipo else '',
+        ))
 
 
 def _check_pattern_point(point: list, precedente: Any = None) -> None:

--- a/src/pge/parameters/read_direction.py
+++ b/src/pge/parameters/read_direction.py
@@ -100,6 +100,21 @@ _REPS_ARITY_HINT = (
     "elementi precedenti."
 )
 
+_PATTERN_X_HINT = (
+    "la prima coordinata di un punto del pattern e' una percentuale del ciclo "
+    "e sta in [0, 100]. Fuori da li' il ciclo sfonda i propri confini: sopra "
+    "100 il ciclo successivo comincia prima che questo sia finito, sotto 0 "
+    "esce un breakpoint a tempo negativo."
+)
+
+_PATTERN_ORDER_HINT = (
+    "le percentuali del pattern non possono tornare indietro: il ciclo si "
+    "percorre in avanti una volta sola. Con tempi che si invertono l'envelope "
+    "a 'step' legge l'ultimo valore scritto, e il verso dichiarato prima non "
+    "comparirebbe in nessun grano. Una percentuale ripetuta invece va bene: "
+    "e' la discontinuita'."
+)
+
 _DIST_HINT = (
     "la distribuzione temporale del formato compatto non e' costruibile: {err}. "
     "Il verso di lettura non ha una distribuzione propria — e' quella "
@@ -121,8 +136,14 @@ def _reject(value: Any, hint: str) -> None:
 
 
 def _check_direction_value(value: Any) -> None:
-    """Un valore dichiarato — scalare o Y di un breakpoint — vale -1 o +1."""
-    if not _is_number(value) or float(value) not in READ_DIRECTION_VALUES:
+    """Un valore dichiarato — scalare o Y di un breakpoint — vale -1 o +1.
+
+    Il confronto e' sull'appartenenza e non converte: `float()` su un `int`
+    piu' grande di ogni double alza `OverflowError`, cioe' un errore senza
+    campo sollevato proprio da chi deve produrne uno che ce l'ha. `1 == 1.0`
+    in Python, quindi il confronto misto costa niente in leggibilita'.
+    """
+    if not _is_number(value) or value not in READ_DIRECTION_VALUES:
         _reject(value, _VALUE_HINT)
 
 
@@ -235,8 +256,10 @@ def _check_compact(compact: list) -> None:
         _reject(n_reps, _REPS_ARITY_HINT)
     if not pattern:
         _reject(pattern, _FORM_HINT)
+    precedente = None
     for point in pattern:
-        _check_pattern_point(point)
+        _check_pattern_point(point, precedente)
+        precedente = point[0]
     _check_time_dist(time_dist)
 
 
@@ -272,16 +295,34 @@ def _check_time_dist(spec: Any) -> None:
         _reject(spec, _DIST_HINT.format(err=err))
 
 
-def _check_pattern_point(point: list) -> None:
+def _check_pattern_point(point: list, precedente: Any = None) -> None:
     """Un punto del pattern di un ciclo: `[x%, y]` o `[x%, y, type]`, piatto.
 
     Non passa da `_check_item` perche' li' le macro-forme sono ammesse, e qui
     non lo sono: `_is_compact_format` filtra i punti del pattern sulla sola
     lunghezza (2 o 3) e un BP group e' lungo 2, quindi ci si infila: il builder
     poi fa `x_pct / 100.0` sul primo elemento e solleva un TypeError nudo.
+
+    La `x` e' una percentuale del ciclo e deve percorrerlo in avanti una volta
+    sola. Fuori da `[0, 100]` il ciclo sfonda i propri confini — con `150` il
+    ciclo successivo comincia prima che questo sia finito, con `-10` esce un
+    breakpoint a tempo negativo; tornando indietro (`[[100, v], [0, w]]`, con
+    entrambe le x in range) i tempi si invertono e con `step` il valore
+    dichiarato per primo non compare in nessun grano. Sono i due modi in cui
+    la regola 2 del modulo — non renderizzare qualcosa di diverso da cio' che
+    e' scritto — verrebbe violata dal modulo stesso.
+
+    Args:
+        point: il punto da controllare.
+        precedente: la `x` del punto che lo precede nel pattern, o `None` se
+            e' il primo. Una `x` ripetuta e' ammessa: e' la discontinuita'.
     """
     if not _is_number(point[0]):
         _reject(point, _FORM_HINT)
+    if not 0 <= point[0] <= 100:
+        _reject(point[0], _PATTERN_X_HINT)
+    if precedente is not None and point[0] < precedente:
+        _reject(point[0], _PATTERN_ORDER_HINT)
     if len(point) == 3:
         _check_interp(point[2])
     _check_direction_value(point[1])

--- a/src/pge/rendering/envelope_extractor.py
+++ b/src/pge/rendering/envelope_extractor.py
@@ -44,6 +44,8 @@ ENVELOPE_COLORS = {
     'grain_duration_range': '#08519c',  # blu scuro (deviazione per-grano)
     'reverse': '#999999',         # grigio
     'reverse_prob': '#cccccc',    # grigio chiarissimo
+    'read_direction': '#666666',       # grigio scuro (l'altra chiave del verso)
+    'read_direction_prob': '#b3b3b3',  # grigio medio
 
     # === POINTER ===
     'pointer_start': '#8dd3c7',   # celeste

--- a/src/pge/rendering/page_layout.py
+++ b/src/pge/rendering/page_layout.py
@@ -258,6 +258,9 @@ LEGEND_SHORT_NAMES = {
     'fill_factor': 'fill',
     # Override compatto: 'grain dur rng' (13) sforerebbe la colonna (issue #141)
     'grain_duration_range': 'gr dur rng',
+    # 'read direction' (14) sforerebbe; con l'abbreviazione anche la curva di
+    # probabilita' resta in colonna ('read dir %', issue #207).
+    'read_direction': 'read dir',
 }
 
 

--- a/src/pge/rendering/visualizer_config.py
+++ b/src/pge/rendering/visualizer_config.py
@@ -85,6 +85,8 @@ ENVELOPE_RANGES = {
     'grain_duration_prob': (0, 100),
     'reverse': (0, 1),
     'reverse_prob': (0, 100),
+    'read_direction': (-1, 1),           # -1 indietro, +1 avanti
+    'read_direction_prob': (0, 100),
 
     # === POINTER ===
     'pointer_start': (0.0, 1.0),         # normalizzato

--- a/src/pge/strategies/variation_registry.py
+++ b/src/pge/strategies/variation_registry.py
@@ -11,6 +11,7 @@ from pge.strategies.variation_strategy import (
     AdditiveVariation,
     QuantizedVariation,
     InvertVariation,
+    NegateVariation,
     ChoiceVariation
 )
 from pge.shared.exceptions import StrategyNotFoundError
@@ -23,6 +24,7 @@ VARIATION_STRATEGIES: Dict[str, Type[VariationStrategy]] = {
     'additive': AdditiveVariation,
     'quantized': QuantizedVariation,
     'invert': InvertVariation,
+    'negate': NegateVariation,
     'choice': ChoiceVariation,
 }
 

--- a/src/pge/strategies/variation_strategy.py
+++ b/src/pge/strategies/variation_strategy.py
@@ -29,10 +29,24 @@ class QuantizedVariation(VariationStrategy):
         return base
 
 class InvertVariation(VariationStrategy):
-    def apply(self, base: float, mod_range: float, 
+    def apply(self, base: float, mod_range: float,
               distribution: DistributionStrategy) -> float:
         return 1.0 - base
-    
+
+
+class NegateVariation(VariationStrategy):
+    """Flip su un dominio con segno: cambia il segno, non il modulo.
+
+    Usata da `grain.read_direction` (issue #207), che vive su -1/+1.
+    `InvertVariation` non e' riusabile li': `1 - base` produrrebbe 2 e 0,
+    cioe' due valori che non sono un verso.
+    """
+
+    def apply(self, base: float, mod_range: float,
+              distribution: DistributionStrategy) -> float:
+        return -base
+
+
 class ChoiceVariation(VariationStrategy):
     """
     Selezione casuale da lista discreta.

--- a/tests/core/test_stream.py
+++ b/tests/core/test_stream.py
@@ -168,6 +168,10 @@ def stream_factory():
         s.volume = _make_mock_parameter(volume_value, 'volume')
         s.pan = _make_mock_parameter(pan_value, 'pan')
         s.reverse = _make_mock_parameter(0, 'reverse')
+        # I due membri del gruppo esclusivo 'grain_direction' esistono sempre
+        # entrambi come attributi: l'orchestratore mette a None il non
+        # selezionato (issue #207).
+        s.read_direction = None
         s.grain_envelope = 'hanning'
 
         # Reverse mode
@@ -919,14 +923,37 @@ class TestCalculateGrainReverse:
         assert result is False
 
     def test_forced_mode_always_reverse(self, stream_factory):
-        """Mode True con valore > 0.5 -> reverse."""
+        """Mode True (chiave presente e vuota) -> sempre reverse."""
         s = stream_factory(reverse_mode=True)
-        s.reverse._value = 1.0
         s.reverse._probability_gate.should_apply.return_value = False
 
         result = s._calculate_grain_reverse(0.0)
 
         assert result is True
+
+    def test_forced_mode_ignora_il_valore_del_parametro(self, stream_factory):
+        """Il verso base del ramo forzato non dipende da `reverse._value`.
+
+        Non e' una scelta ma una constatazione: `_init_grain_reverse` accetta
+        `grain.reverse` solo vuota, quindi in questo ramo il valore e' sempre
+        None. Leggerlo — e gestirne il caso Envelope — era codice morto
+        (issue #207), rimosso insieme al ramo.
+        """
+        s = stream_factory(reverse_mode=True)
+        s.reverse._probability_gate.should_apply.return_value = False
+
+        for valore in (None, 0.0, 1.0, Mock()):
+            s.reverse._value = valore
+            assert s._calculate_grain_reverse(0.0) is True
+
+    def test_un_envelope_su_grain_reverse_e_irraggiungibile(self, stream_factory):
+        """La controprova alla fonte: nessuno YAML puo' portare un Envelope
+        dentro `reverse._value`, perche' la chiave non accetta valori."""
+        s = object.__new__(Stream)
+        s.stream_id = 'test_stream'
+
+        with pytest.raises(ValueError, match="grain.reverse"):
+            s._init_grain_reverse({'grain': {'reverse': [[0, 0], [1, 1]]}})
 
     def test_flip_with_gate_auto_mode(self, stream_factory):
         """Gate aperto in auto mode flippa il risultato."""
@@ -948,33 +975,6 @@ class TestCalculateGrainReverse:
         result = s._calculate_grain_reverse(0.0)
 
         # Backward (True) flippato -> False
-        assert result is False
-
-    def test_forced_mode_with_envelope(self, stream_factory):
-        """Mode True con Envelope come _value."""
-        s = stream_factory(reverse_mode=True)
-
-        mock_env = Mock()
-        mock_env.evaluate.return_value = 0.8  # > 0.5 -> True base
-        s.reverse._value = mock_env
-        s.reverse._probability_gate.should_apply.return_value = False
-
-        result = s._calculate_grain_reverse(5.0)
-
-        mock_env.evaluate.assert_called_once_with(5.0)
-        assert result is True
-
-    def test_forced_mode_envelope_below_threshold(self, stream_factory):
-        """Envelope < 0.5 in forced mode -> not reverse."""
-        s = stream_factory(reverse_mode=True)
-
-        mock_env = Mock()
-        mock_env.evaluate.return_value = 0.2  # < 0.5 -> False base
-        s.reverse._value = mock_env
-        s.reverse._probability_gate.should_apply.return_value = False
-
-        result = s._calculate_grain_reverse(5.0)
-
         assert result is False
 
 

--- a/tests/core/test_stream_multivoice.py
+++ b/tests/core/test_stream_multivoice.py
@@ -113,6 +113,9 @@ def _make_stream(
     s.volume = _make_mock_parameter(-6.0, 'volume')
     s.pan = _make_mock_parameter(pan_value, 'pan')
     s.reverse = _make_mock_parameter(0, 'reverse')
+    # I due membri del gruppo esclusivo 'grain_direction' esistono sempre
+    # entrambi come attributi: l'orchestratore mette a None il non selezionato.
+    s.read_direction = None
     s.grain_envelope = 'hanning'
 
     s._pointer = _make_mock_pointer(pointer_pos, s.sample_dur_sec)

--- a/tests/core/test_stream_read_direction.py
+++ b/tests/core/test_stream_read_direction.py
@@ -387,6 +387,8 @@ class TestNienteValueErrorNudo:
         {'type': 'logarithmic', 'base': 1},        # parametro fuori dominio
         {'ratio': 1.5},                            # parametro estraneo al tipo
         {'type': 5},                               # il tipo non e' un nome
+        {'type': 'exponential', 'rate': 0},        # bound: alza ParameterBoundError
+        {'type': 'power', 'exponent': 'x'},        # validato dal costruttore
     ])
     def test_distribuzione_temporale_non_costruibile(self, build, dist):
         """Il quinto elemento del formato compatto e' la distribuzione

--- a/tests/core/test_stream_read_direction.py
+++ b/tests/core/test_stream_read_direction.py
@@ -63,6 +63,23 @@ def _segni(stream):
     return [g.pitch_ratio < 0 for g in stream.grains]
 
 
+def _transizioni(stream):
+    """Gli istanti in cui il verso cambia, come `[(onset, segno), ...]`.
+
+    L'insieme dei segni dice *se* i due versi compaiono; questo dice *quando*.
+    Serve per tutto cio' che governa i confini nel tempo — la distribuzione
+    dei cicli, la posizione dei breakpoint — dove l'insieme resta identico
+    anche quando il comportamento cambia del tutto.
+    """
+    out, precedente = [], None
+    for grain in stream.grains:
+        segno = 1 if grain.pitch_ratio > 0 else -1
+        if segno != precedente:
+            out.append((round(grain.onset, 4), segno))
+            precedente = segno
+    return out
+
+
 # =============================================================================
 # 1. REGRESSIONE: i quattro casi di grain.reverse
 # =============================================================================
@@ -193,10 +210,19 @@ class TestEnvelope:
     def test_punto_del_pattern_senza_interp_renderizza(self, build):
         """`[x%, y, None]` dentro il pattern di un ciclo: il validatore lo
         accetta come punto piatto con l'interp lasciato al default, e qui si
-        verifica che il builder lo espanda davvero invece di romperci sopra."""
-        stream = build(grain={'read_direction':
-                              [[[0, 1], [50, 1, None], [75, -1]], 2.0, 2]})
-        assert {g.pitch_ratio for g in stream.grains} == {1.0, -1.0}
+        verifica che il builder lo espanda davvero invece di romperci sopra.
+
+        Il punto porta un `y` **diverso** da quello che lo precede: con lo
+        stesso valore il grafico sarebbe identico a quello senza il punto, e
+        il test passerebbe senza osservare cio' che dichiara di pinnare.
+        """
+        con = build(grain={'read_direction':
+                           [[[0, 1], [50, -1, None], [100, 1]], 2.0, 2]})
+        senza = build(grain={'read_direction':
+                             [[[0, 1], [100, 1]], 2.0, 2]})
+
+        assert {g.pitch_ratio for g in con.grains} == {1.0, -1.0}
+        assert _transizioni(con) != _transizioni(senza)
 
     def test_time_unit_del_dict_resta_onorato(self, build):
         """La normalizzazione preserva le altre chiavi del dict: con
@@ -401,8 +427,24 @@ class TestNienteValueErrorNudo:
         assert exc.value.stream_id == 'test_stream'
 
     def test_distribuzione_valida_renderizza(self, build):
-        """Il guard non chiude la porta: le distribuzioni vere passano."""
-        stream = build(grain={'read_direction':
-                              [[[0, 1], [100, -1]], 2.0, 2, 'step',
-                               {'type': 'geometric', 'ratio': 1.5}]})
-        assert {g.pitch_ratio for g in stream.grains} == {1.0, -1.0}
+        """Il guard non chiude la porta: la distribuzione dichiarata passa
+        **e si vede**.
+
+        L'insieme dei segni non basta a osservarla: veniva identico con
+        `linear`, con `geometric` e senza alcun quinto elemento. Cio' che la
+        distribuzione governa sono i confini dei cicli, quindi l'osservabile
+        e' l'istante in cui il verso cambia. Il pattern flippa a meta' ciclo
+        proprio per rendere quei confini leggibili.
+        """
+        pattern = [[0, 1], [50, -1]]
+        geometrica = build(grain={'read_direction':
+                                  [pattern, 2.0, 2, 'step',
+                                   {'type': 'geometric', 'ratio': 2.0}]})
+        uniforme = build(grain={'read_direction':
+                                [pattern, 2.0, 2, 'step', 'linear']})
+
+        assert _transizioni(geometrica) != _transizioni(uniforme)
+        # ratio 2: il secondo ciclo dura il doppio del primo, quindi comincia
+        # a ~1/3 dello stream invece che a meta'.
+        assert _transizioni(geometrica)[2][0] < 0.8
+        assert _transizioni(uniforme)[2][0] == pytest.approx(1.0, abs=0.05)

--- a/tests/core/test_stream_read_direction.py
+++ b/tests/core/test_stream_read_direction.py
@@ -175,6 +175,33 @@ class TestEnvelope:
         assert verso(0.6, 1.4) == {-1.0}
         assert verso(1.4, 2.0) == {1.0}
 
+    def test_macro_forme_dentro_il_dict_renderizzano(self, build):
+        """Le forme che il dict accetta devono anche renderizzare.
+
+        `Envelope` costruisce un formato compatto e un BP group dentro
+        `points`, quindi il validatore li accetta: qui si verifica che sia
+        davvero cosi' fino ai grani, e non solo un permesso concesso a monte.
+        """
+        compatto = build(grain={'read_direction': {
+            'points': [[[0, 1], [50, -1]], 2.0, 2]}})
+        gruppo = build(grain={'read_direction': {
+            'points': [[[0, 1], [1.0, -1]], 'step']}})
+
+        assert {g.pitch_ratio for g in compatto.grains} == {1.0, -1.0}
+        assert {g.pitch_ratio for g in gruppo.grains} == {1.0, -1.0}
+
+    def test_time_unit_del_dict_resta_onorato(self, build):
+        """La normalizzazione preserva le altre chiavi del dict: con
+        `time_unit: normalized` il breakpoint a 0.5 cade a meta' stream."""
+        stream = build(grain={'read_direction': {
+            'points': [[0, 1], [0.5, -1]], 'time_unit': 'normalized'}})
+
+        prima = [g.pitch_ratio for g in stream.grains if g.onset < 1.0]
+        dopo = [g.pitch_ratio for g in stream.grains if g.onset >= 1.0]
+        assert prima and dopo
+        assert all(r > 0 for r in prima)
+        assert all(r < 0 for r in dopo)
+
     def test_envelope_indipendente_dalla_velocita(self, build):
         """Il verso dichiarato non e' corretto dal segno di speed_ratio."""
         avanti = build(pointer={'speed_ratio': 1},

--- a/tests/core/test_stream_read_direction.py
+++ b/tests/core/test_stream_read_direction.py
@@ -1,0 +1,332 @@
+"""
+test_stream_read_direction.py
+
+`grain.read_direction` end-to-end sullo Stream (issue #207).
+
+L'osservabile e' il **segno di `Grain.pitch_ratio`**: e' l'unica grandezza che
+decide il verso di lettura interno al grano (`pitch_controller.calculate()`
+nega il ratio quando `grain_reverse=True`, e il renderer ne fa l'incremento di
+fasore). Nessun test qui guarda flag interni: guarda i grani prodotti.
+
+Organizzazione:
+1. Regressione: i quattro casi di `grain.reverse` restano invariati
+2. read_direction scalare
+3. read_direction come envelope (il verso cambia ai breakpoint, e solo li')
+4. Interpolazione: ogni interp diverso da `step` e' errore
+5. Dominio dei valori
+6. Exclusivity group con grain.reverse
+7. deviation_probability: chiave dedicata
+"""
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+from pge.core.stream import Stream
+from pge.shared.exceptions import InvalidFieldValueError
+
+SR = 48000
+
+
+@pytest.fixture
+def build(tmp_path):
+    """Stream vero attraverso __init__, pronto a generare grani.
+
+    Il sample e' un wav silenzioso di 2 s: la generazione dei grani e'
+    simbolica, conta solo la durata dichiarata dall'header. I riferimenti
+    Csound li assegna il Generator in produzione: qui vanno iniettati a mano.
+    """
+    sf.write(str(tmp_path / 'tone.wav'),
+             np.zeros(int(SR * 2.0), dtype='float32'), SR)
+
+    def _build(**overrides):
+        grain = {'duration': 0.05, 'envelope': 'hanning'}
+        grain.update(overrides.pop('grain', {}))
+        params = {
+            'stream_id': 'test_stream',
+            'onset': 0.0,
+            'duration': 2.0,
+            'sample': 'tone.wav',
+            'grain': grain,
+        }
+        params.update(overrides)
+        stream = Stream(params, samples_dir=str(tmp_path))
+        stream.sample_table_num = 1
+        stream.window_table_map = {'hanning': 2}
+        return stream
+
+    return _build
+
+
+def _segni(stream):
+    """I segni di pitch_ratio dei grani generati, in ordine di onset."""
+    return [g.pitch_ratio < 0 for g in stream.grains]
+
+
+# =============================================================================
+# 1. REGRESSIONE: i quattro casi di grain.reverse
+# =============================================================================
+
+class TestReverseInvariata:
+    """La tabella della issue #207, riga per riga. `grain.reverse` non cambia:
+    questa e' la garanzia di nessun breaking change."""
+
+    def test_speed_negativo_senza_reverse_legge_indietro(self, build):
+        """Modalita' 'auto': il verso base segue il segno di speed_ratio."""
+        stream = build(pointer={'speed_ratio': -1})
+        assert all(_segni(stream))
+
+    def test_speed_negativo_con_reverse_identico(self, build):
+        """La dichiarazione non cambia nulla rispetto al caso sopra."""
+        stream = build(pointer={'speed_ratio': -1}, grain={'reverse': None})
+        assert all(_segni(stream))
+
+    def test_speed_positivo_con_reverse_legge_indietro(self, build):
+        """Forzato: il verso base e' sempre indietro, comunque vada la testina."""
+        stream = build(pointer={'speed_ratio': 1}, grain={'reverse': None})
+        assert all(_segni(stream))
+
+    def test_gate_saturato_ribalta_ogni_grano(self, build):
+        """`deviation_probability: {reverse: 100}` flippa il verso di ogni
+        grano: e' il caso deterministico ottenuto per via stocastica che ha
+        generato la issue. Resta valido."""
+        stream = build(pointer={'speed_ratio': -1}, grain={'reverse': None},
+                       deviation_probability={'reverse': 100})
+        assert not any(_segni(stream))
+
+    def test_speed_positivo_senza_niente_legge_avanti(self, build):
+        """Entrambe le chiavi assenti: comportamento 'auto' di sempre."""
+        stream = build(pointer={'speed_ratio': 1})
+        assert not any(_segni(stream))
+
+    def test_reverse_con_valore_resta_un_errore(self, build):
+        with pytest.raises(InvalidFieldValueError):
+            build(grain={'reverse': True})
+
+
+# =============================================================================
+# 2. READ_DIRECTION SCALARE
+# =============================================================================
+
+class TestScalare:
+    """Il verso e' dichiarato, e non dipende dal segno della velocita'."""
+
+    @pytest.mark.parametrize("speed", [1, -1])
+    def test_meno_uno_legge_indietro(self, build, speed):
+        stream = build(pointer={'speed_ratio': speed},
+                       grain={'read_direction': -1})
+        assert all(_segni(stream))
+
+    @pytest.mark.parametrize("speed", [1, -1])
+    def test_piu_uno_legge_avanti(self, build, speed):
+        stream = build(pointer={'speed_ratio': speed},
+                       grain={'read_direction': 1})
+        assert not any(_segni(stream))
+
+    def test_testina_indietro_grani_avanti(self, build):
+        """Il caso della issue, senza saturare nessun gate."""
+        stream = build(pointer={'speed_ratio': -1},
+                       grain={'read_direction': 1})
+        assert not any(_segni(stream))
+
+    def test_il_modulo_del_pitch_non_cambia(self, build):
+        """La chiave governa il verso, non la trasposizione."""
+        stream = build(grain={'read_direction': -1})
+        assert {abs(g.pitch_ratio) for g in stream.grains} == {1.0}
+
+
+# =============================================================================
+# 3. READ_DIRECTION COME ENVELOPE
+# =============================================================================
+
+class TestEnvelope:
+    """Il verso cambia nel tempo ai breakpoint, e SOLO li'."""
+
+    def test_il_verso_cambia_al_breakpoint(self, build):
+        stream = build(grain={'read_direction': [[0, 1], [1.0, -1]]})
+
+        prima = [g.pitch_ratio for g in stream.grains if g.onset < 1.0]
+        dopo = [g.pitch_ratio for g in stream.grains if g.onset >= 1.0]
+
+        assert prima and dopo
+        assert all(r > 0 for r in prima)
+        assert all(r < 0 for r in dopo)
+
+    def test_nessun_valore_intermedio(self, build):
+        """`step` imposto: fra i due stati non c'e' rampa, quindi i grani
+        portano solo i valori dichiarati."""
+        stream = build(grain={'read_direction': [[0, 1], [1.0, -1]]})
+        assert {g.pitch_ratio for g in stream.grains} == {1.0, -1.0}
+
+    def test_step_esplicito_stessa_semantica(self, build):
+        nudo = build(grain={'read_direction': [[0, 1], [1.0, -1]]})
+        esplicito = build(grain={'read_direction': {
+            'type': 'step', 'points': [[0, 1], [1.0, -1]]}})
+        assert _segni(nudo) == _segni(esplicito)
+
+    def test_tre_zone(self, build):
+        stream = build(grain={'read_direction': [[0, 1], [0.6, -1], [1.4, 1]]})
+
+        def verso(t0, t1):
+            return {g.pitch_ratio for g in stream.grains
+                    if t0 <= g.onset < t1}
+
+        assert verso(0.0, 0.6) == {1.0}
+        assert verso(0.6, 1.4) == {-1.0}
+        assert verso(1.4, 2.0) == {1.0}
+
+    def test_envelope_indipendente_dalla_velocita(self, build):
+        """Il verso dichiarato non e' corretto dal segno di speed_ratio."""
+        avanti = build(pointer={'speed_ratio': 1},
+                       grain={'read_direction': [[0, 1], [1.0, -1]]})
+        indietro = build(pointer={'speed_ratio': -1},
+                         grain={'read_direction': [[0, 1], [1.0, -1]]})
+        assert _segni(avanti) == _segni(indietro)
+
+
+# =============================================================================
+# 4. INTERPOLAZIONE
+# =============================================================================
+
+class TestInterpolazione:
+    """Ogni interp diverso da `step` e' un errore esplicito, in tutte e tre le
+    forme in cui e' dichiarabile. Mai un avviso, mai una correzione silenziosa."""
+
+    @pytest.mark.parametrize("interp", ['linear', 'cubic'])
+    def test_forma_dict(self, build, interp):
+        with pytest.raises(InvalidFieldValueError) as exc:
+            build(grain={'read_direction': {
+                'type': interp, 'points': [[0, 1], [1.0, -1]]}})
+        assert exc.value.field == 'grain.read_direction'
+
+    @pytest.mark.parametrize("interp", ['linear', 'cubic'])
+    def test_tag_per_punto(self, build, interp):
+        with pytest.raises(InvalidFieldValueError):
+            build(grain={'read_direction': [[0, 1, interp], [1.0, -1]]})
+
+    @pytest.mark.parametrize("interp", ['linear', 'cubic'])
+    def test_bp_group(self, build, interp):
+        with pytest.raises(InvalidFieldValueError):
+            build(grain={'read_direction': [[[0, 1], [1.0, -1]], interp]})
+
+    def test_hint_leggibile(self, build):
+        with pytest.raises(InvalidFieldValueError) as exc:
+            build(grain={'read_direction': {
+                'type': 'linear', 'points': [[0, 1], [1.0, -1]]}})
+        assert 'due stati' in exc.value.hint.lower()
+
+    def test_errore_attribuito_allo_stream(self, build):
+        """L'errore dice QUALE stream lo contiene."""
+        with pytest.raises(InvalidFieldValueError) as exc:
+            build(grain={'read_direction': {
+                'type': 'linear', 'points': [[0, 1], [1.0, -1]]}})
+        assert exc.value.stream_id == 'test_stream'
+
+
+# =============================================================================
+# 5. DOMINIO
+# =============================================================================
+
+class TestDominio:
+
+    @pytest.mark.parametrize("value", [0, 0.5, -0.5, 2])
+    def test_scalare_fuori_dominio(self, build, value):
+        with pytest.raises(InvalidFieldValueError):
+            build(grain={'read_direction': value})
+
+    def test_breakpoint_fuori_dominio(self, build):
+        with pytest.raises(InvalidFieldValueError):
+            build(grain={'read_direction': [[0, 1], [1.0, 0]]})
+
+    def test_chiave_vuota(self, build):
+        """`read_direction:` senza valore non dichiara nessun verso."""
+        with pytest.raises(InvalidFieldValueError):
+            build(grain={'read_direction': None})
+
+
+# =============================================================================
+# 6. EXCLUSIVITY GROUP
+# =============================================================================
+
+class TestExclusivity:
+    """Le due chiavi insieme sono un errore, non una priorita'."""
+
+    def test_entrambe_presenti_e_errore(self, build):
+        with pytest.raises(InvalidFieldValueError) as exc:
+            build(grain={'reverse': None, 'read_direction': 1})
+        assert exc.value.field == 'grain.read_direction'
+
+    def test_hint_nomina_entrambe(self, build):
+        with pytest.raises(InvalidFieldValueError) as exc:
+            build(grain={'reverse': None, 'read_direction': 1})
+        assert 'grain.reverse' in exc.value.hint
+
+    def test_errore_prima_di_ogni_altra_validazione(self, build):
+        """Anche con un read_direction a sua volta invalido, l'errore
+        segnalato e' quello che l'utente deve risolvere per primo."""
+        with pytest.raises(InvalidFieldValueError) as exc:
+            build(grain={'reverse': None, 'read_direction': 0.5})
+        assert 'grain.reverse' in exc.value.hint
+
+    def test_solo_read_direction_annulla_il_parametro_reverse(self, build):
+        stream = build(grain={'read_direction': 1})
+        assert stream.reverse is None
+        assert stream.read_direction is not None
+
+    def test_solo_reverse_annulla_il_parametro_read_direction(self, build):
+        stream = build(grain={'reverse': None})
+        assert stream.read_direction is None
+        assert stream.reverse is not None
+
+    def test_nessuna_delle_due_lascia_reverse(self, build):
+        """Con entrambe assenti vince reverse: la modalita' 'auto' di sempre."""
+        stream = build()
+        assert stream.read_direction is None
+        assert stream.grain_reverse_mode == 'auto'
+
+
+# =============================================================================
+# 7. DEVIATION_PROBABILITY
+# =============================================================================
+
+class TestDeviationProbability:
+    """Il verso stocastico si dichiara sulla chiave che governa il verso."""
+
+    def test_default_deterministico(self, build):
+        """Senza deviation_probability il verso dichiarato e' quello reso: non
+        serve saturare nessun gate."""
+        stream = build(grain={'read_direction': 1})
+        assert not any(_segni(stream))
+
+    def test_gate_saturato_ribalta(self, build):
+        stream = build(grain={'read_direction': 1},
+                       deviation_probability={'read_direction': 100})
+        assert all(_segni(stream))
+
+    def test_gate_a_zero_non_tocca_nulla(self, build):
+        stream = build(grain={'read_direction': -1},
+                       deviation_probability={'read_direction': 0})
+        assert all(_segni(stream))
+
+    def test_la_chiave_reverse_non_governa_read_direction(self, build):
+        """Un vecchio `reverse: 100` rimasto nello YAML non ribalta in
+        silenzio il verso appena dichiarato."""
+        stream = build(grain={'read_direction': 1},
+                       deviation_probability={'reverse': 100})
+        assert not any(_segni(stream))
+
+    def test_gate_intermedio_mescola_i_due_versi(self, build):
+        """A probabilita' intermedia i grani portano entrambi i versi: e' la
+        via dichiarativa del verso stocastico."""
+        stream = build(grain={'read_direction': 1},
+                       deviation_probability={'read_direction': 50},
+                       seed=1234)
+        segni = _segni(stream)
+        assert any(segni) and not all(segni)
+
+    def test_gate_globale_come_ogni_altro_parametro(self, build):
+        """Un numero globale vale per tutte le chiavi dello schema, questa
+        compresa: nessuna eccezione inventata."""
+        stream = build(grain={'read_direction': 1},
+                       deviation_probability=100)
+        assert all(_segni(stream))

--- a/tests/core/test_stream_read_direction.py
+++ b/tests/core/test_stream_read_direction.py
@@ -190,6 +190,14 @@ class TestEnvelope:
         assert {g.pitch_ratio for g in compatto.grains} == {1.0, -1.0}
         assert {g.pitch_ratio for g in gruppo.grains} == {1.0, -1.0}
 
+    def test_punto_del_pattern_senza_interp_renderizza(self, build):
+        """`[x%, y, None]` dentro il pattern di un ciclo: il validatore lo
+        accetta come punto piatto con l'interp lasciato al default, e qui si
+        verifica che il builder lo espanda davvero invece di romperci sopra."""
+        stream = build(grain={'read_direction':
+                              [[[0, 1], [50, 1, None], [75, -1]], 2.0, 2]})
+        assert {g.pitch_ratio for g in stream.grains} == {1.0, -1.0}
+
     def test_time_unit_del_dict_resta_onorato(self, build):
         """La normalizzazione preserva le altre chiavi del dict: con
         `time_unit: normalized` il breakpoint a 0.5 cade a meta' stream."""

--- a/tests/core/test_stream_read_direction.py
+++ b/tests/core/test_stream_read_direction.py
@@ -357,3 +357,42 @@ class TestDeviationProbability:
         stream = build(grain={'read_direction': 1},
                        deviation_probability=100)
         assert all(_segni(stream))
+
+
+# =============================================================================
+# 8. NIENTE ERRORI FUORI DALLA GERARCHIA
+# =============================================================================
+
+class TestNienteValueErrorNudo:
+    """Un `read_direction` che `Stream` accetta non deve morire piu' in la'
+    con un errore che non porta il campo.
+
+    L'osservabile e' il tipo di cio' che risale dal costruttore: dentro la
+    gerarchia `EngineError` (campo, hint, stream_id) oppure fuori, dove
+    l'utente perde la riga di contesto e PGE-ls perde il messaggio che parsa.
+    """
+
+    @pytest.mark.parametrize("dist", [
+        'bogus',                                   # nome ignoto, stringa
+        {'type': 'bogus'},                         # nome ignoto, dict
+        {'type': 'geometric', 'ratio': 0},         # parametro fuori dominio
+        {'type': 'logarithmic', 'base': 1},        # parametro fuori dominio
+        {'ratio': 1.5},                            # parametro estraneo al tipo
+        {'type': 5},                               # il tipo non e' un nome
+    ])
+    def test_distribuzione_temporale_non_costruibile(self, build, dist):
+        """Il quinto elemento del formato compatto e' la distribuzione
+        temporale: `_is_compact_format` accetta li' qualunque `str` o `dict`,
+        e cio' che ne esce non e' sempre una distribuzione."""
+        with pytest.raises(InvalidFieldValueError) as exc:
+            build(grain={'read_direction':
+                         [[[0, 1], [100, -1]], 2.0, 2, 'step', dist]})
+        assert exc.value.field == 'grain.read_direction'
+        assert exc.value.stream_id == 'test_stream'
+
+    def test_distribuzione_valida_renderizza(self, build):
+        """Il guard non chiude la porta: le distribuzioni vere passano."""
+        stream = build(grain={'read_direction':
+                              [[[0, 1], [100, -1]], 2.0, 2, 'step',
+                               {'type': 'geometric', 'ratio': 1.5}]})
+        assert {g.pitch_ratio for g in stream.grains} == {1.0, -1.0}

--- a/tests/envelopes/test_time_distribution.py
+++ b/tests/envelopes/test_time_distribution.py
@@ -174,7 +174,7 @@ class TestPowerDistribution:
         for i in range(len(durations) - 1):
             assert durations[i] < durations[i+1]
     
-    @pytest.mark.parametrize("exponent", ['x', None, True, [2]])
+    @pytest.mark.parametrize("exponent", ['x', None, [2], {'v': 2}])
     def test_invalid_exponent(self, exponent):
         """`exponent` non numerico -> errore alla costruzione.
 
@@ -186,6 +186,27 @@ class TestPowerDistribution:
         with pytest.raises(InvalidFieldValueError) as exc:
             PowerDistribution(exponent=exponent)
         assert exc.value.field == 'power.exponent'
+
+    @pytest.mark.parametrize("dist,kwargs", [
+        (PowerDistribution, {'exponent': True}),
+        (ExponentialDistribution, {'rate': True}),
+        (GeometricDistribution, {'ratio': True}),
+    ])
+    def test_bool_accettato_come_in_tutto_il_registro(self, dist, kwargs):
+        """Il guard e' sui non-numeri, non sui `bool`.
+
+        In questo modulo i costruttori validano i **bound** — `rate <= 0`,
+        `ratio <= 0`, `base <= 1` — e un `bool` li supera valendo 0 o 1. Un
+        `exponent: true` non alzava nulla nemmeno prima: `True ** n` fa 1, cioe'
+        distribuzione lineare. Rifiutarlo qui e non in `rate` o `ratio`
+        renderebbe `power` l'unica del registro a decidere sul tipo, e
+        romperebbe YAML che oggi renderizzano — su ogni chiave, non solo su
+        quelle di questa feature.
+        """
+        strategy = dist(**kwargs)
+        starts, durations = strategy.calculate_distribution(10.0, 3)
+        assert len(durations) == 3
+        assert sum(durations) == pytest.approx(10.0)
 
     def test_exponent_equals_one(self):
         """Exponent = 1 → lineare."""

--- a/tests/envelopes/test_time_distribution.py
+++ b/tests/envelopes/test_time_distribution.py
@@ -19,6 +19,7 @@ from pge.envelopes.time_distribution import (
     PowerDistribution,
     validate_distribution
 )
+from pge.shared.exceptions import InvalidFieldValueError
 
 
 # =============================================================================
@@ -173,6 +174,19 @@ class TestPowerDistribution:
         for i in range(len(durations) - 1):
             assert durations[i] < durations[i+1]
     
+    @pytest.mark.parametrize("exponent", ['x', None, True, [2]])
+    def test_invalid_exponent(self, exponent):
+        """`exponent` non numerico -> errore alla costruzione.
+
+        E' l'unico costruttore del registro che assegnava senza guardare: il
+        valore restava buono fino a `calculate_distribution`, dove
+        `(i + 1) ** exponent` alzava un `TypeError` nudo. Chi valida la spec
+        prima di usarla — costruendola — non vedeva niente.
+        """
+        with pytest.raises(InvalidFieldValueError) as exc:
+            PowerDistribution(exponent=exponent)
+        assert exc.value.field == 'power.exponent'
+
     def test_exponent_equals_one(self):
         """Exponent = 1 → lineare."""
         dist = PowerDistribution(exponent=1.0)

--- a/tests/envelopes/test_time_distribution.py
+++ b/tests/envelopes/test_time_distribution.py
@@ -187,24 +187,20 @@ class TestPowerDistribution:
             PowerDistribution(exponent=exponent)
         assert exc.value.field == 'power.exponent'
 
-    @pytest.mark.parametrize("dist,kwargs", [
-        (PowerDistribution, {'exponent': True}),
-        (ExponentialDistribution, {'rate': True}),
-        (GeometricDistribution, {'ratio': True}),
-    ])
-    def test_bool_accettato_come_in_tutto_il_registro(self, dist, kwargs):
-        """Il guard e' sui non-numeri, non sui `bool`.
+    def test_bool_non_e_rifiutato_dal_guard_sul_tipo(self):
+        """Il guard di `power` e' sui non-numeri, e un `bool` non lo e'.
 
-        In questo modulo i costruttori validano i **bound** — `rate <= 0`,
-        `ratio <= 0`, `base <= 1` — e un `bool` li supera valendo 0 o 1. Un
-        `exponent: true` non alzava nulla nemmeno prima: `True ** n` fa 1, cioe'
-        distribuzione lineare. Rifiutarlo qui e non in `rate` o `ratio`
-        renderebbe `power` l'unica del registro a decidere sul tipo, e
-        romperebbe YAML che oggi renderizzano — su ogni chiave, non solo su
-        quelle di questa feature.
+        `exponent: true` non alzava nulla nemmeno prima — `True ** n` fa 1,
+        cioe' distribuzione lineare. Aggiungere qui un controllo di tipo che
+        nessun'altra del registro fa romperebbe YAML che rendono, su ogni
+        chiave con un formato compatto e non solo su quelle di questa feature.
+
+        Cosa poi succeda ai `bool` *dopo* questo guard dipende dai bound di
+        ciascuna distribuzione, ed e' la tabella di
+        `test_bool_contro_i_bound_di_ciascuna_distribuzione`.
         """
-        strategy = dist(**kwargs)
-        starts, durations = strategy.calculate_distribution(10.0, 3)
+        starts, durations = PowerDistribution(
+            exponent=True).calculate_distribution(10.0, 3)
         assert len(durations) == 3
         assert sum(durations) == pytest.approx(10.0)
 
@@ -374,7 +370,48 @@ class TestValidateDistribution:
 
 class TestEdgeCases:
     """Test edge cases e corner cases."""
-    
+
+    @pytest.mark.parametrize("dist,kwargs,accettato", [
+        # `power` non ha bound: qualunque numero e' un esponente legittimo,
+        # quindi entrambi i booleani passano.
+        (PowerDistribution, {'exponent': True}, True),
+        (PowerDistribution, {'exponent': False}, True),
+        # `rate > 0` e `ratio > 0`: `true` vale 1 e li supera, `false` vale 0
+        # e ci cade sopra.
+        (ExponentialDistribution, {'rate': True}, True),
+        (ExponentialDistribution, {'rate': False}, False),
+        (GeometricDistribution, {'ratio': True}, True),
+        (GeometricDistribution, {'ratio': False}, False),
+        # `base > 1`: `true` vale **esattamente** 1, quindi non lo supera.
+        # Nessuno dei due passa.
+        (LogarithmicDistribution, {'base': True}, False),
+        (LogarithmicDistribution, {'base': False}, False),
+    ])
+    def test_bool_contro_i_bound_di_ciascuna_distribuzione(
+            self, dist, kwargs, accettato):
+        """Un `bool` non ha una risposta unica in questo registro.
+
+        Nessun costruttore decide sul tipo — tranne `power`, che pretende un
+        numero e a cui un `bool` basta. Da li' in poi la sorte di `true` e
+        `false` dipende dai **bound** della singola distribuzione, che non
+        sono la stessa condizione: `true` passa dove il bound e' `> 0` e cade
+        dove e' `> 1`, perche' vale esattamente 1.
+
+        La tabella e' scritta per intero, casi negativi compresi, proprio
+        perche' e' la parte che non si indovina — e perche' un parametrizzato
+        che coprisse solo i casi che passano darebbe un nome vero a un test
+        che osserva meta' del fenomeno.
+        """
+        if accettato:
+            starts, durations = dist(**kwargs).calculate_distribution(10.0, 3)
+            assert len(durations) == 3
+            assert sum(durations) == pytest.approx(10.0)
+        else:
+            # `ParameterBoundError` eredita da `ValueError`: il ramo copre sia
+            # i bound tipizzati sia i `ValueError` nudi ancora in giro.
+            with pytest.raises(ValueError):
+                dist(**kwargs)
+
     def test_single_repetition(self):
         """n_reps=1 funziona per tutte le strategie."""
         strategies = [

--- a/tests/parameters/test_parameter_definitions.py
+++ b/tests/parameters/test_parameter_definitions.py
@@ -45,7 +45,7 @@ EXPECTED_PARAMETERS = {
     # Density & Time
     'density', 'fill_factor', 'distribution', 'effective_density',
     # Grain Properties
-    'grain_duration', 'reverse', 'grain_envelope',
+    'grain_duration', 'reverse', 'read_direction', 'grain_envelope',
     # Pitch: i bounds sono unit-driven (PitchUnit.value_bounds), non registrati qui.
     # Pointer
     'pointer_speed_ratio', 'pointer_deviation',
@@ -58,7 +58,7 @@ EXPECTED_PARAMETERS = {
 }
 
 # Variation modes validi nel sistema
-VALID_VARIATION_MODES = {'additive', 'quantized', 'invert', 'choice'}
+VALID_VARIATION_MODES = {'additive', 'quantized', 'invert', 'negate', 'choice'}
 
 
 # =============================================================================
@@ -383,6 +383,17 @@ class TestGrainPropertiesBounds:
     def test_reverse_variation_mode_invert(self):
         """reverse usa variation_mode='invert' (boolean flip)."""
         assert GRANULAR_PARAMETERS['reverse'].variation_mode == 'invert'
+
+    def test_read_direction_bounds(self):
+        """read_direction vive su [-1, +1]: il negativo e' 'indietro'."""
+        b = GRANULAR_PARAMETERS['read_direction']
+        assert b.min_val == -1
+        assert b.max_val == 1
+
+    def test_read_direction_variation_mode_negate(self):
+        """read_direction usa 'negate': il flip su un dominio con segno e'
+        un cambio di segno, non `1 - base` (che darebbe 2 e 0)."""
+        assert GRANULAR_PARAMETERS['read_direction'].variation_mode == 'negate'
 
     def test_grain_envelope_variation_mode_choice(self):
         """grain_envelope usa variation_mode='choice'."""

--- a/tests/parameters/test_parameter_schema.py
+++ b/tests/parameters/test_parameter_schema.py
@@ -279,7 +279,8 @@ class TestStreamParameterSchema:
     def test_expected_parameters_present(self):
         """I parametri core di Stream sono presenti."""
         names = {s.name for s in STREAM_PARAMETER_SCHEMA}
-        expected_core = {'volume', 'pan', 'grain_duration', 'grain_envelope', 'reverse'}
+        expected_core = {'volume', 'pan', 'grain_duration', 'grain_envelope',
+                         'reverse', 'read_direction'}
         assert expected_core.issubset(names), (
             f"Mancanti: {expected_core - names}"
         )
@@ -322,12 +323,38 @@ class TestStreamParameterSchema:
         assert spec.default == 0
         assert spec.deviation_probability_key == 'reverse'
 
-    def test_no_exclusive_groups(self):
-        """STREAM schema non ha gruppi esclusivi."""
-        for spec in STREAM_PARAMETER_SCHEMA:
-            assert spec.exclusive_group is None, (
-                f"'{spec.name}' ha exclusive_group='{spec.exclusive_group}'"
-            )
+    def test_read_direction_spec(self):
+        """read_direction ha una deviation_probability_key propria: il verso
+        stocastico si dichiara sulla chiave che governa il verso, non su
+        'reverse' (issue #207)."""
+        spec = next(s for s in STREAM_PARAMETER_SCHEMA
+                    if s.name == 'read_direction')
+        assert spec.yaml_path == 'grain.read_direction'
+        assert spec.default is None
+        assert spec.deviation_probability_key == 'read_direction'
+        assert spec.is_smart is True
+
+    def test_grain_direction_exclusive_group(self):
+        """reverse e read_direction sono nello stesso gruppo esclusivo."""
+        group = {s.name for s in STREAM_PARAMETER_SCHEMA
+                 if s.exclusive_group == 'grain_direction'}
+        assert group == {'reverse', 'read_direction'}
+
+    def test_reverse_wins_when_neither_declared(self):
+        """Con entrambe le chiavi assenti vince 'reverse' (default non-None e
+        priorita' piu' alta): il comportamento resta l'attuale 'auto'."""
+        reverse = next(s for s in STREAM_PARAMETER_SCHEMA if s.name == 'reverse')
+        read_direction = next(s for s in STREAM_PARAMETER_SCHEMA
+                              if s.name == 'read_direction')
+        assert reverse.group_priority < read_direction.group_priority
+        assert reverse.default is not None
+        assert read_direction.default is None
+
+    def test_only_grain_direction_is_exclusive_in_stream(self):
+        """L'unico gruppo esclusivo dello STREAM schema e' grain_direction."""
+        groups = {s.exclusive_group for s in STREAM_PARAMETER_SCHEMA
+                  if s.exclusive_group}
+        assert groups == {'grain_direction'}
 
     def test_unique_names(self):
         """Tutti i nomi nello schema sono unici."""
@@ -867,7 +894,7 @@ class TestCrossSchemaInvariants:
             for spec in schema_list:
                 if spec.exclusive_group:
                     all_groups.add(spec.exclusive_group)
-        expected_groups = {'loop_bounds', 'density_mode'}
+        expected_groups = {'loop_bounds', 'density_mode', 'grain_direction'}
         assert all_groups == expected_groups, (
             f"Gruppi esclusivi inattesi: {all_groups - expected_groups} "
             f"o mancanti: {expected_groups - all_groups}"

--- a/tests/parameters/test_read_direction.py
+++ b/tests/parameters/test_read_direction.py
@@ -332,12 +332,17 @@ class TestStessaGrammaticaNeiDueIngressi:
         assert exc.value.value == interp
 
     def test_dict_con_compatto_fuori_dominio(self):
-        with pytest.raises(InvalidFieldValueError):
+        with pytest.raises(InvalidFieldValueError) as exc:
             normalize_read_direction({'points': [[[0, 1], [50, 0]], 20, 2]})
+        # La ragione, non solo il tipo: senza questa riga il test passerebbe
+        # anche se il corpo fosse rifiutato per la forma invece che per lo 0.
+        assert exc.value.value == 0
+        assert 'segno' in exc.value.hint
 
     def test_dict_con_bp_group_fuori_dominio(self):
-        with pytest.raises(InvalidFieldValueError):
+        with pytest.raises(InvalidFieldValueError) as exc:
             normalize_read_direction({'points': [[[0, 1], [10, 0.5]], 'step']})
+        assert exc.value.value == 0.5
 
     def test_il_type_del_dict_vale_anche_sulle_macro_forme(self):
         """`type: linear` sul dict resta un errore comunque sia scritto il
@@ -361,16 +366,17 @@ class TestStessaGrammaticaNeiDueIngressi:
 
     def test_lista_mista_valida_i_valori_della_sezione_compatta(self):
         misto = [[0, 1], [0.3, 1], [[[0, 0], [100, 1]], 1.3, 2]]
-        with pytest.raises(InvalidFieldValueError):
+        with pytest.raises(InvalidFieldValueError) as exc:
             normalize_read_direction({'points': misto})
+        assert exc.value.value == 0
 
-    def test_corpo_malformato_rifiutato(self):
-        """Una lista che non e' ne' una macro-forma ne' una sequenza di
-        breakpoint validi resta un errore: la simmetria fra i due ingressi non
-        e' permissivita'."""
-        with pytest.raises(InvalidFieldValueError):
+    def test_elemento_estraneo_in_una_lista_mista(self):
+        """Il marcatore stringa e' l'elemento che cade, non la sezione
+        compatta che lo precede: quella e' valida e viene accettata."""
+        with pytest.raises(InvalidFieldValueError) as exc:
             normalize_read_direction(
                 {'points': [[[[0, 1], [50, -1]], 20, 2], 'step']})
+        assert exc.value.value == 'step'
 
 
 # =============================================================================

--- a/tests/parameters/test_read_direction.py
+++ b/tests/parameters/test_read_direction.py
@@ -202,8 +202,103 @@ class TestDominio:
 
 
 # =============================================================================
-# 5. FORME NON RICONOSCIUTE
+# 5. LA STESSA GRAMMATICA AI DUE INGRESSI
 # =============================================================================
+
+class TestStessaGrammaticaNeiDueIngressi:
+    """Una curva scritta come lista nuda e la stessa curva dentro
+    `{points: ...}` sono la stessa curva.
+
+    I due ingressi — dict e lista — devono accettare e rifiutare le stesse
+    cose. Non e' una comodita': `Envelope` costruisce entrambe le forme (il
+    dict con `points` in formato compatto e' l'esempio nel suo docstring),
+    quindi un ingresso piu' stretto dell'altro rifiuterebbe uno YAML che il
+    motore renderizza, e con un messaggio che elenca fra le forme valide
+    proprio quella che sta rifiutando.
+    """
+
+    COMPATTO = [[[0, 1], [50, -1]], 20, 2]
+    GRUPPO = [[[0, 1], [10, -1]], 'step']
+
+    def test_compatto_accettato_nel_dict(self):
+        assert normalize_read_direction(
+            {'points': self.COMPATTO})['points'] is self.COMPATTO
+
+    def test_compatto_stessa_risposta_nei_due_ingressi(self):
+        assert (normalize_read_direction({'points': self.COMPATTO})
+                == normalize_read_direction(self.COMPATTO))
+
+    def test_bp_group_accettato_nel_dict(self):
+        assert normalize_read_direction(
+            {'points': self.GRUPPO})['points'] is self.GRUPPO
+
+    def test_bp_group_stessa_risposta_nei_due_ingressi(self):
+        assert (normalize_read_direction({'points': self.GRUPPO})
+                == normalize_read_direction(self.GRUPPO))
+
+    def test_lista_vuota_dentro_il_dict(self):
+        with pytest.raises(InvalidFieldValueError):
+            normalize_read_direction({'points': []})
+
+    # --- I rifiuti valgono anche dentro le macro-forme nel dict ---------------
+    # Simmetria non vuol dire permissivita': allargare l'ingresso dict alle
+    # macro-forme non deve aprire una scorciatoia per dichiarare un interp o un
+    # valore che la chiave non ammette.
+
+    @pytest.mark.parametrize("interp", ['linear', 'cubic'])
+    def test_dict_con_compatto_a_interp_non_step(self, interp):
+        with pytest.raises(InvalidFieldValueError) as exc:
+            normalize_read_direction(
+                {'points': [[[0, 1], [50, -1]], 20, 2, interp]})
+        assert exc.value.value == interp
+
+    @pytest.mark.parametrize("interp", ['linear', 'cubic'])
+    def test_dict_con_bp_group_a_interp_non_step(self, interp):
+        with pytest.raises(InvalidFieldValueError) as exc:
+            normalize_read_direction(
+                {'points': [[[0, 1], [10, -1]], interp]})
+        assert exc.value.value == interp
+
+    def test_dict_con_compatto_fuori_dominio(self):
+        with pytest.raises(InvalidFieldValueError):
+            normalize_read_direction({'points': [[[0, 1], [50, 0]], 20, 2]})
+
+    def test_dict_con_bp_group_fuori_dominio(self):
+        with pytest.raises(InvalidFieldValueError):
+            normalize_read_direction({'points': [[[0, 1], [10, 0.5]], 'step']})
+
+    def test_il_type_del_dict_vale_anche_sulle_macro_forme(self):
+        """`type: linear` sul dict resta un errore comunque sia scritto il
+        corpo: le due dichiarazioni non si annullano a vicenda."""
+        with pytest.raises(InvalidFieldValueError) as exc:
+            normalize_read_direction(
+                {'type': 'linear', 'points': self.COMPATTO})
+        assert exc.value.value == 'linear'
+
+    # --- Le stesse posizioni in cui le riconosce il builder -------------------
+
+    MISTO = [[0, 1], [0.3, 1], [[[0, -1], [100, 1]], 1.3, 2]]
+
+    def test_lista_mista_accettata_nei_due_ingressi(self):
+        """Una sezione compatta dentro una lista di breakpoint e' forma
+        documentata del builder, e passa da entrambi gli ingressi."""
+        assert (normalize_read_direction({'points': self.MISTO})['points']
+                is self.MISTO)
+        assert (normalize_read_direction(self.MISTO)['points']
+                is self.MISTO)
+
+    def test_lista_mista_valida_i_valori_della_sezione_compatta(self):
+        misto = [[0, 1], [0.3, 1], [[[0, 0], [100, 1]], 1.3, 2]]
+        with pytest.raises(InvalidFieldValueError):
+            normalize_read_direction({'points': misto})
+
+    def test_corpo_malformato_rifiutato(self):
+        """Una lista che non e' ne' una macro-forma ne' una sequenza di
+        breakpoint validi resta un errore: la simmetria fra i due ingressi non
+        e' permissivita'."""
+        with pytest.raises(InvalidFieldValueError):
+            normalize_read_direction(
+                {'points': [[[[0, 1], [50, -1]], 20, 2], 'step']})
 
 class TestFormeNonRiconosciute:
 

--- a/tests/parameters/test_read_direction.py
+++ b/tests/parameters/test_read_direction.py
@@ -520,6 +520,24 @@ class TestFormeNonRiconosciute:
         with pytest.raises(InvalidFieldValueError):
             normalize_read_direction({'type': 'step'})
 
+    @pytest.mark.parametrize("t", ['x', None, True, [0]])
+    @pytest.mark.parametrize("ingresso", ['dict', 'lista'])
+    def test_breakpoint_dict_con_t_non_numerico(self, ingresso, t):
+        """Il breakpoint in forma `{t, v}` deve dichiarare un tempo come
+        quello in forma lista: là `_is_number(item[0])` è già preteso, qui no,
+        e il valore arriva al builder che lo rifiuta con un `ValueError` nudo.
+        È l'asimmetria fra le forme che il modulo dichiara chiusa."""
+        corpo = [{'t': t, 'v': 1}, {'t': 1.0, 'v': -1}]
+        raw = {'points': corpo} if ingresso == 'dict' else corpo
+
+        with pytest.raises(InvalidFieldValueError) as exc:
+            normalize_read_direction(raw)
+        assert exc.value.value == corpo[0]
+
+    def test_breakpoint_dict_valido_resta_valido(self):
+        corpo = [{'t': 0, 'v': 1}, {'t': 1.0, 'v': -1}]
+        assert normalize_read_direction(corpo)['points'] is corpo
+
     def test_elemento_non_breakpoint(self):
         with pytest.raises(InvalidFieldValueError):
             normalize_read_direction([[0, 1], 'cycle'])

--- a/tests/parameters/test_read_direction.py
+++ b/tests/parameters/test_read_direction.py
@@ -66,6 +66,23 @@ class TestScalari:
         with pytest.raises(InvalidFieldValueError):
             normalize_read_direction('avanti')
 
+    @pytest.mark.parametrize("value", [
+        10 ** 400,          # int arbitrariamente grande: non ha un float
+        -(10 ** 400),
+        float('nan'),
+        float('inf'),
+    ])
+    def test_numeri_senza_float_o_senza_ordine(self, value):
+        """Un numero fuori dominio va rifiutato, non fatto esplodere.
+
+        `float()` su un `int` più grande di ogni double alza `OverflowError`
+        dentro il validatore: un errore che non porta il campo, sollevato
+        proprio da chi deve produrne uno che lo porta. Il confronto
+        sull'appartenenza non converte niente."""
+        with pytest.raises(InvalidFieldValueError) as exc:
+            normalize_read_direction(value)
+        assert exc.value.field == READ_DIRECTION_FIELD
+
 
 # =============================================================================
 # 2. ENVELOPE COME LISTA DI BREAKPOINT
@@ -311,6 +328,47 @@ class TestGuardDiArita:
     def test_pattern_vuoto_rifiutato(self):
         with pytest.raises(InvalidFieldValueError):
             normalize_read_direction({'points': [[], 2.0, 2]})
+
+    @pytest.mark.parametrize("x", [150, -10, 100.5])
+    @pytest.mark.parametrize("ingresso", ['dict', 'lista'])
+    def test_x_del_pattern_fuori_da_zero_cento(self, ingresso, x):
+        """La x di un punto del pattern è una **percentuale del ciclo**, e il
+        vincolo `[0, 100]` è dichiarato nel docstring di `EnvelopeBuilder` ma
+        non applicato da nessuno. Fuori da lì il ciclo sfonda i propri
+        confini: con `x = 150` il ciclo dopo comincia prima che questo sia
+        finito, con `x = -10` esce un breakpoint a tempo negativo."""
+        corpo = [[[0, 1], [x, -1]], 2.0, 2]
+        raw = {'points': corpo} if ingresso == 'dict' else corpo
+
+        with pytest.raises(InvalidFieldValueError) as exc:
+            normalize_read_direction(raw)
+        assert exc.value.value == x
+
+    @pytest.mark.parametrize("ingresso", ['dict', 'lista'])
+    def test_x_del_pattern_che_tornano_indietro(self, ingresso):
+        """Le x possono stare in `[0, 100]` e ciononostante tornare indietro:
+        `[[100, 1], [0, -1]]` espande in `[[1.0, 1], [0.0, -1]]`, tempi
+        all'indietro. L'envelope a `step` legge l'ultimo valore scritto e il
+        `+1` dichiarato non compare in nessun grano — la regola 2 del modulo
+        violata dal modulo."""
+        corpo = [[[100, 1], [0, -1]], 2.0, 2]
+        raw = {'points': corpo} if ingresso == 'dict' else corpo
+
+        with pytest.raises(InvalidFieldValueError) as exc:
+            normalize_read_direction(raw)
+        assert exc.value.value == 0
+
+    def test_x_ripetuta_resta_valida(self):
+        """Una x ripetuta è una discontinuità voluta, non un errore: il
+        vincolo è non-decrescente, non strettamente crescente."""
+        corpo = [[[0, 1], [50, 1], [50, -1], [100, -1]], 2.0, 2]
+        assert normalize_read_direction({'points': corpo})['points'] is corpo
+
+    @pytest.mark.parametrize("x", [0, 100, 0.0, 100.0])
+    def test_estremi_del_pattern_ammessi(self, x):
+        """`0` e `100` sono i confini del ciclo, non valori fuori."""
+        corpo = [[[x, 1], [100, -1]], 2.0, 2]
+        assert normalize_read_direction({'points': corpo})['points'] is corpo
 
 
 # =============================================================================

--- a/tests/parameters/test_read_direction.py
+++ b/tests/parameters/test_read_direction.py
@@ -29,6 +29,7 @@ import pytest
 from pge.parameters.read_direction import (
     READ_DIRECTION_FIELD,
     READ_DIRECTION_VALUES,
+    _FORM_HINT,
     _REPS_ARITY_HINT,
     normalize_read_direction,
 )
@@ -289,7 +290,23 @@ class TestGuardDiArita:
 
         with pytest.raises(InvalidFieldValueError) as exc:
             normalize_read_direction(raw)
-        assert exc.value.field == READ_DIRECTION_FIELD
+        # Il valore dice QUALE elemento e' caduto: il gruppo annidato, non la
+        # lista che lo contiene. Se un domani `_is_compact_format` si
+        # stringesse e il corpo finisse su `_check_item`, cadrebbe `corpo[0]`
+        # e questa asserzione lo direbbe.
+        assert exc.value.value == corpo[0][0]
+        assert exc.value.hint == _FORM_HINT
+
+    @pytest.mark.parametrize("ingresso", ['dict', 'lista'])
+    def test_punto_del_pattern_senza_interp_dichiarato(self, ingresso):
+        """`[x%, y, None]` e' un punto piatto con l'interp lasciato al default,
+        non una forma annidata: passa, e il builder lo espande in un
+        breakpoint a due elementi. Il guard sul pattern pretende che il primo
+        elemento sia un numero, non che il punto abbia due soli elementi."""
+        corpo = [[[0, 1], [50, 1, None], [100, -1]], 2.0, 2]
+        raw = {'points': corpo} if ingresso == 'dict' else corpo
+
+        assert normalize_read_direction(raw)['points'] is corpo
 
     def test_pattern_vuoto_rifiutato(self):
         with pytest.raises(InvalidFieldValueError):

--- a/tests/parameters/test_read_direction.py
+++ b/tests/parameters/test_read_direction.py
@@ -19,7 +19,9 @@ Organizzazione:
 2. Envelope in forma di lista di breakpoint
 3. Interpolazione: step implicito, step esplicito, tutto il resto errore
 4. Dominio dei valori
-5. Forme composte (compatto, BP group, per-punto, dict)
+5. Guard di arita': quello che passa di qui arriva vivo al builder
+6. La stessa grammatica ai due ingressi (lista nuda e dict {points})
+7. Forme non riconosciute
 """
 
 import pytest
@@ -202,7 +204,77 @@ class TestDominio:
 
 
 # =============================================================================
-# 5. LA STESSA GRAMMATICA AI DUE INGRESSI
+# 5. QUELLO CHE PASSA DI QUI ARRIVA VIVO AL BUILDER
+# =============================================================================
+
+class TestGuardDiArita:
+    """Un corpo che il validatore accetta non deve esplodere nel builder.
+
+    `normalize_read_direction` dichiara di sollevare `InvalidFieldValueError`,
+    che porta il campo e a cui `Stream` attribuisce lo stream_id. Un `ValueError`
+    nudo che risale da `EnvelopeBuilder` esce dalla gerarchia `EngineError`:
+    l'utente perde la riga di contesto e PGE-ls perde il messaggio che parsa.
+
+    Sono guard di **arità**, non una seconda validazione del builder: dicono
+    quanti elementi servono perché la forma sia quella dichiarata, non se i
+    valori hanno senso.
+    """
+
+    @pytest.mark.parametrize("ingresso", ['dict', 'lista'])
+    def test_bp_group_con_un_solo_punto(self, ingresso):
+        """Una zona con meno di 2 punti non ha segmenti interni: e' la stessa
+        condizione che il builder verifica, sollevata dove ha un campo."""
+        corpo = [[[0, 1]], 'step']
+        raw = {'points': corpo} if ingresso == 'dict' else corpo
+
+        with pytest.raises(InvalidFieldValueError) as exc:
+            normalize_read_direction(raw)
+        assert exc.value.field == READ_DIRECTION_FIELD
+        assert '2 punti' in exc.value.hint
+
+    @pytest.mark.parametrize("ingresso", ['dict', 'lista'])
+    def test_compatto_con_zero_ripetizioni(self, ingresso):
+        corpo = [[[0, 1], [100, -1]], 2.0, 0]
+        raw = {'points': corpo} if ingresso == 'dict' else corpo
+
+        with pytest.raises(InvalidFieldValueError) as exc:
+            normalize_read_direction(raw)
+        assert exc.value.value == 0
+
+    @pytest.mark.parametrize("ingresso", ['dict', 'lista'])
+    def test_compatto_con_ripetizioni_negative(self, ingresso):
+        corpo = [[[0, 1], [100, -1]], 2.0, -3]
+        raw = {'points': corpo} if ingresso == 'dict' else corpo
+
+        with pytest.raises(InvalidFieldValueError) as exc:
+            normalize_read_direction(raw)
+        assert exc.value.value == -3
+
+    def test_una_ripetizione_resta_valida(self):
+        """Il guard e' `>= 1`, non `> 1`: un ciclo solo e' legittimo."""
+        corpo = [[[0, 1], [100, -1]], 2.0, 1]
+        assert normalize_read_direction({'points': corpo})['points'] is corpo
+
+    @pytest.mark.parametrize("ingresso", ['dict', 'lista'])
+    def test_macro_forma_dentro_il_pattern_di_un_ciclo(self, ingresso):
+        """`_is_compact_format` guarda solo la lunghezza dei punti del pattern
+        (2 o 3), e un BP group e' lungo 2: passa quel filtro e arriva al
+        builder, che sul primo elemento fa `x_pct / 100.0` e solleva un
+        TypeError nudo. Qui il punto del pattern deve essere piatto."""
+        corpo = [[[[[0, 1], [50, -1]], 'step']], 2.0, 2]
+        raw = {'points': corpo} if ingresso == 'dict' else corpo
+
+        with pytest.raises(InvalidFieldValueError) as exc:
+            normalize_read_direction(raw)
+        assert exc.value.field == READ_DIRECTION_FIELD
+
+    def test_pattern_vuoto_rifiutato(self):
+        with pytest.raises(InvalidFieldValueError):
+            normalize_read_direction({'points': [[], 2.0, 2]})
+
+
+# =============================================================================
+# 6. LA STESSA GRAMMATICA AI DUE INGRESSI
 # =============================================================================
 
 class TestStessaGrammaticaNeiDueIngressi:
@@ -299,6 +371,11 @@ class TestStessaGrammaticaNeiDueIngressi:
         with pytest.raises(InvalidFieldValueError):
             normalize_read_direction(
                 {'points': [[[[0, 1], [50, -1]], 20, 2], 'step']})
+
+
+# =============================================================================
+# 7. FORME NON RICONOSCIUTE
+# =============================================================================
 
 class TestFormeNonRiconosciute:
 

--- a/tests/parameters/test_read_direction.py
+++ b/tests/parameters/test_read_direction.py
@@ -1,0 +1,216 @@
+"""
+test_read_direction.py
+
+Validazione e normalizzazione del valore grezzo di `grain.read_direction`
+(issue #207).
+
+La chiave dichiara il verso di lettura INTERNO al grano: due stati, -1
+(indietro) e +1 (avanti). Da questa natura discendono le due regole che il
+modulo fa rispettare, entrambe come errore esplicito e mai come correzione
+silenziosa:
+
+1. l'interpolazione e' `step`, implicita e obbligatoria — dichiarare `linear`
+   o `cubic` (dict, per-punto o BP group) e' errore;
+2. i valori dichiarati stanno in {-1, +1} — 0 non ha un segno, 0.3 non e' un
+   verso.
+
+Organizzazione:
+1. Scalari
+2. Envelope in forma di lista di breakpoint
+3. Interpolazione: step implicito, step esplicito, tutto il resto errore
+4. Dominio dei valori
+5. Forme composte (compatto, BP group, per-punto, dict)
+"""
+
+import pytest
+
+from pge.parameters.read_direction import (
+    READ_DIRECTION_FIELD,
+    READ_DIRECTION_VALUES,
+    normalize_read_direction,
+)
+from pge.shared.exceptions import InvalidFieldValueError
+
+
+# =============================================================================
+# 1. SCALARI
+# =============================================================================
+
+class TestScalari:
+    """Uno scalare resta uno scalare: niente envelope da costruire."""
+
+    @pytest.mark.parametrize("value", [1, 1.0, -1, -1.0])
+    def test_valori_ammessi(self, value):
+        assert normalize_read_direction(value) == float(value)
+
+    def test_restituisce_float(self):
+        assert isinstance(normalize_read_direction(1), float)
+
+    def test_chiave_vuota_e_errore(self):
+        """`read_direction:` senza valore non e' una dichiarazione di verso."""
+        with pytest.raises(InvalidFieldValueError) as exc:
+            normalize_read_direction(None)
+        assert exc.value.field == READ_DIRECTION_FIELD
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_booleani_rifiutati(self, value):
+        """`true` non e' +1: la chiave non e' un flag."""
+        with pytest.raises(InvalidFieldValueError):
+            normalize_read_direction(value)
+
+    def test_stringa_rifiutata(self):
+        with pytest.raises(InvalidFieldValueError):
+            normalize_read_direction('avanti')
+
+
+# =============================================================================
+# 2. ENVELOPE COME LISTA DI BREAKPOINT
+# =============================================================================
+
+class TestListaDiBreakpoint:
+    """La forma normale: una spezzata qualsiasi, il gradino lo impone la chiave."""
+
+    def test_lista_normalizzata_in_dict_step(self):
+        raw = [[0, 1], [12, -1], [20, 1]]
+        assert normalize_read_direction(raw) == {'type': 'step', 'points': raw}
+
+    def test_punti_preservati(self):
+        raw = [[0, -1], [5, 1]]
+        assert normalize_read_direction(raw)['points'] == raw
+
+    def test_lista_vuota_rifiutata(self):
+        with pytest.raises(InvalidFieldValueError):
+            normalize_read_direction([])
+
+
+# =============================================================================
+# 3. INTERPOLAZIONE
+# =============================================================================
+
+class TestInterpolazione:
+    """`step` e' la natura della chiave: implicito, e l'unico ammesso."""
+
+    def test_step_implicito_sulla_lista_nuda(self):
+        assert normalize_read_direction([[0, 1], [3, -1]])['type'] == 'step'
+
+    def test_step_esplicito_e_ridondanza_accettata(self):
+        raw = {'type': 'step', 'points': [[0, 1], [3, -1]]}
+        assert normalize_read_direction(raw) == raw
+
+    def test_dict_senza_type_riceve_step(self):
+        out = normalize_read_direction({'points': [[0, 1], [3, -1]]})
+        assert out['type'] == 'step'
+
+    def test_dict_preserva_le_altre_chiavi(self):
+        """time_unit governa la scala dei tempi: non va persa nella normalizzazione."""
+        raw = {'points': [[0, 1], [1, -1]], 'time_unit': 'normalized'}
+        assert normalize_read_direction(raw)['time_unit'] == 'normalized'
+
+    @pytest.mark.parametrize("interp", ['linear', 'cubic'])
+    def test_dict_con_interp_diverso_da_step_e_errore(self, interp):
+        with pytest.raises(InvalidFieldValueError) as exc:
+            normalize_read_direction({'type': interp, 'points': [[0, 1], [3, -1]]})
+        assert exc.value.field == READ_DIRECTION_FIELD
+
+    @pytest.mark.parametrize("interp", ['linear', 'cubic'])
+    def test_per_punto_con_interp_diverso_da_step_e_errore(self, interp):
+        """Tag per-punto (issue #54): [t, v, type]."""
+        with pytest.raises(InvalidFieldValueError):
+            normalize_read_direction([[0, 1, interp], [3, -1]])
+
+    def test_per_punto_step_accettato(self):
+        raw = [[0, 1, 'step'], [3, -1]]
+        assert normalize_read_direction(raw)['points'] == raw
+
+    @pytest.mark.parametrize("interp", ['linear', 'cubic'])
+    def test_bp_group_con_interp_diverso_da_step_e_errore(self, interp):
+        """BP group (issue #64): [points, interp]."""
+        with pytest.raises(InvalidFieldValueError):
+            normalize_read_direction([[[0, 1], [3, -1]], interp])
+
+    def test_bp_group_step_accettato(self):
+        raw = [[[0, 1], [3, -1]], 'step']
+        assert normalize_read_direction(raw) == {'type': 'step', 'points': raw}
+
+    @pytest.mark.parametrize("interp", ['linear', 'cubic'])
+    def test_compatto_con_interp_diverso_da_step_e_errore(self, interp):
+        with pytest.raises(InvalidFieldValueError):
+            normalize_read_direction([[[0, 1], [50, -1]], 4.0, 2, interp])
+
+    def test_compatto_step_accettato(self):
+        raw = [[[0, 1], [50, -1]], 4.0, 2, 'step']
+        assert normalize_read_direction(raw) == {'type': 'step', 'points': raw}
+
+    def test_compatto_senza_interp_accettato(self):
+        raw = [[[0, 1], [50, -1]], 4.0, 2]
+        assert normalize_read_direction(raw) == {'type': 'step', 'points': raw}
+
+    def test_hint_spiega_il_perche(self):
+        """Il messaggio dice PERCHE', non solo COSA: due stati, non una rampa."""
+        with pytest.raises(InvalidFieldValueError) as exc:
+            normalize_read_direction({'type': 'linear', 'points': [[0, 1], [3, -1]]})
+        hint = exc.value.hint.lower()
+        assert 'step' in hint
+        assert 'due stati' in hint
+
+    def test_errore_nomina_l_interp_trovato(self):
+        with pytest.raises(InvalidFieldValueError) as exc:
+            normalize_read_direction({'type': 'cubic', 'points': [[0, 1], [3, -1]]})
+        assert exc.value.value == 'cubic'
+
+
+# =============================================================================
+# 4. DOMINIO DEI VALORI
+# =============================================================================
+
+class TestDominio:
+    """Con `step` imposto l'envelope emette solo i valori scritti: si validano
+    quelli, invece di arrotondarli al segno."""
+
+    def test_valori_ammessi_sono_due(self):
+        assert set(READ_DIRECTION_VALUES) == {-1.0, 1.0}
+
+    @pytest.mark.parametrize("value", [0, 0.5, -0.3, 2, -2])
+    def test_scalare_fuori_dominio_e_errore(self, value):
+        with pytest.raises(InvalidFieldValueError) as exc:
+            normalize_read_direction(value)
+        assert exc.value.field == READ_DIRECTION_FIELD
+
+    def test_zero_e_errore_esplicito(self):
+        """0 non ha un segno: non c'e' risposta non arbitraria."""
+        with pytest.raises(InvalidFieldValueError) as exc:
+            normalize_read_direction(0)
+        assert '0' in exc.value.hint or 'segno' in exc.value.hint.lower()
+
+    @pytest.mark.parametrize("value", [0, 0.5, 3])
+    def test_breakpoint_fuori_dominio_e_errore(self, value):
+        with pytest.raises(InvalidFieldValueError):
+            normalize_read_direction([[0, 1], [3, value]])
+
+    def test_breakpoint_fuori_dominio_nel_gruppo(self):
+        with pytest.raises(InvalidFieldValueError):
+            normalize_read_direction([[[0, 1], [3, 0]], 'step'])
+
+    def test_breakpoint_fuori_dominio_nel_compatto(self):
+        with pytest.raises(InvalidFieldValueError):
+            normalize_read_direction([[[0, 1], [50, 0.5]], 4.0, 2])
+
+    def test_end_time_e_n_reps_non_sono_valori(self):
+        """Nel formato compatto solo i pattern points portano il verso."""
+        raw = [[[0, 1], [50, -1]], 4.0, 2]
+        assert normalize_read_direction(raw)['points'] is raw
+
+
+# =============================================================================
+# 5. FORME NON RICONOSCIUTE
+# =============================================================================
+
+class TestFormeNonRiconosciute:
+
+    def test_dict_senza_points(self):
+        with pytest.raises(InvalidFieldValueError):
+            normalize_read_direction({'type': 'step'})
+
+    def test_elemento_non_breakpoint(self):
+        with pytest.raises(InvalidFieldValueError):
+            normalize_read_direction([[0, 1], 'cycle'])

--- a/tests/parameters/test_read_direction.py
+++ b/tests/parameters/test_read_direction.py
@@ -29,6 +29,7 @@ import pytest
 from pge.parameters.read_direction import (
     READ_DIRECTION_FIELD,
     READ_DIRECTION_VALUES,
+    _REPS_ARITY_HINT,
     normalize_read_direction,
 )
 from pge.shared.exceptions import InvalidFieldValueError
@@ -261,6 +262,21 @@ class TestGuardDiArita:
         """Il guard e' `>= 1`, non `> 1`: un ciclo solo e' legittimo."""
         corpo = [[[0, 1], [100, -1]], 2.0, 1]
         assert normalize_read_direction({'points': corpo})['points'] is corpo
+
+    @pytest.mark.parametrize("ingresso", ['dict', 'lista'])
+    def test_ripetizioni_booleane_rifiutate(self, ingresso):
+        """`isinstance(True, int)` è vero, quindi `true` supera il
+        riconoscimento della forma e poi `True < 1` è falso: il guard non
+        scatta e `range(True)` rende un ciclo, in silenzio. È la stessa
+        politica per cui `true` non è `+1` in nessun altro punto del modulo —
+        e `false` era già rifiutato, per il valore, non per il tipo."""
+        corpo = [[[0, 1], [100, -1]], 2.0, True]
+        raw = {'points': corpo} if ingresso == 'dict' else corpo
+
+        with pytest.raises(InvalidFieldValueError) as exc:
+            normalize_read_direction(raw)
+        assert exc.value.value is True
+        assert exc.value.hint == _REPS_ARITY_HINT
 
     @pytest.mark.parametrize("ingresso", ['dict', 'lista'])
     def test_macro_forma_dentro_il_pattern_di_un_ciclo(self, ingresso):

--- a/tests/parameters/test_read_direction.py
+++ b/tests/parameters/test_read_direction.py
@@ -282,6 +282,39 @@ class TestGuardDiArita:
         assert normalize_read_direction({'points': corpo})['points'] is corpo
 
     @pytest.mark.parametrize("ingresso", ['dict', 'lista'])
+    def test_end_time_booleano_rifiutato(self, ingresso):
+        """Stessa coercizione `bool` -> `int` già vietata su `n_reps`: `true`
+        passa il riconoscimento della forma e il builder lo usa come `1.0`.
+        Verificato che non è innocuo — `[[[0,1],[50,-1]], true, 2]` rende le
+        stesse transizioni di `end_time: 1.0` e diverse da `2.0`, in
+        silenzio."""
+        corpo = [[[0, 1], [50, -1]], True, 2]
+        raw = {'points': corpo} if ingresso == 'dict' else corpo
+
+        with pytest.raises(InvalidFieldValueError) as exc:
+            normalize_read_direction(raw)
+        assert exc.value.value is True
+
+    @pytest.mark.parametrize("end_time", [0, -1.5])
+    @pytest.mark.parametrize("ingresso", ['dict', 'lista'])
+    def test_end_time_non_positivo_rifiutato(self, ingresso, end_time):
+        """`end_time` deve superare l'istante da cui il ciclo parte, e quello
+        non è mai negativo: `end_time <= 0` è quindi decidibile qui, senza
+        conoscere l'offset accumulato."""
+        corpo = [[[0, 1], [50, -1]], end_time, 2]
+        raw = {'points': corpo} if ingresso == 'dict' else corpo
+
+        with pytest.raises(InvalidFieldValueError) as exc:
+            normalize_read_direction(raw)
+        assert exc.value.value == end_time
+
+    def test_end_time_positivo_resta_valido(self):
+        """Il guard è sul segno, non sul confronto con l'offset: quello resta
+        al builder."""
+        corpo = [[[0, 1], [50, -1]], 0.001, 2]
+        assert normalize_read_direction({'points': corpo})['points'] is corpo
+
+    @pytest.mark.parametrize("ingresso", ['dict', 'lista'])
     def test_ripetizioni_booleane_rifiutate(self, ingresso):
         """`isinstance(True, int)` è vero, quindi `true` supera il
         riconoscimento della forma e poi `True < 1` è falso: il guard non

--- a/tests/parameters/test_read_direction.py
+++ b/tests/parameters/test_read_direction.py
@@ -217,7 +217,14 @@ class TestGuardDiArita:
 
     Sono guard di **arità**, non una seconda validazione del builder: dicono
     quanti elementi servono perché la forma sia quella dichiarata, non se i
-    valori hanno senso.
+    valori hanno senso. L'unica eccezione è la distribuzione temporale, che
+    non si controlla ma si delega al suo factory (vedi `_check_time_dist`).
+
+    L'invariante non è chiuso, e non lo si dichiari tale: restano fuori le
+    condizioni che dipendono da quanto il builder ha già percorso — `end_time`
+    contro l'offset accumulato — e una distribuzione che validi i propri
+    parametri solo quando la si usa (oggi `power`). Sono pinnate a Stream in
+    `TestNienteValueErrorNudo`, che copre ciò che è davvero coperto.
     """
 
     @pytest.mark.parametrize("ingresso", ['dict', 'lista'])

--- a/tests/rendering/test_envelope_extractor.py
+++ b/tests/rendering/test_envelope_extractor.py
@@ -841,7 +841,8 @@ class TestPublishedSurfaceResolves:
 
     def _configurazioni(self, build_stream):
         """Un ventaglio che copre i gruppi esclusivi: density contro
-        fill_factor, loop_end contro loop_dur, pointer e voci espliciti."""
+        fill_factor, loop_end contro loop_dur, reverse contro read_direction,
+        pointer e voci espliciti."""
         return [
             build_stream(
                 stream_id='A',
@@ -865,6 +866,15 @@ class TestPublishedSurfaceResolves:
                 stream_id='C',
                 density=10,
                 pointer={'loop_start': 0.1, 'loop_dur': 0.5},
+            ),
+            # L'altro membro del gruppo 'grain_direction' (issue #207): dove
+            # read_direction e' dichiarata, 'reverse' e' None e viceversa.
+            build_stream(
+                stream_id='D',
+                density=10,
+                grain={'duration': 0.05, 'envelope': 'hanning',
+                       'read_direction': [[0, 1], [1.0, -1]]},
+                deviation_probability={'read_direction': 40},
             ),
         ]
 
@@ -895,6 +905,38 @@ class TestPublishedSurfaceResolves:
         difetto di copertura invece che per correttezza."""
         pubblicate, vive = self._pubblicate_e_vive(build_stream)
         assert len(vive) >= len(pubblicate) - len(self.DICHIARATE_MORTE)
+
+
+class TestReadDirectionIsPlottable:
+    """Le curve di `read_direction` hanno un colore, quindi sono filtrabili.
+
+    `PLOT_ENVELOPE_KEYS` — l'universo dei nomi accettati da `--plot-envelopes`
+    e i colori dei layer SV — e' derivato da `ENVELOPE_COLORS`. Una chiave
+    pubblicata senza colore produce la curva ma viene rifiutata dal filtro che
+    dovrebbe selezionarla: promessa e superficie divergerebbero in silenzio.
+
+    (L'invariante non e' generale: `grain_envelope`, `loop_start` e `loop_end`
+    sono pubblicate senza colore da prima di questa chiave — precedente da non
+    estendere, non da imitare.)
+    """
+
+    def test_chiavi_read_direction_hanno_un_colore(self):
+        from pge.rendering.envelope_extractor import (
+            ENVELOPE_COLORS, _curve_sources, VoiceOffsetSource)
+
+        pubblicate = {
+            source.key for source in _curve_sources()
+            if not isinstance(source, VoiceOffsetSource)
+            and source.key.startswith('read_direction')
+        }
+        assert pubblicate == {'read_direction', 'read_direction_prob'}
+        assert pubblicate <= set(ENVELOPE_COLORS)
+
+    def test_filtro_plot_le_accetta(self):
+        from pge.rendering.envelope_extractor import PLOT_ENVELOPE_KEYS
+
+        assert 'read_direction' in PLOT_ENVELOPE_KEYS
+        assert 'read_direction_prob' in PLOT_ENVELOPE_KEYS
 
 
 class TestEffectiveDensityIsPublished:

--- a/tests/rendering/test_page_layout.py
+++ b/tests/rendering/test_page_layout.py
@@ -307,3 +307,9 @@ class TestLegendDisplayName:
         """'grain_duration_range' avrebbe 'grain dur rng' (13 caratteri), che
         sfora: un override esplicito ha la precedenza sulla regola."""
         assert legend_display_name('grain_duration_range') == 'gr dur rng'
+
+    def test_read_direction_abbreviated(self):
+        """'read direction' (14) sfora la colonna; l'override vale anche per
+        la curva di probabilita', che eredita il nome accorciato."""
+        assert legend_display_name('read_direction') == 'read dir'
+        assert legend_display_name('read_direction_prob') == 'read dir %'

--- a/tests/strategies/test_variation_registry.py
+++ b/tests/strategies/test_variation_registry.py
@@ -32,6 +32,7 @@ from pge.strategies.variation_strategy import (
     AdditiveVariation,
     QuantizedVariation,
     InvertVariation,
+    NegateVariation,
     ChoiceVariation,
 )
 from pge.strategies.variation_registry import (
@@ -69,7 +70,7 @@ EXPECTED_STRATEGIES = {
     'choice': ChoiceVariation,
 }
 
-EXPECTED_MODE_NAMES = {'additive', 'quantized', 'invert', 'choice'}
+EXPECTED_MODE_NAMES = {'additive', 'quantized', 'invert', 'negate', 'choice'}
 
 
 # =============================================================================
@@ -106,9 +107,9 @@ class TestVariationStrategiesRegistry:
         """VARIATION_STRATEGIES e' un dizionario."""
         assert isinstance(VARIATION_STRATEGIES, dict)
 
-    def test_registry_has_four_entries(self):
-        """Il registry contiene esattamente 4 strategie."""
-        assert len(VARIATION_STRATEGIES) == 4
+    def test_registry_entries_match_expected_modes(self):
+        """Il registry contiene esattamente le strategie attese."""
+        assert len(VARIATION_STRATEGIES) == len(EXPECTED_MODE_NAMES)
 
     def test_registry_contains_all_expected_modes(self):
         """Tutti i modi attesi sono presenti nel registry."""
@@ -126,6 +127,10 @@ class TestVariationStrategiesRegistry:
         """'invert' mappa a InvertVariation."""
         assert VARIATION_STRATEGIES['invert'] is InvertVariation
 
+    def test_negate_maps_to_correct_class(self):
+        """'negate' mappa a NegateVariation (flip su dominio con segno)."""
+        assert VARIATION_STRATEGIES['negate'] is NegateVariation
+
     def test_choice_maps_to_correct_class(self):
         """'choice' mappa a ChoiceVariation."""
         assert VARIATION_STRATEGIES['choice'] is ChoiceVariation
@@ -134,6 +139,7 @@ class TestVariationStrategiesRegistry:
         ('additive', AdditiveVariation),
         ('quantized', QuantizedVariation),
         ('invert', InvertVariation),
+        ('negate', NegateVariation),
         ('choice', ChoiceVariation),
     ])
     def test_each_mode_maps_correctly(self, mode_name, expected_class):
@@ -338,6 +344,7 @@ class TestVariationFactoryCreate:
         ('additive', AdditiveVariation),
         ('quantized', QuantizedVariation),
         ('invert', InvertVariation),
+        ('negate', NegateVariation),
         ('choice', ChoiceVariation),
     ])
     def test_create_parametrized(self, mode_name, expected_class):
@@ -717,7 +724,7 @@ class TestCoerenceWithParameterDefinitions:
     qui, il sistema fallira' a runtime.
     """
 
-    VALID_VARIATION_MODES = {'additive', 'quantized', 'invert', 'choice'}
+    VALID_VARIATION_MODES = {'additive', 'quantized', 'invert', 'negate', 'choice'}
 
     def test_all_valid_modes_in_registry(self):
         """Ogni variation_mode valido ha una strategia registrata."""

--- a/tests/strategies/test_variation_registry.py
+++ b/tests/strategies/test_variation_registry.py
@@ -63,13 +63,10 @@ class MockDistribution(DistributionStrategy):
 # COSTANTI DI RIFERIMENTO
 # =============================================================================
 
-EXPECTED_STRATEGIES = {
-    'additive': AdditiveVariation,
-    'quantized': QuantizedVariation,
-    'invert': InvertVariation,
-    'choice': ChoiceVariation,
-}
-
+# La mappa nome -> classe non vive qui: e' asserita direttamente da
+# `test_each_mode_maps_correctly` e dai cinque test per singolo modo. Una
+# tabella in piu' sarebbe una terza copia dello stesso contratto, che nessuno
+# legge e che si scorda di crescere.
 EXPECTED_MODE_NAMES = {'additive', 'quantized', 'invert', 'negate', 'choice'}
 
 

--- a/tests/strategies/test_variation_strategy.py
+++ b/tests/strategies/test_variation_strategy.py
@@ -33,6 +33,7 @@ from pge.strategies.variation_strategy import (
     AdditiveVariation,
     QuantizedVariation,
     InvertVariation,
+    NegateVariation,
     ChoiceVariation,
 )
 
@@ -68,6 +69,12 @@ def quantized():
 def invert():
     """Istanza InvertVariation."""
     return InvertVariation()
+
+
+@pytest.fixture
+def negate():
+    """Istanza NegateVariation."""
+    return NegateVariation()
 
 
 @pytest.fixture
@@ -398,6 +405,57 @@ class TestInvertVariationApply:
                                      base, expected):
         """Inversione corretta per range [0, 1] a passi di 0.1."""
         assert invert.apply(base, 0.0, mock_distribution) == pytest.approx(expected)
+
+
+# =============================================================================
+# 4-bis. TEST NegateVariation
+# =============================================================================
+
+class TestNegateVariationInit:
+    """Test costruzione NegateVariation."""
+
+    def test_instantiation(self, negate):
+        assert negate is not None
+
+    def test_is_variation_strategy(self, negate):
+        assert isinstance(negate, VariationStrategy)
+
+
+class TestNegateVariationApply:
+    """
+    apply() ritorna sempre -base.
+
+    E' il flip su un dominio con segno (grain.read_direction: -1/+1), dove
+    InvertVariation non serve: `1 - base` su -1/+1 darebbe 2 e 0, cioe' due
+    valori che non sono un verso.
+    """
+
+    def test_negate_positive(self, negate, mock_distribution):
+        assert negate.apply(1.0, 0.0, mock_distribution) == -1.0
+
+    def test_negate_negative(self, negate, mock_distribution):
+        assert negate.apply(-1.0, 0.0, mock_distribution) == 1.0
+
+    def test_ignores_mod_range(self, negate, mock_distribution):
+        r1 = negate.apply(1.0, 0.0, mock_distribution)
+        r2 = negate.apply(1.0, 100.0, mock_distribution)
+        assert r1 == r2 == -1.0
+
+    def test_ignores_distribution(self, negate):
+        assert negate.apply(-1.0, 5.0, None) == 1.0
+
+    def test_distribution_sample_never_called(self, negate, mock_distribution):
+        negate.apply(1.0, 10.0, mock_distribution)
+        mock_distribution.sample.assert_not_called()
+
+    def test_double_negation_identity(self, negate, mock_distribution):
+        first = negate.apply(1.0, 0.0, mock_distribution)
+        second = negate.apply(first, 0.0, mock_distribution)
+        assert second == 1.0
+
+    def test_preserva_il_modulo(self, negate, mock_distribution):
+        """Cambia solo il segno: il modulo resta quello dichiarato."""
+        assert negate.apply(0.25, 0.0, mock_distribution) == pytest.approx(-0.25)
 
 
 # =============================================================================


### PR DESCRIPTION
Closes #207.

## Cosa cambia nella superficie YAML

Nuova chiave `grain.read_direction`: il verso di lettura **interno al grano**,
dichiarato come funzione del tempo e indipendente dal segno di
`pointer.speed_ratio`.

```yaml
grain:
  read_direction: 1                       # +1 avanti, -1 indietro
  read_direction: [[0, 1], [12, -1]]      # envelope: il verso cambia a t=12
```

Il caso che oggi richiede di saturare un gate stocastico a 100 — testina che
percorre il buffer all'indietro, grani letti in avanti — si scrive:

```yaml
# prima
pointer: {speed_ratio: -1}
grain: {reverse:}
deviation_probability: {reverse: 100}

# adesso
pointer: {speed_ratio: -1}
grain: {read_direction: 1}
```

- dominio `[-1, +1]`, scalare o envelope;
- interpolazione `step` **imposta**: il valore grezzo viene avvolto in
  `{type: step, points: }` prima del parser, e ogni altro interp —
  `linear`/`cubic` in forma dict, tag per-punto `[t, v, type]`, BP group
  `[points, interp]`, quarto elemento del formato compatto — solleva
  `InvalidFieldValueError`. Mai un avviso, mai una correzione silenziosa;
- `grain.reverse` e `grain.read_direction` insieme → errore esplicito di
  exclusivity group. Divergenza voluta dal precedente `loop_end`/`loop_dur`,
  che risolve per priorità: qui le due chiavi dicono cose opposte e una
  priorità silenziosa nasconderebbe l'errore dell'utente invece di segnalarlo;
- nuova chiave `deviation_probability.read_direction` (vedi decisione 1);
- `read_direction` e `read_direction_prob` sono registrate fra gli envelope
  plottabili (`--plot-envelopes`, layer SV), con nome di legenda `read dir`.

Il messaggio d'errore dice *perché*, non solo *cosa*:

> grain.read_direction ammette solo l'interpolazione 'step', che è già
> implicita: il verso di lettura ha due stati, non una rampa fra i due, e un
> valore intermedio fra -1 e +1 non è un verso.

## Le due decisioni aperte nella issue

### 1. Interazione con `deviation_probability` → chiave dedicata

**`deviation_probability.read_direction`.** `deviation_probability.reverse`
continua a governare **solo** `grain.reverse`, esattamente com'è oggi; la
chiave nuova ha la propria voce nel blocco, come ogni altro parametro dello
schema. Con la chiave assente dal dict il gate è `NeverGate`, quindi **il
default è deterministico** — che era il punto della issue — e lo stocastico
resta raggiungibile con la sintassi che tutti gli altri parametri già usano:

```yaml
grain:
  read_direction: 1        # base: avanti
deviation_probability:
  read_direction: 30       # il 30% dei grani legge all'indietro
```

Le altre due opzioni sono state scartate perché: *(a)* lasciare che
`deviation_probability.reverse` flippi anche il valore dichiarato terrebbe una
chiave chiamata `reverse` a governare un parametro chiamato `read_direction`, e
un vecchio `reverse: 100` rimasto nello YAML ribalterebbe in silenzio un verso
appena scritto; *(b)* ignorare il gate quando la chiave è presente toglierebbe
il verso stocastico a chi lo vuole senza dargli una via dichiarativa.

Sotto `deviation_probability` **globale** (un numero o un envelope per tutte le
chiavi) la nuova chiave si comporta come ogni altro parametro dello schema,
`reverse` compresa: nessuna eccezione inventata. Attenzione al caso
`deviation_probability:` scritto e lasciato **vuoto**, che non equivale alla
chiave assente ma attiva il jitter implicito (~1% dei grani) — comportamento
preesistente e non specifico di questa chiave, tracciato in #210.

Implementazione: nuovo `variation_mode='negate'` (`NegateVariation`, `base →
-base`). Su un dominio con segno il flip per-grano è un cambio di segno, mentre
`'invert'` (`1 - base`) produrrebbe `2` e `0`. Con il gate e il flip dentro il
`Parameter`, il verso si legge in una riga:
`self.read_direction.get_value(t) < 0`.

### 2. Valori fuori da `{-1, +1}` → rifiuto esplicito, `y = 0` compreso

Con `step` imposto l'envelope emette **solo** i valori scritti ai breakpoint:
arrotondare al segno significherebbe accettare una scrittura
(`read_direction: 0.3`) e renderizzarne un'altra (`+1`). Lo `0` poi non ha un
segno e non ha una risposta non arbitraria. Coerente con il rifiuto degli altri
interp: la chiave ha due stati e li pretende scritti.

Il controllo è a parse-time e **precede** il clamp dei bounds, così
`read_direction: 0.5` produce un errore che parla del dominio a due valori
invece di passare silenziosamente il clamp `[-1, 1]`. Anche `read_direction:`
vuota è un errore: non dichiara nessun verso.

## Cosa NON cambia

- **`grain.reverse`**: identica. Chiave assente = modalità `auto` (il verso
  segue `pointer.speed_ratio`), chiave presente-e-vuota = sempre indietro,
  ogni valore rifiutato. Con entrambe le chiavi assenti il comportamento è
  quello di oggi. Nessun breaking change: i quattro casi della tabella nella
  issue sono una classe di test di regressione
  (`TestReverseInvariata` in `tests/core/test_stream_read_direction.py`).
- **La map**: `grain_visuals.arrow_vertices` / `window_vertices` decidono il
  verso sul solo `sign(pitch_ratio)` e il colore usa `abs(pitch_ratio)`.
  Verificato, non riscritto: i test esistenti
  (`test_arrow_points_down_when_reverse`,
  `test_edge_falls_below_the_pointer_when_reverse`,
  `test_reverse_grains_count_by_their_absolute_pitch`) passano invariati.
- **Il blocco `pitch`**: intatto. Resta interfaccia umana per la sola altezza
  percepita, con bounds positivi per costruzione. `Grain.pitch_ratio` non è
  rinominato: è l'incremento di fasore che porta modulo e segno.
- **Ogni chiave che non sia `read_direction`.** L'unica modifica fuori dalla
  feature è in `PowerDistribution`, e per la sola classe di valori che prima
  alzava un `TypeError` nudo — vedi quinta review.

## Codice morto risolto

Il ramo `hasattr(val, 'evaluate')` in `_calculate_grain_reverse` è stato
**rimosso**, non reso raggiungibile. Con `grain.reverse` presente,
`_init_grain_reverse` rifiuta ogni valore non-`None`, quindi in quel ramo
`self.reverse._value` è sempre `None` e il verso base è sempre `True`: il ramo
forzato è ora `is_reverse_base = True`. `read_direction` non lo riabilita —
ha un ramo proprio, che legge il suo Parameter.

I due test che lo pinnavano (`test_forced_mode_with_envelope`,
`test_forced_mode_envelope_below_threshold`) sono sostituiti da due che dicono
la verità: il ramo forzato ignora il valore del parametro, e un `Envelope` su
`grain.reverse` è irraggiungibile alla fonte.

## Dopo le review

**Prima review** — i due ingressi del validatore (lista nuda e `{points: ...}`)
non validavano la stessa grammatica: un formato compatto o un BP group dentro
`points` veniva rifiutato, benché `Envelope` lo costruisca, e con un hint che
elencava fra le forme valide proprio quella scartata. Un solo
`_check_envelope_body` chiamato dai due ingressi (`39602b1`).

**Seconda review** — il fix di simmetria aveva allineato il ramo dict ai buchi
del ramo lista: un BP group con un punto solo, o un compatto con `n_reps <= 0`,
passavano il validatore e morivano dentro `EnvelopeBuilder` come `ValueError`
nudi. Aggiunti due **guard di arità**, e chiuso il caso del pattern di un ciclo,
dove `_is_compact_format` filtra i punti sulla sola lunghezza (2 o 3) e un BP
group è lungo 2: ci si infilava e il builder sollevava un `TypeError` su
`x_pct / 100.0` (`8f6005f`).

**Terza review** — il validatore saltava del tutto il **quinto** elemento del
formato compatto, la distribuzione temporale. Sei famiglie verificate attraverso
`Stream`, e la distribuzione è ora costruita dal suo factory invece di essere
ignorata (`ebc6668`). Corretto anche `n_reps: true`, che scavalcava il guard
perché `isinstance(True, int)` è vero (`aa9d884`).

**Quarta review** — 17 finding, riprodotti tutti eseguendo codice prima di
toccare qualsiasi cosa. Dieci chiusi qui, cinque aperti come issue separate
(#209, #210, #211, #212, #213), due erano note.

I fix nel validatore, in ordine di gravità:

| Cosa passava | Cosa faceva | Commit |
|---|---|---|
| `x` del pattern fuori da `[0, 100]`, o che torna indietro | renderizzava in silenzio: con `[[100, 1], [0, -1]]` il `+1` scritto non compariva in **nessun** grano | `ae2ed3f` |
| `end_time: true` | renderizzava come `1.0`, e diversamente da `2.0` | `52b5d1b` |
| `{t: 'x', v: 1}` | `ValueError` nudo dal builder | `532249f` |
| `read_direction: <int enorme>` | `OverflowError` **dentro il validatore** | `ae2ed3f` |
| `{type: exponential, rate: 0}` | `ParameterBoundError` senza campo né `stream_id` | `efbf8c6` |
| `{type: power, exponent: 'x'}` | `TypeError` nudo, invisibile a chi valida costruendo | `efbf8c6` |

Tre note su come sono stati chiusi, perché in due casi la diagnosi andava
corretta e in uno il fix suggerito sarebbe stato incompleto:

- **La `x` del pattern.** Il bound `[0, 100]` da solo non chiude lo scenario del
  finding: in `[[100, 1], [0, -1]]` entrambe le `x` sono in range, e i tempi
  espansi diventano `[[1.0, 1], [0.0, -1]]`, all'indietro. Serviva anche il
  verso di percorrenza. Il vincolo è **non-decrescente**, non strettamente
  crescente: una percentuale ripetuta è la discontinuità, ed è legittima.
- **`except EngineError: raise`.** La premessa su cui l'avevo scritto —
  «ha già campo e hint» — era falsa. Il tipo dell'eccezione non è sbagliato (è
  pinnato da `test_engine_exceptions.py`): era il fatto che qui non venisse
  attribuito. Il catch è ora `(ValueError, TypeError)`, che copre anche gli
  `EngineError` perché `ConfigError` eredita da `ValueError` — voluto, e scritto
  accanto.
- **`power.exponent` non era «lo stesso confine di `end_time`».** Non dipende da
  nessun contesto runtime: `PowerDistribution` era semplicemente l'unico
  costruttore del registro ad assegnare senza guardare.

Il `except Exception` largo è sparito su entrambi i fronti segnalati. Il nome
della distribuzione si legge ora dal registro *prima* di costruire — stessa
lista che il factory consulta, quindi non è duplicazione — e `{type: 5}` cade lì
invece di risalire come `AttributeError`; gli hint non riversano più `str(exc)`,
che per alcune famiglie conteneva stringhe generate da CPython, instabili fra
versioni e dentro ciò che PGE-ls parsa. Il caso `{ratio: 1.5}` non incolpa più
un `'linear'` che l'utente non ha scritto: dice che senza `type` la
distribuzione è `linear` e che `linear` non prende parametri.

**I test che non osservavano ciò che dichiaravano.**
`test_distribuzione_valida_renderizza` passava per coincidenza — verificato che
dava lo stesso risultato con `'linear'` e senza alcun quinto elemento, e che al
variare del solo `ratio` diventava rosso. L'insieme dei segni dice *se* i due
versi compaiono, non *quando*: ciò che una distribuzione governa sono i confini
dei cicli. Nuovo helper `_transizioni` accanto a `_segni`, e i due test
riscritti confrontano geometric contro linear. Entrambe le riscritture sono
verificate **per mutazione**: riportando `geometric` a `linear`, e il punto del
pattern al valore precedente, i test falliscono.

**Il confine dichiarato, adesso.** Resta al builder la sola condizione che
dipende da quanto ha già percorso: `end_time` contro l'istante in cui il ciclo
comincia, che in una lista mista è l'offset accumulato dagli elementi
precedenti. Il **segno** di `end_time` è invece verificato qui, perché
quell'istante non è mai negativo. È scritto nel modulo, nel docstring dei test
e in `docs/reference/yaml.md` §10.5, che ora elenca in tabella tutte le
condizioni e cosa succede altrove.

**Quinta review** — condotta fuori da `read_direction.py`, sul resto del diff.
Tre finding, nessuno bloccante, tutti chiusi in `3ffcf1c`.

Il solo che toccava utenti fuori dalla feature: il guard che avevo aggiunto a
`PowerDistribution` rifiutava anche i **booleani**, e questo rompeva YAML che su
`main` rendevano — su ogni chiave che usi un compatto con `{type: power}`, non
solo su quelle di questa PR. A/B contro `git archive main src`:

| | `main` | branch (prima) | branch (ora) |
|---|---|---|---|
| `grain.duration`, `exponent: true` | 91 grani | errore | **91 grani** |
| `grain.duration`, `exponent: '2'` | `TypeError` nudo | errore con campo | errore con campo |
| `density`, `exponent: true` | 38 grani | errore | **38 grani** |

**Il guard è stato ristretto ai soli non-numeri, invece di dichiarare il
restringimento nel CHANGELOG.** Due ragioni, la seconda decisiva:

- `True ** n` fa `1`, quindi `exponent: true` non ha mai prodotto il
  `TypeError` nudo che il finding voleva chiudere: rendeva una distribuzione
  lineare. Il caso davvero rotto era `'x'` / `None`, che resta rifiutato.
- Rifiutarlo lì soltanto era **incoerente col modulo in cui vive**: quel guard
  era l'unico `isinstance(..., bool)` del file, cioè una politica introdotta in
  un costruttore su cinque.

Se i booleani vadano rifiutati nelle distribuzioni temporali è una domanda sola
per tutte e cinque, con la sua voce di CHANGELOG sotto *Changed*: annotata su
#212, fuori da questa PR. Con il guard ristretto **non resta nessun cambio di
comportamento da dichiarare**, quindi il CHANGELOG conserva la sola sezione
*Aggiunto*.

Gli altri due, entrambi su codice preesistente:

- **`ENVELOPE_RANGES['read_direction']`**: confermato dato morto — dopo la issue
  #114 la normalizzazione è data-driven e il visualizer legge da lì il solo
  `['pan']`. **Le entry restano**, consapevolmente: il commento del modulo
  dichiara già la tabella come riferimento, `reverse`/`reverse_prob` sono lì per
  la stessa ragione, e una tabella di riferimento che salta l'unica chiave nuova
  pubblicata fra gli envelope plottabili mentirebbe per omissione.
- **`EXPECTED_STRATEGIES`** in `test_variation_registry.py`: **rimossa**. Non
  era consumata da nessun test, e la mappa nome → classe che dichiarava è già
  asserita da `test_each_mode_maps_correctly` e dai cinque test per singolo
  modo.

**Sesta review** — due finding, entrambi di sola scrittura: il codice di
`3ffcf1c` era giusto, la sua *motivazione* affermava più del vero. Chiusi in
`84c9fff`.

La frase «un bool quei bound li supera valendo 0 o 1» era falsa per due
distribuzioni su cinque, e il docstring si smentiva da solo citando `base <= 1`
fra gli esempi — che è il bound di `logarithmic`, dove `True` vale esattamente
1 e quindi **non** lo supera. Misurato su tutti e quattro i costruttori
parametrici, in entrambi i valori:

| | `true` (vale 1) | `false` (vale 0) |
|---|---|---|
| `power.exponent` (nessun bound) | passa | passa |
| `exponential.rate > 0` | passa | errore |
| `geometric.ratio > 0` | passa | errore |
| `logarithmic.base > 1` | **errore** | errore |

La decisione della quinta review non cambia — regge con la formulazione più
debole e più vera: qui si valida il **tipo** perché i bound sono affare di
ciascuna distribuzione, e cosa faccia un bool contro quei bound dipende dalla
distribuzione. La stessa affermazione era rivolta al lettore in
`docs/reference/yaml.md` §6.5, dove è stata sostituita dalla tabella qui sopra.

Il test che l'accompagnava copriva tre distribuzioni su quattro e saltava
proprio `logarithmic`, l'unica dove il suo nome era falso; e provava solo `True`,
mai `False`, che è il valore su cui due delle tre coperte falliscono — lo stesso
pattern del parametrizzato che evita la famiglia scomoda già trovato al quarto
giro. Verificato che aggiungere `logarithmic` lo rendeva rosso, poi spezzato in
due: il pin sul guard di `power` resta accanto a `power`, la tabella completa
(quattro distribuzioni × due valori, casi negativi compresi) sta in
`TestEdgeCases`, dove vive ciò che attraversa il registro.

## Come si verifica

`make tests` → **5565 passed, 2 skipped** (baseline su `main`: 5356 passed).
L'osservabile dei test end-to-end è il **segno di `Grain.pitch_ratio`** e, per
tutto ciò che governa il tempo, l'**istante in cui il verso cambia**.

Nuovi file di test:

- `tests/parameters/test_read_direction.py` — validazione e normalizzazione del
  valore grezzo (forme, interp, dominio, guard di arità e di valore, simmetria
  dei due ingressi);
- `tests/core/test_stream_read_direction.py` — Stream vero, grani veri
  (regressione sui quattro casi di `reverse`, scalare, envelope, interp
  rifiutati nelle tre forme, dominio, exclusivity, deviation_probability, e
  `TestNienteValueErrorNudo`: niente errori fuori dalla gerarchia).

Smoke test manuale (render reale, renderer NumPy, sidecar dei grani):

```
grain: {read_direction: [[0, 1], [1.0, -1]]}
→ 40 grani con pitch_ratio +1.0 prima di t=1.0
→ 39 grani con pitch_ratio -1.0 dopo
→ nessun valore intermedio
```

Partitura con `--visualize --plot-envelopes read_direction,read_direction_prob`:
PDF generato, filtro accettato.

**Convivenza con `main` a v7.2.0** (PR #215, «POC Projection»): merge di prova in
locale, **zero conflitti** e **5611 passed, 2 skipped**. Le due PR toccano
`visualizer_config.py` in zone diverse.

`make e2e-tests`: **non eseguibile in locale** — csound assente e `refs/` vuota
(i `.wav` sono gitignored), quindi ogni test e2e fallisce sul sample mancante;
verificato che il risultato è identico su `main` e su questo branch (45 failed,
17 passed, 15 skipped in entrambi). In CI il job e2e gira davvero (csound
installato) ed è stato verde fino al run 291.

## Impatto cross-repo

Issue companion aperte, con il nome della chiave ormai fissato:

- DMGiulioRomano/PGE-ls#43 — autocomplete, dominio a due valori, rifiuto degli
  interp non-`step`, diagnostica dell'exclusivity group, hover/snippet,
  rigenerazione dello snapshot. Aggiornata a ogni review: i rifiuti di arità, la
  validazione della distribuzione temporale — che il language server oggi non
  controlla affatto, verificato — e da ultimo i sei rifiuti nuovi, **più
  l'avviso che i messaggi degli hint sono cambiati** e che conviene agganciare
  la diagnostica alla coppia `field` + tipo di eccezione, non al testo.
- DMGiulioRomano/PGE-ui#119 — controllo a due stati (non slider continuo), caso
  envelope a gradino, mutua esclusione con `reverse`, default = chiave assente.
  Aggiornata con i punti concreti trovati leggendo il codice: `truncateEnvArray`
  **interpola** il breakpoint di chiusura, quindi su questa chiave un
  freeze-on-resize può generare un valore intermedio che il motore rifiuta;
  `computeCycleDurations` **ripiega su `linear`** per un nome ignoto invece di
  segnalarlo. Per i sei rifiuti del quarto giro ho verificato le vie di
  emissione dell'editor e **cinque su sei non lo riguardano** — l'`EnvelopeEditor`
  già clampa `xPct` a `[0.1, 99.9]`, vincola il drag ai vicini, clampa
  `end_time` a `1.0` e non emette breakpoint in forma `{t, v}`.

**Submodule del paper CIM 2026**: nessun bump necessario. La modifica è
additiva e nessun esempio `exN.yml` usa la chiave nuova; rendering, score
visualizer e la superficie usata da `render_example.py` non cambiano, e con
`show_static_params: False` la curva assente non entra nelle figure.

## Nota fuori scope

Aggiungendo il colore per le curve nuove è emerso che `grain_envelope`,
`grain_envelope_prob`, `loop_start` e `loop_end` sono **pubblicate da
`envelope_extractor` senza una voce in `ENVELOPE_COLORS`**: producono la curva
ma `--plot-envelopes` le rifiuta come nomi sconosciuti. Precedente non esteso e
non toccato qui — segnalato per una issue separata.