### PR TITLE
Envelope malformato, overflow delle potenze e debito del formato compatto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   avere variazione su quella chiave — scrivere `false` o omettere la chiave.
   Per la probabilità piena, `100`. (#209)
 
+  **Quanto è ruvido il breaking, in concreto:** meno di quanto la parola
+  suggerisca per chi chiama PGE da codice. `ConfigError` eredita da
+  `ValueError` (`src/pge/shared/exceptions.py`), quindi un `except ValueError`
+  già presente attorno al parsing continua a intercettare senza modifiche —
+  cambia il tipo esatto, non la categoria. A rompersi è solo ciò che sul
+  vecchio comportamento *contava*: un YAML con un envelope malformato che
+  prima renderizzava (male, al 100% dei grani) e ora si ferma.
+
 - **I riconoscitori di forma di `EnvelopeBuilder` diventano pubblici**:
   `is_compact_format`, `is_bp_group`, `is_3tuple_breakpoint`. Nessun alias
   privato lasciato dietro. Non cambia nulla a runtime, ma è una rinomina di
@@ -70,6 +78,28 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   decodificavano le stesse posizioni per conto proprio: se il `time_dist_spec`
   avesse cambiato slot, il validatore avrebbe continuato a controllare quello
   vecchio in silenzio, senza che nessun test se ne accorgesse. (#213, punto 2)
+  Lo slot dell'interp è letto dalla costante anche da `extract_interp_type`,
+  che era l'ultimo punto fuori da `is_compact_format` a decodificarlo a mano.
+
+- **Gli errori nati costruendo l'envelope portano lo stream.** Il
+  `ParameterBoundError` dell'overflow e l'`InvalidFieldValueError`
+  dell'envelope malformato arrivavano senza `stream_id`: la riga `Stream:` che
+  gli esempi di `docs/reference/errors.md` mostrano non compariva. Ora il
+  parser avvolge `create_scaled_envelope` come già avvolgeva
+  `validate_range_anchor`, e l'orchestratore fa lo stesso per `GateFactory`.
+  I punti di origine restano isolati: continuano a nominare il campo e basta,
+  cambia chi intercetta.
+
+- **L'hint dell'envelope malformato riporta la causa** che arriva dal builder
+  (`Causa: KeyError: 'points'`), invece del solo elenco delle forme note: con
+  quello soltanto l'utente doveva indovinare quale delle forme stava
+  sbagliando.
+
+- **Il rimedio suggerito sull'overflow segue il parametro.** «Avvicina X a 1»
+  vale per i fattori (`ratio`, `rate`), non per `exponent`, dove 1 è un valore
+  ordinario ed è l'ordine di grandezza a traboccare: con `exponent: 1e10` il
+  vecchio testo indicava un valore che non era né il problema né la
+  soluzione. (#212)
 
 ### Documentazione
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,83 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ---
 
+## [Unreleased]
+
+### Modificato (breaking)
+
+- **Un envelope malformato sotto `deviation_probability` ora è un errore.**
+  Smette di funzionare — cioè comincia a fallire il rendering invece di
+  proseguire in silenzio — ogni YAML in cui il valore di
+  `deviation_probability` (globale o per chiave) è un corpo che non si
+  costruisce come envelope: lista vuota `[]`, lista di non-breakpoint
+  `['x']`, dict senza `points` come `{punti: [[0, 50]]}`. Da ora
+  `InvalidFieldValueError` sul campo `deviation_probability.<chiave>`
+  (o `deviation_probability` per la forma globale).
+
+  Prima tornavano `AlwaysGate` con un `logger.error`: probabilità 100%, cioè
+  la variazione applicata a **tutti** i grani. Su `grain.read_direction: 1`
+  significava 79 grani su 79 letti nel verso opposto a quello dichiarato. Non
+  c'è comportamento utile da preservare: passavano rendendo l'opposto di
+  quanto scritto.
+
+  Il `logger.error` sparisce, perché non c'è più un fallback da tracciare. La
+  costruzione dell'envelope passa da un punto unico, letto dai tre siti che
+  prima decidevano per conto proprio: prima il corpo riconosciuto da
+  `is_envelope_like` faceva risalire un `ValueError` nudo mentre quello più
+  malformato veniva silenziato — più l'errore era grossolano, meno il sistema
+  lo segnalava.
+
+  **Migrazione:** correggere l'envelope, oppure — se l'intenzione era non
+  avere variazione su quella chiave — scrivere `false` o omettere la chiave.
+  Per la probabilità piena, `100`. (#209)
+
+- **I riconoscitori di forma di `EnvelopeBuilder` diventano pubblici**:
+  `is_compact_format`, `is_bp_group`, `is_3tuple_breakpoint`. Nessun alias
+  privato lasciato dietro. Non cambia nulla a runtime, ma è una rinomina di
+  simboli: chi chiamava i vecchi nomi privati dall'esterno (in-tree, solo
+  `read_direction.py`) va aggiornato. (#213, punto 1)
+
+### Corretto
+
+- **L'overflow delle potenze nelle distribuzioni temporali non risale più
+  nudo.** `rate ** -i`, `ratio ** n_reps` e `(i + 1) ** exponent` alzavano un
+  `OverflowError` di CPython — fuori dalla gerarchia `EngineError`, senza
+  campo e senza stream_id, con un testo (*integer division result too large
+  for a float*) che non nomina nessuna delle due cose da cambiare. Ora
+  `ParameterBoundError` che nomina **entrambi** i valori, il parametro e
+  `n_reps`: né `ratio: 10` né `n_reps: 400` sono sbagliati da soli, lo è la
+  coppia, e senza entrambi l'utente non sa quale ridurre.
+
+  L'intercettazione sta dove il calcolo avviene e non nei costruttori: la
+  soglia dipende dai due valori insieme, e il costruttore che riceve il
+  parametro non vede `n_reps`. Resta fuori scope `end_time <= time_offset`,
+  che è del builder perché `time_offset` dipende dagli elementi che precedono
+  il ciclo in una lista mista. (#212)
+
+- `ParameterBoundError` accetta un `hint` opzionale e omette la riga `Bounds`
+  quando entrambi i bound sono ignoti, invece di stampare `[None, None]`: il
+  vincolo violato non è sempre un intervallo sul singolo valore. (#212)
+
+- **Gli indici del formato compatto sono costanti nominate** in
+  `EnvelopeBuilder` (`COMPACT_PATTERN`, `COMPACT_END_TIME`, `COMPACT_N_REPS`,
+  `COMPACT_INTERP`, `COMPACT_TIME_DIST`, `COMPACT_WRAP`), lette sia da
+  `_expand_compact_format` sia da `read_direction._check_compact`. I due lati
+  decodificavano le stesse posizioni per conto proprio: se il `time_dist_spec`
+  avesse cambiato slot, il validatore avrebbe continuato a controllare quello
+  vecchio in silenzio, senza che nessun test se ne accorgesse. (#213, punto 2)
+
+### Documentazione
+
+- **La tabella delle cinque scritture di `deviation_probability`** in
+  `docs/reference/yaml.md`. Quattro su cinque danno `NeverGate`; la chiave
+  **scritta e lasciata vuota** (`deviation_probability:` → `null`) è l'unica a
+  non darlo — applica l'1% di jitter implicito. È la scrittura che più
+  assomiglia a "non voglio deviazione" e fa l'opposto. Nessun cambio di
+  comportamento: la modalità implicita resta, e ora è documentata dove
+  l'utente la incontra, con un test che la fissa. (#210)
+
+---
+
 ## [v7.3.0] — "Declared Reverse" — 2026-08-17
 
 ### Aggiunto

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -5,7 +5,7 @@ status: stable
 tags: [errors, exceptions, user-facing]
 sources:
   - src/pge/shared/exceptions.py
-last_synced_commit: 4c4fee4
+last_synced_commit: d0dcd01
 entry_for: [error-handling]
 ---
 
@@ -203,6 +203,26 @@ streams:
 [ERRORE] Parametro 'pitch' fuori bounds
   value:        999.0
   Bounds:       [0.1, 100.0]
+  Stream:       s1
+  Config:       configs/PGE_test.yml
+```
+
+`ParameterBoundError` accetta anche un `hint` opzionale, per i casi in cui il
+vincolo violato **non è un intervallo sul singolo valore**. È il caso
+dell'overflow delle potenze nelle distribuzioni temporali del formato compatto
+(`ratio ** n_reps`): nessuno dei due valori è fuori posto da solo, quindi non
+c'è nessun `[min, max]` da stampare — e infatti la riga `Bounds` viene omessa
+quando entrambi i bound sono ignoti, invece di scrivere `[None, None]`.
+
+```yaml
+streams:
+  s1:
+    density: [[[0, 5], [100, 50]], 10.0, 400, 'linear', {type: geometric, ratio: 10}]
+```
+```
+[ERRORE] Parametro 'ratio' fuori bounds
+  value:        10
+  Hint:         la distribuzione 'geometric(ratio=10)' calcola ratio ** n_reps con n_reps=400, e il risultato non sta in un float. Ne' ratio=10 ne' n_reps=400 e' fuori posto da solo: e' la coppia a esplodere. Riduci n_reps, oppure avvicina ratio a 1.
   Stream:       s1
   Config:       configs/PGE_test.yml
 ```

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -5,7 +5,7 @@ status: stable
 tags: [errors, exceptions, user-facing]
 sources:
   - src/pge/shared/exceptions.py
-last_synced_commit: d0dcd01
+last_synced_commit: ae61d22
 entry_for: [error-handling]
 ---
 

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -2180,7 +2180,7 @@ un envelope dal YAML al runtime è:
 - `src/pge/envelopes/envelope.py` — classe `Envelope`, `is_envelope_like`,
   `create_scaled_envelope`, `_scale_raw_values_y`
 - `src/pge/envelopes/envelope_builder.py` — `EnvelopeBuilder.parse`,
-  `_is_compact_format`, `_expand_compact_format`, `_is_bp_group`,
+  `is_compact_format`, `_expand_compact_format`, `is_bp_group`,
   `_expand_bp_group`, `DISCONTINUITY_OFFSET`
 - `src/pge/envelopes/envelope_interpolation.py` — `LinearInterpolation`,
   `StepInterpolation`, `CubicInterpolation`

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -11,7 +11,7 @@ sources:
   - src/pge/envelopes/
   - src/pge/shared/seeding.py
   - src/pge/shared/distribution_strategy.py
-last_synced_commit: d0dcd01
+last_synced_commit: bbd4709
 entry_for: [yaml-syntax, envelope-syntax]
 ---
 

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -11,7 +11,7 @@ sources:
   - src/pge/envelopes/
   - src/pge/shared/seeding.py
   - src/pge/shared/distribution_strategy.py
-last_synced_commit: 3ffcf1c
+last_synced_commit: d0dcd01
 entry_for: [yaml-syntax, envelope-syntax]
 ---
 
@@ -738,6 +738,37 @@ deviation_probability:
   volume: [[0, 0], [30, 80]]
   pan: 50
 ```
+
+### Le cinque scritture della chiave
+
+Ci sono cinque modi di scrivere `deviation_probability` "senza dirgli niente",
+e **quattro su cinque danno lo stesso risultato**. Misurato su uno stream reale
+(79 grani, `grain.read_direction: 1`, seed fisso, nessun `_range` dichiarato):
+
+| YAML | gate | grani deviati |
+|---|---|---|
+| chiave **omessa** | `NeverGate` | 0 / 79 |
+| `deviation_probability:` (scritta, vuota → `null`) | **probabilità implicita** (`DEFAULT_PROB`, 1%) | 1 / 79 |
+| `deviation_probability: {}` | `NeverGate` | 0 / 79 |
+| `deviation_probability: false` | `NeverGate` | 0 / 79 |
+| `deviation_probability: {<chiave>: null}` | `NeverGate` | 0 / 79 |
+
+L'eccezione è la seconda riga: **la chiave scritta e lasciata vuota è l'unica a
+non dare `NeverGate`**. `null` non significa "assente" — significa *modalità
+implicita*, cioè l'1% di jitter per grano su ogni parametro dello schema.
+
+È la scrittura che più assomiglia a "non voglio deviazione" e fa l'opposto. Se
+l'intenzione è disattivare, la scrittura da usare è `false` (o l'omissione); la
+chiave vuota è una dichiarazione, non un'assenza.
+
+> Non è specifico di un parametro: la modalità implicita vale per tutti. Si
+> nota di più su `grain.read_direction`, dove il flip è udibile come inversione
+> del verso, mentre su un parametro additivo l'1% si confonde con la grana.
+>
+> Con un `_range` esplicito le righe `NeverGate` diventano `AlwaysGate`: è la
+> semantica *range-only* descritta qui sotto, e non riguarda queste scritture.
+
+Il contratto è fissato da `tests/parameters/test_deviation_probability_scritture.py`.
 
 > **Default in modalità per-parametro.** Una chiave **assente** dal dict — o
 > impostata esplicitamente a **`null`** — non riceve probabilità: si comporta come
@@ -1976,6 +2007,13 @@ deviation_probability:
 Vedi `GateFactory._classify_deviation_probability`: il dispatch usa
 `Envelope.is_envelope_like` per riconoscere il formato e crea un
 `EnvelopeGate` invece di un `RandomGate` scalare.
+
+> **Un envelope che non si costruisce è un errore.** Un corpo malformato —
+> `[]`, `['x']`, un dict senza `points` — solleva `InvalidFieldValueError` sul
+> campo `deviation_probability.<chiave>` (o `deviation_probability` per la
+> forma globale). Prima veniva accettato in silenzio come probabilità 100%,
+> cioè la variazione applicata a **tutti** i grani: il contrario di quanto
+> scritto, e senza nulla in output che lo dicesse.
 
 #### 10.3 `voices.*.curve` per window transition
 

--- a/src/pge/envelopes/envelope.py
+++ b/src/pge/envelopes/envelope.py
@@ -118,7 +118,7 @@ class Envelope:
                 points.append(item)
                 seg_types.append(None)
             elif len(item) == 3:
-                if not _EB._is_3tuple_breakpoint(item):
+                if not _EB.is_3tuple_breakpoint(item):
                     raise ValueError(
                         f"Formato breakpoint non valido: {item}. "
                         "Deve essere [time, value] o [time, value, type]."
@@ -370,11 +370,11 @@ class Envelope:
                 return False
             
             # Formato compatto
-            if EnvelopeBuilder._is_compact_format(obj):
+            if EnvelopeBuilder.is_compact_format(obj):
                 return True
 
             # BP group diretto [points, interp] (issue #64)
-            if EnvelopeBuilder._is_bp_group(obj):
+            if EnvelopeBuilder.is_bp_group(obj):
                 return True
 
             # Lista con almeno un [t, v]
@@ -382,10 +382,10 @@ class Envelope:
                 if isinstance(item, list) and len(item) == 2:
                     return True
                 # Formato compatto dentro lista
-                if EnvelopeBuilder._is_compact_format(item):
+                if EnvelopeBuilder.is_compact_format(item):
                     return True
                 # BP group dentro lista
-                if EnvelopeBuilder._is_bp_group(item):
+                if EnvelopeBuilder.is_bp_group(item):
                     return True
             return False
         
@@ -417,20 +417,20 @@ class Envelope:
         def _scale_list_y(points_list):
             scaled = []
             for item in points_list:
-                if EnvelopeBuilder._is_compact_format(item):
+                if EnvelopeBuilder.is_compact_format(item):
                     pattern = item[0]
                     scaled_pattern = [[p[0], p[1] * scale_factor] for p in pattern]
                     new_item = list(item)
                     new_item[0] = scaled_pattern
                     scaled.append(new_item)
-                elif EnvelopeBuilder._is_bp_group(item):
+                elif EnvelopeBuilder.is_bp_group(item):
                     # BP group: scala i valori Y dei punti, preserva interp e
                     # type per-punto. Prima del branch [t, v]: anche il gruppo
                     # è una lista a 2 elementi.
                     scaled.append(_scale_group_y(item))
                 elif isinstance(item, list) and len(item) == 2:
                     scaled.append([item[0], item[1] * scale_factor])
-                elif EnvelopeBuilder._is_3tuple_breakpoint(item):
+                elif EnvelopeBuilder.is_3tuple_breakpoint(item):
                     scaled.append([item[0], item[1] * scale_factor, item[2]])
                 elif isinstance(item, dict) and 't' in item and 'v' in item:
                     scaled_dict = dict(item)
@@ -447,13 +447,13 @@ class Envelope:
             return new_data
 
         if isinstance(raw_data, list):
-            if EnvelopeBuilder._is_compact_format(raw_data):
+            if EnvelopeBuilder.is_compact_format(raw_data):
                 pattern = raw_data[0]
                 scaled_pattern = [[p[0], p[1] * scale_factor] for p in pattern]
                 new_data = list(raw_data)
                 new_data[0] = scaled_pattern
                 return new_data
-            elif EnvelopeBuilder._is_bp_group(raw_data):
+            elif EnvelopeBuilder.is_bp_group(raw_data):
                 # BP group diretto [points, interp]
                 return _scale_group_y(raw_data)
             else:
@@ -544,24 +544,24 @@ def _scale_time_recursive(points: List, factor: float) -> List:
     from pge.envelopes.envelope_builder import EnvelopeBuilder
 
     # CASO 1: L'intera lista è un formato compatto
-    if EnvelopeBuilder._is_compact_format(points):
+    if EnvelopeBuilder.is_compact_format(points):
         # NUOVO: Scala il total_time (elemento [1])
         scaled_compact = list(points)
         scaled_compact[1] = points[1] * factor
         return scaled_compact
 
     # CASO 1b: L'intera lista è un BP group diretto [points, interp]
-    if EnvelopeBuilder._is_bp_group(points):
+    if EnvelopeBuilder.is_bp_group(points):
         return [_scale_group_points_time(points[0], factor), points[1]]
 
     # CASO 2: Lista di elementi misti
     scaled = []
     for item in points:
-        if EnvelopeBuilder._is_compact_format(item):
+        if EnvelopeBuilder.is_compact_format(item):
             scaled_compact = list(item)
             scaled_compact[1] = item[1] * factor
             scaled.append(scaled_compact)
-        elif EnvelopeBuilder._is_bp_group(item):
+        elif EnvelopeBuilder.is_bp_group(item):
             # BP group: scala i tempi dei punti, preserva interp e type per-punto.
             # Va controllato prima del branch [t, v]: un gruppo è anch'esso
             # una lista a 2 elementi.
@@ -569,7 +569,7 @@ def _scale_time_recursive(points: List, factor: float) -> List:
         elif isinstance(item, list) and len(item) == 2:
             # Standard breakpoint: [t, v] -> [t * factor, v]
             scaled.append([item[0] * factor, item[1]])
-        elif EnvelopeBuilder._is_3tuple_breakpoint(item):
+        elif EnvelopeBuilder.is_3tuple_breakpoint(item):
             # 3-tuple breakpoint: [t, v, type] -> [t * factor, v, type]
             scaled.append([item[0] * factor, item[1], item[2]])
         elif isinstance(item, dict) and 't' in item and 'v' in item:

--- a/src/pge/envelopes/envelope_builder.py
+++ b/src/pge/envelopes/envelope_builder.py
@@ -393,6 +393,12 @@ class EnvelopeBuilder:
         from pge.envelopes.time_distribution import TimeDistributionFactory
         
         # Parse input
+        # Precondizione: `compact` ha gia' passato `is_compact_format`, che
+        # ammette da 3 a 6 elementi. I tre `len(compact) > SLOT` qui sotto
+        # distinguono quindi solo gli slot opzionali assenti — non c'e' un
+        # settimo slot da cui difendersi, e `COMPACT_WRAP` e' l'ultimo per
+        # costruzione: e' quel limite superiore a rendere questi test
+        # esaustivi invece che parziali.
         pattern_points_pct = compact[cls.COMPACT_PATTERN]
         end_time = compact[cls.COMPACT_END_TIME]  # Tempo assoluto finale
         n_reps = compact[cls.COMPACT_N_REPS]

--- a/src/pge/envelopes/envelope_builder.py
+++ b/src/pge/envelopes/envelope_builder.py
@@ -56,7 +56,22 @@ class EnvelopeBuilder:
     
     # Offset infinitesimale per discontinuità
     DISCONTINUITY_OFFSET = 0.000001
-    
+
+    # Gli slot del formato compatto (issue #213). Non sono una comodità di
+    # lettura: sono il punto unico in cui il layout della tupla esiste. Chi
+    # espande (`_expand_compact_format`) e chi valida a monte
+    # (`read_direction._check_compact`) decodificavano le stesse posizioni per
+    # conto proprio, e il caso peggiore non era un errore ma un silenzio — un
+    # `time_dist_spec` spostato di slot avrebbe lasciato il validatore a
+    # controllare quello vecchio senza che nessun test se ne accorgesse.
+    COMPACT_PATTERN = 0
+    COMPACT_END_TIME = 1
+    COMPACT_N_REPS = 2
+    COMPACT_INTERP = 3
+    COMPACT_TIME_DIST = 4
+    COMPACT_WRAP = 5
+
+
     @classmethod
     def parse(cls, raw_points: list) -> list:
         """
@@ -91,7 +106,7 @@ class EnvelopeBuilder:
             [[0, 0], [1, 10], 'cycle']
         """
         # FIX 1: Controlla PRIMA se raw_points STESSO è un formato compatto
-        if cls._is_compact_format(raw_points):
+        if cls.is_compact_format(raw_points):
             # Formato compatto diretto: offset = 0
             expanded = cls._expand_compact_format(raw_points, time_offset=0.0)
 
@@ -101,7 +116,7 @@ class EnvelopeBuilder:
             return expanded
 
         # BP group diretto [points, interp] (issue #64), simmetrico al compatto
-        if cls._is_bp_group(raw_points):
+        if cls.is_bp_group(raw_points):
             expanded = cls._expand_bp_group(raw_points)
 
             cls._log_final_envelope(raw_points, expanded)
@@ -119,7 +134,7 @@ class EnvelopeBuilder:
                     item = [item['t'], item['v'], item['type']]
                 else:
                     item = [item['t'], item['v']]
-            if cls._is_compact_format(item):
+            if cls.is_compact_format(item):
                 # Espandi formato compatto CON OFFSET
                 compact_expanded = cls._expand_compact_format(item, time_offset=current_time)
                 expanded.extend(compact_expanded)
@@ -127,7 +142,7 @@ class EnvelopeBuilder:
                 # Aggiorna tempo corrente (ultimo breakpoint espanso)
                 if compact_expanded:
                     current_time = compact_expanded[-1][0]
-            elif cls._is_bp_group(item):
+            elif cls.is_bp_group(item):
                 # Espandi BP group [points, interp] in 3-tuple (issue #64)
                 group_expanded = cls._expand_bp_group(
                     item, current_time=current_time, has_preceding=bool(expanded)
@@ -135,7 +150,7 @@ class EnvelopeBuilder:
                 expanded.extend(group_expanded)
                 current_time = max(current_time, group_expanded[-1][0])
             else:
-                if cls._is_3tuple_breakpoint(item):
+                if cls.is_3tuple_breakpoint(item):
                     expanded.append(item)
                     current_time = max(current_time, item[0])
                 elif (isinstance(item, list) and len(item) == 2
@@ -157,7 +172,7 @@ class EnvelopeBuilder:
     VALID_INTERP_TYPES = ('linear', 'cubic', 'step')
 
     @classmethod
-    def _is_3tuple_breakpoint(cls, item) -> bool:
+    def is_3tuple_breakpoint(cls, item) -> bool:
         """
         Rileva se item è breakpoint 3-tuple [t, v, type].
 
@@ -179,7 +194,7 @@ class EnvelopeBuilder:
         return True
 
     @classmethod
-    def _is_bp_group(cls, item) -> bool:
+    def is_bp_group(cls, item) -> bool:
         """
         Rileva se item è un BP group [points, interp] (issue #64).
 
@@ -188,7 +203,7 @@ class EnvelopeBuilder:
           come i breakpoint nudi — non percentuali come nei loop block)
         - item[1] è stringa: interp della macrozona
 
-        Check strutturale (come _is_3tuple_breakpoint): il valore di interp
+        Check strutturale (come is_3tuple_breakpoint): il valore di interp
         e il vincolo "almeno 2 punti" vengono validati in _expand_bp_group,
         per dare errori precisi. Discriminato da:
         - breakpoint [t, v]: elem[0] numerico, non lista
@@ -283,7 +298,7 @@ class EnvelopeBuilder:
         return expanded
 
     @classmethod
-    def _is_compact_format(cls, item) -> bool:
+    def is_compact_format(cls, item) -> bool:
         """
         Rileva se item è formato compatto.
         
@@ -378,12 +393,15 @@ class EnvelopeBuilder:
         from pge.envelopes.time_distribution import TimeDistributionFactory
         
         # Parse input
-        pattern_points_pct = compact[0]
-        end_time = compact[1]  # Tempo assoluto finale
-        n_reps = compact[2]
-        interp_type = compact[3] if len(compact) >= 4 else None
-        time_dist_spec = compact[4] if len(compact) >= 5 else None
-        wrap = compact[5] if len(compact) == 6 else False
+        pattern_points_pct = compact[cls.COMPACT_PATTERN]
+        end_time = compact[cls.COMPACT_END_TIME]  # Tempo assoluto finale
+        n_reps = compact[cls.COMPACT_N_REPS]
+        interp_type = (compact[cls.COMPACT_INTERP]
+                       if len(compact) > cls.COMPACT_INTERP else None)
+        time_dist_spec = (compact[cls.COMPACT_TIME_DIST]
+                          if len(compact) > cls.COMPACT_TIME_DIST else None)
+        wrap = (compact[cls.COMPACT_WRAP]
+                if len(compact) > cls.COMPACT_WRAP else False)
         if wrap is None:
             wrap = False
         
@@ -592,15 +610,15 @@ class EnvelopeBuilder:
         n_group = 0
         n_standard = 0
 
-        if cls._is_compact_format(raw_input):
+        if cls.is_compact_format(raw_input):
             n_compact = 1
-        elif cls._is_bp_group(raw_input):
+        elif cls.is_bp_group(raw_input):
             n_group = 1
         else:
             for item in raw_input:
-                if cls._is_compact_format(item):
+                if cls.is_compact_format(item):
                     n_compact += 1
-                elif cls._is_bp_group(item):
+                elif cls.is_bp_group(item):
                     n_group += 1
                 elif isinstance(item, list) and len(item) == 2:
                     n_standard += 1
@@ -617,9 +635,9 @@ class EnvelopeBuilder:
         logger.info(f"  Standard breakpoints: {n_standard}")
         logger.info(f"  Compact sections: {n_compact}")
         logger.info(f"  BP groups: {n_group}")
-        if cls._is_compact_format(raw_input):
+        if cls.is_compact_format(raw_input):
             format_type = 'compact'
-        elif cls._is_bp_group(raw_input):
+        elif cls.is_bp_group(raw_input):
             format_type = 'bp_group'
         elif n_compact > 0 or n_group > 0:
             format_type = 'mixed'
@@ -680,7 +698,7 @@ class EnvelopeBuilder:
             str or None: Tipo interpolazione ('linear', 'cubic', 'step')
         """
         # FIX 2: Controlla PRIMA se raw_points STESSO è formato compatto con tipo
-        if cls._is_compact_format(raw_points):
+        if cls.is_compact_format(raw_points):
             # Formato compatto con >= 4 elementi include interp_type in posizione 3
             if len(raw_points) >= 4 and raw_points[3] is not None:
                 return raw_points[3]
@@ -688,7 +706,7 @@ class EnvelopeBuilder:
 
         # Altrimenti itera sugli elementi (formato misto)
         for item in raw_points:
-            if cls._is_compact_format(item):
+            if cls.is_compact_format(item):
                 # Formato compatto con >= 4 elementi include interp_type in posizione 3
                 if len(item) >= 4 and item[3] is not None:
                     return item[3]
@@ -710,10 +728,10 @@ def detect_format_type(item) -> str:
     if isinstance(item, str) and item.lower() == 'cycle':
         return 'cycle'
 
-    if EnvelopeBuilder._is_compact_format(item):
+    if EnvelopeBuilder.is_compact_format(item):
         return 'compact'
 
-    if EnvelopeBuilder._is_bp_group(item):
+    if EnvelopeBuilder.is_bp_group(item):
         return 'bp_group'
 
     if isinstance(item, list) and len(item) == 2:

--- a/src/pge/envelopes/envelope_builder.py
+++ b/src/pge/envelopes/envelope_builder.py
@@ -699,17 +699,21 @@ class EnvelopeBuilder:
         """
         # FIX 2: Controlla PRIMA se raw_points STESSO è formato compatto con tipo
         if cls.is_compact_format(raw_points):
-            # Formato compatto con >= 4 elementi include interp_type in posizione 3
-            if len(raw_points) >= 4 and raw_points[3] is not None:
-                return raw_points[3]
+            # Lo slot dell'interp e' quello nominato (issue #213): scritto a
+            # mano, un giorno che cambiasse posizione questa funzione tornerebbe
+            # None invece del tipo dichiarato — non un errore, un envelope
+            # interpolato col default.
+            if (len(raw_points) > cls.COMPACT_INTERP
+                    and raw_points[cls.COMPACT_INTERP] is not None):
+                return raw_points[cls.COMPACT_INTERP]
             return None
 
         # Altrimenti itera sugli elementi (formato misto)
         for item in raw_points:
             if cls.is_compact_format(item):
-                # Formato compatto con >= 4 elementi include interp_type in posizione 3
-                if len(item) >= 4 and item[3] is not None:
-                    return item[3]
+                if (len(item) > cls.COMPACT_INTERP
+                        and item[cls.COMPACT_INTERP] is not None):
+                    return item[cls.COMPACT_INTERP]
 
         return None
 

--- a/src/pge/envelopes/time_distribution.py
+++ b/src/pge/envelopes/time_distribution.py
@@ -11,6 +11,19 @@ from typing import List, Tuple, Union, Dict, Any
 import math
 
 
+# Come uscire da un overflow, per parametro (issue #212, review #216). Non e'
+# lo stesso consiglio per tutti: `ratio` e `rate` sono fattori di una
+# progressione, e verso 1 la progressione si appiattisce e la potenza smette di
+# crescere; `exponent` e' una scala, dove 1 e' un valore ordinario e a
+# traboccare e' l'ordine di grandezza. Un parametro non elencato ricade su
+# "riduci <nome>", che e' vero per costruzione: l'overflow arriva dall'alto.
+_RIMEDI_OVERFLOW = {
+    'ratio': "avvicina ratio a 1",
+    'rate': "avvicina rate a 1",
+    'exponent': "riduci exponent in valore assoluto",
+}
+
+
 # =============================================================================
 # ABSTRACT BASE CLASS
 # =============================================================================
@@ -63,6 +76,10 @@ class TimeDistributionStrategy(ABC):
         Per la stessa ragione il messaggio li nomina entrambi: nessuno dei due
         e' il colpevole, quindi dire solo l'uno o solo l'altro non direbbe
         all'utente quale ridurre.
+
+        Il rimedio finale, invece, dipende dal parametro: `ratio` e `rate` sono
+        fattori, e verso 1 la progressione diventa uniforme; `exponent` no — 1
+        e' un esponente ordinario, ed e' la sua scala a essere fuori misura.
         """
         from pge.shared.exceptions import ParameterBoundError
 
@@ -77,7 +94,7 @@ class TimeDistributionStrategy(ABC):
                 f"n_reps={n_reps}, e il risultato non sta in un float. "
                 f"Ne' {param_name}={value} ne' n_reps={n_reps} e' fuori posto "
                 f"da solo: e' la coppia a esplodere. Riduci n_reps, oppure "
-                f"avvicina {param_name} a 1."
+                f"{_RIMEDI_OVERFLOW.get(param_name, f'riduci {param_name}')}."
             ),
         )
 

--- a/src/pge/envelopes/time_distribution.py
+++ b/src/pge/envelopes/time_distribution.py
@@ -50,6 +50,37 @@ class TimeDistributionStrategy(ABC):
         """Nome della distribuzione."""
         pass
     
+    def _overflow(self, param_name: str, value, n_reps: int, formula: str):
+        """L'errore di una potenza che trabocca (issue #212).
+
+        Non e' un bound sul valore e non poteva esserlo: `ratio: 10` e
+        `n_reps: 400` sono legittimi da soli, e il costruttore che riceve il
+        primo non vede il secondo. La soglia esatta oltre cui `ratio ** n_reps`
+        esce dai float dipende dai due insieme, e replicarla a monte sarebbe
+        aritmetica destinata a divergere dal comportamento reale di CPython.
+        Il punto in cui l'overflow accade e' gia' quello che sa entrambi.
+
+        Per la stessa ragione il messaggio li nomina entrambi: nessuno dei due
+        e' il colpevole, quindi dire solo l'uno o solo l'altro non direbbe
+        all'utente quale ridurre.
+        """
+        from pge.shared.exceptions import ParameterBoundError
+
+        return ParameterBoundError(
+            param_name=param_name,
+            value_type="value",
+            min_bound=None,
+            max_bound=None,
+            value=value,
+            hint=(
+                f"la distribuzione '{self.name}' calcola {formula} con "
+                f"n_reps={n_reps}, e il risultato non sta in un float. "
+                f"Ne' {param_name}={value} ne' n_reps={n_reps} e' fuori posto "
+                f"da solo: e' la coppia a esplodere. Riduci n_reps, oppure "
+                f"avvicina {param_name} a 1."
+            ),
+        )
+
     def _validate_inputs(self, total_time: float, n_reps: int):
         """Validazione comune."""
         if n_reps < 1:
@@ -135,7 +166,12 @@ class ExponentialDistribution(TimeDistributionStrategy):
         self._validate_inputs(total_time, n_reps)
         
         # Genera pesi esponenziali decrescenti
-        weights = [self.rate ** (-i) for i in range(n_reps)]
+        try:
+            weights = [self.rate ** (-i) for i in range(n_reps)]
+        except OverflowError as exc:
+            raise self._overflow(
+                'rate', self.rate, n_reps, 'rate ** -i'
+            ) from exc
         sum_weights = sum(weights)
         
         # Normalizza a total_time
@@ -231,7 +267,15 @@ class GeometricDistribution(TimeDistributionStrategy):
         
         # Progressione geometrica: a, a*r, a*r^2, ..., a*r^(n-1)
         # Somma = a * (1 - r^n) / (1 - r)
-        sum_geometric = (1 - self.ratio ** n_reps) / (1 - self.ratio)
+        # Con `ratio` intero la potenza non trabocca — Python la calcola esatta
+        # su interi illimitati — ma la divisione che segue si': l'intercettazione
+        # va attorno all'espressione, non attorno alla sola potenza.
+        try:
+            sum_geometric = (1 - self.ratio ** n_reps) / (1 - self.ratio)
+        except OverflowError as exc:
+            raise self._overflow(
+                'ratio', self.ratio, n_reps, 'ratio ** n_reps'
+            ) from exc
         first_duration = total_time / sum_geometric
         
         # Genera durate
@@ -310,7 +354,12 @@ class PowerDistribution(TimeDistributionStrategy):
         self._validate_inputs(total_time, n_reps)
                 
         # Genera pesi usando power law
-        weights = [(i + 1) ** self.exponent for i in range(n_reps)]
+        try:
+            weights = [(i + 1) ** self.exponent for i in range(n_reps)]
+        except OverflowError as exc:
+            raise self._overflow(
+                'exponent', self.exponent, n_reps, '(i + 1) ** exponent'
+            ) from exc
         sum_weights = sum(weights)
         
         # Normalizza

--- a/src/pge/envelopes/time_distribution.py
+++ b/src/pge/envelopes/time_distribution.py
@@ -294,8 +294,15 @@ class GeometricDistribution(TimeDistributionStrategy):
                 'ratio', self.ratio, n_reps, 'ratio ** n_reps'
             ) from exc
         first_duration = total_time / sum_geometric
-        
+
         # Genera durate
+        # La quarta potenza del file resta fuori dal try, e non per svista:
+        # qui l'esponente `i` e' sempre < n_reps, quindi con ratio > 1 questa
+        # potenza e' minore di `ratio ** n_reps`, che poche righe sopra e' gia'
+        # passata; con ratio < 1 decresce verso zero e non trabocca in alcun
+        # caso. Il prodotto nemmeno: con ratio > 1 `sum_geometric` e' grande
+        # nella stessa misura, quindi `first_duration` e' piccolo e le durate
+        # restano nell'ordine di `total_time`.
         cycle_durations = [first_duration * (self.ratio ** i) for i in range(n_reps)]
         
         # Normalizza per garantire sum == total_time (correzione errori floating point)

--- a/src/pge/parameters/gate_factory.py
+++ b/src/pge/parameters/gate_factory.py
@@ -8,7 +8,24 @@ from typing import Optional, Any, Union
 from pge.shared.probability_gate import *
 from enum import Enum
 from pge.envelopes.envelope import Envelope, create_scaled_envelope
-from pge.shared.exceptions import InvalidParameterError
+from pge.shared.exceptions import (
+    EngineError,
+    InvalidFieldValueError,
+    InvalidParameterError,
+)
+
+# La chiave nello YAML: identita' del campo in ogni errore. In modalita'
+# per-parametro il campo e' la coppia `deviation_probability.<chiave>`, che e'
+# quanto l'utente ha scritto e quanto PGE-ls deve poter attribuire.
+DEVIATION_PROBABILITY_FIELD = 'deviation_probability'
+
+_ENVELOPE_HINT = (
+    "il valore di deviation_probability e' una probabilita' (0-100) o un "
+    "envelope in una delle forme note: lista di breakpoint [[t, v], ...], "
+    "dict {points: [...]}, BP group o formato compatto. Questo corpo non si "
+    "costruisce come envelope."
+)
+
 
 class DeviationProbabilityMode(Enum):
     """Stati semantici di deviation_probability."""
@@ -80,8 +97,9 @@ class GateFactory:
             return GateFactory._create_probability_gate(float(deviation_probability), rng)
         elif mode == DeviationProbabilityMode.GLOBAL_ENV:
             # Crea Envelope dai dati grezzi
-            envelope = create_scaled_envelope(deviation_probability, duration, time_mode)
-            return EnvelopeGate(envelope, rng=rng)
+            return GateFactory._envelope_gate(
+                deviation_probability, duration, time_mode, rng
+            )
         elif mode == DeviationProbabilityMode.SPECIFIC:
             # Chiave assente o null: il parametro non ha probabilità dichiarata e
             # segue la semantica range-only (come deviation_probability:false). Il range
@@ -95,10 +113,13 @@ class GateFactory:
                     return GateFactory._range_only_gate(has_explicit_range)
                 elif GateFactory._is_envelope_like(raw_value):
                     # Valore envelope per questo parametro specifico
-                    envelope = create_scaled_envelope(raw_value, duration, time_mode)
-                    return EnvelopeGate(envelope, rng=rng)
+                    return GateFactory._envelope_gate(
+                        raw_value, duration, time_mode, rng, param_key
+                    )
                 else:
-                    return GateFactory._parse_raw_value(raw_value, duration, time_mode, rng)
+                    return GateFactory._parse_raw_value(
+                        raw_value, duration, time_mode, rng, param_key
+                    )
             else:
                 return GateFactory._range_only_gate(has_explicit_range)
         return NeverGate()
@@ -130,7 +151,54 @@ class GateFactory:
             return RandomGate(probability, rng=rng)
 
     @staticmethod
-    def _parse_raw_value(raw_value: Any, duration: float, time_mode: str, rng=None) -> ProbabilityGate:
+    def _field_name(param_key: Optional[str] = None) -> str:
+        """Il campo da nominare nell'errore: la chiave come l'utente l'ha scritta."""
+        if param_key is None:
+            return DEVIATION_PROBABILITY_FIELD
+        return f"{DEVIATION_PROBABILITY_FIELD}.{param_key}"
+
+    @staticmethod
+    def _envelope_gate(
+        raw_value: Any,
+        duration: float,
+        time_mode: str,
+        rng=None,
+        param_key: Optional[str] = None,
+    ) -> ProbabilityGate:
+        """Costruisce l'EnvelopeGate, o dichiara che quel corpo non e' un envelope.
+
+        Punto unico in cui `deviation_probability` diventa un envelope (issue
+        #209). Prima ce n'erano tre, e rispondevano in tre modi diversi allo
+        stesso guasto: il corpo che superava `_is_envelope_like` faceva risalire
+        il `ValueError` nudo del builder, quello piu' malformato veniva
+        silenziato con un `AlwaysGate` e un log. Piu' l'errore era grossolano,
+        meno il sistema lo segnalava — e `AlwaysGate` non e' un ripiego neutro:
+        e' il gate piu' lontano da quanto scritto, applicato al 100% dei grani.
+
+        Gli `EngineError` risalgono intatti: sono gia' nella gerarchia, portano
+        gia' il proprio campo e il proprio hint, e riavvolgerli qui li
+        renderebbe meno precisi, non piu'.
+        """
+        try:
+            envelope = create_scaled_envelope(raw_value, duration, time_mode)
+        except EngineError:
+            raise
+        except Exception as exc:
+            raise InvalidFieldValueError(
+                field=GateFactory._field_name(param_key),
+                value=raw_value,
+                hint=_ENVELOPE_HINT,
+            ) from exc
+        return EnvelopeGate(envelope, rng=rng)
+
+    @staticmethod
+    def _parse_raw_value(
+        raw_value: Any,
+        duration: float,
+        time_mode: str,
+        rng=None,
+        param_key: Optional[str] = None,
+    ) -> ProbabilityGate:
         # Numero
         if isinstance(raw_value, (int, float)):
             prob = float(raw_value)
@@ -141,21 +209,15 @@ class GateFactory:
             else:
                 return RandomGate(prob, rng=rng)
 
-        # Envelope (con gestione errori)
+        # Envelope: se non si costruisce, e' un errore di scrittura come ogni
+        # altro (issue #209) e lo dice la stessa funzione che lo dice al corpo
+        # riconosciuto come envelope.
         if isinstance(raw_value, (list, dict)):
-            try:
-                envelope = create_scaled_envelope(raw_value, duration, time_mode)
-                return EnvelopeGate(envelope, rng=rng)
-            except Exception as e:
-                # Envelope malformato - fallback con logging
-                import logging
-                logger = logging.getLogger(__name__)
-                logger.error(
-                    f"Envelope deviation_probability invalido: {raw_value}. "
-                    f"Errore: {e}. Usando AlwaysGate (probabilità 100%) come fallback."
-                )
-                return AlwaysGate()
-        
+            return GateFactory._envelope_gate(
+                raw_value, duration, time_mode, rng, param_key
+            )
+
+
         # Tipo completamente sbagliato
         raise InvalidParameterError(
             param_name="deviation_probability",

--- a/src/pge/parameters/gate_factory.py
+++ b/src/pge/parameters/gate_factory.py
@@ -181,10 +181,14 @@ class GateFactory:
         except EngineError:
             raise
         except Exception as exc:
+            # L'elenco delle forme dice cosa era lecito scrivere, non quale
+            # delle forme si stava sbagliando: quello lo sa solo l'eccezione
+            # che arriva dal builder, e va letta prima di buttarla via. Col
+            # tipo davanti, perche' da solo un KeyError e' la chiave nuda.
             raise InvalidFieldValueError(
                 field=GateFactory._field_name(param_key),
                 value=raw_value,
-                hint=_ENVELOPE_HINT,
+                hint=f"{_ENVELOPE_HINT} Causa: {type(exc).__name__}: {exc}",
             ) from exc
         return EnvelopeGate(envelope, rng=rng)
 

--- a/src/pge/parameters/gate_factory.py
+++ b/src/pge/parameters/gate_factory.py
@@ -111,15 +111,12 @@ class GateFactory:
                 raw_value = deviation_probability[param_key]
                 if raw_value is None:
                     return GateFactory._range_only_gate(has_explicit_range)
-                elif GateFactory._is_envelope_like(raw_value):
-                    # Valore envelope per questo parametro specifico
-                    return GateFactory._envelope_gate(
-                        raw_value, duration, time_mode, rng, param_key
-                    )
-                else:
-                    return GateFactory._parse_raw_value(
-                        raw_value, duration, time_mode, rng, param_key
-                    )
+                # Envelope o numero, la distinzione la fa _parse_raw_value: da
+                # #209 i due rami convergono li' dentro, e sceglierne uno qui
+                # significava solo anticipare la stessa domanda.
+                return GateFactory._parse_raw_value(
+                    raw_value, duration, time_mode, rng, param_key
+                )
             else:
                 return GateFactory._range_only_gate(has_explicit_range)
         return NeverGate()
@@ -212,11 +209,15 @@ class GateFactory:
         # Envelope: se non si costruisce, e' un errore di scrittura come ogni
         # altro (issue #209) e lo dice la stessa funzione che lo dice al corpo
         # riconosciuto come envelope.
-        if isinstance(raw_value, (list, dict)):
+        #
+        # `Envelope` sta nella tupla perche' e' l'unico corpo che
+        # `_is_envelope_like` riconosce senza essere ne' lista ne' dict: e' cio'
+        # che rende questa funzione l'unico ingresso, invece di lasciare al
+        # chiamante un ramo suo per quel caso solo.
+        if isinstance(raw_value, (list, dict, Envelope)):
             return GateFactory._envelope_gate(
                 raw_value, duration, time_mode, rng, param_key
             )
-
 
         # Tipo completamente sbagliato
         raise InvalidParameterError(

--- a/src/pge/parameters/parameter_orchestrator.py
+++ b/src/pge/parameters/parameter_orchestrator.py
@@ -22,6 +22,7 @@ from pge.parameters.parameter_schema import ParameterSpec, resolve_yaml_path
 from pge.parameters.parameter_definitions import DEFAULT_PROB
 from pge.parameters.exclusive_selector import ExclusiveGroupSelector
 from pge.core.stream_config import StreamConfig
+from pge.shared.exceptions import ConfigError
 from pge.shared.seeding import component_rng
 
 class ParameterOrchestrator:
@@ -112,20 +113,42 @@ class ParameterOrchestrator:
 
         # 2. Crea il ProbabilityGate corrispondente, con RNG per-componente
         # (issue #154): i draw del gate non shiftano gli altri componenti.
-        gate = GateFactory.create_gate(
-            deviation_probability=self._config.deviation_probability,
+        gate = self._create_gate(
             param_key=param_spec.deviation_probability_key,
-            default_prob=DEFAULT_PROB,
             has_explicit_range=has_explicit_range,
-            range_always_active=self._config.range_always_active,
-            duration=self._config.context.duration,
-            time_mode=self._config.time_mode,
-            rng=self._gate_rng(param_spec.deviation_probability_key),
         )
         # 3. Inietta il gate nel Parameter (modifica la classe Parameter)
         param.set_probability_gate(gate)
 
         return param
+
+    def _create_gate(
+        self,
+        param_key: Optional[str],
+        has_explicit_range: bool,
+    ) -> ProbabilityGate:
+        """Il gate del parametro, attribuito allo stream se non si costruisce.
+
+        `GateFactory` e' isolata per progetto: non conosce lo stream, e infatti
+        i suoi errori nominano il campo (`deviation_probability.<chiave>`) e
+        basta. L'attribuzione tocca al chiamante, come gia' fa il parser per i
+        propri — senza, la riga `Stream:` che `docs/reference/errors.md`
+        promette negli esempi non compare.
+        """
+        try:
+            return GateFactory.create_gate(
+                deviation_probability=self._config.deviation_probability,
+                param_key=param_key,
+                default_prob=DEFAULT_PROB,
+                has_explicit_range=has_explicit_range,
+                range_always_active=self._config.range_always_active,
+                duration=self._config.context.duration,
+                time_mode=self._config.time_mode,
+                rng=self._gate_rng(param_key),
+            )
+        except ConfigError as err:
+            err.stream_id = self._config.context.stream_id
+            raise
 
     def _gate_rng(self, deviation_probability_key: Optional[str]):
         """RNG locale del gate, derivato da (seed, rng_id, gate:<key>) —
@@ -157,15 +180,9 @@ class ParameterOrchestrator:
             range_raw=range_raw,
             bounds_override=bounds,
         )
-        gate = GateFactory.create_gate(
-            deviation_probability=self._config.deviation_probability,
+        gate = self._create_gate(
             param_key=deviation_probability_key,
-            default_prob=DEFAULT_PROB,
             has_explicit_range=param.has_explicit_range,
-            range_always_active=self._config.range_always_active,
-            duration=self._config.context.duration,
-            time_mode=self._config.time_mode,
-            rng=self._gate_rng(deviation_probability_key),
         )
         param.set_probability_gate(gate)
         return param

--- a/src/pge/parameters/parser.py
+++ b/src/pge/parameters/parser.py
@@ -22,6 +22,7 @@ from pge.shared.distribution_strategy import (
     validate_range_anchor,
 )
 from pge.shared.exceptions import (
+    ConfigError,
     InvalidFieldValueError,
     InvalidParameterError,
     ParameterBoundError,
@@ -172,7 +173,16 @@ class GranularParser:
 
         # Caso 2: Struttura complessa (Lista o Dict) -> Envelope
         if isinstance(raw_data, (list, dict)):
-            return create_scaled_envelope(raw_data, self.duration, self.time_mode)
+            # La costruzione dell'envelope ha errori suoi (bounds del formato
+            # compatto, overflow delle potenze): nascono dove lo stream non si
+            # conosce, e vanno attribuiti qui come ogni altro errore del parser.
+            try:
+                return create_scaled_envelope(
+                    raw_data, self.duration, self.time_mode
+                )
+            except ConfigError as err:
+                err.stream_id = self.stream_id
+                raise
         # Caso Errore: Tipo non supportato
         err = InvalidParameterError(
             param_name=context_info,

--- a/src/pge/parameters/read_direction.py
+++ b/src/pge/parameters/read_direction.py
@@ -189,20 +189,20 @@ def _check_envelope_body(body: Any) -> None:
     `EnvelopeBuilder.parse`. Piu' in fondo non sono ammesse, ma per due ragioni
     diverse, che vale la pena non confondere:
 
-    - dentro un BP group basta il riconoscimento della forma: `_is_bp_group`
+    - dentro un BP group basta il riconoscimento della forma: `is_bp_group`
       pretende che ogni punto sia `[num, num]` o `[num, num, str]`, quindi un
       annidamento fa fallire il riconoscimento e il valore non arriva mai a
       chiamarsi gruppo;
-    - dentro il pattern di un ciclo no: `_is_compact_format` filtra i punti
+    - dentro il pattern di un ciclo no: `is_compact_format` filtra i punti
       sulla sola lunghezza (2 o 3), e un BP group e' lungo 2. Li' il rifiuto lo
       fa `_check_pattern_point`, altrimenti il valore passa di qui e muore nel
       builder con un TypeError nudo.
     """
-    if EnvelopeBuilder._is_compact_format(body):
+    if EnvelopeBuilder.is_compact_format(body):
         _check_compact(body)
         return
 
-    if EnvelopeBuilder._is_bp_group(body):
+    if EnvelopeBuilder.is_bp_group(body):
         _check_bp_group(body)
         return
 
@@ -220,15 +220,15 @@ def _check_points(points: Any) -> None:
 
 def _check_item(item: Any) -> None:
     """Un elemento della lista: breakpoint, gruppo, ciclo compatto o dict."""
-    if EnvelopeBuilder._is_compact_format(item):
+    if EnvelopeBuilder.is_compact_format(item):
         _check_compact(item)
         return
 
-    if EnvelopeBuilder._is_bp_group(item):
+    if EnvelopeBuilder.is_bp_group(item):
         _check_bp_group(item)
         return
 
-    if EnvelopeBuilder._is_3tuple_breakpoint(item):
+    if EnvelopeBuilder.is_3tuple_breakpoint(item):
         # Tag per-punto (issue #54): il type governa il segmento uscente.
         _check_interp(item[2])
         _check_direction_value(item[1])
@@ -256,7 +256,7 @@ def _check_bp_group(group: list) -> None:
     points, interp = group
     _check_interp(interp)
     # Solo l'arita': che `points` sia una lista di breakpoint piatti lo
-    # garantisce gia' `_is_bp_group`, che qui e' sempre passato.
+    # garantisce gia' `is_bp_group`, che qui e' sempre passato.
     if len(points) < 2:
         _reject(points, _GROUP_ARITY_HINT)
     _check_points(points)
@@ -265,11 +265,19 @@ def _check_bp_group(group: list) -> None:
 def _check_compact(compact: list) -> None:
     """Formato compatto: l'interp e' il quarto elemento, i valori stanno nel
     pattern. Di `end_time` si verifica il segno, che e' decidibile qui, non il
-    confronto con l'istante di partenza (vedi `_END_TIME_HINT`)."""
-    pattern = compact[0]
-    end_time = compact[1]
-    n_reps = compact[2]
-    interp = compact[3] if len(compact) >= 4 else None
+    confronto con l'istante di partenza (vedi `_END_TIME_HINT`).
+
+    Gli slot si leggono dalle costanti di `EnvelopeBuilder` (issue #213): il
+    layout della tupla e' suo, e questo modulo lo valida, non lo ridefinisce.
+    Con una copia propria degli indici, un giorno che il `time_dist_spec`
+    cambiasse posizione questa funzione avrebbe continuato a controllare lo
+    slot vecchio — in silenzio, perche' li' dentro ci sarebbe stato comunque
+    qualcosa di plausibile."""
+    pattern = compact[EnvelopeBuilder.COMPACT_PATTERN]
+    end_time = compact[EnvelopeBuilder.COMPACT_END_TIME]
+    n_reps = compact[EnvelopeBuilder.COMPACT_N_REPS]
+    interp = (compact[EnvelopeBuilder.COMPACT_INTERP]
+              if len(compact) > EnvelopeBuilder.COMPACT_INTERP else None)
     _check_interp(interp)
     # `end_time` deve superare l'istante da cui il ciclo parte, che non e' mai
     # negativo: il segno e' quindi decidibile qui, il confronto no. E il
@@ -277,7 +285,7 @@ def _check_compact(compact: list) -> None:
     if not _is_number(end_time) or end_time <= 0:
         _reject(end_time, _END_TIME_HINT)
     # Solo la natura di `n_reps`: che sia un `int` lo garantisce gia'
-    # `_is_compact_format`. Resta fuori il solo `bool`, che li' passa per
+    # `is_compact_format`. Resta fuori il solo `bool`, che li' passa per
     # sottoclasse e qui no, per la stessa ragione per cui `true` non e' `+1`:
     # senza questo `True < 1` e' falso, il guard non scatta e `range(True)`
     # rende un ciclo in silenzio.
@@ -291,15 +299,15 @@ def _check_compact(compact: list) -> None:
         precedente = point[0]
     # Solo se dichiarata: senza questo, ogni elemento compatto costruirebbe e
     # butterebbe via una LinearDistribution per non dire niente.
-    if len(compact) >= 5:
-        _check_time_dist(compact[4])
+    if len(compact) > EnvelopeBuilder.COMPACT_TIME_DIST:
+        _check_time_dist(compact[EnvelopeBuilder.COMPACT_TIME_DIST])
 
 
 def _check_time_dist(spec: Any) -> None:
     """La distribuzione temporale del ciclo: la valida il factory, costruendola.
 
     Qui non c'e' niente da decidere — il verso di lettura non ha una
-    distribuzione propria, e' quella dell'envelope. Ma `_is_compact_format`
+    distribuzione propria, e' quella dell'envelope. Ma `is_compact_format`
     accetta in quella posizione qualunque `str` o `dict`, e cio' che ne esce
     fallisce dentro `TimeDistributionFactory` con errori che non portano ne'
     il campo ne' lo stream_id — `ParameterBoundError` compreso, che sta nella
@@ -349,7 +357,7 @@ def _check_pattern_point(point: list, precedente: Any = None) -> None:
     """Un punto del pattern di un ciclo: `[x%, y]` o `[x%, y, type]`, piatto.
 
     Non passa da `_check_item` perche' li' le macro-forme sono ammesse, e qui
-    non lo sono: `_is_compact_format` filtra i punti del pattern sulla sola
+    non lo sono: `is_compact_format` filtra i punti del pattern sulla sola
     lunghezza (2 o 3) e un BP group e' lungo 2, quindi ci si infila: il builder
     poi fa `x_pct / 100.0` sul primo elemento e solleva un TypeError nudo.
 

--- a/src/pge/shared/exceptions.py
+++ b/src/pge/shared/exceptions.py
@@ -311,6 +311,7 @@ class ParameterBoundError(ConfigError):
         max_bound: float | None,
         value: float | None = None,
         violations: list[tuple[float, float]] | None = None,
+        hint: str | None = None,
     ):
         if value is None and not violations:
             raise TypeError("ParameterBoundError richiede 'value' o 'violations'")
@@ -320,6 +321,11 @@ class ParameterBoundError(ConfigError):
         self.violations = list(violations or [])
         self.min_bound = min_bound
         self.max_bound = max_bound
+        # Il vincolo violato non e' sempre un intervallo sul singolo valore
+        # (issue #212): `ratio ** n_reps` trabocca per la coppia, e la coppia
+        # non si stampa come [min, max]. L'hint la nomina, come nelle sorelle
+        # della stessa famiglia (InvalidFieldValueError, InvalidParameterError).
+        self.hint = hint
         if violations:
             base = f"Envelope '{param_name}' fuori bounds: {len(violations)} violazione(i)"
         else:
@@ -327,10 +333,15 @@ class ParameterBoundError(ConfigError):
         super().__init__(base)
 
     def user_message(self) -> str:
+        # Bounds entrambi ignoti: la riga non si stampa. Un intervallo che non
+        # esiste scritto come `[None, None]` e' rumore che sembra un dato.
+        ha_bounds = self.min_bound is not None or self.max_bound is not None
         bounds = f"[{self.min_bound}, {self.max_bound}]"
         if self.violations:
             head = f"[ERRORE] Envelope '{self.param_name}' fuori bounds"
-            lines = [head, f"  Bounds:       {bounds}"]
+            lines = [head]
+            if ha_bounds:
+                lines.append(f"  Bounds:       {bounds}")
             for t, y in self.violations:
                 lines.append(f"  t={t}: {self.value_type}={y}")
         else:
@@ -338,7 +349,10 @@ class ParameterBoundError(ConfigError):
             lines = [
                 head,
                 f"  {self.value_type}:        {self.value}",
-                f"  Bounds:       {bounds}",
             ]
+            if ha_bounds:
+                lines.append(f"  Bounds:       {bounds}")
+        if self.hint:
+            lines.append(f"  Hint:         {self.hint}")
         lines.extend(self._context_lines())
         return "\n".join(lines)

--- a/tests/core/test_stream_read_direction.py
+++ b/tests/core/test_stream_read_direction.py
@@ -418,7 +418,7 @@ class TestNienteValueErrorNudo:
     ])
     def test_distribuzione_temporale_non_costruibile(self, build, dist):
         """Il quinto elemento del formato compatto e' la distribuzione
-        temporale: `_is_compact_format` accetta li' qualunque `str` o `dict`,
+        temporale: `is_compact_format` accetta li' qualunque `str` o `dict`,
         e cio' che ne esce non e' sempre una distribuzione."""
         with pytest.raises(InvalidFieldValueError) as exc:
             build(grain={'read_direction':

--- a/tests/envelopes/test_envelope_bp_group.py
+++ b/tests/envelopes/test_envelope_bp_group.py
@@ -331,48 +331,48 @@ class TestBPGroupRecognition:
     """Disambiguazione shape: gruppo vs breakpoint vs 3-tuple vs loop block."""
 
     def test_group_recognized(self):
-        assert EnvelopeBuilder._is_bp_group([[[0.0, 0], [1.0, 1]], 'cubic']) is True
+        assert EnvelopeBuilder.is_bp_group([[[0.0, 0], [1.0, 1]], 'cubic']) is True
 
     def test_group_with_3tuple_point_recognized(self):
-        assert EnvelopeBuilder._is_bp_group(
+        assert EnvelopeBuilder.is_bp_group(
             [[[0.0, 0], [1.0, 1, 'step']], 'cubic']
         ) is True
 
     def test_group_with_invalid_interp_still_structurally_group(self):
-        # Come _is_3tuple_breakpoint: check strutturale, validazione dopo
-        assert EnvelopeBuilder._is_bp_group([[[0.0, 0], [1.0, 1]], 'qubic']) is True
+        # Come is_3tuple_breakpoint: check strutturale, validazione dopo
+        assert EnvelopeBuilder.is_bp_group([[[0.0, 0], [1.0, 1]], 'qubic']) is True
 
     def test_bare_breakpoint_not_group(self):
-        assert EnvelopeBuilder._is_bp_group([0.5, 1.0]) is False
+        assert EnvelopeBuilder.is_bp_group([0.5, 1.0]) is False
 
     def test_2elem_with_string_value_not_group(self):
-        assert EnvelopeBuilder._is_bp_group([0.5, 'cubic']) is False
+        assert EnvelopeBuilder.is_bp_group([0.5, 'cubic']) is False
 
     def test_single_point_with_marker_not_group(self):
         # elem[0] è UN punto [t, v], non una lista di punti
-        assert EnvelopeBuilder._is_bp_group([[0, 5], 'cycle']) is False
+        assert EnvelopeBuilder.is_bp_group([[0, 5], 'cycle']) is False
 
     def test_3tuple_breakpoint_not_group(self):
-        assert EnvelopeBuilder._is_bp_group([0.5, 1.0, 'cubic']) is False
+        assert EnvelopeBuilder.is_bp_group([0.5, 1.0, 'cubic']) is False
 
     def test_loop_blocks_not_group(self):
-        assert EnvelopeBuilder._is_bp_group([[[0, 0], [100, 1]], 0.4, 4]) is False
-        assert EnvelopeBuilder._is_bp_group(
+        assert EnvelopeBuilder.is_bp_group([[[0, 0], [100, 1]], 0.4, 4]) is False
+        assert EnvelopeBuilder.is_bp_group(
             [[[0, 0], [100, 1]], 0.4, 4, 'cubic', 'exponential']
         ) is False
 
     def test_group_not_compact_nor_3tuple(self):
         group = [[[0.0, 0], [1.0, 1]], 'cubic']
-        assert EnvelopeBuilder._is_compact_format(group) is False
-        assert EnvelopeBuilder._is_3tuple_breakpoint(group) is False
+        assert EnvelopeBuilder.is_compact_format(group) is False
+        assert EnvelopeBuilder.is_3tuple_breakpoint(group) is False
 
     def test_group_with_non_string_interp_not_group(self):
-        assert EnvelopeBuilder._is_bp_group([[[0.0, 0], [1.0, 1]], 4]) is False
+        assert EnvelopeBuilder.is_bp_group([[[0.0, 0], [1.0, 1]], 4]) is False
 
     def test_bool_poisoned_points_not_group(self):
-        assert EnvelopeBuilder._is_bp_group([[[True, 0], [1.0, 1]], 'cubic']) is False
-        assert EnvelopeBuilder._is_bp_group([[[0.0, True], [1.0, 1]], 'cubic']) is False
+        assert EnvelopeBuilder.is_bp_group([[[True, 0], [1.0, 1]], 'cubic']) is False
+        assert EnvelopeBuilder.is_bp_group([[[0.0, True], [1.0, 1]], 'cubic']) is False
 
     def test_plain_two_breakpoint_envelope_not_group(self):
         # Envelope nudo a 2 breakpoint: elem[1] non è stringa
-        assert EnvelopeBuilder._is_bp_group([[0.0, 0], [1.0, 1]]) is False
+        assert EnvelopeBuilder.is_bp_group([[0.0, 0], [1.0, 1]]) is False

--- a/tests/envelopes/test_envelope_builder.py
+++ b/tests/envelopes/test_envelope_builder.py
@@ -3,7 +3,7 @@
 Test suite COMPLETA per EnvelopeBuilder.
 
 Coverage:
-1. Test riconoscimento formato compatto (_is_compact_format)
+1. Test riconoscimento formato compatto (is_compact_format)
 2. Test espansione formato compatto (_expand_compact_format)
 3. Test estrazione tipo interpolazione (extract_interp_type)
 4. Test parse - formato diretto
@@ -92,69 +92,69 @@ def mixed_with_interp():
 # =============================================================================
 
 class TestIsCompactFormat:
-    """Test _is_compact_format() - riconoscimento pattern."""
+    """Test is_compact_format() - riconoscimento pattern."""
     
     def test_recognize_simple_compact(self, simple_compact):
         """Riconosce formato compatto semplice (3 elementi)."""
-        assert EnvelopeBuilder._is_compact_format(simple_compact)
+        assert EnvelopeBuilder.is_compact_format(simple_compact)
     
     def test_recognize_compact_with_interp(self, compact_with_interp):
         """Riconosce formato compatto con interpolazione (4 elementi)."""
-        assert EnvelopeBuilder._is_compact_format(compact_with_interp)
+        assert EnvelopeBuilder.is_compact_format(compact_with_interp)
     
     def test_recognize_compact_three_points(self, compact_three_points):
         """Riconosce formato compatto con 3 punti nel pattern."""
-        assert EnvelopeBuilder._is_compact_format(compact_three_points)
+        assert EnvelopeBuilder.is_compact_format(compact_three_points)
     
     def test_recognize_compact_single_rep(self, compact_single_rep):
         """Riconosce formato compatto con singola ripetizione."""
-        assert EnvelopeBuilder._is_compact_format(compact_single_rep)
+        assert EnvelopeBuilder.is_compact_format(compact_single_rep)
     
     def test_reject_legacy_breakpoint(self):
         """Rifiuta breakpoint legacy [t, v]."""
-        assert not EnvelopeBuilder._is_compact_format([0, 10])
+        assert not EnvelopeBuilder.is_compact_format([0, 10])
     
     def test_reject_legacy_list(self, legacy_breakpoints):
         """Rifiuta lista di breakpoints legacy."""
-        assert not EnvelopeBuilder._is_compact_format(legacy_breakpoints)
+        assert not EnvelopeBuilder.is_compact_format(legacy_breakpoints)
     
 
     
     def test_reject_empty_list(self):
         """Rifiuta lista vuota."""
-        assert not EnvelopeBuilder._is_compact_format([])
+        assert not EnvelopeBuilder.is_compact_format([])
     
     def test_reject_wrong_length(self):
         """Rifiuta liste con lunghezza sbagliata."""
-        assert not EnvelopeBuilder._is_compact_format([[[0, 0]], 0.4])  # 2 elementi (troppo pochi)
+        assert not EnvelopeBuilder.is_compact_format([[[0, 0]], 0.4])  # 2 elementi (troppo pochi)
         # 6° elemento (wrap) deve essere bool, non stringa
-        assert not EnvelopeBuilder._is_compact_format([[[0, 0]], 0.4, 4, 'linear', 'linear', 'altro'])
+        assert not EnvelopeBuilder.is_compact_format([[[0, 0]], 0.4, 4, 'linear', 'linear', 'altro'])
         # 7 elementi (troppi)
-        assert not EnvelopeBuilder._is_compact_format([[[0, 0]], 0.4, 4, 'linear', 'linear', True, 'extra'])
+        assert not EnvelopeBuilder.is_compact_format([[[0, 0]], 0.4, 4, 'linear', 'linear', True, 'extra'])
 
     def test_reject_non_list(self):
         """Rifiuta non-liste."""
-        assert not EnvelopeBuilder._is_compact_format(42)
-        assert not EnvelopeBuilder._is_compact_format("compact")
-        assert not EnvelopeBuilder._is_compact_format(None)
+        assert not EnvelopeBuilder.is_compact_format(42)
+        assert not EnvelopeBuilder.is_compact_format("compact")
+        assert not EnvelopeBuilder.is_compact_format(None)
     
     def test_reject_wrong_types(self):
         """Rifiuta tipi sbagliati negli elementi."""
         # Pattern non-lista
-        assert not EnvelopeBuilder._is_compact_format(["pattern", 0.4, 4])
+        assert not EnvelopeBuilder.is_compact_format(["pattern", 0.4, 4])
         
         # Total_time non-numero
-        assert not EnvelopeBuilder._is_compact_format([[[0, 0]], "0.4", 4])
+        assert not EnvelopeBuilder.is_compact_format([[[0, 0]], "0.4", 4])
         
         # N_reps non-int
-        assert not EnvelopeBuilder._is_compact_format([[[0, 0]], 0.4, 4.5])
+        assert not EnvelopeBuilder.is_compact_format([[[0, 0]], 0.4, 4.5])
         
         # Interp_type non-string
-        assert not EnvelopeBuilder._is_compact_format([[[0, 0]], 0.4, 4, 123])
+        assert not EnvelopeBuilder.is_compact_format([[[0, 0]], 0.4, 4, 123])
     
     def test_accept_empty_pattern(self):
         """Accetta pattern vuoto (validazione in expand)."""
-        assert EnvelopeBuilder._is_compact_format([[], 0.4, 4])
+        assert EnvelopeBuilder.is_compact_format([[], 0.4, 4])
 
 
 # =============================================================================
@@ -777,11 +777,11 @@ class TestRobustnessMalformedInput:
         assert len(expanded) == 4  # 2*2 + 1
     
     def test_float_n_reps_rejected(self):
-        """n_reps float rifiutato da _is_compact_format."""
+        """n_reps float rifiutato da is_compact_format."""
         compact = [[[0, 0], [100, 1]], 0.4, 4.5]
         
-        # _is_compact_format deve rifiutare
-        assert not EnvelopeBuilder._is_compact_format(compact)
+        # is_compact_format deve rifiutare
+        assert not EnvelopeBuilder.is_compact_format(compact)
 
     # Test aggiuntivi per _log_compact_transformation (da aggiungere a TestLoggingTransformations)
 
@@ -968,7 +968,7 @@ class TestEnvelopeBuilderMissingLines:
         """
         # 5 elementi con quinto elemento intero (non str, non dict)
         item = [[[0, 0], [100, 1]], 1.0, 2, 'linear', 42]
-        assert EnvelopeBuilder._is_compact_format(item) is False
+        assert EnvelopeBuilder.is_compact_format(item) is False
 
     def test_log_compact_transformation_with_time_dist_spec(self):
         """
@@ -1054,3 +1054,78 @@ class TestLogTransformationsFlag:
         )
 
         assert mock_logger.info.called
+
+# =============================================================================
+# 15. SUPERFICIE PUBBLICA E INDICI DEL FORMATO COMPATTO (issue #213)
+# =============================================================================
+
+class TestSuperficiePubblica:
+    """I tre riconoscitori di forma sono pubblici (issue #213, punto 1).
+
+    `read_direction.py` e' l'unico chiamante fuori da `pge.envelopes`, e
+    chiamava tre metodi privati. Usarli era la scelta giusta — riconoscere le
+    forme da capo sarebbe stata duplicazione peggiore, ed e' cio' che garantisce
+    che validatore e costruttore riconoscano *le stesse* forme — ma allora la
+    superficie deve dirlo.
+    """
+
+    def test_i_riconoscitori_sono_pubblici(self):
+        assert EnvelopeBuilder.is_compact_format([[[0, 0], [100, 1]], 0.4, 4])
+        assert EnvelopeBuilder.is_bp_group([[[0, 0], [1, 1]], 'linear'])
+        assert EnvelopeBuilder.is_3tuple_breakpoint([0.5, 1.0, 'cubic'])
+
+    @pytest.mark.parametrize("privato", [
+        '_is_compact_format',
+        '_is_bp_group',
+        '_is_3tuple_breakpoint',
+    ])
+    def test_nessun_alias_privato_dietro(self, privato):
+        """Promuovere e lasciare l'alias sarebbe due nomi per una cosa sola.
+
+        Con i chiamanti aggiornati insieme non serve una transizione: l'alias
+        sopravviverebbe a se stesso e il prossimo chiamante sceglierebbe a caso.
+        """
+        assert not hasattr(EnvelopeBuilder, privato)
+
+
+class TestIndiciFormatoCompatto:
+    """Gli slot del formato compatto hanno un nome (issue #213, punto 2).
+
+    Il rischio non era un errore ma un silenzio: i due lati — chi espande e chi
+    valida — decodificavano le stesse posizioni per conto proprio, quindi se il
+    `time_dist_spec` avesse cambiato slot il validatore avrebbe continuato a
+    controllare quello vecchio senza che nessun test se ne accorgesse. Con una
+    costante sola letta da entrambi, quel disallineamento non e' esprimibile.
+    """
+
+    def test_gli_slot_sono_nominati(self):
+        assert EnvelopeBuilder.COMPACT_PATTERN == 0
+        assert EnvelopeBuilder.COMPACT_END_TIME == 1
+        assert EnvelopeBuilder.COMPACT_N_REPS == 2
+        assert EnvelopeBuilder.COMPACT_INTERP == 3
+        assert EnvelopeBuilder.COMPACT_TIME_DIST == 4
+        assert EnvelopeBuilder.COMPACT_WRAP == 5
+
+    def test_l_espansione_legge_gli_slot_nominati(self):
+        """Un compatto costruito per posizione a partire dalle costanti.
+
+        Se un giorno le costanti cambiassero valore, questo test cambierebbe
+        con loro — ed e' esattamente il punto: il layout esiste in un posto
+        solo, e chi lo legge non puo' averne una copia propria.
+        """
+        compatto = [None] * 6
+        compatto[EnvelopeBuilder.COMPACT_PATTERN] = [[0, 0], [100, 1]]
+        compatto[EnvelopeBuilder.COMPACT_END_TIME] = 1.0
+        compatto[EnvelopeBuilder.COMPACT_N_REPS] = 2
+        compatto[EnvelopeBuilder.COMPACT_INTERP] = 'step'
+        compatto[EnvelopeBuilder.COMPACT_TIME_DIST] = 'linear'
+        compatto[EnvelopeBuilder.COMPACT_WRAP] = False
+
+        assert EnvelopeBuilder.is_compact_format(compatto)
+
+        espanso = EnvelopeBuilder._expand_compact_format(compatto)
+
+        # Due cicli sul pattern a due punti, ultimo breakpoint a end_time.
+        assert len(espanso) == 4
+        assert espanso[-1][0] == pytest.approx(1.0)
+        assert EnvelopeBuilder.extract_interp_type(compatto) == 'step'

--- a/tests/envelopes/test_envelope_builder.py
+++ b/tests/envelopes/test_envelope_builder.py
@@ -22,6 +22,7 @@ Coverage:
 import pytest
 from unittest.mock import patch, MagicMock, call
 from pge.envelopes.envelope_builder import EnvelopeBuilder, detect_format_type
+from pge.shared.exceptions import InvalidFieldValueError
 
 
 # =============================================================================
@@ -1129,3 +1130,44 @@ class TestIndiciFormatoCompatto:
         assert len(espanso) == 4
         assert espanso[-1][0] == pytest.approx(1.0)
         assert EnvelopeBuilder.extract_interp_type(compatto) == 'step'
+
+    def test_il_validatore_segue_gli_slot_insieme_all_espansione(self, monkeypatch):
+        """Il lato che valida si muove con quello che espande.
+
+        Il test qui sopra fissa una meta' dell'invariante: che l'espansione
+        legga le costanti. Ma il rischio di #213 e' il *disallineamento* fra i
+        due lati, e nessuno lo osserva finche' non si muove il layout.
+
+        Qui il layout si muove davvero: `n_reps` e `end_time` si scambiano di
+        posto nelle costanti, e i due lati devono seguire lo scambio. Chi
+        avesse una copia propria degli indici resterebbe sul layout vecchio —
+        dove nella lista permutata c'e' comunque qualcosa di plausibile, che e'
+        il motivo per cui il guasto sarebbe silenzioso.
+
+        `is_compact_format` non e' toccata di proposito: e' lei a *definire* il
+        layout per posizione, quindi le due funzioni si chiamano dirette, come
+        fa il builder dopo che il riconoscimento e' gia' avvenuto.
+        """
+        from pge.parameters import read_direction
+
+        monkeypatch.setattr(EnvelopeBuilder, 'COMPACT_END_TIME', 2)
+        monkeypatch.setattr(EnvelopeBuilder, 'COMPACT_N_REPS', 1)
+
+        # Lista scritta nel layout permutato: n_reps allo slot 1, end_time al 2.
+        permutato = [[[0, -1], [100, 1]], 3, 1.0, 'step']
+
+        # Lato che espande: tre cicli su un pattern a due punti, fine a 1.0.
+        espanso = EnvelopeBuilder._expand_compact_format(permutato)
+        assert len(espanso) == 6
+        assert espanso[-1][0] == pytest.approx(1.0)
+
+        # Lato che valida: accetta lo stesso corpo.
+        read_direction._check_compact(permutato)
+
+        # E rifiuta `n_reps` dove le costanti dicono che sta ora. Un validatore
+        # fermo al layout vecchio rifiuterebbe anche lui, ma come `end_time`:
+        # e' l'hint a dire quale dei due slot ha davvero letto.
+        rotto = [[[0, -1], [100, 1]], 0, 1.0, 'step']
+        with pytest.raises(InvalidFieldValueError) as exc_info:
+            read_direction._check_compact(rotto)
+        assert exc_info.value.hint == read_direction._REPS_ARITY_HINT

--- a/tests/envelopes/test_envelope_builder.py
+++ b/tests/envelopes/test_envelope_builder.py
@@ -1131,6 +1131,27 @@ class TestIndiciFormatoCompatto:
         assert espanso[-1][0] == pytest.approx(1.0)
         assert EnvelopeBuilder.extract_interp_type(compatto) == 'step'
 
+    def test_l_estrazione_dell_interp_segue_lo_slot(self, monkeypatch):
+        """Anche chi legge il solo interp lo legge dalla costante.
+
+        `extract_interp_type` decodificava lo slot con un `3` scritto a mano,
+        due volte (il compatto diretto e quello dentro una lista mista). Con
+        l'interp spostato di posto tornava `None` invece del tipo dichiarato:
+        non un errore, un envelope interpolato col default.
+
+        Qui lo slot 3 resta occupato da `None` — cosi' la lista e' ancora un
+        compatto valido per `is_compact_format`, che il layout lo definisce e
+        non va toccata — e l'interp vero sta al 4.
+        """
+        monkeypatch.setattr(EnvelopeBuilder, 'COMPACT_INTERP', 4)
+
+        compatto = [[[0, 0], [100, 1]], 1.0, 2, None, 'step']
+        assert EnvelopeBuilder.is_compact_format(compatto)
+
+        assert EnvelopeBuilder.extract_interp_type(compatto) == 'step'
+        # Stessa cosa per il compatto annidato in una lista mista.
+        assert EnvelopeBuilder.extract_interp_type([compatto]) == 'step'
+
     def test_il_validatore_segue_gli_slot_insieme_all_espansione(self, monkeypatch):
         """Il lato che valida si muove con quello che espande.
 

--- a/tests/envelopes/test_envelope_per_point_interp.py
+++ b/tests/envelopes/test_envelope_per_point_interp.py
@@ -47,23 +47,23 @@ class TestParserDisambiguation:
     """Disambiguazione tra compact format e 3-tuple breakpoint."""
 
     def test_3tuple_not_recognized_as_compact(self):
-        assert EnvelopeBuilder._is_compact_format([0.5, 1.0, 'cubic']) is False
+        assert EnvelopeBuilder.is_compact_format([0.5, 1.0, 'cubic']) is False
 
     def test_compact_not_recognized_as_3tuple(self):
-        assert EnvelopeBuilder._is_3tuple_breakpoint(
+        assert EnvelopeBuilder.is_3tuple_breakpoint(
             [[[0, 0], [100, 1]], 0.4, 4]
         ) is False
 
     def test_compact_still_recognized(self):
-        assert EnvelopeBuilder._is_compact_format(
+        assert EnvelopeBuilder.is_compact_format(
             [[[0, 0], [100, 1]], 0.4, 4]
         ) is True
 
     def test_3tuple_recognized(self):
-        assert EnvelopeBuilder._is_3tuple_breakpoint([0.5, 1.0, 'cubic']) is True
+        assert EnvelopeBuilder.is_3tuple_breakpoint([0.5, 1.0, 'cubic']) is True
 
     def test_2elem_not_3tuple(self):
-        assert EnvelopeBuilder._is_3tuple_breakpoint([0.5, 1.0]) is False
+        assert EnvelopeBuilder.is_3tuple_breakpoint([0.5, 1.0]) is False
 
     def test_invalid_2elem_with_string_raises(self):
         # Forma vietata: [0.5, 'cubic'] — elem[1] non numerico
@@ -73,31 +73,31 @@ class TestParserDisambiguation:
     def test_compact_4elem_not_3tuple(self):
         # Compact con interp: 4 elem → non confondibile con 3-tuple
         item = [[[0, 0], [100, 1]], 0.4, 4, 'cubic']
-        assert EnvelopeBuilder._is_compact_format(item) is True
-        assert EnvelopeBuilder._is_3tuple_breakpoint(item) is False
+        assert EnvelopeBuilder.is_compact_format(item) is True
+        assert EnvelopeBuilder.is_3tuple_breakpoint(item) is False
 
     def test_compact_5elem_not_3tuple(self):
         # Compact con time_dist: 5 elem
         item = [[[0, 0], [100, 1]], 0.4, 4, 'cubic', 'exponential']
-        assert EnvelopeBuilder._is_compact_format(item) is True
-        assert EnvelopeBuilder._is_3tuple_breakpoint(item) is False
+        assert EnvelopeBuilder.is_compact_format(item) is True
+        assert EnvelopeBuilder.is_3tuple_breakpoint(item) is False
 
     def test_3tuple_with_negative_time(self):
         # 3-tuple con t negativo riconosciuto
-        assert EnvelopeBuilder._is_3tuple_breakpoint([-0.5, 1, 'cubic']) is True
+        assert EnvelopeBuilder.is_3tuple_breakpoint([-0.5, 1, 'cubic']) is True
 
     def test_3tuple_with_int_time_and_value(self):
         # 3-tuple con int (non float) riconosciuto
-        assert EnvelopeBuilder._is_3tuple_breakpoint([0, 1, 'step']) is True
+        assert EnvelopeBuilder.is_3tuple_breakpoint([0, 1, 'step']) is True
 
     def test_3tuple_with_bool_rejected(self):
         # bool è sottoclasse di int — non deve passare
-        assert EnvelopeBuilder._is_3tuple_breakpoint([True, 1, 'step']) is False
-        assert EnvelopeBuilder._is_3tuple_breakpoint([0, True, 'step']) is False
+        assert EnvelopeBuilder.is_3tuple_breakpoint([True, 1, 'step']) is False
+        assert EnvelopeBuilder.is_3tuple_breakpoint([0, True, 'step']) is False
 
     def test_3tuple_with_invalid_type_string_still_recognized_as_3tuple(self):
-        # _is_3tuple_breakpoint solo struttura; validazione type avviene dopo
-        assert EnvelopeBuilder._is_3tuple_breakpoint([0, 1, 'foo']) is True
+        # is_3tuple_breakpoint solo struttura; validazione type avviene dopo
+        assert EnvelopeBuilder.is_3tuple_breakpoint([0, 1, 'foo']) is True
 
     def test_legacy_dict_format_still_works(self):
         # Vecchio dict {type, points} con bare [t,v] continua a funzionare
@@ -122,8 +122,8 @@ class TestParserDisambiguation:
 
     def test_empty_3tuple_breakpoint(self):
         # Lista vuota non confondibile
-        assert EnvelopeBuilder._is_3tuple_breakpoint([]) is False
-        assert EnvelopeBuilder._is_compact_format([]) is False
+        assert EnvelopeBuilder.is_3tuple_breakpoint([]) is False
+        assert EnvelopeBuilder.is_compact_format([]) is False
 
     def test_3tuple_passed_as_raw_envelope_not_misread(self):
         # Envelope([0.5, 1, 'cubic']) → iter sugli elementi 0.5, 1, 'cubic' → errore

--- a/tests/envelopes/test_envelope_wrap.py
+++ b/tests/envelopes/test_envelope_wrap.py
@@ -19,34 +19,34 @@ from pge.envelopes.envelope import Envelope
 # =============================================================================
 
 class TestWrapParser:
-    """Test _is_compact_format con 6° elemento wrap."""
+    """Test is_compact_format con 6° elemento wrap."""
 
     def test_accept_wrap_true(self):
-        assert EnvelopeBuilder._is_compact_format(
+        assert EnvelopeBuilder.is_compact_format(
             [[[0, 0], [50, 1]], 1.0, 2, 'linear', None, True]
         )
 
     def test_accept_wrap_false(self):
-        assert EnvelopeBuilder._is_compact_format(
+        assert EnvelopeBuilder.is_compact_format(
             [[[0, 0], [50, 1]], 1.0, 2, 'linear', None, False]
         )
 
     def test_accept_wrap_none(self):
         """None ammesso (default False)."""
-        assert EnvelopeBuilder._is_compact_format(
+        assert EnvelopeBuilder.is_compact_format(
             [[[0, 0], [50, 1]], 1.0, 2, 'linear', None, None]
         )
 
     def test_reject_wrap_non_bool(self):
-        assert not EnvelopeBuilder._is_compact_format(
+        assert not EnvelopeBuilder.is_compact_format(
             [[[0, 0], [50, 1]], 1.0, 2, 'linear', None, 'wrap']
         )
-        assert not EnvelopeBuilder._is_compact_format(
+        assert not EnvelopeBuilder.is_compact_format(
             [[[0, 0], [50, 1]], 1.0, 2, 'linear', None, 1]
         )
 
     def test_reject_7_elements(self):
-        assert not EnvelopeBuilder._is_compact_format(
+        assert not EnvelopeBuilder.is_compact_format(
             [[[0, 0]], 1.0, 2, 'linear', None, True, 'extra']
         )
 

--- a/tests/envelopes/test_time_distribution.py
+++ b/tests/envelopes/test_time_distribution.py
@@ -601,5 +601,81 @@ class TestDistributionsDifferInShape:
                 starts, durations, self.TOTAL_TIME) is True
 
 
+# =============================================================================
+# 6. OVERFLOW DELLE POTENZE (issue #212)
+# =============================================================================
+
+class TestOverflowDellePotenze:
+    """Le tre potenze del registro traboccano, e lo dicono (issue #212).
+
+    Nessuna delle tre e' un bound sul singolo valore: `ratio: 10` e
+    `n_reps: 400` sono entrambi legittimi, e insieme chiedono `10 ** 400`.
+    Per questo l'intercettazione sta dove il calcolo avviene e non nel
+    costruttore — la soglia dipende dai due valori insieme, e il costruttore
+    `n_reps` non lo vede nemmeno.
+
+    Prima di #212 l'`OverflowError` di CPython risaliva nudo: fuori dalla
+    gerarchia `EngineError`, senza campo, senza stream_id, e con un testo
+    ("integer division result too large for a float") che non nomina nessuna
+    delle due cose da cambiare.
+    """
+
+    # (distribuzione, parametro, valore che trabocca, n_reps che lo fa
+    #  traboccare, n_reps innocuo con lo stesso valore)
+    COPPIE = [
+        # Repro della issue: geometric con ratio grande.
+        (GeometricDistribution, 'ratio', 10, 400, 2),
+        # Repro della issue: exponential con rate infinitesimo. Il peso e'
+        # `rate ** -i`, quindi a traboccare e' l'inverso di un numero piccolo.
+        (ExponentialDistribution, 'rate', 1e-300, 400, 2),
+        # `power` non ha bound sull'esponente, che e' proprio il motivo per cui
+        # puo' esplodere: qualunque reale e' legittimo, e qui bastano due cicli.
+        (PowerDistribution, 'exponent', 1e10, 2, 1),
+    ]
+
+    @pytest.mark.parametrize("dist,parametro,valore,n_reps,_innocuo", COPPIE)
+    def test_overflow_diventa_parameter_bound_error(
+            self, dist, parametro, valore, n_reps, _innocuo):
+        """L'errore nomina ENTRAMBI i valori, il parametro e `n_reps`.
+
+        Senza entrambi l'utente non sa quale ridurre: non c'e' un colpevole,
+        c'e' una coppia.
+        """
+        from pge.shared.exceptions import ParameterBoundError
+
+        with pytest.raises(ParameterBoundError) as exc:
+            dist(**{parametro: valore}).calculate_distribution(10.0, n_reps)
+
+        messaggio = exc.value.user_message()
+        assert parametro in messaggio
+        assert str(valore) in messaggio
+        assert 'n_reps' in messaggio
+        assert str(n_reps) in messaggio
+
+    def test_resta_dentro_la_gerarchia_engine_error(self):
+        """Catturabile come EngineError: e' un errore di configurazione."""
+        from pge.shared.exceptions import ConfigError, EngineError
+
+        with pytest.raises(EngineError) as exc:
+            GeometricDistribution(ratio=10).calculate_distribution(10.0, 400)
+
+        assert isinstance(exc.value, ConfigError)
+        assert isinstance(exc.value, ValueError)
+
+    @pytest.mark.parametrize("dist,parametro,valore,_n_reps,innocuo", COPPIE)
+    def test_la_coppia_innocua_continua_a_rendere(
+            self, dist, parametro, valore, _n_reps, innocuo):
+        """Gli stessi valori con meno cicli non hanno mai avuto un problema.
+
+        La controprova che il rifiuto e' della coppia e non del valore: nessuno
+        dei tre e' diventato un bound del costruttore.
+        """
+        starts, durations = dist(
+            **{parametro: valore}).calculate_distribution(10.0, innocuo)
+
+        assert len(durations) == innocuo
+        assert sum(durations) == pytest.approx(10.0)
+
+
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])

--- a/tests/envelopes/test_time_distribution.py
+++ b/tests/envelopes/test_time_distribution.py
@@ -662,6 +662,41 @@ class TestOverflowDellePotenze:
         assert isinstance(exc.value, ConfigError)
         assert isinstance(exc.value, ValueError)
 
+    # (distribuzione, parametro, valore, n_reps, rimedio atteso)
+    RIMEDI = [
+        (GeometricDistribution, 'ratio', 10, 400, 'avvicina ratio a 1'),
+        (ExponentialDistribution, 'rate', 1e-300, 400, 'avvicina rate a 1'),
+        (PowerDistribution, 'exponent', 1e10, 2,
+         'riduci exponent in valore assoluto'),
+    ]
+
+    @pytest.mark.parametrize("dist,parametro,valore,n_reps,rimedio", RIMEDI)
+    def test_il_rimedio_e_quello_della_famiglia(
+            self, dist, parametro, valore, n_reps, rimedio):
+        """Il consiglio finale cambia col parametro, perche' non e' lo stesso.
+
+        `ratio` e `rate` sono fattori: si va verso 1, dove la progressione
+        diventa uniforme e la potenza smette di crescere. `exponent` no — 1 e'
+        un esponente perfettamente ordinario, e' `1e10` a essere fuori scala.
+        Dire "avvicina exponent a 1" manderebbe l'utente verso un valore che
+        non e' ne' il problema ne' la soluzione.
+        """
+        from pge.shared.exceptions import ParameterBoundError
+
+        with pytest.raises(ParameterBoundError) as exc:
+            dist(**{parametro: valore}).calculate_distribution(10.0, n_reps)
+
+        assert rimedio in exc.value.hint
+
+    def test_il_rimedio_della_power_non_parla_di_1(self):
+        """La controprova: il testo tarato sui fattori non e' rimasto sotto."""
+        from pge.shared.exceptions import ParameterBoundError
+
+        with pytest.raises(ParameterBoundError) as exc:
+            PowerDistribution(exponent=1e10).calculate_distribution(10.0, 2)
+
+        assert 'avvicina exponent a 1' not in exc.value.hint
+
     @pytest.mark.parametrize("dist,parametro,valore,_n_reps,innocuo", COPPIE)
     def test_la_coppia_innocua_continua_a_rendere(
             self, dist, parametro, valore, _n_reps, innocuo):

--- a/tests/parameters/test_deviation_probability_scritture.py
+++ b/tests/parameters/test_deviation_probability_scritture.py
@@ -1,0 +1,106 @@
+# =============================================================================
+# tests/parameters/test_deviation_probability_scritture.py
+# =============================================================================
+"""
+Il contratto delle scritture di `deviation_probability` (issue #209, #210).
+
+Otto modi di scrivere la chiave e il gate che ne esce. La tabella sta qui
+perche' altrimenti l'unica cosa che la sostiene e' la documentazione: le
+cinque scritture "vuote" di #210 non cambiano comportamento — restano quelle
+misurate nel corpo di quella issue — e cio' che non cambia non lo protegge
+nessun test a meno che non lo si scriva apposta.
+
+    deviation_probability OMESSA          -> NeverGate                (#210)
+    deviation_probability:  (cioe' None)  -> jitter implicito         (#210)
+    deviation_probability: {}             -> NeverGate                (#210)
+    deviation_probability: false          -> NeverGate                (#210)
+    {read_direction: null}                -> NeverGate                (#210)
+    {read_direction: {punti: [[0, 50]]}}  -> InvalidFieldValueError   (#209)
+    {read_direction: ['x']}               -> InvalidFieldValueError   (#209)
+    {read_direction: []}                  -> InvalidFieldValueError   (#209)
+
+La riga che vale la pena non spostare e' la seconda: la chiave **scritta e
+lasciata vuota** e' l'unica delle cinque a non dare `NeverGate`. E' la
+scrittura che piu' assomiglia a "non voglio deviazione" e fa l'opposto —
+applica `DEFAULT_PROB`, l'1% di jitter implicito — ma e' una scelta di design
+che precede #208, e #210 ha deciso di documentarla, non di cambiarla.
+
+Le ultime tre sono corpi malformati che fino a #209 davano `AlwaysGate`, cioe'
+il ribaltamento del 100% dei grani su un verso di lettura dichiarato: da li'
+in poi sono un errore di scrittura come ogni altro.
+
+Il gate e' letto su `read_direction` senza `_range` esplicito (la chiave non
+ne ha uno), che e' la condizione in cui la tabella di #210 e' stata misurata:
+con un `_range` dichiarato le righe `NeverGate` darebbero `AlwaysGate`, che e'
+la semantica *range-only* e non ha niente a che vedere con queste scritture.
+"""
+import pytest
+
+from pge.parameters.gate_factory import GateFactory
+from pge.parameters.parameter_definitions import DEFAULT_PROB
+from pge.shared.exceptions import InvalidFieldValueError
+from pge.shared.probability_gate import NeverGate, RandomGate
+
+# Il valore che StreamConfig porta quando la chiave e' assente dallo YAML
+# (`stream_config.py`): la chiave omessa non e' `None`, e' `False`.
+OMESSA = False
+
+
+def _gate(deviation_probability):
+    return GateFactory.create_gate(
+        deviation_probability=deviation_probability,
+        param_key='read_direction',
+        default_prob=DEFAULT_PROB,
+        has_explicit_range=False,
+        range_always_active=False,
+        duration=1.0,
+        time_mode='absolute',
+    )
+
+
+class TestScrittureVuote:
+    """Le cinque scritture di #210: nessuna cambia comportamento."""
+
+    @pytest.mark.parametrize("scrittura", [
+        OMESSA,
+        {},
+        False,
+        {'read_direction': None},
+    ])
+    def test_niente_deviazione(self, scrittura):
+        """Quattro scritture su cinque: nessuna variazione sul parametro."""
+        assert isinstance(_gate(scrittura), NeverGate)
+
+    def test_chiave_vuota_applica_il_jitter_implicito(self):
+        """`deviation_probability:` senza valore -> `DEFAULT_PROB`.
+
+        L'unica delle cinque a non dare `NeverGate`, ed e' il motivo per cui
+        #210 esiste. Il test la fissa: se un giorno la si volesse rendere
+        equivalente alla chiave assente, e' una decisione da prendere, non un
+        effetto collaterale da scoprire dopo.
+        """
+        gate = _gate(None)
+        assert isinstance(gate, RandomGate)
+        assert gate.get_probability_value(0.0) == pytest.approx(DEFAULT_PROB)
+
+
+class TestCorpiMalformati:
+    """Le tre righe di #209: da `AlwaysGate` silenzioso a errore esplicito."""
+
+    @pytest.mark.parametrize("corpo", [
+        {'punti': [[0, 50]]},   # dict senza `points`: KeyError nel builder
+        ['x'],                  # lista di non-breakpoint
+        [],                     # lista vuota
+    ])
+    def test_envelope_malformato_alza_errore(self, corpo):
+        """Un envelope che non si costruisce e' un errore di scrittura.
+
+        Prima di #209 questi tre corpi tornavano `AlwaysGate` e loggavano:
+        il gate piu' lontano da quanto scritto, applicato al 100% dei grani.
+        """
+        with pytest.raises(InvalidFieldValueError) as exc:
+            _gate({'read_direction': corpo})
+
+        assert exc.value.field == 'deviation_probability.read_direction'
+        assert exc.value.value == corpo
+        assert exc.value.hint

--- a/tests/parameters/test_deviation_probability_scritture.py
+++ b/tests/parameters/test_deviation_probability_scritture.py
@@ -34,16 +34,25 @@ ne ha uno), che e' la condizione in cui la tabella di #210 e' stata misurata:
 con un `_range` dichiarato le righe `NeverGate` darebbero `AlwaysGate`, che e'
 la semantica *range-only* e non ha niente a che vedere con queste scritture.
 """
+from dataclasses import fields
+
 import pytest
 
+from pge.core.stream_config import StreamConfig
 from pge.parameters.gate_factory import GateFactory
 from pge.parameters.parameter_definitions import DEFAULT_PROB
 from pge.shared.exceptions import InvalidFieldValueError
 from pge.shared.probability_gate import NeverGate, RandomGate
 
-# Il valore che StreamConfig porta quando la chiave e' assente dallo YAML
-# (`stream_config.py`): la chiave omessa non e' `None`, e' `False`.
-OMESSA = False
+# Il valore che StreamConfig porta quando la chiave e' assente dallo YAML: la
+# chiave omessa non e' `None`, e' `False`. Letto dal default reale invece che
+# ricopiato — scritto a mano, questo era un secondo `False` che non seguiva il
+# primo: cambiando il default in `stream_config.py` la tabella qui sotto
+# restava verde continuando a misurare la scrittura sbagliata.
+OMESSA = next(
+    campo.default for campo in fields(StreamConfig)
+    if campo.name == 'deviation_probability'
+)
 
 
 def _gate(deviation_probability):

--- a/tests/parameters/test_gate_factory.py
+++ b/tests/parameters/test_gate_factory.py
@@ -29,6 +29,7 @@ from pge.shared.probability_gate import (
     ProbabilityGate, NeverGate, AlwaysGate, RandomGate, EnvelopeGate
 )
 from pge.envelopes.envelope import Envelope
+from pge.shared.exceptions import InvalidFieldValueError
 
 
 # =============================================================================
@@ -710,32 +711,34 @@ class TestParseRawValue:
         # Con normalized: t=1.0*5.0=5.0
         assert gate.get_probability_value(5.0) == pytest.approx(100.0)
 
-    def test_malformed_envelope_returns_always_gate_fallback(self):
-        """Envelope malformato (lista vuota) → fallback AlwaysGate."""
-        # Lista vuota causa "Envelope deve contenere almeno un breakpoint"
-        gate = GateFactory._parse_raw_value(
-            [], duration=1.0, time_mode='absolute'
-        )
-        assert isinstance(gate, AlwaysGate)
+    def test_malformed_envelope_raises(self):
+        """Envelope malformato (lista vuota) → InvalidFieldValueError (issue #209).
 
-    def test_envelope_generic_error_fallback(self):
-        """Dict senza 'points' → fallback AlwaysGate (KeyError interno)."""
-        gate = GateFactory._parse_raw_value(
-            {"not_points": "invalid"}, duration=1.0, time_mode='absolute'
-        )
-        assert isinstance(gate, AlwaysGate)
-
-    def test_malformed_envelope_logs_error(self, caplog):
-        """Fallback per envelope malformato logga l'errore."""
-        with caplog.at_level(logging.ERROR):
+        Tornava `AlwaysGate`: il gate piu' lontano da quanto scritto, applicato
+        al 100% dei grani, per un envelope che non si costruisce.
+        """
+        with pytest.raises(InvalidFieldValueError):
             GateFactory._parse_raw_value([], duration=1.0, time_mode='absolute')
-        
-        assert any("Envelope deviation_probability invalido" in record.message for record in caplog.records)
-        """Fallback per envelope malformato logga l'errore."""
+
+    def test_envelope_generic_error_raises(self):
+        """Dict senza 'points' → InvalidFieldValueError (era KeyError interno)."""
+        with pytest.raises(InvalidFieldValueError):
+            GateFactory._parse_raw_value(
+                {"not_points": "invalid"}, duration=1.0, time_mode='absolute'
+            )
+
+    def test_malformed_envelope_does_not_log(self, caplog):
+        """Nessun log di fallback: non c'e' piu' un fallback (issue #209)."""
         with caplog.at_level(logging.ERROR):
-            GateFactory._parse_raw_value([1, 2, 3], duration=1.0, time_mode='absolute')
-        
-        assert any("Envelope deviation_probability invalido" in record.message for record in caplog.records)
+            with pytest.raises(InvalidFieldValueError):
+                GateFactory._parse_raw_value(
+                    [1, 2, 3], duration=1.0, time_mode='absolute'
+                )
+
+        assert not any(
+            "Envelope deviation_probability invalido" in record.getMessage()
+            for record in caplog.records
+        )
 
     # --- Tipo invalido ---
 

--- a/tests/parameters/test_gate_factory.py
+++ b/tests/parameters/test_gate_factory.py
@@ -1115,3 +1115,33 @@ class TestCreateGateFallthrough:
             )
 
         assert isinstance(gate, NeverGate)
+
+def test_envelope_gia_costruito_e_respinto_come_envelope_non_come_tipo():
+    """Un `Envelope` gia' costruito non si ricostruisce, e lo dice come tale.
+
+    Non arriva dallo YAML — arriva da chi chiama la factory con un envelope in
+    mano. `_is_envelope_like` lo riconosce da sempre (e' il suo primo caso),
+    quindi il corpo entra dal ramo envelope e ne esce con l'errore di quel
+    ramo: campo `deviation_probability.volume`, non "tipo non supportato".
+
+    Che poi `create_scaled_envelope` non sappia ricostruire un `Envelope` e'
+    un'altra questione, aperta prima di questa PR. Qui conta *da quale ramo*
+    passa: nessun test lo osservava, e il ramo si poteva rimuovere lasciando
+    la suite verde.
+    """
+    from pge.envelopes.envelope import Envelope
+    from pge.shared.exceptions import InvalidFieldValueError
+
+    envelope = Envelope([[0.0, 0.0], [1.0, 100.0]])
+
+    with pytest.raises(InvalidFieldValueError) as exc_info:
+        GateFactory.create_gate(
+            deviation_probability={'volume': envelope},
+            param_key='volume',
+            default_prob=1.0,
+            has_explicit_range=False,
+            duration=1.0,
+            time_mode='absolute',
+        )
+
+    assert exc_info.value.field == 'deviation_probability.volume'

--- a/tests/parameters/test_gate_factory_errors.py
+++ b/tests/parameters/test_gate_factory_errors.py
@@ -18,6 +18,7 @@ from pge.shared.exceptions import (
     ConfigError,
     InvalidFieldValueError,
     InvalidParameterError,
+    ParameterBoundError,
 )
 
 
@@ -119,3 +120,26 @@ def test_parse_raw_value_invalid_type_raises_invalid_parameter_error():
     err = exc_info.value
     assert isinstance(err, ConfigError)
     assert "deviation_probability" in err.param_name
+
+
+def test_engine_error_del_builder_risale_intatto():
+    """L'`EngineError` del builder non viene riavvolto (issue #209).
+
+    Il corpo qui sotto e' un envelope ben formato: quello che esplode e' la
+    coppia `ratio ** n_reps` dentro la distribuzione temporale, e l'errore che
+    ne esce nomina gia' il parametro e la coppia. Riavvolgerlo in un
+    `InvalidFieldValueError` su `deviation_probability.volume` direbbe che il
+    corpo non e' un envelope — che e' falso — e perderebbe l'hint che dice
+    quale dei due valori ridurre.
+    """
+    compatto_che_trabocca = [
+        [[0, 5], [100, 50]], 10.0, 400, 'linear',
+        {'type': 'geometric', 'ratio': 10},
+    ]
+
+    with pytest.raises(ParameterBoundError) as exc_info:
+        _create_gate(compatto_che_trabocca)
+
+    err = exc_info.value
+    assert not isinstance(err, InvalidFieldValueError)
+    assert err.hint

--- a/tests/parameters/test_gate_factory_errors.py
+++ b/tests/parameters/test_gate_factory_errors.py
@@ -143,3 +143,21 @@ def test_engine_error_del_builder_risale_intatto():
     err = exc_info.value
     assert not isinstance(err, InvalidFieldValueError)
     assert err.hint
+
+
+def test_l_hint_riporta_la_causa_precisa():
+    """L'hint elenca le forme note *e* dice cosa e' andato storto (review #216).
+
+    Senza la causa, l'utente legge che il suo corpo "non si costruisce come
+    envelope" e deve indovinare quale delle forme elencate stava sbagliando.
+    La causa la conosce solo l'eccezione che arriva dal builder, e va letta
+    prima di buttarla via.
+    """
+    with pytest.raises(InvalidFieldValueError) as exc_info:
+        _create_gate({'punti': [[0, 50]]})
+
+    hint = exc_info.value.hint
+    # Le forme note restano.
+    assert "formato compatto" in hint
+    # E in coda la ragione, come l'ha detta il builder.
+    assert str(exc_info.value.__cause__) in hint

--- a/tests/parameters/test_gate_factory_errors.py
+++ b/tests/parameters/test_gate_factory_errors.py
@@ -4,11 +4,21 @@
 """
 Issue #38, PR2 — GateFactory solleva InvalidParameterError per deviation_probability
 malformato (tipo non supportato o valore non parsabile).
+
+Issue #209 — anche l'envelope che non si costruisce e' un errore: il ramo
+envelope non torna piu' `AlwaysGate` con un log, e i due percorsi che portano
+a costruirlo rispondono uguale.
 """
+import logging
+
 import pytest
 
 from pge.parameters.gate_factory import GateFactory
-from pge.shared.exceptions import ConfigError, InvalidParameterError
+from pge.shared.exceptions import (
+    ConfigError,
+    InvalidFieldValueError,
+    InvalidParameterError,
+)
 
 
 def test_classify_deviation_probability_invalid_type_raises_invalid_parameter_error():
@@ -19,6 +29,86 @@ def test_classify_deviation_probability_invalid_type_raises_invalid_parameter_er
     err = exc_info.value
     assert isinstance(err, ConfigError)
     assert "deviation_probability" in err.param_name
+
+
+def _create_gate(raw_value):
+    """Il gate per una chiave del dict per-parametro, come lo crea lo Stream."""
+    return GateFactory.create_gate(
+        deviation_probability={'volume': raw_value},
+        param_key='volume',
+        default_prob=1.0,
+        has_explicit_range=False,
+        duration=1.0,
+        time_mode='absolute',
+    )
+
+
+@pytest.mark.parametrize("raw_value", [
+    # Supera `_is_envelope_like`: prima di #209 arrivava a
+    # `create_scaled_envelope` senza rete e ne risaliva il ValueError nudo.
+    {'points': []},
+    {'type': 'linear', 'points': []},
+    # Non lo supera: prima di #209 finiva nel ramo con `except Exception`,
+    # che tornava AlwaysGate e loggava. Piu' l'errore era grossolano, meno il
+    # sistema lo segnalava.
+    [],
+    ['x'],
+    {'punti': [[0, 50]]},
+])
+def test_envelope_malformato_alza_invalid_field_value_error(raw_value):
+    """I due percorsi verso l'envelope rispondono uguale (issue #209).
+
+    La forma dell'errore non dipende piu' da quanto il corpo somigliasse a un
+    envelope: stessa classe, stesso campo, in entrambi i casi dentro la
+    gerarchia `EngineError` — cioe' attribuibile allo stream da chi la
+    intercetta risalendo.
+    """
+    with pytest.raises(InvalidFieldValueError) as exc_info:
+        _create_gate(raw_value)
+
+    err = exc_info.value
+    assert isinstance(err, ConfigError)
+    assert err.field == 'deviation_probability.volume'
+    assert err.value == raw_value
+    assert err.hint
+
+
+def test_envelope_malformato_non_e_piu_un_fallback_da_loggare(caplog):
+    """Il `logger.error` sparisce: non c'e' piu' nessun fallback da tracciare.
+
+    Il log serviva a rendere visibile una scelta presa in silenzio. Ora la
+    scelta non c'e' — il valore non viene interpretato in un altro modo, viene
+    rifiutato — e un log di errore accanto a un'eccezione dice la stessa cosa
+    due volte.
+    """
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(InvalidFieldValueError):
+            _create_gate([])
+
+    assert not [
+        r for r in caplog.records
+        if 'deviation_probability' in r.getMessage()
+    ]
+
+
+def test_envelope_globale_malformato_alza_lo_stesso_errore():
+    """Anche l'envelope globale, non solo quello per-chiave (issue #209).
+
+    `deviation_probability: {points: []}` e' envelope-like, quindi finiva
+    nell'unico altro punto del file che costruiva senza rete: stesso ValueError
+    nudo, fuori dalla gerarchia. Restava l'ultima delle asimmetrie.
+    """
+    with pytest.raises(InvalidFieldValueError) as exc_info:
+        GateFactory.create_gate(
+            deviation_probability={'points': []},
+            param_key='volume',
+            default_prob=1.0,
+            has_explicit_range=False,
+            duration=1.0,
+            time_mode='absolute',
+        )
+
+    assert exc_info.value.field == 'deviation_probability'
 
 
 def test_parse_raw_value_invalid_type_raises_invalid_parameter_error():

--- a/tests/parameters/test_parameter_orchestrator.py
+++ b/tests/parameters/test_parameter_orchestrator.py
@@ -718,3 +718,69 @@ class TestParserDynamicGrainDurationMin:
             parser.parse_parameter(
                 'grain_duration', [[0.0, 0.05], [5.0, 0.5 / 48000]]
             )
+
+
+# =============================================================================
+# 11. ATTRIBUZIONE ALLO STREAM DEGLI ERRORI DEL GATE (review #216)
+# =============================================================================
+
+class TestGateErroriAttribuitiAlloStream:
+    """L'errore che nasce in `GateFactory` porta lo stream che l'ha scritto.
+
+    `GateFactory` e' isolata per progetto: non conosce lo stream, e infatti
+    nomina il campo (`deviation_probability.<chiave>`) e non altro.
+    L'attribuzione tocca al chiamante — qui, come gia' fa il parser dieci righe
+    piu' su nel proprio file. Senza, la riga `Stream:` promessa da
+    `docs/reference/errors.md` non compare.
+    """
+
+    def _config_con_envelope_rotto(self, chiave: str) -> StreamConfig:
+        context = StreamContext(
+            stream_id='drone_gate',
+            onset=0.0,
+            duration=10.0,
+            sample='test.wav',
+            sample_dur_sec=5.0,
+        )
+        return StreamConfig(
+            context=context,
+            deviation_probability={chiave: ['x']},
+        )
+
+    def test_gate_del_parametro_normale(self):
+        from pge.shared.exceptions import InvalidFieldValueError
+
+        orchestrator = ParameterOrchestrator(
+            self._config_con_envelope_rotto('volume')
+        )
+        spec = ParameterSpec(
+            name='volume',
+            yaml_path='volume',
+            default=0.0,
+            range_path='volume_range',
+            deviation_probability_key='volume',
+        )
+
+        with pytest.raises(InvalidFieldValueError) as exc_info:
+            orchestrator.create_parameter_with_gate({'volume': 0.0}, spec)
+
+        assert exc_info.value.stream_id == 'drone_gate'
+
+    def test_gate_del_pitch(self):
+        from pge.shared.exceptions import InvalidFieldValueError
+        from pge.parameters.pitch_unit import make_pitch_unit
+
+        orchestrator = ParameterOrchestrator(
+            self._config_con_envelope_rotto('pitch')
+        )
+        unit = make_pitch_unit('semitones')
+
+        with pytest.raises(InvalidFieldValueError) as exc_info:
+            orchestrator.create_pitch_parameter(
+                name='pitch_semitones',
+                value_raw=0.0,
+                range_raw=None,
+                bounds=unit.value_bounds(),
+            )
+
+        assert exc_info.value.stream_id == 'drone_gate'

--- a/tests/parameters/test_parser_errors.py
+++ b/tests/parameters/test_parser_errors.py
@@ -70,3 +70,25 @@ def test_parser_envelope_out_of_bounds_raises_parameter_bound_error():
     assert err.stream_id == "drone_c"
     assert err.param_name == "density"
     assert len(err.violations) >= 1
+
+
+def test_parser_errore_dentro_la_costruzione_envelope_e_attribuito_allo_stream():
+    """L'errore che nasce *costruendo* l'envelope porta lo stream (review #216).
+
+    I due errori qui sopra sono sollevati dal parser stesso, che si attribuisce
+    da se'. Questo no: nasce dentro `create_scaled_envelope`, che lo stream non
+    lo conosce — e senza attribuzione la riga `Stream:` di
+    `docs/reference/errors.md` non compare, mentre l'esempio la promette.
+    """
+    parser = _make_parser(stream_id="drone_d", duration=10.0)
+    compatto_che_trabocca = [
+        [[0, 5], [100, 50]], 10.0, 400, 'linear',
+        {'type': 'geometric', 'ratio': 10},
+    ]
+
+    with pytest.raises(ParameterBoundError) as exc_info:
+        parser.parse_parameter(name="density", value_raw=compatto_che_trabocca)
+
+    err = exc_info.value
+    assert isinstance(err, ConfigError)
+    assert err.stream_id == "drone_d"

--- a/tests/parameters/test_read_direction.py
+++ b/tests/parameters/test_read_direction.py
@@ -331,7 +331,7 @@ class TestGuardDiArita:
 
     @pytest.mark.parametrize("ingresso", ['dict', 'lista'])
     def test_macro_forma_dentro_il_pattern_di_un_ciclo(self, ingresso):
-        """`_is_compact_format` guarda solo la lunghezza dei punti del pattern
+        """`is_compact_format` guarda solo la lunghezza dei punti del pattern
         (2 o 3), e un BP group e' lungo 2: passa quel filtro e arriva al
         builder, che sul primo elemento fa `x_pct / 100.0` e solleva un
         TypeError nudo. Qui il punto del pattern deve essere piatto."""
@@ -341,7 +341,7 @@ class TestGuardDiArita:
         with pytest.raises(InvalidFieldValueError) as exc:
             normalize_read_direction(raw)
         # Il valore dice QUALE elemento e' caduto: il gruppo annidato, non la
-        # lista che lo contiene. Se un domani `_is_compact_format` si
+        # lista che lo contiene. Se un domani `is_compact_format` si
         # stringesse e il corpo finisse su `_check_item`, cadrebbe `corpo[0]`
         # e questa asserzione lo direbbe.
         assert exc.value.value == corpo[0][0]

--- a/tests/shared/test_engine_exceptions.py
+++ b/tests/shared/test_engine_exceptions.py
@@ -313,6 +313,28 @@ def test_parameter_bound_error_keeps_bounds_when_known():
     assert "[0.0, 100.0]" in msg
 
 
+def test_parameter_bound_error_keeps_bounds_when_partially_known():
+    """Un solo bound dichiarato basta a stampare la riga.
+
+    Non e' un caso di laboratorio: `parser.py` clippa gia' con `max_bound`
+    None (bound superiore aperto), e in quel caso `[0.0, None]` e' il dato
+    vero — il minimo esiste, il massimo no. Sopprimere la riga qui
+    nasconderebbe l'unico bound che c'e'.
+    """
+    from pge.shared.exceptions import ParameterBoundError
+
+    err = ParameterBoundError(
+        param_name="grain_duration",
+        value_type="value",
+        value=-1.0,
+        min_bound=0.0,
+        max_bound=None,
+    )
+    msg = err.user_message()
+    assert "Bounds:" in msg
+    assert "[0.0, None]" in msg
+
+
 def test_parameter_bound_error_supports_envelope_violations():
     """ParameterBoundError accetta lista violazioni per envelope."""
     from pge.shared.exceptions import ParameterBoundError

--- a/tests/shared/test_engine_exceptions.py
+++ b/tests/shared/test_engine_exceptions.py
@@ -253,6 +253,66 @@ def test_parameter_bound_error_includes_optional_context():
     assert "c.yml" in msg
 
 
+def test_parameter_bound_error_accepts_hint():
+    """`hint` opzionale, come nelle sorelle della stessa famiglia (issue #212).
+
+    Serve dove il vincolo violato non e' un intervallo sul singolo valore:
+    l'overflow di `ratio ** n_reps` non ha un bound da stampare, ha una coppia
+    da nominare.
+    """
+    from pge.shared.exceptions import ParameterBoundError
+
+    err = ParameterBoundError(
+        param_name="ratio",
+        value_type="value",
+        value=10,
+        min_bound=None,
+        max_bound=None,
+        hint="ratio=10 con n_reps=400 trabocca",
+    )
+    msg = err.user_message()
+    assert "Hint:" in msg
+    assert "n_reps=400" in msg
+
+
+def test_parameter_bound_error_omits_bounds_when_unknown():
+    """Senza bounds la riga Bounds sparisce, invece di stampare `[None, None]`.
+
+    Un intervallo che non esiste non va scritto come se esistesse: il valore
+    non e' fuori da nessun `[min, max]`, e' la sua combinazione con un altro
+    a non stare in un float.
+    """
+    from pge.shared.exceptions import ParameterBoundError
+
+    err = ParameterBoundError(
+        param_name="ratio",
+        value_type="value",
+        value=10,
+        min_bound=None,
+        max_bound=None,
+        hint="la coppia trabocca",
+    )
+    msg = err.user_message()
+    assert "Bounds:" not in msg
+    assert "None" not in msg
+
+
+def test_parameter_bound_error_keeps_bounds_when_known():
+    """Il caso storico non cambia: con bounds dichiarati la riga resta."""
+    from pge.shared.exceptions import ParameterBoundError
+
+    err = ParameterBoundError(
+        param_name="density",
+        value_type="value",
+        value=999.0,
+        min_bound=0.0,
+        max_bound=100.0,
+    )
+    msg = err.user_message()
+    assert "Bounds:" in msg
+    assert "[0.0, 100.0]" in msg
+
+
 def test_parameter_bound_error_supports_envelope_violations():
     """ParameterBoundError accetta lista violazioni per envelope."""
     from pge.shared.exceptions import ParameterBoundError


### PR DESCRIPTION
Chiude #209, #210, #212.

Avanza #213 (punti 1-2); il punto 3 resta su #211.

#211 non e' toccata: la salita dei guard in `EnvelopeBuilder` e' decisa ma
isolata in un lavoro suo, e il punto 3 di #213 dipende da li'.

---

## #209 — l'envelope malformato smette di essere un fallback

`_parse_raw_value` tornava `AlwaysGate` e loggava quando l'envelope non si
costruiva. `AlwaysGate` non e' un ripiego neutro: e' probabilita' 100%, cioe'
la variazione applicata a **tutti** i grani — su un `grain.read_direction: 1`
dichiarato, 79 grani su 79 letti nel verso opposto. Ora
`InvalidFieldValueError` sul campo `deviation_probability.<chiave>`.

Il `logger.error` sparisce: non c'e' piu' un fallback da tracciare.

Sparisce anche l'asimmetria interna al file. Erano tre i punti che
costruivano l'envelope e rispondevano in tre modi diversi allo stesso guasto:
il corpo riconosciuto da `is_envelope_like` faceva risalire un `ValueError`
nudo, quello piu' malformato veniva silenziato — piu' l'errore era
grossolano, meno il sistema lo segnalava. Ora la costruzione passa da un
punto unico (`_envelope_gate`).

**Oltre le due righe della issue:** ho fatto passare da quel punto unico
anche l'envelope **globale** (`DeviationProbabilityMode.GLOBAL_ENV`), non
solo i due percorsi per-chiave che la issue nomina. Era l'ultimo sito che
costruiva senza rete e avrebbe conservato esattamente l'asimmetria che #209
chiede di togliere. Se si preferisce tenerlo fuori, e' una riga.

Gli `EngineError` risalgono intatti: portano gia' campo e hint propri, e
riavvolgerli li renderebbe meno precisi.

## #210 — solo documentazione

Nessun cambio di comportamento. La tabella delle cinque scritture entra in
`docs/reference/yaml.md` §DeviationProbability, con il punto reso leggibile:
la chiave **scritta e lasciata vuota** e' l'unica delle cinque a non dare
`NeverGate` — la scrittura che piu' assomiglia a "non voglio deviazione" e fa
l'opposto.

La tabella e' fissata da `tests/parameters/test_deviation_probability_scritture.py`,
otto righe (le cinque di #210 piu' le tre di #209). Altrimenti l'unica cosa
che la sostiene e' la documentazione.

## #212 — l'overflow delle potenze

`try/except OverflowError` attorno alle tre potenze, rialzato come
`ParameterBoundError` che nomina **entrambi** i valori, il parametro e
`n_reps`: ne' `ratio: 10` ne' `n_reps: 400` sono sbagliati da soli, lo e' la
coppia, e senza entrambi non si sa quale ridurre.

Nessun controllo predittivo nei costruttori: la soglia dipende dai due valori
insieme e il costruttore non vede `n_reps`.

Un dettaglio emerso implementando: nel caso `geometric` la potenza su interi
**non** trabocca — Python la calcola esatta su interi illimitati — e a
traboccare e' la divisione che segue. Il `try` avvolge quindi l'espressione,
non la sola potenza.

`ParameterBoundError` guadagna un `hint` opzionale, ed e' la parte di questa
PR che vale la pena guardare con piu' attenzione perche' tocca una classe
condivisa: il vincolo violato qui non e' un intervallo sul singolo valore,
quindi non c'e' nessun `[min, max]` da stampare. Di conseguenza la riga
`Bounds` viene omessa quando entrambi i bound sono ignoti, invece di scrivere
`[None, None]`. Il caso storico (bound dichiarati) e' invariato e ha un test
che lo dice.

Fuori scope, come da decisione: `end_time <= time_offset` resta un
`ValueError` del builder.

## #213 — punti 1 e 2

1. I tre `_is_*` diventano pubblici (`is_compact_format`, `is_bp_group`,
   `is_3tuple_breakpoint`). Call site aggiornati insieme, nessun alias
   privato dietro (c'e' un test che lo pretende).
2. Gli indici del compatto diventano costanti di `EnvelopeBuilder`, lette da
   `_expand_compact_format` e da `read_direction._check_compact`. E' il punto
   con il rischio peggiore: non un errore ma un silenzio — con due decodifiche
   indipendenti, un `time_dist_spec` spostato di slot avrebbe lasciato il
   validatore a controllare quello vecchio senza che nessun test se ne
   accorgesse.

   **Oltre i cinque nomi della decisione:** ho aggiunto anche `COMPACT_WRAP`
   (slot 5). E' letto dal solo builder, quindi non e' conoscenza condivisa —
   ma lasciarlo come unico letterale accanto a cinque costanti sarebbe
   sembrato una dimenticanza.

La duplicazione dei **vincoli** (`n_reps >= 1`, pattern non vuoto) resta
finche' non si chiude #211. E' consapevole.

## Extra — il parametrizzato sui bool

Il residuo di review su `test_bool_accettato_come_in_tutto_il_registro`
risulta **gia' risolto** su `main` (commit `84c9fff`, incluso in v7.3.0):
quel test non esiste piu'. Al suo posto ci sono
`test_bool_non_e_rifiutato_dal_guard_sul_tipo` — nome ristretto a cio' che
osserva davvero — e `test_bool_contro_i_bound_di_ciascuna_distribuzione`, che
copre tutte e quattro le famiglie con `True` **e** `False`, casi negativi
compresi. Cioe' entrambi gli esiti accettabili, gia' presi. Non ho toccato
niente.

## Impatto cross-repo

C'e' impatto: #209 e #212 cambiano la superficie degli errori. Issue aperte:

- PGE-ls: DMGiulioRomano/PGE-ls#45 — diagnostica pre-render sull'envelope di
  `deviation_probability`, hover che distingue chiave vuota da chiave
  assente, e la nota per chi parsa l'output (`hint` nuovo, riga `Bounds`
  ora omissibile).
- PGE-ui: DMGiulioRomano/PGE-ui#123 — l'envelope svuotato dall'editor ora fa
  fallire il render, e lo stato "off" del controllo va serializzato come
  `false` o chiave assente, mai come chiave vuota. Nessun impatto su
  `GET /bounds`: schema e bounds non cambiano.

## Test

- `make tests`: **5642 passed, 2 skipped** (i due skip sono preesistenti,
  "nessun sample disponibile"). Base: 5611 passed.
- `make e2e-tests`: **non verdi in questo ambiente, ma identiche alla base**.
  45 fallimenti sia su `origin/main` sia su questo branch, stesso elenco
  esatto (diff vuoto). La causa e' ambientale: `refs/` contiene solo
  `.gitkeep` — i sample audio sono gitignored — quindi gli YAML di test
  muoiono su `SampleNotFoundError` prima di arrivare all'asserzione, e
  `csound` non e' installato (il target lo dichiara come requisito). Non c'e'
  modo di verificarle qui; su una macchina con refs e csound vanno rilanciate.

Nota: il branch e' stato ribasato su `origin/main` (`0761e36`), che era due
commit avanti rispetto a `d0defb2`/v7.3.0.

---
_Generated by [Claude Code](https://claude.ai/code/session_016njT7k4w6Yf3Gd35tBmBGC)_