### PR TITLE
Colorbar del pitch solo dove le altezze variano davvero (#217)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ---
 
+## [Unreleased]
+
+### Modificato
+
+- **La colorbar del pitch compare solo dove le altezze variano davvero**
+  (#217). Prima si disegnava su ogni subplot con almeno un grano visibile: con
+  l'auto-zoom attivo (default) il range non è mai nullo — `pitch_cents_range`
+  allarga comunque al floor `min_span_cents` di mezzo semitono — quindi una
+  pagina di grani tutti alla stessa altezza otteneva una scala col gradiente
+  pieno sopra grani tutti dello stesso colore: prometteva un'escursione che non
+  c'era.
+
+  La soglia è **1 cent**, non l'uguaglianza esatta: i `pitch_ratio` arrivano da
+  rapporti calcolati in float (semitoni moltiplicati uno alla volta, cent
+  convertiti in rapporti) e la stessa altezza raggiunta per due strade diverse
+  differisce all'ultimo bit — con l'uguaglianza esatta quella deriva
+  riaccenderebbe la scala. Un cent è anche sotto la soglia percettiva, quindi
+  la soglia sbaglia solo dove sbagliare non si sente, con la stessa
+  motivazione del floor di mezzo semitono.
+
+  La soppressione è **per-stream** e vale anche col range fisso
+  (`pitch_color_autozoom.enabled: false`), dove un colore unico resta unico. La
+  **colonna** del GridSpec riservata da `colorbar_width_ratio` si recupera solo
+  se **nessuno** stream della pagina varia: in quel caso la larghezza torna
+  all'area dati invece di restare una cella vuota. Nessuna nuova chiave di
+  config e nessun opt-out: le partiture con pitch variabile sono invariate.
+
+---
+
 ## [v7.3.0] — "Declared Reverse" — 2026-08-17
 
 ### Aggiunto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,15 +65,25 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   convertiti in rapporti) e la stessa altezza raggiunta per due strade diverse
   differisce all'ultimo bit — con l'uguaglianza esatta quella deriva
   riaccenderebbe la scala. Un cent è anche sotto la soglia percettiva, quindi
-  la soglia sbaglia solo dove sbagliare non si sente, con la stessa
-  motivazione del floor di mezzo semitono.
+  la soglia sbaglia solo dove sbagliare non si sente.
+
+  Fra 1 e 50 cent di escursione reale, però, la scala resta **più larga di
+  quello che mostra**: la colorbar viene disegnata, ma `pitch_cents_range`
+  allarga comunque al floor `min_span_cents`, quindi il gradiente copre mezzo
+  semitono mentre i grani ne occupano una frazione. È la lamentela della #217
+  in forma attenuata, ed è una scelta: alzare la soglia a 50 cent spegnerebbe
+  la colorbar proprio dove l'auto-zoom del micro-detune serve.
 
   La soppressione è **per-stream** e vale anche col range fisso
   (`pitch_color_autozoom.enabled: false`), dove un colore unico resta unico. La
-  **colonna** del GridSpec riservata da `colorbar_width_ratio` si recupera solo
-  se **nessuno** stream della pagina varia: in quel caso la larghezza torna
-  all'area dati invece di restare una cella vuota. Nessuna nuova chiave di
-  config e nessun opt-out: le partiture con pitch variabile sono invariate.
+  **colonna** del GridSpec riservata da `colorbar_width_ratio` si decide invece
+  una volta per l'**intera partitura**: si recupera solo se nessuna pagina ha
+  escursione, e altrimenti resta riservata su tutte. Deciderla per pagina
+  avrebbe dato due scale mm/secondo diverse a pagine dello stesso brano, con
+  l'asse dei tempi non più confrontabile a occhio da una pagina all'altra; il
+  prezzo è una colonna vuota sulle pagine di soli stream uniformi. Nessuna
+  nuova chiave di config e nessun opt-out: le partiture con pitch variabile
+  sono invariate.
 
 ### Corretto
 

--- a/docs/explanation/score-visualizer-layout.md
+++ b/docs/explanation/score-visualizer-layout.md
@@ -11,7 +11,7 @@ sources:
   - src/pge/rendering/magnifier_projection.py
   - src/pge/rendering/score_visualizer.py
   - src/pge/rendering/visualizer_config.py
-last_synced_commit: 51c49f8
+last_synced_commit: 1e9c892
 ---
 
 # Il layout della partitura: separare i numeri dal disegno
@@ -98,6 +98,24 @@ questa.
 `pan_range`, `hist_bins`, `page_duration`: i moduli non conoscono il dict di
 config, è l'adapter a leggerlo e a passarne i valori. È anche ciò che rende
 possibile tipizzare la config senza toccare le regole.
+
+### Una decisione che deve precedere il disegno
+
+Non tutto quello che il visualizer chiede ai moduli riguarda un artista già
+esistente. La colorbar del pitch (#217) si disegna solo dove i grani hanno
+davvero altezze diverse, e la domanda «variano?» non è quella a cui risponde
+`pitch_cents_range`: quello è un range da colorare, e lo restituisce sempre non
+nullo perché applica il floor `min_span_cents`. Il dato grezzo — l'escursione
+in cent dei grani visibili, confrontata con una soglia di un cent che assorbe
+la deriva float dei `pitch_ratio` — è `grain_visuals.has_pitch_variation`.
+
+Le due conseguenze cadono in due punti diversi, e per una ragione strutturale:
+la soppressione della singola colorbar è per-stream e sta dove la colorbar si
+disegna, ma la **colonna** che la ospita è una colonna sola per tutta la pagina,
+riservata dal `GridSpec`. Recuperarne la larghezza quando nessuno stream varia
+significa deciderlo **prima** di costruire il `GridSpec`: dopo, la colonna
+esiste già e l'unica cosa ancora possibile è lasciarla vuota. È lo stesso
+motivo per cui `has_envelopes` si calcola in cima a `render_page`.
 
 ### I dati dichiarati
 

--- a/docs/explanation/score-visualizer-layout.md
+++ b/docs/explanation/score-visualizer-layout.md
@@ -11,7 +11,7 @@ sources:
   - src/pge/rendering/magnifier_projection.py
   - src/pge/rendering/score_visualizer.py
   - src/pge/rendering/visualizer_config.py
-last_synced_commit: 1e9c892
+last_synced_commit: 62ec803
 ---
 
 # Il layout della partitura: separare i numeri dal disegno
@@ -111,11 +111,32 @@ la deriva float dei `pitch_ratio` — è `grain_visuals.has_pitch_variation`.
 
 Le due conseguenze cadono in due punti diversi, e per una ragione strutturale:
 la soppressione della singola colorbar è per-stream e sta dove la colorbar si
-disegna, ma la **colonna** che la ospita è una colonna sola per tutta la pagina,
-riservata dal `GridSpec`. Recuperarne la larghezza quando nessuno stream varia
-significa deciderlo **prima** di costruire il `GridSpec`: dopo, la colonna
-esiste già e l'unica cosa ancora possibile è lasciarla vuota. È lo stesso
-motivo per cui `has_envelopes` si calcola in cima a `render_page`.
+disegna, ma la **colonna** che la ospita è una colonna sola, riservata dal
+`GridSpec`. Recuperarne la larghezza significa deciderlo **prima** di costruire
+il `GridSpec`: dopo, la colonna esiste già e l'unica cosa ancora possibile è
+lasciarla vuota. È lo stesso motivo per cui `has_envelopes` si calcola in cima
+a `render_page`.
+
+E la decisione sulla colonna non è per pagina ma per **partitura**
+(`_score_has_pitch_variation`, memoizzata e invalidata da `analyze`). Deciderla
+per pagina — la prima versione — dava geometrie diverse a pagine dello stesso
+brano: una pagina con escursione riservava la colonna, una senza la recuperava,
+e la stessa finestra temporale finiva disegnata su due scale mm/secondo diverse.
+L'asse dei tempi di una partitura deve poter essere confrontato a occhio da una
+pagina all'altra, quindi o tutte le pagine hanno la colonna o nessuna. Il prezzo
+è dichiarato: dentro una partitura che altrove varia, una pagina di soli stream
+uniformi tiene una colonna vuota.
+
+**Dove la scala resta più larga di quello che mostra.** Il predicato e il floor
+dell'auto-zoom rispondono a due domande diverse e non combaciano nel mezzo: con
+un'escursione reale fra 1 e 50 cent la colorbar viene disegnata (c'è variazione)
+ma `pitch_cents_range` allarga comunque a `min_span_cents`, quindi il gradiente
+copre mezzo semitono mentre i grani ne occupano una frazione, e appaiono di
+colori vicini. È la lamentela della #217 in forma attenuata, ed è una scelta:
+alzare la soglia del predicato a 50 cent spegnerebbe la colorbar proprio dove
+l'auto-zoom del micro-detune serve — sui pochi cent di differenza che la mappa
+divergente esiste per rendere visibili. Fra "nessuna scala dove servirebbe" e
+"scala più larga del contenuto" si è scelto il secondo.
 
 ### I dati dichiarati
 

--- a/src/pge/rendering/grain_visuals.py
+++ b/src/pge/rendering/grain_visuals.py
@@ -168,6 +168,51 @@ def window_vertices(grain, xs, w):
     return vertices
 
 
+def _visible_cents(streams, t_start, t_end):
+    """Altezze in cent dei grani visibili degli stream dati.
+
+    Valore assoluto: un grano reverse ha ratio negativo ma la sua ALTEZZA e'
+    la stessa del forward corrispondente, ed e' l'altezza che il colore
+    racconta. Il verso lo dice gia' la forma della freccia.
+    """
+    return [
+        1200.0 * np.log2(abs(g.pitch_ratio))
+        for stream in streams
+        for g in visible_grains(stream, t_start, t_end)
+        # Il pitch in cent e' un logaritmo: ratio zero non ne ha uno.
+        if abs(g.pitch_ratio) > 0
+    ]
+
+
+# Sotto quale escursione due grani si considerano della stessa altezza.
+# Un cent, non l'uguaglianza esatta: i pitch_ratio arrivano da rapporti
+# calcolati in float (semitoni moltiplicati uno alla volta, cent convertiti in
+# rapporti) e la stessa altezza raggiunta per due strade diverse differisce
+# all'ultimo bit. Con l'uguaglianza esatta quella deriva riaccenderebbe la
+# scala di colore. Un cent e' anche sotto la soglia percettiva, quindi la
+# soglia sbaglia solo dove sbagliare non si sente — ed e' coerente col floor
+# di mezzo semitono che l'autozoom applica per la stessa ragione.
+PITCH_VARIATION_EPSILON_CENTS = 1.0
+
+
+def has_pitch_variation(streams, t_start, t_end,
+                        *, epsilon_cents=PITCH_VARIATION_EPSILON_CENTS):
+    """True se i grani visibili hanno davvero altezze diverse.
+
+    Domanda distinta da quella di `pitch_cents_range`, che risponde sempre con
+    un range non nullo (applica il floor `min_span_cents`): qui serve il dato
+    grezzo, perche' una scala di colore senza escursione da leggere promette
+    un'informazione che non c'e' (issue #217).
+
+    Nessun grano visibile, o nessuno con un'altezza definita, e' assenza di
+    variazione: non c'e' scala da disegnare.
+    """
+    cents = _visible_cents(streams, t_start, t_end)
+    if not cents:
+        return False
+    return (max(cents) - min(cents)) > epsilon_cents
+
+
 def pitch_cents_range(streams, t_start, t_end, *, min_span_cents, pad_ratio):
     """Range colore del pitch, in cent, sui grani visibili degli stream dati.
 
@@ -178,16 +223,7 @@ def pitch_cents_range(streams, t_start, t_end, *, min_span_cents, pad_ratio):
         (lo, hi) in cent, oppure None se non c'e' nessun pitch da misurare —
         allora chi disegna ripiega sul range fisso.
     """
-    # Valore assoluto: un grano reverse ha ratio negativo ma la sua ALTEZZA e'
-    # la stessa del forward corrispondente, ed e' l'altezza che il colore
-    # racconta. Il verso lo dice gia' la forma della freccia.
-    cents = [
-        1200.0 * np.log2(abs(g.pitch_ratio))
-        for stream in streams
-        for g in visible_grains(stream, t_start, t_end)
-        # Il pitch in cent e' un logaritmo: ratio zero non ne ha uno.
-        if abs(g.pitch_ratio) > 0
-    ]
+    cents = _visible_cents(streams, t_start, t_end)
     if not cents:
         return None
 

--- a/src/pge/rendering/grain_visuals.py
+++ b/src/pge/rendering/grain_visuals.py
@@ -195,8 +195,7 @@ def _visible_cents(streams, t_start, t_end):
 PITCH_VARIATION_EPSILON_CENTS = 1.0
 
 
-def has_pitch_variation(streams, t_start, t_end,
-                        *, epsilon_cents=PITCH_VARIATION_EPSILON_CENTS):
+def has_pitch_variation(streams, t_start, t_end):
     """True se i grani visibili hanno davvero altezze diverse.
 
     Domanda distinta da quella di `pitch_cents_range`, che risponde sempre con
@@ -210,7 +209,7 @@ def has_pitch_variation(streams, t_start, t_end,
     cents = _visible_cents(streams, t_start, t_end)
     if not cents:
         return False
-    return (max(cents) - min(cents)) > epsilon_cents
+    return (max(cents) - min(cents)) > PITCH_VARIATION_EPSILON_CENTS
 
 
 def pitch_cents_range(streams, t_start, t_end, *, min_span_cents, pad_ratio):

--- a/src/pge/rendering/score_visualizer.py
+++ b/src/pge/rendering/score_visualizer.py
@@ -98,6 +98,10 @@ class ScoreVisualizer:
         self.total_duration = None
         self.page_count = None
         self.page_layouts = []
+        # Se la partitura, in QUALCHE pagina, ha una colorbar da mostrare:
+        # decide la colonna del GridSpec per tutte (vedi
+        # _score_has_pitch_variation). None = non ancora calcolato.
+        self._score_pitch_variation = None
         
         # Colormap. grain_colormap accetta sia una stringa (nome registrato,
         # incluso 'pitch_div') sia un oggetto Colormap gia' costruito.
@@ -125,6 +129,8 @@ class ScoreVisualizer:
         self.page_layouts = page_layout.paginate(
             self.streams, self.config['page_duration'])
         self.page_count = len(self.page_layouts)
+        # Le pagine sono cambiate: la risposta sulla colorbar va rifatta.
+        self._score_pitch_variation = None
 
         print(f"Analisi completata: {self.page_count} pagine, "
               f"durata totale {self.total_duration:.2f}s")
@@ -196,6 +202,30 @@ class ScoreVisualizer:
         return grain_visuals.pitch_cents_range(
             streams, page_start, page_end,
             min_span_cents=az['min_span_cents'], pad_ratio=az['pad_ratio'])
+
+    def _score_has_pitch_variation(self):
+        """True se in almeno una pagina almeno uno stream ha un'escursione di
+        altezza, cioe' se da qualche parte una colorbar verra' disegnata.
+
+        E' la domanda che decide la COLONNA del GridSpec, e si pone una volta
+        sola sull'intera partitura invece che pagina per pagina. Deciderla per
+        pagina faceva variare la larghezza dell'area dati da una pagina
+        all'altra dello stesso brano: stessa finestra temporale, due scale
+        mm/secondo diverse, e l'asse dei tempi non piu' confrontabile a occhio.
+        La geometria della pagina e' una proprieta' della partitura; quale
+        stream mostra la barra resta una proprieta' dello stream.
+
+        Memoizzata: la risposta dipende dai grani e dalle finestre di pagina,
+        che dopo `analyze` non cambiano piu' (ed e' `analyze` a invalidarla).
+        """
+        if self._score_pitch_variation is None:
+            self._score_pitch_variation = any(
+                grain_visuals.has_pitch_variation(
+                    [s], layout.t_start, layout.t_end)
+                for layout in self.page_layouts
+                for s in layout.streams
+            )
+        return self._score_pitch_variation
 
     def _add_pitch_colorbar(self, fig, cax_spec, cents_range, streams,
                             page_start, page_end):
@@ -335,18 +365,15 @@ class ScoreVisualizer:
         # cosi' un testo piu' grande non viene croppato. A fs=1.0 e' identita'.
         fs = self.config['font_scale']
         waveform_ratio = self.config['waveform_width_ratio'] * fs
-        # La colonna della colorbar si riserva solo se almeno uno stream della
-        # pagina ha davvero un'escursione di altezza (issue #217). Le colorbar
-        # sono impilate in quella sola colonna: basta uno stream che varii
-        # perche' serva, e se non varia nessuno la larghezza torna all'area
-        # dati invece di restare una cella vuota. La decisione va presa qui e
-        # non dentro _add_pitch_colorbar: dopo il GridSpec la colonna c'e' gia'.
-        page_has_pitch_variation = any(
-            grain_visuals.has_pitch_variation([s], page_start, page_end)
-            for s in active_streams
-        )
+        # La colonna della colorbar si riserva solo se la partitura ha, da
+        # qualche parte, un'escursione di altezza da mostrare (issue #217). La
+        # domanda e' sull'intero score e non su questa pagina: cosi' tutte le
+        # pagine hanno la stessa geometria e la stessa scala mm/secondo. Se
+        # nessuna pagina varia, la larghezza torna all'area dati invece di
+        # restare una cella vuota. La decisione va presa qui e non dentro
+        # _add_pitch_colorbar: dopo il GridSpec la colonna c'e' gia'.
         colorbar_ratio = (self.config['colorbar_width_ratio']
-                          if page_has_pitch_variation else 0.0)
+                          if self._score_has_pitch_variation() else 0.0)
         envelope_ratio = self.config['envelope_panel_ratio'] if has_envelopes else 0.0
 
         # Altezza banda per stream (divisa equamente). Con envelope attivi ogni

--- a/src/pge/rendering/score_visualizer.py
+++ b/src/pge/rendering/score_visualizer.py
@@ -209,7 +209,15 @@ class ScoreVisualizer:
         Senza: scala fissa pitch_range in ratio, solo se il subplot ha grani
         visibili (cents_range None copre anche il caso zero grani). Se non c'e'
         nulla da disegnare la cella resta vuota (nessun asse creato).
+
+        Niente colorbar dove le altezze non variano (issue #217): l'autozoom
+        allarga comunque al floor di mezzo semitono, quindi la scala mostrerebbe
+        un gradiente pieno sopra grani tutti dello stesso colore. Vale anche col
+        range fisso, dove il colore unico resta unico.
         """
+        if not grain_visuals.has_pitch_variation(streams, page_start, page_end):
+            return
+
         if cents_range is not None:
             norm = Normalize(cents_range[0], cents_range[1])
             label = 'pitch (cents)'
@@ -327,7 +335,18 @@ class ScoreVisualizer:
         # cosi' un testo piu' grande non viene croppato. A fs=1.0 e' identita'.
         fs = self.config['font_scale']
         waveform_ratio = self.config['waveform_width_ratio'] * fs
-        colorbar_ratio = self.config['colorbar_width_ratio']
+        # La colonna della colorbar si riserva solo se almeno uno stream della
+        # pagina ha davvero un'escursione di altezza (issue #217). Le colorbar
+        # sono impilate in quella sola colonna: basta uno stream che varii
+        # perche' serva, e se non varia nessuno la larghezza torna all'area
+        # dati invece di restare una cella vuota. La decisione va presa qui e
+        # non dentro _add_pitch_colorbar: dopo il GridSpec la colonna c'e' gia'.
+        page_has_pitch_variation = any(
+            grain_visuals.has_pitch_variation([s], page_start, page_end)
+            for s in active_streams
+        )
+        colorbar_ratio = (self.config['colorbar_width_ratio']
+                          if page_has_pitch_variation else 0.0)
         envelope_ratio = self.config['envelope_panel_ratio'] if has_envelopes else 0.0
 
         # Altezza banda per stream (divisa equamente). Con envelope attivi ogni

--- a/src/pge/rendering/score_visualizer.py
+++ b/src/pge/rendering/score_visualizer.py
@@ -227,37 +227,32 @@ class ScoreVisualizer:
             )
         return self._score_pitch_variation
 
-    def _add_pitch_colorbar(self, fig, cax_spec, cents_range, streams,
-                            page_start, page_end):
+    def _add_pitch_colorbar(self, fig, cax_spec, cents_range, has_variation):
         """
         Colorbar compatta con la scala colore pitch del subplot, disegnata in una
         cella dedicata del GridSpec (cax_spec). Con un asse colorbar esplicito
         (cax=) invece di ax=, non viene rubata larghezza al subplot dei grani:
         grani ed envelope restano allineati sullo stesso bordo destro.
 
-        Con cents_range (auto-zoom attivo): scala in cents zoomata.
-        Senza: scala fissa pitch_range in ratio, solo se il subplot ha grani
-        visibili (cents_range None copre anche il caso zero grani). Se non c'e'
-        nulla da disegnare la cella resta vuota (nessun asse creato).
+        has_variation: se le altezze dei grani di questo subplot variano
+        davvero, calcolato una volta da chi disegna (grain_visuals
+        .has_pitch_variation). Niente colorbar dove non variano (issue #217):
+        l'autozoom allarga comunque al floor di mezzo semitono, quindi la scala
+        mostrerebbe un gradiente pieno sopra grani tutti dello stesso colore.
+        Vale anche col range fisso, dove il colore unico resta unico — e copre
+        il caso zero grani, che di variazione non ne ha. Se non c'e' nulla da
+        disegnare la cella resta vuota (nessun asse creato).
 
-        Niente colorbar dove le altezze non variano (issue #217): l'autozoom
-        allarga comunque al floor di mezzo semitono, quindi la scala mostrerebbe
-        un gradiente pieno sopra grani tutti dello stesso colore. Vale anche col
-        range fisso, dove il colore unico resta unico.
+        Con cents_range (auto-zoom attivo): scala in cents zoomata. Senza:
+        scala fissa pitch_range in ratio.
         """
-        if not grain_visuals.has_pitch_variation(streams, page_start, page_end):
+        if not has_variation:
             return
 
         if cents_range is not None:
             norm = Normalize(cents_range[0], cents_range[1])
             label = 'pitch (cents)'
         else:
-            has_grains = any(
-                grain_visuals.visible_grains(s, page_start, page_end)
-                for s in streams
-            )
-            if not has_grains:
-                return
             p_min, p_max = self.config['pitch_range']
             norm = Normalize(p_min, p_max)
             label = 'pitch (ratio)'
@@ -457,8 +452,12 @@ class ScoreVisualizer:
             # subplot anche se il sample e' condiviso; _load_waveform fa cache).
             self._draw_waveform_full(ax_wave, stream, sample_duration)
 
-            # Range colore pitch auto-zoomato sui grani di questo stream
+            # Range colore pitch auto-zoomato sui grani di questo stream, e se
+            # quei grani un'escursione ce l'hanno davvero (una volta sola: la
+            # risposta serve alla colorbar piu' sotto).
             cents_range = self._compute_pitch_color_range(
+                [stream], page_start, page_end)
+            stream_pitch_varies = grain_visuals.has_pitch_variation(
                 [stream], page_start, page_end)
 
             # Disegna grani, loop mask e label dello stream
@@ -485,7 +484,7 @@ class ScoreVisualizer:
             # Legenda della scala colore pitch (auto-zoomata o fissa) nella
             # colonna dedicata della riga grani: non ruba larghezza al subplot.
             self._add_pitch_colorbar(fig, gs[grain_row, 2], cents_range,
-                                     [stream], page_start, page_end)
+                                     stream_pitch_varies)
             # Configura assi waveform
             ax_wave.set_ylim(-0.02, sample_duration+0.02)
             ax_wave.set_xlim(-1.1, 1.1)

--- a/tests/rendering/test_grain_visuals.py
+++ b/tests/rendering/test_grain_visuals.py
@@ -382,6 +382,11 @@ class TestHasPitchVariation:
         stream = self._stream(1.0, 2.0 ** (5.0 / 1200.0))
         assert has_pitch_variation([stream], 0.0, 10.0)
 
+    def test_a_single_grain_does_not_vary(self):
+        """Un grano solo non e' un'escursione: non c'e' niente da cui differire,
+        e una scala di colore su un unico valore direbbe meno di niente."""
+        assert not has_pitch_variation([self._stream(1.5)], 0.0, 10.0)
+
     def test_no_pitched_grains_do_not_vary(self):
         """Nessun grano (o solo ratio zero, che un'altezza non ce l'ha):
         niente da misurare, quindi niente variazione."""

--- a/tests/rendering/test_grain_visuals.py
+++ b/tests/rendering/test_grain_visuals.py
@@ -23,6 +23,7 @@ from pge.rendering.grain_visuals import (
     window_silhouette,
     window_vertices,
     visible_grains,
+    has_pitch_variation,
     pitch_cents_range,
     pitch_position,
     volume_alpha,
@@ -342,6 +343,70 @@ class TestPitchCentsRange:
         assert pitch_cents_range(
             [self._stream(0.0)], 0.0, 10.0,
             min_span_cents=0.0, pad_ratio=0.0) is None
+
+
+class TestHasPitchVariation:
+    """Se le altezze dei grani variano davvero (issue #217).
+
+    E' la domanda che il range zoomato non puo' rispondere: `pitch_cents_range`
+    applica comunque il floor di mezzo semitono, quindi da' un'escursione anche
+    dove non ce n'e'. Chi disegna la scala di colore ha bisogno del dato grezzo,
+    non del range gia' allargato."""
+
+    def _stream(self, *ratios):
+        return SimpleNamespace(
+            voices=[[grain(onset=1.0, pitch_ratio=r) for r in ratios]])
+
+    def test_identical_pitches_do_not_vary(self):
+        assert not has_pitch_variation([self._stream(1.5, 1.5, 1.5)], 0.0, 10.0)
+
+    def test_float_drift_does_not_count_as_variation(self):
+        """La stessa ottava raggiunta per due strade diverse — dodici semitoni
+        moltiplicati uno alla volta contro il rapporto 2.0 — differisce
+        all'ultimo bit. E' rumore aritmetico, non una variazione d'altezza:
+        con l'uguaglianza esatta la colorbar ricomparirebbe."""
+        drifted = 1.0
+        for _ in range(12):
+            drifted *= 2.0 ** (1.0 / 12.0)
+        assert drifted != 2.0                       # la deriva c'e' davvero
+        assert not has_pitch_variation([self._stream(2.0, drifted)], 0.0, 10.0)
+
+    def test_sub_cent_difference_does_not_vary(self):
+        """Mezzo cent e' sotto la soglia percettiva: la scala di colore
+        prometterebbe un'escursione che nessuno sente."""
+        stream = self._stream(1.0, 2.0 ** (0.5 / 1200.0))
+        assert not has_pitch_variation([stream], 0.0, 10.0)
+
+    def test_audible_difference_varies(self):
+        """Cinque cent si sentono: la scala di colore ha qualcosa da dire."""
+        stream = self._stream(1.0, 2.0 ** (5.0 / 1200.0))
+        assert has_pitch_variation([stream], 0.0, 10.0)
+
+    def test_no_pitched_grains_do_not_vary(self):
+        """Nessun grano (o solo ratio zero, che un'altezza non ce l'ha):
+        niente da misurare, quindi niente variazione."""
+        assert not has_pitch_variation([self._stream()], 0.0, 10.0)
+        assert not has_pitch_variation([self._stream(0.0)], 0.0, 10.0)
+
+    def test_only_visible_grains_count(self):
+        """Un grano fuori pagina non fa comparire una variazione dentro."""
+        stream = SimpleNamespace(voices=[[
+            grain(onset=1.0, duration=1.0, pitch_ratio=1.0),
+            grain(onset=50.0, duration=1.0, pitch_ratio=4.0),
+        ]])
+        assert not has_pitch_variation([stream], 0.0, 10.0)
+
+    def test_reverse_grains_count_by_their_absolute_pitch(self):
+        """Il colore racconta l'altezza, non il verso: 1.0 e -1.0 sono lo
+        stesso pitch, quindi nessuna variazione."""
+        assert not has_pitch_variation([self._stream(1.0, -1.0)], 0.0, 10.0)
+
+    def test_variation_can_come_from_two_streams_together(self):
+        """La domanda si puo' porre su piu' stream insieme: due stream uniformi
+        ma di altezza diversa, guardati insieme, variano."""
+        streams = [self._stream(1.0), self._stream(2.0)]
+        assert has_pitch_variation(streams, 0.0, 10.0)
+        assert not has_pitch_variation([streams[0]], 0.0, 10.0)
 
 
 class TestPitchPosition:

--- a/tests/rendering/test_score_visualizer.py
+++ b/tests/rendering/test_score_visualizer.py
@@ -1374,6 +1374,84 @@ class TestPitchColorbarSuppression:
         assert len(self._colorbar_axes(fig)) == 1
 
 
+class TestPitchColorbarColumnIsScoreWide:
+    """La colonna della colorbar si decide una volta per l'INTERA partitura,
+    non pagina per pagina.
+
+    Deciderla per pagina rendeva la larghezza dell'area dati diversa fra le
+    pagine di uno stesso brano — una pagina con escursione e una senza hanno
+    la stessa finestra temporale ma due scale mm/secondo diverse, e l'asse dei
+    tempi smette di essere confrontabile a occhio da una pagina all'altra. La
+    geometria della pagina e' una proprieta' della partitura; la colorbar
+    resta una proprieta' dello stream."""
+
+    @staticmethod
+    def _uniform_stream(sid, onset):
+        s = make_stream(sid, onset=onset, duration=10.0,
+                        sample='piano.wav', n_grains=0)
+        s.voices = [[make_grain(onset + 1.0 + i, pitch_ratio=1.5)
+                     for i in range(3)]]
+        return s
+
+    @staticmethod
+    def _varied_stream(sid, onset):
+        return make_pitched_stream(sid, onset=onset, duration=10.0,
+                                   sample='piano.wav')
+
+    @staticmethod
+    def _colorbar_axes(fig):
+        return [ax for ax in fig.axes if ax.get_label() == '<colorbar>']
+
+    @staticmethod
+    def _width_ratios(fig):
+        ax = next(ax for ax in fig.axes
+                  if ax.get_ylabel().startswith('Read position (s)'))
+        return list(ax.get_subplotspec().get_gridspec().get_width_ratios())
+
+    def _render_pages(self, streams):
+        """Due pagine da 30s: lo stream a onset 0 sulla prima, quello a
+        onset 40 sulla seconda."""
+        viz = make_viz(streams, config={'page_duration': 30.0})
+        with patch('soundfile.read', return_value=(FAKE_AUDIO, SR)):
+            viz.analyze()
+            figs = [viz.render_page(i) for i in range(viz.page_count)]
+        return viz, figs
+
+    def test_column_width_is_the_same_on_every_page(self):
+        """Prima pagina con escursione, seconda senza: stessa larghezza di
+        colonna, quindi stessa scala dell'asse temporale."""
+        viz, figs = self._render_pages([
+            self._varied_stream('s1', onset=0.0),
+            self._uniform_stream('s2', onset=40.0),
+        ])
+        assert len(figs) == 2
+        wr = [self._width_ratios(f) for f in figs]
+        assert wr[0] == pytest.approx(wr[1])
+        assert wr[0][2] == pytest.approx(viz.config['colorbar_width_ratio'])
+
+    def test_the_page_without_variation_keeps_the_column_but_draws_nothing(self):
+        """La colonna resta riservata per la geometria, ma sulla pagina senza
+        escursione non ci finisce dentro nessuna colorbar: e' il prezzo
+        dichiarato della stabilita' fra pagine."""
+        _, figs = self._render_pages([
+            self._varied_stream('s1', onset=0.0),
+            self._uniform_stream('s2', onset=40.0),
+        ])
+        assert len(self._colorbar_axes(figs[0])) == 1
+        assert self._colorbar_axes(figs[1]) == []
+
+    def test_column_is_recovered_on_every_page_when_the_score_never_varies(self):
+        """Nessuna pagina con escursione: la colonna sparisce ovunque, e le
+        pagine restano identiche fra loro."""
+        _, figs = self._render_pages([
+            self._uniform_stream('s1', onset=0.0),
+            self._uniform_stream('s2', onset=40.0),
+        ])
+        wr = [self._width_ratios(f) for f in figs]
+        assert wr[0][2] == 0.0
+        assert wr[0] == pytest.approx(wr[1])
+
+
 # =============================================================================
 # GROUP - Allineamento larghezza envelope/stream (colonna colorbar dedicata)
 # =============================================================================

--- a/tests/rendering/test_score_visualizer.py
+++ b/tests/rendering/test_score_visualizer.py
@@ -114,6 +114,36 @@ def single_stream_scene():
     return [make_stream('s1', onset=0.0, duration=20.0, sample='piano.wav')]
 
 
+def make_pitched_stream(stream_id='s1', onset=0.0, duration=20.0,
+                        sample='piano.wav', n_grains=4, cents_span=120.0):
+    """Come make_stream, ma coi grani distribuiti su un'escursione di pitch
+    reale (default: un semitono, oltre il floor dell'autozoom).
+
+    Serve ai test che guardano la colonna della colorbar: dalla issue #217 la
+    colonna esiste solo dove un'escursione da leggere c'e' davvero, e i grani
+    di make_stream hanno tutti lo stesso pitch_ratio.
+    """
+    s = make_stream(stream_id, onset=onset, duration=duration,
+                    sample=sample, n_grains=0)
+    spacing = duration / max(n_grains, 1)
+    half = cents_span / 2.0
+    s.voices = [[
+        make_grain(
+            onset + i * spacing,
+            pitch_ratio=2.0 ** ((-half + i * cents_span / max(n_grains - 1, 1))
+                                / 1200.0))
+        for i in range(n_grains)
+    ]]
+    return s
+
+
+def pitched_single_stream_scene():
+    """single_stream_scene con un'escursione di pitch: la pagina riserva la
+    colonna della colorbar."""
+    return [make_pitched_stream('s1', onset=0.0, duration=20.0,
+                                sample='piano.wav')]
+
+
 def two_stream_single_sample_scene():
     """Due stream sullo stesso sample, sovrapposti parzialmente."""
     return [
@@ -1237,6 +1267,114 @@ class TestPitchColorAutozoom:
 
 
 # =============================================================================
+# GROUP - Colorbar solo dove il pitch varia davvero (issue #217)
+# =============================================================================
+
+class TestPitchColorbarSuppression:
+    """Una scala di colore ha senso solo se c'e' un'escursione da leggere.
+
+    Con l'autozoom il range non e' mai nullo — `pitch_cents_range` allarga
+    comunque al floor di mezzo semitono — quindi grani tutti alla stessa
+    altezza ottenevano una colorbar con un gradiente pieno e, sotto, grani
+    tutti dello stesso colore: una scala che promette informazione e non ne
+    ha. La soppressione e' per-stream; la colonna del GridSpec si recupera
+    solo se nessuno stream della pagina varia."""
+
+    @staticmethod
+    def _uniform_stream(sid='s1'):
+        """Tre grani, stesso pitch: nessuna escursione da colorare."""
+        s = make_stream(sid, onset=0.0, duration=10.0,
+                        sample='piano.wav', n_grains=0)
+        s.voices = [[make_grain(onset=1.0 + i, pitch_ratio=1.5)
+                     for i in range(3)]]
+        return s
+
+    @staticmethod
+    def _varied_stream(sid='s2'):
+        """Grani distribuiti su un semitono: un'escursione reale."""
+        return make_pitched_stream(sid, onset=0.0, duration=10.0,
+                                   sample='piano.wav')
+
+    @staticmethod
+    def _colorbar_axes(fig):
+        return [ax for ax in fig.axes if ax.get_label() == '<colorbar>']
+
+    @staticmethod
+    def _width_ratios(fig):
+        ax = next(ax for ax in fig.axes
+                  if ax.get_ylabel().startswith('Read position (s)'))
+        return list(ax.get_subplotspec().get_gridspec().get_width_ratios())
+
+    def _render(self, streams, config=None):
+        cfg = {'page_duration': 30.0}
+        cfg.update(config or {})
+        viz = make_viz(streams, config=cfg)
+        with patch('soundfile.read', return_value=(FAKE_AUDIO, SR)):
+            viz.analyze()
+            fig = viz.render_page(0)
+        return viz, fig
+
+    def test_no_colorbar_when_all_pitches_are_equal(self):
+        """Il caso della issue: un solo pitch, nessuna colorbar."""
+        _, fig = self._render([self._uniform_stream()])
+        assert self._colorbar_axes(fig) == []
+
+    def test_colorbar_stays_when_pitches_differ(self):
+        """Nessuna regressione dove la scala serve davvero."""
+        _, fig = self._render([self._varied_stream()])
+        assert len(self._colorbar_axes(fig)) == 1
+
+    def test_colorbar_only_on_the_stream_that_varies(self):
+        """Due stream, uno solo con escursione: una colorbar sola, e sulla
+        riga giusta (la soppressione e' per-stream, non per-pagina)."""
+        streams = [self._uniform_stream('s1'), self._varied_stream('s2')]
+        _, fig = self._render(streams)
+        cbars = self._colorbar_axes(fig)
+        assert len(cbars) == 1
+        # Senza envelope c'e' una riga per stream: la riga 1 e' quella di s2.
+        assert cbars[0].get_subplotspec().rowspan.start == 1
+
+    def test_column_kept_when_at_least_one_stream_varies(self):
+        """La colonna resta riservata anche se una sola riga la usa: le
+        colorbar sono impilate in una colonna sola."""
+        viz, fig = self._render(
+            [self._uniform_stream('s1'), self._varied_stream('s2')])
+        wr = self._width_ratios(fig)
+        assert wr[2] == pytest.approx(viz.config['colorbar_width_ratio'])
+
+    def test_column_is_recovered_when_no_stream_varies(self):
+        """Nessuno stream con escursione: la larghezza della colonna non resta
+        una cella vuota, torna all'area dati."""
+        _, fig = self._render(
+            [self._uniform_stream('s1'), self._uniform_stream('s2')])
+        wr = self._width_ratios(fig)
+        assert wr[2] == 0.0
+        assert wr[1] == pytest.approx(1.0 - wr[0])
+
+    def test_column_is_recovered_when_the_page_has_no_grains(self):
+        """Stesso trattamento per una pagina senza grani: non c'e' scala da
+        disegnare, quindi non c'e' colonna da riservare."""
+        s = make_stream('s1', onset=0.0, duration=10.0, n_grains=0)
+        _, fig = self._render([s])
+        wr = self._width_ratios(fig)
+        assert wr[2] == 0.0
+
+    def test_no_colorbar_when_pitches_are_equal_and_autozoom_off(self):
+        """Anche col range fisso la scala mentirebbe allo stesso modo: i grani
+        sono tutti dello stesso colore comunque."""
+        _, fig = self._render([self._uniform_stream()],
+                              config={'pitch_color_autozoom': {'enabled': False}})
+        assert self._colorbar_axes(fig) == []
+
+    def test_colorbar_stays_with_autozoom_off_when_pitches_differ(self):
+        """Col range fisso e un'escursione reale la colorbar resta: dice su
+        quale scala (ratio) sono stati scelti i colori."""
+        _, fig = self._render([self._varied_stream()],
+                              config={'pitch_color_autozoom': {'enabled': False}})
+        assert len(self._colorbar_axes(fig)) == 1
+
+
+# =============================================================================
 # GROUP - Allineamento larghezza envelope/stream (colonna colorbar dedicata)
 # =============================================================================
 
@@ -1249,12 +1387,14 @@ class TestEnvelopeStreamWidthAlignment:
 
     @staticmethod
     def _scene():
-        """Due stream con grani (-> colorbar) e un envelope dinamico
-        (pointer_speed) -> esiste il pannello envelope sotto agli stream."""
+        """Due stream con grani di altezza variabile (-> colorbar, issue #217)
+        e un envelope dinamico (pointer_speed) -> esiste il pannello envelope
+        sotto agli stream."""
         from pge.envelopes.envelope import Envelope
         streams = []
         for sid in ('s1', 's2'):
-            s = make_stream(sid, onset=0.0, duration=10.0, sample='piano.wav')
+            s = make_pitched_stream(sid, onset=0.0, duration=10.0,
+                                    sample='piano.wav')
             s.pointer_speed = Envelope([[0, -2.0], [10, 4.0]])
             streams.append(s)
         return streams
@@ -1434,7 +1574,9 @@ class TestFontScaleLayout:
     togliere lo spazio attorno alle parole."""
 
     def _render(self, config):
-        viz = make_viz(single_stream_scene(), config=config)
+        # Scena con escursione di pitch: le tre colonne esistono tutte solo
+        # dove la colorbar serve davvero (issue #217).
+        viz = make_viz(pitched_single_stream_scene(), config=config)
         with patch('soundfile.read', return_value=(FAKE_AUDIO, SR)):
             viz.analyze()
             return viz.render_page(0)
@@ -1447,7 +1589,8 @@ class TestFontScaleLayout:
 
     def test_font_scale_1_preserves_default_columns(self):
         """A font_scale=1.0 le colonne restano ai valori di default."""
-        viz = make_viz(single_stream_scene(), config={'page_duration': 30.0})
+        viz = make_viz(pitched_single_stream_scene(),
+                       config={'page_duration': 30.0})
         wr = self._width_ratios(self._render({'page_duration': 30.0}))
         assert wr[0] == pytest.approx(viz.config['waveform_width_ratio'])
         assert wr[2] == pytest.approx(viz.config['colorbar_width_ratio'])


### PR DESCRIPTION
Closes #217.

## Cosa cambia

La colorbar del pitch si disegnava su ogni subplot con almeno un grano visibile. Con l'auto-zoom attivo (default) `pitch_cents_range` non restituisce mai un range nullo — applica il floor `min_span_cents=50` — quindi una pagina di grani tutti alla stessa altezza otteneva una scala col gradiente pieno sopra grani tutti dello stesso colore: prometteva un'escursione che non esiste.

Ora la scala compare solo dove c'è un'escursione da leggere.

- `grain_visuals.has_pitch_variation(streams, t_start, t_end)` — nuova funzione pura: l'escursione **grezza** in cent dei grani visibili contro una soglia. È la domanda a cui `pitch_cents_range` non può rispondere, perché quello restituisce un range già allargato dal floor. Il collect dei cent è ora condiviso (`_visible_cents`) fra le due.
- `_add_pitch_colorbar` esce subito se lo stream non varia: la soppressione è **per-stream**.
- `render_page` calcola `page_has_pitch_variation` **prima** del GridSpec e azzera `colorbar_ratio` quando nessuno stream della pagina varia. Il clamp `main_ratio = max(1 - side_ratio, (3/7) * side_ratio)` è ricalcolato coerentemente perché legge `side_ratio`, che ora vale il solo `waveform_ratio`.

## La soglia: 1 cent, non l'uguaglianza esatta

`PITCH_VARIATION_EPSILON_CENTS = 1.0`.

I `pitch_ratio` arrivano da rapporti calcolati in float — semitoni moltiplicati uno alla volta, cent convertiti in rapporti — e la stessa altezza raggiunta per due strade diverse differisce all'ultimo bit: dodici `2**(1/12)` moltiplicati danno `2.000000000000001`, cioè `7.7e-13` cent di scarto da `2.0`. Con l'uguaglianza esatta quella deriva riaccenderebbe la colorbar su una pagina che di variazione non ne ha, e sarebbe un comportamento che dipende dal modo in cui l'utente ha scritto il pitch, non da cosa si sente.

Un cent è anche sotto la soglia percettiva: la soglia sbaglia solo dove sbagliare non si sente. È la stessa motivazione del floor di mezzo semitono che l'auto-zoom applica già — e sarebbe incoerente che il floor giudicasse "trascurabili" 12 cent di scarto mentre la colorbar considerasse degno di una scala uno scarto di 0.001 cent.

La soglia è una costante di modulo, esposta come keyword arg di default: nessuna nuova chiave di config.

## La colonna: recuperata, non lasciata vuota

Se **nessuno** stream della pagina varia, la terza colonna non viene riservata affatto (`width_ratios[2] == 0`) e la larghezza torna all'area dati. Con almeno uno stream che varia la colonna resta al valore di `colorbar_width_ratio`: le colorbar sono impilate in quella colonna sola, quindi basta uno stream a giustificarla, e le colorbar presenti restano allineate con quelle degli altri. Verificato a occhio su due pagine renderizzate (uno stream uniforme + uno variato → una sola colorbar, sulla riga giusta, colonna conservata; due stream uniformi → nessuna colonna).

## Test (TDD, rosso prima)

`tests/rendering/test_grain_visuals.py` — nuova `TestHasPitchVariation`: pitch identici, deriva float della stessa ottava, mezzo cent, cinque cent, nessun grano / solo `ratio` zero, grani fuori pagina, reverse (`1.0` e `-1.0` sono la stessa altezza), variazione che nasce da due stream insieme.

`tests/rendering/test_score_visualizer.py` — nuova `TestPitchColorbarSuppression`: pitch identici → nessun asse colorbar; pitch diversi → colorbar come oggi; due stream di cui uno solo variato → una colorbar, sulla riga di quello variato, colonna conservata; nessuno variato → colonna recuperata; pagina senza grani → colonna recuperata; entrambi i casi anche con `pitch_color_autozoom.enabled: false`.

**Fixture esistenti toccate** (il caso previsto dalla consegna): tre test di layout — `TestEnvelopeStreamWidthAlignment::test_colorbar_in_dedicated_column_right_of_content`, `TestFontScaleLayout::test_font_scale_1_preserves_default_columns`, `TestFontScaleLayout::test_main_ratio_clamped_at_extreme_font_scale` — costruivano la scena con `make_stream`, i cui grani hanno tutti `pitch_ratio=1.0`. Guardano le tre colonne del GridSpec, quindi ora devono partire da una pagina che la colorbar ce l'ha davvero: nuova factory `make_pitched_stream` (grani distribuiti su un semitono) e `pitched_single_stream_scene`. Nessuna asserzione è stata indebolita, solo la scena resa pertinente a ciò che il test misura.

Sedici test nuovi in tutto. Sul commit iniziale (prima dell'allineamento a main): `make tests` 5627 passed contro una baseline misurata di 5611.

## Allineamento a main (#216)

Il branch è stato aggiornato con un merge di `main` dopo il merge di #216. Nessun conflitto sul codice — main tocca `envelopes/` e `parameters/`, questo branch `rendering/` — e un solo conflitto sul `CHANGELOG.md`, dove entrambi i lati scrivono sotto `[Unreleased]`: risolto tenendo tutto, con la voce #217 come `### Modificato` dopo la sezione `### Modificato (breaking)` di main.

`make tests` sul risultato del merge: **5671 passed, 2 skipped**. `make docs-lint`: OK, 19 doc.

## Cosa ho deliberatamente NON fatto

- **Nessuna chiave di config, nessun flag di opt-out, nessuna strategia.** Una pagina con un pitch solo non ha una scala da mostrare in nessuna configurazione: renderlo opzionale sarebbe stato offrire di riaccendere il difetto.
- **Il floor `min_span_cents` non è toccato.** Fa il suo mestiere dove una variazione c'è: qui il problema era a monte, sul disegnare o no la scala.
- **Niente soppressione della colonna waveform o del pannello envelope** con criteri analoghi: fuori dallo scope della issue.
- **`pitch_cents_range` continua a restituire il range col floor** anche quando non varia niente — i grani vanno colorati comunque, e il colore unico che ne esce è corretto. La modifica riguarda solo la legenda.
- **Caso limite dichiarato:** uno stream i cui grani hanno tutti `pitch_ratio == 0` (nessuna altezza definita, il logaritmo non esiste) ora non ha colorbar, mentre prima ne otteneva una sulla scala fissa in ratio. È coerente con la regola — grani tutti dello stesso colore — ed è una configurazione degenere.

## Impatto cross-repo

Nessuno. La modifica non tocca la sintassi YAML, i bounds, i nomi di strategy/window/renderer, la gerarchia errori, la CLI o i formati di output: cambia solo cosa finisce sulla figura della map. Niente da aggiornare in `PGE-ls` né in `PGE-ui` (che consuma il PDF prodotto dall'engine, non ne replica il layout), quindi nessuna issue aperta.