### PR TITLE
ScoreVisualizer: la lente proietta il suo istante sulle curve envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,44 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ## [Unreleased]
 
+### Aggiunto
+
+- **La lente di ingrandimento proietta il suo istante sulle curve dello
+  stream.** La lente diceva dove guardare ma non con quali parametri: per
+  sapere a che valori corrispondesse il grumo di grani ingrandito bisognava
+  allineare a occhio la X del cerchio sorgente con le curve della corsia
+  sottostante. Ora ogni lente risolta — automatica o esplicita — disegna sulla
+  corsia envelope del suo stream una verticale tratteggiata a `x = t` e, su
+  ogni curva che incrocia, un marker con il valore reale e la sua unità (lo
+  stesso formato dei breakpoint annotati, ora condiviso in
+  `envelope_display.value_label`).
+
+  Colori dentro il sistema esistente: la verticale prende `magnify_color` — è
+  un pezzo della lente, non un elemento a sé — e il marker la tinta della sua
+  curva con l'anello dell'accento. Stampata in scala di grigi la proiezione
+  resta un tratteggio con pallini cerchiati, non due grigi indistinguibili.
+  Le etichette cadono tutte sulla stessa verticale, quindi il lato si alterna
+  salendo lungo la corsia; i bordi del subplot hanno comunque l'ultima parola,
+  come per i breakpoint.
+
+  Nuovo gruppo di config del visualizer `magnify_projection`
+  (`enabled`, `linestyle`, `linewidth`, `alpha`, `markersize`, `labels`);
+  nessuna flag CLI nuova, la proiezione è parte di `--magnify` /
+  `--magnify-at`. Niente da proiettare, niente disegnato: a magnify spenta,
+  su uno stream senza curve dinamiche o con l'istante fuori dall'estensione
+  dello stream la pagina resta identica a prima. Chiude #214.
+
+### Modificato
+
+- **`ScoreVisualizer._draw_envelopes` restituisce un record invece di un set.**
+  Era l'insieme dei nomi disegnati, che non leggeva nessuno; ora è
+  `EnvelopeLaneRender(curves, display_ranges, y_base, y_height, pitch_unit)`
+  — cosa è finito nella corsia. Serve alla proiezione: i range con cui le
+  curve sono state scalate vivevano solo nello scratchpad d'istanza
+  `_current_display_ranges`, che al momento di disegnare le lenti contiene
+  ormai quelli dell'ultimo stream. Metodo privato, nessun consumatore fuori
+  dal visualizer; `.drawn_types` sul record dà l'informazione di prima.
+
 ---
 
 ## [v7.1.0] — "Sample Duration" — 2026-08-14

--- a/docs/explanation/score-visualizer-layout.md
+++ b/docs/explanation/score-visualizer-layout.md
@@ -8,16 +8,17 @@ sources:
   - src/pge/rendering/grain_visuals.py
   - src/pge/rendering/envelope_display.py
   - src/pge/rendering/magnifier_targets.py
+  - src/pge/rendering/magnifier_projection.py
   - src/pge/rendering/score_visualizer.py
   - src/pge/rendering/visualizer_config.py
-last_synced_commit: 8c13acd
+last_synced_commit: 51c49f8
 ---
 
 # Il layout della partitura: separare i numeri dal disegno
 
 **Documenti collegati:** [[INDEX]] · [[architecture]] · [[parameter-curve]]
 
-Il modello descritto qui è implementato: i quattro moduli vivono in
+Il modello descritto qui è implementato: i moduli vivono in
 `src/pge/rendering/`, e `ScoreVisualizer` li consuma come adapter matplotlib.
 
 ## Problema
@@ -57,16 +58,18 @@ scopriva leggendo chi li costruiva.
 
 ## Modello
 
-Quattro moduli, nessuno dei quali importa matplotlib. Non uno solo: le cluster
-non condividono niente se non "servono a disegnare una pagina", e un modulo
-unico sarebbe stato una borsa.
+Quattro moduli all'estrazione, cinque dalla proiezione della lente (#214), e
+nessuno importa matplotlib. Non uno solo: le cluster non condividono niente se
+non "servono a disegnare una pagina", e un modulo unico sarebbe stato una
+borsa.
 
 | Modulo | Domanda a cui risponde |
 |---|---|
 | `page_layout` | Quali stream su quale pagina, in che corsia, con che legenda |
 | `grain_visuals` | Che forma ha un grano, e dove cade sulle scale di colore e opacità |
-| `envelope_display` | Quanto è alta la corsia di una curva, e dove ci cade un valore |
+| `envelope_display` | Quanto è alta la corsia di una curva, dove ci cade un valore e come si scrive |
 | `magnifier_targets` | Dove puntare la lente di ingrandimento |
+| `magnifier_projection` | A quali valori delle curve corrisponde l'istante della lente |
 
 ### Dove passa la linea
 
@@ -108,6 +111,29 @@ più `EnvelopeLane(stream, stream_id, y_base, y_height, env_types)`.
 In `MagnifyTarget`, `entry` resta una riga opaca di `stream_entries`: il modulo
 ne legge solo `stream` e `sample_duration`, e la restituisce intatta perché chi
 disegna possa raggiungerne l'asse matplotlib.
+
+### Uno stato d'istanza che è diventato un dato
+
+`_current_display_ranges` è lo scratchpad che `_draw_envelopes` riempie per la
+corsia in corso e `_normalize_envelope_value` rilegge: un canale fra metodi,
+non un dato, e per questo azzerato a fine corsia.
+
+La proiezione della lente (issue #214) lo ha messo alla prova. Le corsie si
+disegnano nel giro sugli stream, le lenti dopo — e quando la proiezione deve
+collocare un valore sulla curva, lo scratchpad contiene i range dell'**ultimo**
+stream disegnato, non del suo. Con due stream sulla stessa pagina e escursioni
+diverse la differenza non è teorica: il marker cade appeso al vuoto invece che
+sulla sua curva. Ricalcolare i range al momento della proiezione non è una via
+d'uscita: sarebbe un conto scollegato da quello che sta già sulla pagina, e
+basterebbe una finestra diversa perché i due divergano.
+
+La risposta è la stessa del refactor: il dato esce come valore.
+`_draw_envelopes` restituisce `EnvelopeLaneRender(curves, display_ranges,
+y_base, y_height, pitch_unit)` — cosa è finito nella corsia — e `render_page`
+lo appende alla riga di `stream_entries` insieme al suo `ax_env`. Da lì
+`magnifier_projection.project` produce i punti, e il visualizer li disegna.
+Lo scratchpad resta dov'era, ma non è più l'unico modo per sapere con che
+scala una corsia è stata disegnata.
 
 ## Trade-off
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -135,6 +135,14 @@ Vincoli tra flag e comportamento nelle combinazioni non valide:
   cerchio di partenza (`src`); con più lenti sulla stessa pagina la
   proiezione usa l'angolo configurato in `magnify_defaults['corner']` e può
   sovrapporsi (limite noto dell'MVP).
+  Ogni lente proietta inoltre il proprio istante sulla corsia envelope del
+  suo stream: verticale tratteggiata a `x = t` più un marker col valore
+  reale su ogni curva che incrocia. Non ha una flag propria — è parte della
+  lente — e si spegne dalla config del visualizer
+  (`magnify_projection['enabled']`, con `linestyle`/`linewidth`/`alpha`/
+  `markersize`/`labels` per lo stile). Niente da proiettare, niente
+  disegnato: stream senza curve dinamiche, o istante fuori dall'estensione
+  dello stream.
 - Le flag con valore leggono il token successivo in `sys.argv`; se manca,
   la flag viene ignorata senza errore.
 

--- a/src/pge/rendering/envelope_display.py
+++ b/src/pge/rendering/envelope_display.py
@@ -5,7 +5,8 @@ Scalatura verticale delle curve di uno Stream.
 Risponde a due domande, entrambe geometriche e nessuna delle due grafica:
 quanto e' ampia la finestra verticale in cui disegnare una curva (il range di
 display data-driven, issue #114) e dove cade un valore dentro quella finestra
-(la normalizzazione a [0,1]).
+(la normalizzazione a [0,1]). Piu' una terza, che geometrica non e' ma sta
+nella stessa famiglia: come si scrive quel valore in un'etichetta.
 
 Fratello di envelope_extractor: quello dice QUALI curve ha uno stream, questo
 dice quanto sono alte. Come lui non importa matplotlib, cosi' la regola resta
@@ -141,3 +142,56 @@ def normalize(param_name, value, ranges, *, pan_range):
     # (issue #114 nasce proprio dal clamp che faceva collassare due estremi
     # diversi sullo stesso 1.0).
     return (value - lo) / (hi - lo)
+
+
+# Unita' di misura per parametro. Il nome e' quello pubblicato (chiavi di
+# ENVELOPE_COLORS): una curva senza entry non ha unita' e mostra il numero nudo.
+ENVELOPE_UNITS = {
+    'volume': 'dB',
+    'grain_duration': 'ms',
+    'pan': '°',
+    # pitch: il simbolo (st/c/qt/et/edoN/x) viene dall'unita' attiva dello
+    # stream, non da qui — vedi il parametro pitch_unit di value_label.
+    'density': 'g/s',
+    'pointer_speed': 'x',
+    'fill_factor': '',
+    'distribution': '',
+    'num_voices': ' voices',
+    'scatter': '',  # normalizzato 0-1, adimensionale
+    'pc_rand_reverse': '%',
+}
+
+# Conversioni per la sola leggibilita' dell'etichetta: il valore resta quello
+# scritto nello YAML, cambia come lo si stampa.
+ENVELOPE_MULTIPLIERS = {
+    'grain_duration': 1000,  # secondi -> millisecondi
+}
+
+
+def value_label(param_name, value, pitch_unit=None):
+    """Il valore reale di un parametro, scritto per essere letto sulla pagina.
+
+    Due chiamanti, una regola: i breakpoint annotati sulle curve e la
+    proiezione dell'istante della lente (issue #214). Lo stesso valore deve
+    leggersi nello stesso modo, o le due annotazioni sembrerebbero parlare di
+    grandezze diverse.
+
+    Le cifre decrescono con la grandezza: sotto la corsia envelope c'e' poco
+    spazio, e tre decimali su un numero a tre cifre sono rumore.
+
+    Args:
+        param_name: nome pubblicato della curva.
+        value: valore nell'unita' in cui e' scritto nello YAML.
+        pitch_unit: unita' attiva dello stream, per il solo 'pitch' (che e'
+            unit-driven: st/c/qt/et/edoN/x). None -> nessun simbolo.
+    """
+    unit = ENVELOPE_UNITS.get(param_name, '')
+    if param_name == 'pitch' and pitch_unit is not None:
+        unit = pitch_unit.symbol
+
+    display_value = value * ENVELOPE_MULTIPLIERS.get(param_name, 1)
+    if abs(display_value) >= 100:
+        return f"{display_value:.0f}{unit}"
+    if abs(display_value) >= 10:
+        return f"{display_value:.1f}{unit}"
+    return f"{display_value:.2f}{unit}"

--- a/src/pge/rendering/magnifier_projection.py
+++ b/src/pge/rendering/magnifier_projection.py
@@ -1,0 +1,93 @@
+# src/pge/rendering/magnifier_projection.py
+"""
+Dove cade l'istante della lente sulle curve dello stream.
+
+La lente ingrandisce una regione del piano tempo x posizione-di-lettura;
+magnifier_targets dice DOVE puntarla, questo modulo dice a QUALI valori delle
+curve corrisponde quell'istante e a che quota vanno letti dentro la corsia
+envelope (issue #214). Disegnare la verticale, i marker e le etichette resta di
+ScoreVisualizer: come gli altri moduli di questa famiglia, matplotlib non si
+importa.
+
+Il record `EnvelopeLaneRender` e' il canale fra chi disegna una corsia e chi ci
+proietta sopra. Porta le curve effettivamente disegnate, i range di display CON
+CUI sono state scalate e la geometria della corsia. Serve perche' i due momenti
+sono separati nel tempo: le corsie si disegnano nel giro sugli stream, le lenti
+dopo, quando lo scratchpad dei range della corsia interessata e' gia' stato
+sovrascritto da quello dell'ultimo stream. Ricalcolare i range qui sarebbe un
+conto scollegato da quello che sta gia' sulla pagina, e basterebbe una finestra
+diversa perche' il marker cadesse fuori dalla sua curva.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from pge.rendering.envelope_display import normalize
+
+
+@dataclass(frozen=True)
+class EnvelopeLaneRender:
+    """Cosa e' finito nella corsia envelope di uno stream.
+
+    Vuoto e' uno stato legittimo: uno stream tutto statico ha la sua corsia
+    (la simmetria 1:1 con i grani, issue #113) ma nessuna curva dentro, e la
+    lente non ci deve proiettare niente.
+    """
+    curves: dict = field(default_factory=dict)          # {nome: Envelope}
+    display_ranges: dict = field(default_factory=dict)  # {nome: (min, max)}
+    y_base: float = 0.0
+    y_height: float = 1.0
+    # Unita' pitch dello stream: serve alle etichette, non alla geometria.
+    # Viaggia qui perche' e' per-stream come i range, e leggerla da uno stato
+    # d'istanza darebbe quella dell'ultimo stream disegnato.
+    pitch_unit: object = None
+
+    @property
+    def drawn_types(self):
+        """Nomi delle curve disegnate nella corsia."""
+        return set(self.curves)
+
+
+@dataclass(frozen=True)
+class ProjectedValue:
+    """Un incrocio fra la verticale della lente e una curva: quale parametro,
+    che valore ha li', a che quota disegnarlo."""
+    param: str
+    value: float
+    y: float
+
+
+def project(render, t, stream_start, stream_duration, *, pan_range):
+    """I valori delle curve all'istante `t`, con la quota dentro la corsia.
+
+    Args:
+        render: EnvelopeLaneRender della corsia su cui proiettare.
+        t: istante bersaglio della lente, in tempo assoluto di pagina.
+        stream_start: onset dello stream (i breakpoint sono relativi).
+        stream_duration: estensione dello stream.
+        pan_range: range fisso del parametro ciclico.
+
+    Returns:
+        list[ProjectedValue], nell'ordine in cui le curve sono state disegnate.
+        Vuota se la corsia non ha curve o se l'istante cade fuori
+        dall'estensione dello stream: li' non c'e' nessun valore da leggere, e
+        `Envelope.evaluate` satura sul breakpoint piu' vicino — la lente
+        mostrerebbe un numero che in quel punto non esiste. Gli estremi sono
+        inclusi: una lente sull'attacco o sull'ultimo istante ha un valore.
+    """
+    if not render.curves:
+        return []
+
+    t_rel = t - stream_start
+    if t_rel < 0.0 or t_rel > stream_duration:
+        return []
+
+    points = []
+    for param_name, envelope in render.curves.items():
+        value = float(envelope.evaluate(t_rel))
+        fraction = normalize(param_name, value, render.display_ranges,
+                             pan_range=pan_range)
+        points.append(ProjectedValue(
+            param=param_name, value=value,
+            y=render.y_base + fraction * render.y_height))
+    return points

--- a/src/pge/rendering/score_visualizer.py
+++ b/src/pge/rendering/score_visualizer.py
@@ -51,6 +51,7 @@ except (ValueError, KeyError):
 from pge.rendering.envelope_extractor import ENVELOPE_COLORS, PLOT_ENVELOPE_KEYS  # noqa: F401,E402
 from pge.rendering import envelope_display  # noqa: E402
 from pge.rendering import grain_visuals  # noqa: E402
+from pge.rendering import magnifier_projection  # noqa: E402
 from pge.rendering import magnifier_targets  # noqa: E402
 from pge.rendering import page_layout  # noqa: E402
 from pge.rendering.visualizer_config import VisualizerConfig  # noqa: E402
@@ -420,12 +421,20 @@ class ScoreVisualizer:
                                    page_start, page_end, cents_range)
             self._draw_stream_label_full(ax_grain, stream, page_start, sample_duration)
 
-            stream_entries.append({
+            entry = {
                 'stream': stream,
                 'ax': ax_grain,
                 'sample_duration': sample_duration,
                 'cents_range': cents_range,
-            })
+                # Corsia envelope dello stream: riempite piu' sotto, quando la
+                # riga envelope viene creata. La lente le usa per proiettare il
+                # proprio istante sulle curve (issue #214); restano None per
+                # una pagina senza envelope, e il record resta vuoto per uno
+                # stream tutto statico (corsia presente ma senza curve).
+                'ax_env': None,
+                'env_render': magnifier_projection.EnvelopeLaneRender(),
+            }
+            stream_entries.append(entry)
 
             # Legenda della scala colore pitch (auto-zoomata o fissa) nella
             # colonna dedicata della riga grani: non ruba larghezza al subplot.
@@ -477,14 +486,16 @@ class ScoreVisualizer:
             if has_envelopes:
                 ax_env = fig.add_subplot(gs[grain_row + 1, 1],
                                          label=f'env:{stream.stream_id}')
+                entry['ax_env'] = ax_env
 
                 # Layout condiviso lane/legenda (issue #91), ora calcolato per
                 # il singolo stream: 0 lane (stream tutto statico) o 1 lane.
                 lanes, legend_entries = self._compute_env_legend_layout([stream])
 
                 for lane in lanes:
-                    self._draw_envelopes(ax_env, lane.stream, lane.y_base,
-                                         lane.y_height, page_start, page_end)
+                    entry['env_render'] = self._draw_envelopes(
+                        ax_env, lane.stream, lane.y_base,
+                        lane.y_height, page_start, page_end)
 
                 # Label stream nella lane envelope: presente anche a lane
                 # vuota, cosi' la corsia resta attribuibile al suo stream.
@@ -662,6 +673,78 @@ class ScoreVisualizer:
                                     ec='#222222', lw=2.2, zorder=6)
         lens_ring.set_gid('magnify-lens')
         overlay.add_patch(lens_ring)
+
+        # Proiezione dell'istante sulle curve dello stream (issue #214).
+        self._draw_poc_projection(resolved)
+
+    def _draw_poc_projection(self, resolved):
+        """Proietta l'istante della lente sulla corsia envelope del suo stream:
+        una verticale tratteggiata a x = t e, su ogni curva che incrocia, un
+        marker col valore reale (issue #214).
+
+        Senza, la lente dice DOVE guardare ma non con quali parametri: il
+        collegamento fra il grumo di grani ingrandito e i valori che lo
+        producono va ricostruito allineando a occhio la X del cerchio sorgente
+        con le curve sottostanti.
+
+        Nessun artista se la proiezione e' spenta, se lo stream non ha corsia
+        envelope (pagina tutta statica), se la sua corsia e' vuota o se
+        l'istante cade fuori dall'estensione dello stream: e' lo stesso
+        invariante di retrocompatibilita' del resto della lente.
+        """
+        cfg = self.config['magnify_projection']
+        if not cfg['enabled']:
+            return
+
+        entry = resolved.entry
+        ax_env = entry.get('ax_env')
+        render = entry.get('env_render')
+        if ax_env is None or render is None:
+            return
+
+        stream = entry['stream']
+        points = magnifier_projection.project(
+            render, float(resolved.t), stream.onset, stream.duration,
+            pan_range=self.config['envelope_ranges']['pan'])
+        if not points:
+            return
+
+        # Stesso accento della lente (anello sorgente e connettori): la
+        # proiezione e' un pezzo della lente, non un elemento a se'. Il
+        # tratteggio la tiene distinguibile dalle curve anche in stampa B&W,
+        # dove il rosso e' un grigio come gli altri.
+        accent = self.config['magnify_color']
+        tc = float(resolved.t)
+        line = ax_env.axvline(x=tc, color=accent, linestyle=cfg['linestyle'],
+                              linewidth=cfg['linewidth'], alpha=cfg['alpha'],
+                              zorder=3)
+        line.set_gid('poc-projection')
+
+        page_start, page_end = ax_env.get_xlim()
+        colors = self.config['envelope_colors']
+        # Le etichette cadono tutte sulla stessa verticale: alternare il lato
+        # salendo lungo la corsia tiene separate quelle di due curve vicine,
+        # che altrimenti si sovrascriverebbero (una corsia affollata ne ha
+        # cinque o sei a poche frazioni di corsia l'una dall'altra).
+        for order, point in enumerate(sorted(points, key=lambda p: p.y)):
+            color = colors.get(self._base_param_name(point.param), '#333333')
+            # Faccia del colore della curva (dice a quale valore appartiene),
+            # bordo dell'accento della lente (dice da dove viene il marker):
+            # in scala di grigi resta un pallino cerchiato sulla verticale.
+            marker, = ax_env.plot(
+                [tc], [point.y], 'o', color=color,
+                markersize=cfg['markersize'], markeredgecolor=accent,
+                markeredgewidth=0.8, zorder=4)
+            marker.set_gid('poc-projection-marker')
+
+            if not cfg['labels']:
+                continue
+            label = self._envelope_value_label(
+                point.param, point.value, pitch_unit=render.pitch_unit)
+            annotation = self._annotate_envelope_value(
+                ax_env, tc, point.y, label, color, page_start, page_end,
+                side='right' if order % 2 == 0 else 'left')
+            annotation.set_gid('poc-projection-label')
 
     def _draw_waveform_full(self, ax, stream, sample_duration):
         """Disegna waveform usando tutto lo spazio verticale dello subplot."""
@@ -1010,22 +1093,33 @@ class ScoreVisualizer:
         """
         Disegna tutti gli envelope dello stream nella sua corsia.
         Annota i breakpoint con i valori reali.
-        
+
         Returns:
-            set: nomi dei tipi di envelope disegnati
+            EnvelopeLaneRender: cosa e' finito nella corsia — le curve
+            disegnate, i range di display con cui sono state scalate e la
+            geometria della corsia. Il record esce di qui perche' la lente ci
+            proietta sopra molto dopo (issue #214), quando lo scratchpad
+            `_current_display_ranges` di questa corsia e' gia' stato
+            sovrascritto da quello dello stream successivo.
         """
         envelopes = self._get_stream_envelopes(stream)
 
         # Unità pitch dello stream corrente: serve a _normalize_envelope_value e
         # _annotate_breakpoints per scalare/etichettare la curva 'pitch' (i bounds
         # dipendono dall'unità, non sono statici come gli altri parametri).
-        self._current_pitch_unit = getattr(stream, 'pitch_unit', None)
+        pitch_unit = getattr(stream, 'pitch_unit', None)
+        self._current_pitch_unit = pitch_unit
         self._current_display_ranges = {}
 
-        if not envelopes:
-            return set()
+        def lane_render(curves=None, ranges=None):
+            return magnifier_projection.EnvelopeLaneRender(
+                curves=curves or {}, display_ranges=ranges or {},
+                y_base=y_base, y_height=y_height, pitch_unit=pitch_unit)
 
-        drawn_types = set()
+        if not envelopes:
+            return lane_render()
+
+        drawn = {}
         colors = self.config['envelope_colors']
         
         # Tempo relativo allo stream
@@ -1037,7 +1131,7 @@ class ScoreVisualizer:
         t_end = min(page_end, stream_end)
         
         if t_start >= t_end:
-            return set()
+            return lane_render()
 
         # Auto-zoom: range di display ristretti per i parametri a range ampio.
         self._current_display_ranges = self._compute_display_ranges(
@@ -1056,7 +1150,7 @@ class ScoreVisualizer:
                 self._annotate_breakpoints(ax, envelope, param_name, color,
                                            stream_start, y_base, y_height,
                                            page_start, page_end)
-                drawn_types.add(param_name)
+                drawn[param_name] = envelope
                 continue
 
             # ========== GESTIONE DIFFERENZIATA PER TIPO ==========
@@ -1147,12 +1241,15 @@ class ScoreVisualizer:
                                     stream_start, y_base, y_height,
                                     page_start, page_end)
             
-            drawn_types.add(param_name)
+            drawn[param_name] = envelope
 
-        # Reset: le lane successive ricalcolano i propri display range.
+        # Reset: le lane successive ricalcolano i propri display range. I range
+        # di QUESTA corsia escono nel record, che e' l'unico modo per ritrovarli
+        # quando la lente proietta (dopo il giro su tutti gli stream).
+        ranges = self._current_display_ranges
         self._current_display_ranges = {}
 
-        return drawn_types
+        return lane_render(drawn, ranges)
 
     def _draw_envelope_per_segment(
         self, ax, envelope, param_name, color,
@@ -1214,96 +1311,88 @@ class ScoreVisualizer:
         """
         Annota i breakpoint dell'envelope con i valori reali.
         """
-        # Unità di misura per ogni parametro
-        units = {
-            'volume': 'dB',
-            'grain_duration': 'ms',
-            'pan': '°',
-            # pitch: il simbolo (st/c/qt/et/edoN/x) viene da pu.symbol, vedi sotto
-            'density': 'g/s',
-            'pointer_speed': 'x',
-            'fill_factor': '',
-            'distribution': '',
-            'num_voices': ' voices',
-            'scatter': '',  # normalizzato 0-1, adimensionale
-            'scatter': '',  # normalizzato 0-1, adimensionale
-            'pc_rand_reverse': '%',
-        }
-        
-        # Moltiplicatori per visualizzazione leggibile
-        multipliers = {
-            'grain_duration': 1000,  # secondi → millisecondi
-        }
-        
-        unit = units.get(param_name, '')
-        # PITCH unit-driven: il simbolo (st/c/qt/et/edoN/x) viene dall'unità attiva.
-        if param_name == 'pitch':
-            pu = getattr(self, '_current_pitch_unit', None)
-            if pu is not None:
-                unit = pu.symbol
-        mult = multipliers.get(param_name, 1)
-        
         for t_rel, value in envelope.breakpoints:
             # Tempo assoluto
             t_abs = stream_start + t_rel
-            
+
             # Salta breakpoint fuori dalla pagina
             if t_abs < page_start or t_abs > page_end:
                 continue
-            
+
             # Posizione Y normalizzata
             val_norm = self._normalize_envelope_value(param_name, value)
             y_pos = y_base + val_norm * y_height
-            
-            # Valore da mostrare (con unità)
-            display_value = value * mult
-            
-            # Formatta il numero
-            if abs(display_value) >= 100:
-                label = f"{display_value:.0f}{unit}"
-            elif abs(display_value) >= 10:
-                label = f"{display_value:.1f}{unit}"
-            else:
-                label = f"{display_value:.2f}{unit}"
-            
+
+            label = self._envelope_value_label(
+                param_name, value,
+                pitch_unit=getattr(self, '_current_pitch_unit', None))
+
             # Disegna punto
             ax.plot(t_abs, y_pos, 'o', color=color, markersize=4, alpha=0.9)
 
-            # Lato dell'etichetta scelto dinamicamente in base alla posizione del
-            # breakpoint nel subplot, cosi' il testo resta SEMPRE dentro il plot
-            # dedicato all'envelope (prima un offset fisso in alto-a-destra faceva
-            # sforare i breakpoint vicini al bordo destro o al tetto della corsia).
-            x_span = page_end - page_start
-            x_frac = (t_abs - page_start) / x_span if x_span > 0 else 0.5
-            # ylim del subplot envelope e' (0, 1): y_pos e' gia' la frazione
-            # verticale dentro l'asse.
-            y_frac = y_pos
+            self._annotate_envelope_value(ax, t_abs, y_pos, label, color,
+                                          page_start, page_end)
 
-            # Vicino al bordo destro -> etichetta a sinistra del punto.
-            if x_frac > 0.85:
-                dx, ha = -3, 'right'
-            else:
-                dx, ha = 3, 'left'
-            # Vicino al tetto del subplot -> etichetta sotto il punto.
-            if y_frac > 0.9:
-                dy, va = -3, 'top'
-            else:
-                dy, va = 3, 'bottom'
+    def _envelope_value_label(self, param_name, value, pitch_unit=None):
+        """Etichetta col valore reale di un parametro.
+        Delega a rendering.envelope_display.value_label."""
+        return envelope_display.value_label(param_name, value,
+                                            pitch_unit=pitch_unit)
 
-            # Disegna etichetta (offset dinamico per restare dentro il plot)
-            ax.annotate(
-                label,
-                xy=(t_abs, y_pos),
-                xytext=(dx, dy),
-                textcoords='offset points',
-                fontsize=self._fs(self.config['breakpoint_fontsize']),
-                color=color,
-                alpha=0.9,
-                ha=ha,
-                va=va,
-                bbox=dict(boxstyle='round,pad=0.15', facecolor='white',
-                         alpha=0.7, edgecolor='none')
-            )
+    def _annotate_envelope_value(self, ax, t_abs, y_pos, label, color,
+                                 page_start, page_end, side='right'):
+        """Scrive un valore accanto al punto in cui e' stato letto.
+
+        Lato dell'etichetta scelto dinamicamente in base alla posizione nel
+        subplot, cosi' il testo resta SEMPRE dentro il plot dedicato
+        all'envelope (prima un offset fisso in alto-a-destra faceva sforare i
+        breakpoint vicini al bordo destro o al tetto della corsia).
+
+        Usata dai breakpoint e dalla proiezione della lente (issue #214): le
+        due annotazioni devono stare nel plot con la stessa regola, o la
+        seconda sforerebbe dove la prima non sfora.
+
+        `side` e' la preferenza del chiamante ('right' = a destra del punto,
+        come i breakpoint): la proiezione la alterna fra i suoi valori, che
+        cadono tutti sulla stessa verticale. I bordi hanno comunque l'ultima
+        parola — restare dentro il plot viene prima del non sovrapporsi.
+        """
+        x_span = page_end - page_start
+        x_frac = (t_abs - page_start) / x_span if x_span > 0 else 0.5
+        # ylim del subplot envelope e' (0, 1): y_pos e' gia' la frazione
+        # verticale dentro l'asse.
+        y_frac = y_pos
+
+        # Vicino a un bordo il lato lo decide il bordo.
+        if x_frac > 0.85:
+            side = 'left'
+        elif x_frac < 0.15:
+            side = 'right'
+
+        if side == 'left':
+            dx, ha = -3, 'right'
+        else:
+            dx, ha = 3, 'left'
+        # Vicino al tetto del subplot -> etichetta sotto il punto.
+        if y_frac > 0.9:
+            dy, va = -3, 'top'
+        else:
+            dy, va = 3, 'bottom'
+
+        # Disegna etichetta (offset dinamico per restare dentro il plot)
+        return ax.annotate(
+            label,
+            xy=(t_abs, y_pos),
+            xytext=(dx, dy),
+            textcoords='offset points',
+            fontsize=self._fs(self.config['breakpoint_fontsize']),
+            color=color,
+            alpha=0.9,
+            ha=ha,
+            va=va,
+            bbox=dict(boxstyle='round,pad=0.15', facecolor='white',
+                     alpha=0.7, edgecolor='none')
+        )
 
     def _compute_env_legend_layout(self, active_streams):
         """Geometria condivisa fra corsie envelope e legenda (issue #91).

--- a/src/pge/rendering/visualizer_config.py
+++ b/src/pge/rendering/visualizer_config.py
@@ -70,6 +70,26 @@ class MagnifyDefaults:
     corner: str = 'top-right'            # angolo del subplot dove proiettare
 
 
+@dataclass(frozen=True)
+class MagnifyProjection:
+    """Proiezione dell'istante della lente sulla corsia envelope (issue #214).
+
+    Il colore non sta qui: la verticale prende `magnify_color` (e' un pezzo
+    della lente, non un elemento a se') e i marker il colore della curva che
+    incrociano. Restano lo spessore del tratto e l'ingombro dei numeri, che
+    sono le due cose che cambiano davvero da una partitura all'altra.
+    """
+    enabled: bool = True
+    # Tratteggio e non tinta unita: la partitura deve restare leggibile anche
+    # stampata in scala di grigi, dove il rosso della lente e' un grigio come
+    # gli altri.
+    linestyle: str = '--'
+    linewidth: float = 0.6
+    alpha: float = 0.8
+    markersize: float = 5.0
+    labels: bool = True                  # etichette col valore reale
+
+
 # Range fissi dei parametri. Dopo issue #114 (scaling data-driven) solo 'pan'
 # e' ancora consultato per lo scaling delle curve, essendo ciclico; le altre
 # entry restano per riferimento e retrocompatibilita'.
@@ -204,7 +224,8 @@ class VisualizerConfig:
     magnify_targets: list = field(default_factory=list)
     magnify_defaults: MagnifyDefaults = MagnifyDefaults()
     magnify_hist_bins: tuple = (40, 16)   # bin (tempo, posizione) per l'auto
-    magnify_color: str = '#c1121f'        # marker sorgente e connettori
+    magnify_color: str = '#c1121f'        # marker sorgente, connettori, proiezione
+    magnify_projection: MagnifyProjection = MagnifyProjection()
 
     # =========================================================================
 

--- a/tests/rendering/test_envelope_display.py
+++ b/tests/rendering/test_envelope_display.py
@@ -28,6 +28,7 @@ from pge.rendering.envelope_display import (
     normalize,
     segment_strategy_name,
     is_per_segment_heterogeneous,
+    value_label,
 )
 
 
@@ -317,3 +318,46 @@ class TestHeterogeneity:
         """Un oggetto che non espone segmenti non e' eterogeneo: si disegna in
         blocco, che e' il comportamento di default."""
         assert is_per_segment_heterogeneous(SimpleNamespace()) is False
+
+
+class TestValueLabel:
+    """L'etichetta col valore reale di un parametro: unita' per nome e cifre
+    decrescenti con la grandezza. Estratta da ScoreVisualizer._annotate_breakpoints
+    (issue #214) perche' ora la usano in due — i breakpoint e la proiezione
+    della lente — e lo stesso valore deve leggersi nello stesso modo."""
+
+    def test_unit_comes_from_the_parameter_name(self):
+        assert value_label('volume', -6.0) == '-6.00dB'
+        assert value_label('density', 12.0) == '12.0g/s'
+        assert value_label('pointer_speed', 2.0) == '2.00x'
+
+    def test_grain_duration_is_shown_in_milliseconds(self):
+        """Unico parametro con moltiplicatore: i secondi in cui e' scritto
+        sarebbero illeggibili (0.05 -> 50.0ms)."""
+        assert value_label('grain_duration', 0.05) == '50.0ms'
+
+    def test_digits_shrink_as_the_number_grows(self):
+        """Tre scaglioni: due decimali sotto 10, uno sotto 100, nessuno sopra."""
+        assert value_label('density', 5.0) == '5.00g/s'
+        assert value_label('density', 50.0) == '50.0g/s'
+        assert value_label('density', 150.0) == '150g/s'
+
+    def test_negative_numbers_use_the_same_scaglioni(self):
+        """Gli scaglioni guardano il valore assoluto: -150 non deve mostrare
+        due decimali solo perche' e' negativo."""
+        assert value_label('volume', -150.0) == '-150dB'
+
+    def test_unknown_parameter_has_no_unit(self):
+        assert value_label('scatter', 0.5) == '0.50'
+        assert value_label('voice_pitch_offset__v1', 3.0) == '3.00'
+
+    def test_pitch_symbol_comes_from_the_active_unit(self):
+        """pitch e' unit-driven: il simbolo (st/c/qt/edoN/x) viene dall'unita'
+        dello stream, non da una tabella statica."""
+        unit = SimpleNamespace(symbol='st')
+        assert value_label('pitch', 3.0, pitch_unit=unit) == '3.00st'
+
+    def test_pitch_without_a_unit_falls_back_to_no_symbol(self):
+        """Senza unita' attiva il numero resta leggibile: nessun simbolo
+        inventato."""
+        assert value_label('pitch', 3.0) == '3.00'

--- a/tests/rendering/test_magnifier_projection.py
+++ b/tests/rendering/test_magnifier_projection.py
@@ -1,0 +1,160 @@
+# tests/rendering/test_magnifier_projection.py
+"""
+TDD suite per rendering.magnifier_projection.
+
+La lente punta un istante `t` del piano tempo x posizione-di-lettura. Questo
+modulo dice a QUALI valori delle curve dello stream corrisponde quell'istante e
+a che quota vanno letti dentro la corsia envelope (issue #214). Disegnare la
+verticale, i marker e le etichette resta di ScoreVisualizer: qui si arriva alle
+coordinate e ci si ferma, senza importare matplotlib.
+
+Il record `EnvelopeLaneRender` e' il canale fra chi disegna la corsia e chi ci
+proietta sopra: porta le curve effettivamente disegnate, i range di display CON
+CUI sono state scalate e la geometria della corsia. Senza, la proiezione
+dovrebbe ricalcolare i range per conto suo e potrebbe divergere da quanto e'
+gia' sulla pagina.
+"""
+
+import pytest
+
+from pge.envelopes.envelope import Envelope
+from pge.rendering.magnifier_projection import (
+    EnvelopeLaneRender,
+    ProjectedValue,
+    project,
+)
+
+
+PAN_RANGE = (-180, 180)
+
+
+def lane_render(curves, ranges, y_base=0.0, y_height=1.0, pitch_unit=None):
+    return EnvelopeLaneRender(
+        curves=curves, display_ranges=ranges,
+        y_base=y_base, y_height=y_height, pitch_unit=pitch_unit)
+
+
+class TestEnvelopeLaneRender:
+    """Il record e' vuoto per default: una corsia senza curve non ha niente da
+    proiettare, ed e' lo stato con cui il visualizer esce dai casi degeneri."""
+
+    def test_empty_by_default(self):
+        render = EnvelopeLaneRender()
+        assert render.curves == {}
+        assert render.display_ranges == {}
+        assert render.drawn_types == set()
+
+    def test_drawn_types_are_the_curve_names(self):
+        env = Envelope([[0, 1.0], [10, 2.0]])
+        render = lane_render({'density': env, 'pitch': env}, {})
+        assert render.drawn_types == {'density', 'pitch'}
+
+
+class TestProject:
+    """Un punto per ogni curva disegnata, col valore reale e la quota nella
+    corsia."""
+
+    def test_no_curves_no_points(self):
+        assert project(EnvelopeLaneRender(), t=5.0, stream_start=0.0,
+                       stream_duration=10.0, pan_range=PAN_RANGE) == []
+
+    def test_one_point_per_curve(self):
+        curves = {
+            'density': Envelope([[0, 10.0], [10, 20.0]]),
+            'pointer_speed': Envelope([[0, 1.0], [10, 3.0]]),
+        }
+        ranges = {'density': (10.0, 20.0), 'pointer_speed': (1.0, 3.0)}
+        points = project(lane_render(curves, ranges), t=5.0, stream_start=0.0,
+                         stream_duration=10.0, pan_range=PAN_RANGE)
+        assert [p.param for p in points] == ['density', 'pointer_speed']
+        assert all(isinstance(p, ProjectedValue) for p in points)
+
+    def test_value_is_the_curve_value_at_that_instant(self):
+        """Il valore e' quello reale del parametro, non la quota normalizzata:
+        e' cio' che finisce nell'etichetta."""
+        curves = {'density': Envelope([[0, 10.0], [10, 20.0]])}
+        points = project(lane_render(curves, {'density': (10.0, 20.0)}),
+                         t=5.0, stream_start=0.0, stream_duration=10.0,
+                         pan_range=PAN_RANGE)
+        assert points[0].value == pytest.approx(15.0)
+
+    def test_y_is_the_lane_coordinate(self):
+        """La quota e' y_base + frazione * y_height: la stessa trasformazione
+        con cui la curva e' stata disegnata nella corsia."""
+        curves = {'density': Envelope([[0, 10.0], [10, 20.0]])}
+        points = project(
+            lane_render(curves, {'density': (10.0, 20.0)},
+                        y_base=0.2, y_height=0.6),
+            t=5.0, stream_start=0.0, stream_duration=10.0, pan_range=PAN_RANGE)
+        # meta' escursione -> meta' corsia
+        assert points[0].y == pytest.approx(0.2 + 0.5 * 0.6)
+
+    def test_uses_the_given_ranges(self):
+        """La normalizzazione usa i range del record, non un ricalcolo: con un
+        range doppio lo stesso valore cade a meta' altezza."""
+        curves = {'density': Envelope([[0, 10.0], [10, 20.0]])}
+        points = project(lane_render(curves, {'density': (10.0, 30.0)}),
+                         t=10.0, stream_start=0.0, stream_duration=10.0,
+                         pan_range=PAN_RANGE)
+        assert points[0].value == pytest.approx(20.0)
+        assert points[0].y == pytest.approx(0.5)
+
+    def test_range_missing_falls_back_to_mid_lane(self):
+        """Nessun range per quella curva: la quota e' il centro corsia, come
+        per il disegno (envelope_display.normalize)."""
+        curves = {'density': Envelope([[0, 10.0], [10, 20.0]])}
+        points = project(lane_render(curves, {}, y_base=0.0, y_height=0.4),
+                         t=5.0, stream_start=0.0, stream_duration=10.0,
+                         pan_range=PAN_RANGE)
+        assert points[0].y == pytest.approx(0.2)
+
+    def test_pan_uses_the_cyclic_range(self):
+        """pan non ha range di display (e' ciclico): normalizza sul range fisso."""
+        curves = {'pan': Envelope([[0, 0.0], [10, 0.0]])}
+        points = project(lane_render(curves, {}), t=5.0, stream_start=0.0,
+                         stream_duration=10.0, pan_range=PAN_RANGE)
+        assert points[0].y == pytest.approx(0.5)
+
+    def test_breakpoints_are_relative_to_the_stream(self):
+        """t e' assoluto, i breakpoint sono relativi all'onset: la conversione
+        e' qui, come in display_ranges."""
+        curves = {'density': Envelope([[0, 10.0], [10, 20.0]])}
+        points = project(lane_render(curves, {'density': (10.0, 20.0)}),
+                         t=17.0, stream_start=12.0, stream_duration=10.0,
+                         pan_range=PAN_RANGE)
+        assert points[0].value == pytest.approx(15.0)
+
+    def test_instant_before_the_stream_projects_nothing(self):
+        """Fuori dall'estensione dello stream non c'e' nessun valore da
+        leggere: Envelope.evaluate saturerebbe sul primo breakpoint e la lente
+        mostrerebbe un numero che in quel punto non esiste."""
+        curves = {'density': Envelope([[0, 10.0], [10, 20.0]])}
+        points = project(lane_render(curves, {'density': (10.0, 20.0)}),
+                         t=3.0, stream_start=5.0, stream_duration=10.0,
+                         pan_range=PAN_RANGE)
+        assert points == []
+
+    def test_instant_after_the_stream_projects_nothing(self):
+        curves = {'density': Envelope([[0, 10.0], [10, 20.0]])}
+        points = project(lane_render(curves, {'density': (10.0, 20.0)}),
+                         t=16.0, stream_start=5.0, stream_duration=10.0,
+                         pan_range=PAN_RANGE)
+        assert points == []
+
+    def test_the_two_ends_of_the_stream_are_included(self):
+        """Estremi compresi: una lente sull'attacco o sull'ultimo istante ha
+        comunque un valore da mostrare."""
+        curves = {'density': Envelope([[0, 10.0], [10, 20.0]])}
+        for t, expected in ((5.0, 10.0), (15.0, 20.0)):
+            points = project(lane_render(curves, {'density': (10.0, 20.0)}),
+                             t=t, stream_start=5.0, stream_duration=10.0,
+                             pan_range=PAN_RANGE)
+            assert points[0].value == pytest.approx(expected)
+
+    def test_per_voice_curve_scales_on_its_own_range(self):
+        """Le curve per-voce '__vN' hanno un range proprio, come nel disegno."""
+        curves = {'voice_pitch_offset__v1': Envelope([[0, 0.0], [10, 4.0]])}
+        points = project(
+            lane_render(curves, {'voice_pitch_offset__v1': (0.0, 4.0)}),
+            t=5.0, stream_start=0.0, stream_duration=10.0, pan_range=PAN_RANGE)
+        assert points[0].y == pytest.approx(0.5)

--- a/tests/rendering/test_score_visualizer_poc_projection.py
+++ b/tests/rendering/test_score_visualizer_poc_projection.py
@@ -1,0 +1,402 @@
+# tests/rendering/test_score_visualizer_poc_projection.py
+"""
+Suite per la proiezione dell'istante della lente sulla corsia envelope
+(issue #214).
+
+La lente ingrandisce una regione del piano tempo x posizione-di-lettura, ma non
+diceva a quali valori dei parametri corrisponde quell'istante: il lettore
+doveva allineare a occhio la X del cerchio-sorgente con le curve sottostanti.
+Ora ogni lente proietta sulla corsia envelope del suo stream una verticale
+tratteggiata e, su ogni curva che incrocia, un marker con il valore reale.
+
+Gli artisti della proiezione sono etichettati con un gid dedicato
+('poc-projection', 'poc-projection-marker', 'poc-projection-label'): i test
+contano quelli, non tutte le linee del subplot, che sono gia' decine fra curve,
+breakpoint e griglia.
+
+Invariante di retrocompatibilita': a magnify spenta, o su uno stream senza
+curve, non compare NESSUN artista in piu'.
+"""
+
+import numpy as np
+import pytest
+import matplotlib
+matplotlib.use('Agg')  # backend non-interattivo obbligatorio nei test
+import matplotlib.pyplot as plt
+from unittest.mock import MagicMock, patch
+
+from pge.envelopes.envelope import Envelope  # noqa: E402
+from pge.rendering.score_visualizer import ScoreVisualizer  # noqa: E402
+
+
+SR = 44100
+DUR = 4.0
+FAKE_AUDIO = np.sin(
+    2 * np.pi * 440 * np.linspace(0, DUR, int(SR * DUR))
+).astype(np.float32)
+
+PAGE = 30.0
+TARGET_T = 6.0
+
+
+# =============================================================================
+# FACTORY
+# =============================================================================
+
+def make_grain(onset=0.0, duration=0.05, pointer_pos=0.5,
+               pitch_ratio=1.0, volume=-6.0):
+    g = MagicMock()
+    g.onset = onset
+    g.duration = duration
+    g.pointer_pos = pointer_pos
+    g.pitch_ratio = pitch_ratio
+    g.volume = volume
+    return g
+
+
+def make_stream(stream_id='s1', onset=0.0, duration=20.0,
+                sample='piano.wav', n_grains=8):
+    s = MagicMock()
+    s.stream_id = stream_id
+    s.onset = onset
+    s.duration = duration
+    s.sample = sample
+    spacing = duration / max(n_grains, 1)
+    s.voices = [[make_grain(onset + i * spacing) for i in range(n_grains)]]
+    # Gli attributi cancellati sono quelli che envelope_extractor legge per
+    # nome: senza il del, un MagicMock risponderebbe a qualsiasi getattr e
+    # verrebbe scartato solo piu' avanti.
+    for name in ('volume', 'pan', 'pointer_start', 'density', 'num_voices',
+                 'scatter', 'pointer_speed'):
+        delattr(s, name)
+    return s
+
+
+def make_viz(streams, config=None):
+    generator = MagicMock()
+    generator.streams = streams
+    cfg = {'page_duration': PAGE}
+    cfg.update(config or {})
+    return ScoreVisualizer(generator, config=cfg)
+
+
+def render(streams, config=None):
+    viz = make_viz(streams, config)
+    with patch('soundfile.read', return_value=(FAKE_AUDIO, SR)):
+        viz.analyze()
+        fig = viz.render_page(0)
+    fig.canvas.draw()  # finalizza transform/posizioni
+    return fig
+
+
+@pytest.fixture(autouse=True)
+def close_figures():
+    yield
+    plt.close('all')
+
+
+# =============================================================================
+# SCENARI
+# =============================================================================
+
+def envelope_scene():
+    """Uno stream con due curve dinamiche (density + pointer_speed)."""
+    s = make_stream('s1')
+    s.density = Envelope([[0, 10.0], [20, 30.0]])
+    s.pointer_speed = Envelope([[0, 1.0], [20, 2.0]])
+    return [s]
+
+
+def static_and_dynamic_scene():
+    """Due stream: il primo ha curve, il secondo e' tutto statico (corsia
+    envelope presente ma vuota, issue #113)."""
+    dynamic = make_stream('dyn')
+    dynamic.density = Envelope([[0, 10.0], [20, 30.0]])
+    return [dynamic, make_stream('static', sample='strings.wav')]
+
+
+def crowded_scene(duration=20.0):
+    """Quattro curve nella stessa corsia: tutte le etichette della proiezione
+    cadono sulla stessa verticale, ed e' li' che si pestano i piedi."""
+    s = make_stream('s1', duration=duration)
+    s.density = Envelope([[0, 10.0], [duration, 30.0]])
+    s.pointer_speed = Envelope([[0, 1.0], [duration, 2.0]])
+    s.volume = Envelope([[0, -12.0], [duration, -3.0]])
+    s.grain_duration = Envelope([[0, 0.08], [duration, 0.02]])
+    return [s]
+
+
+def two_dynamic_streams_scene():
+    """Due stream con la stessa curva su escursioni molto diverse: se la
+    proiezione usasse i range dell'ultima corsia disegnata invece di quelli
+    della propria, il marker cadrebbe fuori dalla curva."""
+    first = make_stream('s1')
+    first.density = Envelope([[0, 10.0], [20, 30.0]])
+    second = make_stream('s2', sample='strings.wav')
+    second.density = Envelope([[0, 100.0], [20, 180.0]])
+    return [first, second]
+
+
+# =============================================================================
+# HELPER
+# =============================================================================
+
+def env_ax(fig, stream_id):
+    """Il subplot envelope di uno stream (render_page lo etichetta 'env:<id>')."""
+    for ax in fig.axes:
+        if ax.get_label() == f'env:{stream_id}':
+            return ax
+    return None
+
+
+def by_gid(artists, gid):
+    return [a for a in artists if a.get_gid() == gid]
+
+
+def projection_lines(ax):
+    return by_gid(ax.lines, 'poc-projection')
+
+
+def projection_markers(ax):
+    return by_gid(ax.lines, 'poc-projection-marker')
+
+
+def projection_labels(ax):
+    return by_gid(ax.texts, 'poc-projection-label')
+
+
+def all_projection_artists(fig):
+    found = []
+    for ax in fig.axes:
+        found += (projection_lines(ax) + projection_markers(ax)
+                  + projection_labels(ax))
+    return found
+
+
+def curve_y_at(ax, param_name, t):
+    """Quota della curva disegnata, letta dai dati del suo artista."""
+    curve = next(line for line in ax.lines if line.get_label() == param_name)
+    xs, ys = curve.get_xdata(), curve.get_ydata()
+    return float(np.interp(t, xs, ys))
+
+
+# =============================================================================
+# GROUP - back-compat: niente lente, niente proiezione
+# =============================================================================
+
+class TestBackCompat:
+    """A magnify spenta la pagina resta identica: la proiezione e' un artista
+    della lente, non della corsia."""
+
+    def test_no_projection_without_magnify(self):
+        fig = render(envelope_scene())
+        assert all_projection_artists(fig) == []
+
+    def test_no_projection_on_a_stream_without_curves(self):
+        """Corsia vuota (stream tutto statico): la lente proietta il cerchio ma
+        non tocca la corsia."""
+        fig = render(static_and_dynamic_scene(),
+                     {'magnify_targets': [{'t': TARGET_T, 'y': 1.0,
+                                           'stream': 'static'}]})
+        assert [ax for ax in fig.axes if ax.get_label() == '<magnifier>']
+        assert all_projection_artists(fig) == []
+
+    def test_no_projection_when_the_instant_is_outside_the_stream(self):
+        """Lo stream finisce a 10s, la lente punta a 20s: dentro la pagina ma
+        fuori dallo stream. Non c'e' nessun valore da leggere, quindi nemmeno
+        la verticale."""
+        s = make_stream('s1', duration=10.0)
+        s.density = Envelope([[0, 10.0], [10, 30.0]])
+        fig = render([s], {'magnify_targets': [{'t': 20.0, 'y': 1.0}]})
+        assert all_projection_artists(fig) == []
+
+    def test_disabled_by_config_keeps_the_lens(self):
+        """magnify_projection.enabled=False: la lente resta, la proiezione no."""
+        fig = render(envelope_scene(),
+                     {'magnify_targets': [{'t': TARGET_T, 'y': 1.0}],
+                      'magnify_projection': {'enabled': False}})
+        assert [ax for ax in fig.axes if ax.get_label() == '<magnifier>']
+        assert all_projection_artists(fig) == []
+
+
+# =============================================================================
+# GROUP - la verticale
+# =============================================================================
+
+class TestProjectionLine:
+
+    def _fig(self, config=None):
+        cfg = {'magnify_targets': [{'t': TARGET_T, 'y': 1.0}]}
+        cfg.update(config or {})
+        return render(envelope_scene(), cfg)
+
+    def test_one_line_on_the_envelope_lane(self):
+        ax = env_ax(self._fig(), 's1')
+        assert len(projection_lines(ax)) == 1
+
+    def test_line_sits_on_the_target_instant(self):
+        line = projection_lines(env_ax(self._fig(), 's1'))[0]
+        # axvline: verticale, quindi entrambi gli estremi sull'istante.
+        assert list(line.get_xdata()) == pytest.approx([TARGET_T, TARGET_T])
+
+    def test_line_is_dashed(self):
+        """Tratteggio e non solo colore: la partitura deve restare leggibile
+        anche stampata in scala di grigi."""
+        line = projection_lines(env_ax(self._fig(), 's1'))[0]
+        assert line.get_linestyle() not in ('-', 'None')
+
+    def test_line_uses_the_magnify_accent(self):
+        """Stesso colore dell'anello sorgente e dei connettori: la proiezione e'
+        parte della lente, non un elemento a se'."""
+        fig = self._fig({'magnify_color': '#0000ff'})
+        line = projection_lines(env_ax(fig, 's1'))[0]
+        assert matplotlib.colors.to_hex(line.get_color()) == '#0000ff'
+
+    def test_line_style_is_configurable(self):
+        fig = self._fig({'magnify_projection': {'linewidth': 2.5}})
+        line = projection_lines(env_ax(fig, 's1'))[0]
+        assert line.get_linewidth() == pytest.approx(2.5)
+
+    def test_the_grain_plane_is_untouched(self):
+        """La verticale vive nella corsia envelope: sul piano dei grani ci
+        sono gia' i connettori della lente."""
+        fig = self._fig()
+        grain_axes = [ax for ax in fig.axes
+                      if ax.get_label() not in ('<magnifier>',
+                                                '<magnifier-overlay>',
+                                                'env:s1')]
+        assert all(projection_lines(ax) == [] for ax in grain_axes)
+
+
+# =============================================================================
+# GROUP - i marker sulle curve
+# =============================================================================
+
+class TestProjectionMarkers:
+
+    def _fig(self, streams=None, config=None):
+        cfg = {'magnify_targets': [{'t': TARGET_T, 'y': 1.0}]}
+        cfg.update(config or {})
+        return render(streams or envelope_scene(), cfg)
+
+    def test_one_marker_per_curve(self):
+        ax = env_ax(self._fig(), 's1')
+        assert len(projection_markers(ax)) == 2  # density + pointer_speed
+
+    def test_marker_sits_on_its_curve(self):
+        """L'incrocio e' vero: la quota del marker coincide con quella della
+        curva disegnata nello stesso istante."""
+        ax = env_ax(self._fig(), 's1')
+        markers = projection_markers(ax)
+        drawn = sorted(float(m.get_ydata()[0]) for m in markers)
+        expected = sorted(curve_y_at(ax, name, TARGET_T)
+                          for name in ('density', 'pointer_speed'))
+        assert drawn == pytest.approx(expected, abs=1e-3)
+
+    def test_marker_x_is_the_target_instant(self):
+        ax = env_ax(self._fig(), 's1')
+        for marker in projection_markers(ax):
+            assert float(marker.get_xdata()[0]) == pytest.approx(TARGET_T)
+
+    def test_marker_takes_the_colour_of_its_curve(self):
+        """Con piu' curve nella stessa corsia il colore dice a quale
+        appartiene il valore letto."""
+        ax = env_ax(self._fig(), 's1')
+        colors = {matplotlib.colors.to_hex(m.get_markerfacecolor())
+                  for m in projection_markers(ax)}
+        viz_colors = {matplotlib.colors.to_hex(c)
+                      for c in (ScoreVisualizer(MagicMock(), config=None)
+                                .config['envelope_colors'][name]
+                                for name in ('density', 'pointer_speed'))}
+        assert colors == viz_colors
+
+    def test_each_lane_uses_its_own_display_ranges(self):
+        """Due stream con escursioni molto diverse: il marker del secondo cade
+        sulla curva del secondo, non su una quota calcolata coi range del
+        primo (o dell'ultima corsia disegnata)."""
+        fig = self._fig(
+            two_dynamic_streams_scene(),
+            {'magnify_targets': [{'t': TARGET_T, 'y': 1.0, 'stream': 's1'},
+                                 {'t': TARGET_T, 'y': 1.0, 'stream': 's2'}]})
+        for stream_id in ('s1', 's2'):
+            ax = env_ax(fig, stream_id)
+            marker = projection_markers(ax)[0]
+            assert float(marker.get_ydata()[0]) == pytest.approx(
+                curve_y_at(ax, 'density', TARGET_T), abs=1e-3)
+
+
+# =============================================================================
+# GROUP - le etichette col valore reale
+# =============================================================================
+
+class TestProjectionLabels:
+
+    def _fig(self, config=None):
+        cfg = {'magnify_targets': [{'t': TARGET_T, 'y': 1.0}]}
+        cfg.update(config or {})
+        return render(envelope_scene(), cfg)
+
+    def test_one_label_per_curve(self):
+        ax = env_ax(self._fig(), 's1')
+        assert len(projection_labels(ax)) == 2
+
+    def test_label_shows_the_real_value_with_its_unit(self):
+        """density 10 -> 30 su 20s: a 6s vale 16 g/s. Stesso formato dei
+        breakpoint annotati sulle curve."""
+        ax = env_ax(self._fig(), 's1')
+        texts = {t.get_text() for t in projection_labels(ax)}
+        assert '16.0g/s' in texts   # density
+        assert '1.30x' in texts     # pointer_speed
+
+    def test_labels_alternate_side_going_up_the_lane(self):
+        """Le etichette stanno tutte sulla stessa verticale: se cadessero tutte
+        dallo stesso lato, due curve vicine si sovrascriverebbero (e' quello che
+        succedeva alla prima resa della pagina di prova). Alternando il lato,
+        due valori consecutivi in quota non si toccano mai."""
+        fig = render(crowded_scene(),
+                     {'magnify_targets': [{'t': TARGET_T, 'y': 1.0}]})
+        labels = sorted(projection_labels(env_ax(fig, 's1')),
+                        key=lambda ann: ann.xy[1])
+        assert len(labels) == 4
+        sides = [ann.get_ha() for ann in labels]
+        assert all(a != b for a, b in zip(sides, sides[1:])), sides
+
+    def test_labels_stay_inside_the_plot_near_the_right_edge(self):
+        """L'alternanza non batte il bordo: vicino al margine destro tutte le
+        etichette vanno comunque a sinistra del punto, come i breakpoint."""
+        fig = render(crowded_scene(duration=PAGE),
+                     {'magnify_targets': [{'t': 28.0, 'y': 1.0}]})
+        labels = projection_labels(env_ax(fig, 's1'))
+        assert labels and all(ann.get_ha() == 'right' for ann in labels)
+
+    def test_labels_can_be_turned_off(self):
+        """Corsie affollate: la verticale e i marker restano, i numeri no."""
+        fig = self._fig({'magnify_projection': {'labels': False}})
+        ax = env_ax(fig, 's1')
+        assert projection_labels(ax) == []
+        assert len(projection_markers(ax)) == 2
+        assert len(projection_lines(ax)) == 1
+
+
+# =============================================================================
+# GROUP - integrazione con le due modalita' della lente
+# =============================================================================
+
+class TestBothMagnifyModes:
+
+    def test_auto_lens_projects_too(self):
+        """La lente automatica (cluster piu' denso) proietta come le esplicite."""
+        fig = render(envelope_scene(), {'magnify_auto': True})
+        assert len(projection_lines(env_ax(fig, 's1'))) == 1
+
+    def test_two_lenses_two_projections(self):
+        """Ogni lente ha la sua verticale: due target, due istanti letti."""
+        fig = render(envelope_scene(), {'magnify_targets': [
+            {'t': 4.0, 'y': 1.0, 'corner': 'top-right'},
+            {'t': 12.0, 'y': 1.0, 'corner': 'bottom-left'},
+        ]})
+        ax = env_ax(fig, 's1')
+        xs = sorted(float(line.get_xdata()[0])
+                    for line in projection_lines(ax))
+        assert xs == pytest.approx([4.0, 12.0])
+        assert len(projection_markers(ax)) == 4  # 2 curve x 2 lenti

--- a/tests/rendering/test_score_visualizer_poc_projection.py
+++ b/tests/rendering/test_score_visualizer_poc_projection.py
@@ -379,6 +379,41 @@ class TestProjectionLabels:
 
 
 # =============================================================================
+# GROUP - il record della corsia
+# =============================================================================
+
+class TestEnvelopeLaneRecord:
+    """_draw_envelopes restituisce cosa e' finito nella corsia: e' l'unico modo
+    per ritrovare, al momento della proiezione, i range con cui le curve sono
+    state scalate (lo scratchpad d'istanza a quel punto e' quello dell'ultimo
+    stream disegnato)."""
+
+    def _render_lane(self, stream):
+        viz = make_viz([stream])
+        fig, ax = plt.subplots()
+        with patch('soundfile.read', return_value=(FAKE_AUDIO, SR)):
+            return viz._draw_envelopes(ax, stream, 0.0, 1.0, 0.0, PAGE)
+
+    def test_record_carries_curves_and_ranges(self):
+        stream = envelope_scene()[0]
+        record = self._render_lane(stream)
+        assert record.drawn_types == {'density', 'pointer_speed'}
+        assert set(record.display_ranges) == {'density', 'pointer_speed'}
+        # range data-driven sull'escursione reale + pad (issue #114)
+        lo, hi = record.display_ranges['density']
+        assert lo < 10.0 and hi > 30.0
+
+    def test_record_carries_the_lane_geometry(self):
+        record = self._render_lane(envelope_scene()[0])
+        assert (record.y_base, record.y_height) == (0.0, 1.0)
+
+    def test_static_stream_gives_an_empty_record(self):
+        record = self._render_lane(make_stream('statico'))
+        assert record.drawn_types == set()
+        assert record.display_ranges == {}
+
+
+# =============================================================================
 # GROUP - integrazione con le due modalita' della lente
 # =============================================================================
 


### PR DESCRIPTION
Closes #214

## Cosa fa

Ogni lente risolta — automatica o esplicita — proietta il proprio istante `t` sulla corsia envelope del suo stream: una **verticale tratteggiata** a `x = t` e, su ogni curva che incrocia, un **marker con il valore reale** e la sua unità.

Prima la lente diceva dove guardare ma non con quali parametri: il collegamento fra il grumo di grani ingrandito e i valori che lo producono andava ricostruito allineando a occhio la X del cerchio sorgente con le curve sottostanti.

## Come è fatto

**Livello puro** — `src/pge/rendering/magnifier_projection.py` (matplotlib-free, come i moduli fratelli):

- `project(render, t, stream_start, stream_duration, *, pan_range)` → `[ProjectedValue(param, value, y)]`;
- `EnvelopeLaneRender(curves, display_ranges, y_base, y_height, pitch_unit)` — il canale fra chi disegna la corsia e chi ci proietta sopra.

Il record serve perché i due momenti sono separati: le corsie si disegnano nel giro sugli stream, le lenti dopo. A quel punto lo scratchpad `_current_display_ranges` contiene i range dell'**ultimo** stream disegnato — con due stream su escursioni diverse è la differenza fra un marker sulla sua curva e uno appeso al vuoto. Ricalcolarli al momento della proiezione sarebbe stato un conto scollegato da quello che sta già sulla pagina.

**Wiring** — `score_visualizer.py`:

- `_draw_envelopes` restituisce `EnvelopeLaneRender` invece del set dei nomi disegnati (privato, nessun consumatore fuori dal visualizer; `.drawn_types` dà l'informazione di prima);
- le righe di `stream_entries` portano `ax_env` e `env_render`, che `MagnifyTarget.entry` trasporta intatte fino a chi disegna;
- `_draw_poc_projection(resolved)`, chiamata in coda a `_draw_one_magnifier`;
- la formattazione del valore esce da `_annotate_breakpoints` in `envelope_display.value_label`: i chiamanti sono due e lo stesso valore deve leggersi nello stesso modo. Anche il posizionamento dell'etichetta è ora condiviso (`_annotate_envelope_value`).

**Stile** — nessun sistema parallelo: la verticale prende `magnify_color` (è un pezzo della lente), il marker la tinta della sua curva con l'anello dell'accento. Nuovo gruppo di config `magnify_projection` (`enabled`, `linestyle`, `linewidth`, `alpha`, `markersize`, `labels`). Nessuna flag CLI nuova: la proiezione è parte di `--magnify` / `--magnify-at`.

**Leggibilità in stampa B&W**: tratteggio + pallino cerchiato, non due grigi indistinguibili. Le etichette cadono tutte sulla stessa verticale, quindi il lato si alterna salendo lungo la corsia — i bordi del subplot hanno comunque l'ultima parola, come per i breakpoint.

## Back-compat

Nessun artista in più quando: magnify è spenta, lo stream non ha corsia envelope, la sua corsia è vuota (stream tutto statico), la proiezione è disabilitata da config, o l'istante cade **fuori dall'estensione dello stream** — lì `Envelope.evaluate` saturerebbe sul breakpoint più vicino e la lente mostrerebbe un numero che in quel punto non esiste.

## Come l'ho verificato

**Test** (25 nuovi di integrazione + 15 sul modulo puro + 7 su `value_label`): artisti marcati con gid dedicato (`poc-projection`, `poc-projection-marker`, `poc-projection-label`), così i conteggi non dipendono da tutte le linee del plot. Coperti: verticale sull'istante, tratteggio, accento configurabile, un marker per curva, **il marker cade sulla curva disegnata** (confronto con i dati dell'artista della curva), ogni corsia usa i propri `display_ranges`, etichette col valore reale e unità, alternanza dei lati, bordo destro, i quattro casi in cui non si disegna niente, entrambe le modalità della lente. `make tests` verde (nessuna regressione).

**Verifica grafica** — non mi sono fidato dei soli test unitari per una feature grafica: partitura di prova a due stream (uno con cinque curve dinamiche, uno tutto statico), rigenerata con target espliciti e con `magnify_auto`. La prima resa ha mostrato un problema che i test non vedevano — le etichette di curve vicine si sovrascrivevano (`1.16xIB` al posto di `1.16x` e `-3.00dB`) — da cui l'alternanza dei lati, poi coperta da test. Controllata anche la conversione in scala di grigi: la verticale resta distinguibile dalla griglia e dalle curve, i marker restano leggibili.

Sulla corsia dello stream statico e fuori dall'estensione dello stream: nessun artista, come atteso.

## Impatto cross-repo

Nessuno. La superficie YAML, la gerarchia degli errori, i flag CLI e i formati di output sono invariati: la novità è una chiave di config del visualizer e artisti in più su una figura. Niente da aggiornare in `PGE-ls` (valida YAML) né in `PGE-ui` (invoca `main.py` con gli stessi flag) — nessuna issue aperta.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGVsopXHjCVtDqRmktTaaL)_