### PR TITLE
feat(stream): `onset` opzionale, default = origine della timeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,69 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ## [Unreleased]
 
+### Aggiunto
+
+- **`onset` opzionale nello stream: senza dichiarazione lo stream parte
+  dall'origine della timeline.** Uno stream che non dichiara una posizione non
+  ne ha una indeterminata, ne ha una neutra: `0` non è "nulla", è l'origine.
+  L'argomento con cui v7.1.0 aveva lasciato `onset` fuori — «la posizione in
+  timeline non è deducibile da nulla» — confondeva *non derivabile da
+  un'altra dichiarazione* con *senza valore neutro*. Le condizioni di
+  esistenza di uno stream passano da tre a due: `stream_id` e `sample`.
+
+  Si chiude così l'enunciato che v7.1.0 lasciava a metà: **uno stream a riposo
+  è il sample** — stessa origine, stessa durata, contenuto risintetizzato.
+  Tutto il resto è override compositivo.
+
+  ```yaml
+  streams:
+    - stream_id: risintesi     # parte da 0, dura quanto il sample
+      sample: file.wav
+  ```
+
+  La risoluzione vive in un punto solo, `resolve_stream_onset` in
+  `core/stream_config.py`, per la stessa ragione di `resolve_stream_duration`:
+  i siti che scrivono la posizione sono due e devono dire la stessa cosa.
+  `StreamContext.from_yaml` la risolve **prima** di costruire il dataclass —
+  `onset` è dichiarato prima di `duration`/`sample`/`sample_dur_sec`, quindi
+  un default lì costringerebbe anche loro ad averne uno, e un `onset: null`
+  entrato intatto nel dataclass frozen riemergerebbe lontano come `TypeError`
+  nell'aritmetica dei grani. `Stream._init_stream_context` lo assegna
+  esplicitamente: quel metodo scriveva `self.onset` iterando sui campi
+  obbligatori, e toltolo da quell'insieme l'attributo non esisterebbe più —
+  `AttributeError` alla prima generazione di grani, e a cascata in
+  `page_layout`, `score_visualizer`, i due renderer, `sv_exporter`,
+  `reaper_project_writer`, `grain_json_writer`, che leggono `stream.onset`.
+
+  Il default scatta su `is None`, non sulla truthiness: `onset: null` vale
+  come chiave assente, mentre `onset: 0` resta una dichiarazione esplicita —
+  indistinguibile nel risultato, distinta nell'intenzione. `time_mode` non
+  c'entra: riguarda l'asse degli envelope dentro lo stream, non la posizione
+  dello stream, che è sempre assoluta in secondi.
+
+  Nessuno YAML valido cambia comportamento: se `onset` c'è, vince come prima.
+  Cambia solo il verdetto su input che prima erano rifiutati.
+
+  **Costo accettato.** Un `onset` cancellato per sbaglio non produce più un
+  errore: lo stream si impila silenziosamente a `t=0`. È il prezzo del
+  default, identico a quello già accettato per `duration`.
+
+  **Cache incrementale: nessuna modifica**, e qui sta l'asimmetria con
+  v7.1.0. Là la durata risolta era entrata nel fingerprint perché derivava da
+  un file audio mutabile, fuori dall'hash; qui il default è la costante `0.0`
+  e non c'è nessuna dipendenza esterna da registrare. `onset` resta nell'hash
+  com'è oggi. Che `onset` assente e `onset: 0.0` producano fingerprint diversi
+  è il normale effetto di una chiave in più: un re-render una tantum.
+  Nessun bump di `VARIATION_SEMANTICS_VERSION`, per lo stesso motivo per cui
+  nessuno YAML valido cambia comportamento. (#220)
+
+  **Effetto collaterale sui messaggi d'errore.** Con due sole condizioni di
+  esistenza, e una delle due `sample`, il messaggio plurale di
+  `MissingFieldError` non è più raggiungibile dalla CLI: il controllo su
+  `sample` in `Stream.__init__` precede quello sui campi di contesto e si
+  ferma lì, quindi `stream_id` e `sample` entrambi assenti danno «Campo
+  obbligatorio mancante: 'sample'» e non l'elenco dei due.
+
 ### Modificato (breaking)
 
 - **Un envelope malformato sotto `deviation_probability` ora è un errore.**

--- a/README.md
+++ b/README.md
@@ -209,8 +209,11 @@ streams:
       duration: 0.05
 ```
 
-Both are compositional overrides, written only when they differ from the
-sample:
+Both are compositional overrides. They are not the same kind of default,
+though: `duration` inherits a value from the sample, so writing it means
+choosing a length other than the file's, while `onset` inherits nothing —
+its neutral value is the timeline origin, and writing it means placing the
+stream somewhere other than the beginning.
 
 ```yaml
 streams:

--- a/README.md
+++ b/README.md
@@ -197,12 +197,25 @@ Pages are 30 seconds wide in A3 landscape format. A 120-second piece produces a 
 
 ## YAML Configuration
 
-A minimal stream configuration:
+A minimal stream configuration — `stream_id` and `sample` are the only
+required fields. Without `onset` the stream starts at the timeline origin;
+without `duration` it lasts as long as the sample:
 
 ```yaml
 streams:
   - stream_id: "s01"
-    onset: 0.0
+    sample: "source.wav"
+    grain:
+      duration: 0.05
+```
+
+Both are compositional overrides, written only when they differ from the
+sample:
+
+```yaml
+streams:
+  - stream_id: "s01"
+    onset: 12.5
     duration: 30
     sample: "source.wav"
     grain:

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -11,7 +11,7 @@ sources:
   - src/pge/envelopes/
   - src/pge/shared/seeding.py
   - src/pge/shared/distribution_strategy.py
-last_synced_commit: bbd4709
+last_synced_commit: 8bd9d21
 entry_for: [yaml-syntax, envelope-syntax]
 ---
 
@@ -37,7 +37,9 @@ Sezioni rilevanti in questo doc:
 - [Seed (Riproducibilità)](#seed-riproducibilità) — render NumPy riproducibili;
   `rng_group` per condividere la sequenza fra stream
 - [Parameter Syntax](#parameter-syntax) — scalari, tuple, dict, envelope
-- [Campi Obbligatori di Stream](#campi-obbligatori-di-stream) — `stream_id`, `onset`, `sample`
+- [Campi Obbligatori di Stream](#campi-obbligatori-di-stream) — `stream_id`, `sample`
+- [Posizione dello Stream](#posizione-dello-stream-onset-opzionale) — `onset` opzionale,
+  assente = origine della timeline
 - [Durata dello Stream](#durata-dello-stream-duration-opzionale) — `duration` opzionale,
   assente = durata del sample
 - [Configurazione Processo (StreamConfig)](#configurazione-processo-streamconfig)
@@ -205,13 +207,61 @@ Qualsiasi parametro numerico accetta le seguenti forme:
 ```yaml
 streams:
   - stream_id: "nome_univoco"   # stringa identificativa
-    onset: 0.0                  # tempo di inizio in secondi (assoluto)
     sample: "file.wav"          # nome file (cercato in Media/)
 ```
 
-Le condizioni di esistenza di uno stream sono tre. `onset` resta obbligatorio:
-la posizione in timeline non è deducibile da nulla. Per `duration`, che
-obbligatoria non è, vedi [Durata dello Stream](#durata-dello-stream-duration-opzionale).
+Le condizioni di esistenza di uno stream sono due. Uno stream a riposo **è il
+sample**: stessa origine, stessa durata, contenuto risintetizzato. Tutto il
+resto è override compositivo — vedi
+[Posizione dello Stream](#posizione-dello-stream-onset-opzionale) e
+[Durata dello Stream](#durata-dello-stream-duration-opzionale).
+
+```yaml
+streams:
+  - stream_id: "risintesi"      # parte da 0, dura quanto il sample
+    sample: "file.wav"
+```
+
+---
+
+## Posizione dello Stream (`onset` opzionale)
+
+`onset` è un campo **opzionale**: se assente lo stream comincia all'origine
+della timeline, cioè a `0.0` secondi.
+
+```yaml
+streams:
+  - stream_id: "dall_origine"   # parte da 0
+    sample: "file.wav"
+
+  - stream_id: "spostato"       # override compositivo esplicito
+    onset: 12.5
+    sample: "file.wav"
+```
+
+0 non è "nulla", è l'origine: uno stream che non dichiara una posizione non ha
+una posizione indeterminata, ne ha una neutra. Dichiararla è una scelta
+compositiva, e le scelte compositive stanno bene come override espliciti.
+
+| Dichiarazione | Posizione dello stream |
+|---------------|------------------------|
+| chiave assente | `0.0` s (origine della timeline) |
+| `onset: null` | `0.0` s (come chiave assente) |
+| `onset: 12.5` | 12.5 s (l'esplicito vince sempre) |
+| `onset: 0` | `0.0` s — dichiarazione esplicita, stesso risultato del default |
+
+`onset` è **sempre assoluto in secondi**: `time_mode: normalized` riguarda
+l'asse degli envelope dentro lo stream, non la posizione dello stream nella
+timeline.
+
+**Costo del default.** Un `onset` cancellato per sbaglio non produce più un
+errore: lo stream si impila silenziosamente a `t=0`. È lo stesso prezzo già
+accettato per `duration`.
+
+**Asimmetria con `duration`.** Il default di `duration` è derivato da un dato
+(la lunghezza del file audio), quello di `onset` è la costante `0.0`. Stesso
+gesto, natura diversa: è il motivo per cui la durata risolta entra nel
+fingerprint della cache e la posizione risolta no.
 
 ---
 

--- a/src/pge/core/stream.py
+++ b/src/pge/core/stream.py
@@ -38,7 +38,12 @@ from pge.parameters.read_direction import (
     READ_DIRECTION_FIELD,
     normalize_read_direction,
 )
-from pge.core.stream_config import StreamConfig, StreamContext, resolve_stream_duration
+from pge.core.stream_config import (
+    StreamConfig,
+    StreamContext,
+    resolve_stream_duration,
+    resolve_stream_onset,
+)
 from pge.controllers.voice_manager import VoiceManager, VoiceConfig
 from pge.parameters.pitch_unit import make_pitch_unit
 from pge.strategies.voice_pitch_strategy import VoicePitchStrategyFactory, SEMITONE_LOCKED
@@ -181,11 +186,14 @@ class Stream:
         Esclusi, pur non avendo un default nel dataclass:
         - sample_dur_sec: derivato dal file audio, mai dal YAML;
         - duration: se assente vale la durata del sample (issue #205), risolta
-          da resolve_stream_duration invece che pretesa dallo YAML.
+          da resolve_stream_duration invece che pretesa dallo YAML;
+        - onset: se assente vale l'origine della timeline (issue #220), risolto
+          da resolve_stream_onset. Restano due le condizioni di esistenza di
+          uno stream: stream_id e sample.
         """
         return {
             field.name for field in fields(StreamContext)
-            if field.name not in ('sample_dur_sec', 'duration')
+            if field.name not in ('sample_dur_sec', 'duration', 'onset')
             and field.default is dataclass_MISSING
             and field.default_factory is dataclass_MISSING
         }
@@ -207,10 +215,14 @@ class Stream:
         # con object.__new__ (bypass di __init__), dove samples_dir manca.
         self.sample_dur_sec = get_sample_duration(
             self.sample, base_path=getattr(self, 'samples_dir', None))
-        # duration e' fuori dai campi obbligatori (issue #205): il setattr sopra
-        # non la scrive piu', va risolta qui con la stessa regola di
-        # StreamContext.from_yaml. Senza questa riga self.duration non esiste e
-        # la prima generazione di grani solleva AttributeError.
+        # onset (issue #220) e duration (issue #205) sono fuori dai campi
+        # obbligatori: il setattr sopra non le scrive piu', vanno risolte qui
+        # con la stessa regola di StreamContext.from_yaml. Senza queste righe
+        # gli attributi non esistono e la prima generazione di grani solleva
+        # AttributeError (self.onset + elapsed_time + voice_config.onset_offset),
+        # insieme a page_layout, score_visualizer, i due renderer, sv_exporter,
+        # reaper_project_writer e grain_json_writer, che leggono stream.onset.
+        self.onset = resolve_stream_onset(params)
         self.duration = resolve_stream_duration(params, self.sample_dur_sec)
 
     def _init_stream_parameters(self, params: dict, config: StreamConfig) -> None:

--- a/src/pge/core/stream.py
+++ b/src/pge/core/stream.py
@@ -199,7 +199,15 @@ class Stream:
         }
 
     def _check_required_context_fields(self, params, stream_id):
-        """Verifica campi obbligatori StreamContext prima di StreamConfig.from_yaml."""
+        """Verifica campi obbligatori StreamContext prima di StreamConfig.from_yaml.
+
+        Oggi il ramo plurale non scatta mai da qui: i campi richiesti sono due,
+        stream_id e sample, e `sample` e' controllato prima in __init__, che si
+        ferma li'. Quindi `missing` e' al massimo {'stream_id'}. Il sorted() e
+        il ramo plurale restano per il prossimo campo di contesto senza default
+        — e sono ancora raggiungibili da chi chiama questo metodo bypassando
+        __init__ (tests/core/test_stream.py).
+        """
         missing = self._required_context_fields() - set(params.keys())
         if missing:
             missing_list = sorted(missing)

--- a/src/pge/core/stream_config.py
+++ b/src/pge/core/stream_config.py
@@ -45,6 +45,13 @@ def stream_onset_is_implicit(yaml_data: dict) -> bool:
     `is None` copre sia la chiave assente sia `onset: null` esplicito, e lascia
     fuori `onset: 0`, che nel risultato e' indistinguibile dal default ma
     nell'intenzione e' una dichiarazione.
+
+    A differenza del gemello, questo predicato NON e' condiviso: lo usa solo
+    resolve_stream_onset qui sotto. Il fingerprint della cache importa
+    stream_duration_is_implicit perche' la durata ereditata dipende da un file
+    audio mutabile e va registrata; l'onset ereditato e' la costante 0.0, non
+    dipende da niente di esterno, e non c'e' niente da registrare. Chi cerca il
+    consumatore fuori da questo modulo non lo trova perche' non deve esistere.
     """
     return yaml_data.get('onset') is None
 

--- a/src/pge/core/stream_config.py
+++ b/src/pge/core/stream_config.py
@@ -38,6 +38,35 @@ def resolve_stream_duration(yaml_data: dict, sample_dur_sec: float) -> float:
     return yaml_data['duration']
 
 
+def stream_onset_is_implicit(yaml_data: dict) -> bool:
+    """True quando lo stream non dichiara una posizione propria (issue #220).
+
+    Stesso predicato di stream_duration_is_implicit e per la stessa ragione:
+    `is None` copre sia la chiave assente sia `onset: null` esplicito, e lascia
+    fuori `onset: 0`, che nel risultato e' indistinguibile dal default ma
+    nell'intenzione e' una dichiarazione.
+    """
+    return yaml_data.get('onset') is None
+
+
+def resolve_stream_onset(yaml_data: dict) -> float:
+    """Posizione dello stream: quella dichiarata, o l'origine (issue #220).
+
+    Uno stream che non dichiara nulla comincia all'origine della timeline: 0
+    non e' "nulla", e' l'origine. `onset` e' un override compositivo.
+
+    A differenza di resolve_stream_duration non prende nessun dato esterno: il
+    default e' la costante 0.0, non un valore derivato dal file audio. E' il
+    motivo per cui qui il fingerprint della cache non si muove.
+
+    Punto unico di risoluzione: la usano sia StreamContext.from_yaml sia
+    Stream._init_stream_context, che scrivono lo stesso onset su due oggetti.
+    """
+    if stream_onset_is_implicit(yaml_data):
+        return 0.0
+    return yaml_data['onset']
+
+
 @dataclass(frozen=True)
 class StreamContext:
     stream_id: str
@@ -91,10 +120,14 @@ class StreamContext:
                 if name in yaml_data and yaml_data[name] is not None
             }
         kwargs['sample_dur_sec'] = sample_dur_sec
-        # duration assente o null -> durata del sample (issue #205). Risolta
-        # prima di cls(**kwargs): il dataclass non puo' avere un default,
-        # e' dichiarato prima di sample/sample_dur_sec che ne resterebbero
-        # obbligati ad averne uno.
+        # onset assente o null -> origine della timeline (issue #220), duration
+        # assente o null -> durata del sample (issue #205). Entrambe risolte
+        # prima di cls(**kwargs): nessuna delle due puo' avere un default nel
+        # dataclass, sono dichiarate prima di sample/sample_dur_sec che ne
+        # resterebbero obbligati ad averne uno. Senza questa riga `onset: null`
+        # entrerebbe nel dataclass frozen come None e l'errore riemergerebbe
+        # lontano, come TypeError nell'aritmetica dei grani.
+        kwargs['onset'] = resolve_stream_onset(kwargs)
         kwargs['duration'] = resolve_stream_duration(kwargs, sample_dur_sec)
         return cls(**kwargs)
 

--- a/tests/core/test_stream.py
+++ b/tests/core/test_stream.py
@@ -252,10 +252,12 @@ class TestInitStreamContext:
 
     def test_missing_multiple_fields_raises(self):
         """Piu' parametri mancanti -> ValueError con nomi."""
-        
+
         s = object.__new__(Stream)
-        params = {'sample': 'test.wav'}
-        # Mancano stream_id, onset, duration
+        params = {'onset': 0.0, 'duration': 1.0}
+        # Mancano stream_id e sample: le due condizioni di esistenza rimaste
+        # dopo #205 (duration) e #220 (onset). Omettere `onset` non basta piu'
+        # a rendere plurale il messaggio.
 
         with patch('pge.core.stream.get_sample_duration', return_value=5.0):
             with pytest.raises(ValueError, match="Campi obbligatori mancanti"):

--- a/tests/core/test_stream_config.py
+++ b/tests/core/test_stream_config.py
@@ -228,27 +228,32 @@ class TestStreamContextFromYaml:
 class TestStreamContextAllowNone:
     """Test allow_none su StreamContext.from_yaml()."""
 
+    # NOTA: il vettore di questi due test era `onset`, che dal #220 non serve
+    # piu' allo scopo — entrambi i rami passano da resolve_stream_onset e non
+    # arrivano mai al dataclass con None. Il vettore e' ora `stream_id`, che
+    # e' rimasto un campo senza default e senza risoluzione.
+
     def test_allow_none_true_includes_none_values(self, sample_dur):
         """allow_none=True include campi con valore None."""
         yaml_data = {
-            'stream_id': 's1',
-            'onset': None,       # None esplicito
+            'stream_id': None,   # None esplicito
+            'onset': 0.0,
             'duration': 5.0,
             'sample': 'test.wav',
         }
-        # Con allow_none=True, onset=None viene incluso
+        # Con allow_none=True, stream_id=None viene incluso
         ctx = StreamContext.from_yaml(yaml_data, sample_dur_sec=sample_dur, allow_none=True)
-        assert ctx.onset is None
+        assert ctx.stream_id is None
 
     def test_allow_none_false_excludes_none_values(self, sample_dur):
         """allow_none=False esclude campi con valore None -> TypeError se obbligatori."""
         yaml_data = {
-            'stream_id': 's1',
-            'onset': None,       # Escluso con allow_none=False
+            'stream_id': None,   # Escluso con allow_none=False
+            'onset': 0.0,
             'duration': 5.0,
             'sample': 'test.wav',
         }
-        # onset escluso -> TypeError (campo obbligatorio senza default)
+        # stream_id escluso -> TypeError (campo obbligatorio senza default)
         with pytest.raises(TypeError):
             StreamContext.from_yaml(yaml_data, sample_dur_sec=sample_dur, allow_none=False)
 

--- a/tests/core/test_stream_config_errors.py
+++ b/tests/core/test_stream_config_errors.py
@@ -10,7 +10,9 @@ Verifica:
   - stream_id mancante    -> MissingFieldError, contesto 'unknown'
   - grain.reverse invalido -> InvalidFieldValueError con stream_id
 """
+import numpy as np
 import pytest
+import soundfile as sf
 
 from pge.core.stream import Stream
 from pge.shared.exceptions import (
@@ -19,6 +21,23 @@ from pge.shared.exceptions import (
     InvalidFieldValueError,
     MissingFieldError,
 )
+
+
+SR = 48000
+
+
+def _write_wav(directory, name='tone.wav', seconds=2.0):
+    """Sample generato su tmp_path, non pescato da `refs/`.
+
+    L'idioma precedente leggeva il primo `.wav` di PATHSAMPLES e faceva
+    `pytest.skip` quando non ne trovava: ma `refs/*.wav` e' gitignored e il job
+    `unit tests` della CI non ne genera nessuno (lo fa solo il job e2e, che poi
+    gira `-m e2e`). Questi test restavano cosi' invisibili proprio nell'ambiente
+    dove le regressioni passano.
+    """
+    sf.write(str(directory / name),
+             np.zeros(int(SR * seconds), dtype='float32'), SR)
+    return name
 
 
 def test_stream_missing_sample_raises_missing_field_error():
@@ -49,7 +68,7 @@ def test_stream_missing_sample_user_message_clean():
     assert "drone_a" in msg
 
 
-def test_stream_missing_stream_id_raises_missing_field_error():
+def test_stream_missing_stream_id_raises_missing_field_error(tmp_path):
     """stream_id mancante -> MissingFieldError, senza stream_id da nominare.
 
     Era il test sui "context fields mancanti", che teneva presenti stream_id e
@@ -58,52 +77,37 @@ def test_stream_missing_stream_id_raises_missing_field_error():
     tolto per davvero: qui e' stream_id, e il contesto dell'errore ripiega su
     'unknown' perche' non c'e' nessun id da stampare.
     """
-    # sample valido per superare check sample, esiste in PATHSAMPLES
-    import os
-    from pge.shared.utils import PATHSAMPLES
-    samples = [f for f in os.listdir(PATHSAMPLES) if f.endswith('.wav')]
-    if not samples:
-        pytest.skip("nessun sample disponibile")
-    sample = samples[0]
+    sample = _write_wav(tmp_path)   # sample valido, per superare il check su sample
 
     params = {'sample': sample}
 
     with pytest.raises(MissingFieldError) as exc_info:
-        Stream(params)
+        Stream(params, samples_dir=str(tmp_path))
 
     err = exc_info.value
     assert err.fields == ['stream_id']
     assert err.stream_id == 'unknown'
 
 
-def test_stream_builds_with_the_two_existence_conditions_alone():
+def test_stream_builds_with_the_two_existence_conditions_alone(tmp_path):
     """stream_id + sample bastano: nessun altro campo di contesto e' preteso.
 
     Il rovescio del test precedente, e la ragione per cui ha dovuto cambiare
     forma: `duration` (issue #205) e `onset` (issue #220) hanno un default.
     """
-    import os
-    from pge.shared.utils import PATHSAMPLES
-    samples = [f for f in os.listdir(PATHSAMPLES) if f.endswith('.wav')]
-    if not samples:
-        pytest.skip("nessun sample disponibile")
-    sample = samples[0]
+    sample = _write_wav(tmp_path, seconds=2.0)
 
-    stream = Stream({'stream_id': 'sx', 'sample': sample})
+    stream = Stream({'stream_id': 'sx', 'sample': sample},
+                    samples_dir=str(tmp_path))
 
     assert stream.stream_id == 'sx'
     assert stream.onset == 0.0
-    assert stream.duration == stream.sample_dur_sec
+    assert stream.duration == stream.sample_dur_sec == pytest.approx(2.0)
 
 
-def test_stream_invalid_grain_reverse_raises_invalid_field_value_error():
+def test_stream_invalid_grain_reverse_raises_invalid_field_value_error(tmp_path):
     """grain.reverse: true -> InvalidFieldValueError con stream_id."""
     import os
-    from pge.shared.utils import PATHSAMPLES
-    samples = [f for f in os.listdir(PATHSAMPLES) if f.endswith('.wav')]
-    if not samples:
-        pytest.skip("nessun sample disponibile")
-    sample = samples[0]
 
     # tentativo: minimo necessario per arrivare a _init_grain_reverse.
     # Se altri campi mancano, _init_stream_context fallisce prima:
@@ -121,11 +125,14 @@ def test_stream_invalid_grain_reverse_raises_invalid_field_value_error():
         pytest.skip("nessuno stream nel config di riferimento")
     first = streams[0]
     first_id = first.get('stream_id', 'unknown')
+    # Il sample che il config dichiara, generato su tmp_path: il config resta
+    # la fonte dei parametri, senza dipendere da un file dentro refs/.
+    _write_wav(tmp_path, name=first['sample'])
     # forziamo grain.reverse: true -> deve fallire
     first.setdefault('grain', {})['reverse'] = True
 
     with pytest.raises(InvalidFieldValueError) as exc_info:
-        Stream(first)
+        Stream(first, samples_dir=str(tmp_path))
 
     err = exc_info.value
     assert err.field == 'grain.reverse'

--- a/tests/core/test_stream_config_errors.py
+++ b/tests/core/test_stream_config_errors.py
@@ -10,6 +10,8 @@ Verifica:
   - stream_id mancante    -> MissingFieldError, contesto 'unknown'
   - grain.reverse invalido -> InvalidFieldValueError con stream_id
 """
+from pathlib import Path
+
 import numpy as np
 import pytest
 import soundfile as sf
@@ -107,16 +109,18 @@ def test_stream_builds_with_the_two_existence_conditions_alone(tmp_path):
 
 def test_stream_invalid_grain_reverse_raises_invalid_field_value_error(tmp_path):
     """grain.reverse: true -> InvalidFieldValueError con stream_id."""
-    import os
-
     # tentativo: minimo necessario per arrivare a _init_grain_reverse.
     # Se altri campi mancano, _init_stream_context fallisce prima:
     # in tal caso questo test verifica che il path resti raggiungibile
     # via fixture parametri completi (delegato al test e2e).
     # Qui costruiamo dict via configs/PGE_test.yml.
     import yaml
-    cfg_path = 'configs/PGE_test.yml'
-    if not os.path.exists(cfg_path):
+    # Path ancorata al file di test, non alla cwd: il config e' versionato,
+    # quindi c'e' sempre, e con una path relativa lo skip qui sotto scattava
+    # solo per via della directory da cui si lancia pytest — un test che
+    # sparisce in silenzio, la stessa dinamica dei tre skip appena rimossi.
+    cfg_path = Path(__file__).resolve().parents[2] / 'configs' / 'PGE_test.yml'
+    if not cfg_path.exists():
         pytest.skip("config di riferimento mancante")
     with open(cfg_path) as f:
         cfg = yaml.safe_load(f)

--- a/tests/core/test_stream_config_errors.py
+++ b/tests/core/test_stream_config_errors.py
@@ -7,7 +7,7 @@ verso la gerarchia ConfigError (issue #38, PR1).
 
 Verifica:
   - sample mancante/null  -> MissingFieldError con stream_id
-  - context fields mancanti -> MissingFieldError con stream_id
+  - stream_id mancante    -> MissingFieldError, contesto 'unknown'
   - grain.reverse invalido -> InvalidFieldValueError con stream_id
 """
 import pytest
@@ -49,8 +49,15 @@ def test_stream_missing_sample_user_message_clean():
     assert "drone_a" in msg
 
 
-def test_stream_missing_context_fields_raises_missing_field_error():
-    """context fields mancanti -> MissingFieldError con stream_id."""
+def test_stream_missing_stream_id_raises_missing_field_error():
+    """stream_id mancante -> MissingFieldError, senza stream_id da nominare.
+
+    Era il test sui "context fields mancanti", che teneva presenti stream_id e
+    sample e contava su `onset` per far scattare l'errore. Da #220 quei due
+    campi sono le sole condizioni di esistenza, quindi il campo che manca va
+    tolto per davvero: qui e' stream_id, e il contesto dell'errore ripiega su
+    'unknown' perche' non c'e' nessun id da stampare.
+    """
     # sample valido per superare check sample, esiste in PATHSAMPLES
     import os
     from pge.shared.utils import PATHSAMPLES
@@ -59,14 +66,34 @@ def test_stream_missing_context_fields_raises_missing_field_error():
         pytest.skip("nessun sample disponibile")
     sample = samples[0]
 
-    params = {'stream_id': 'sx', 'sample': sample}  # mancano altri campi obbligatori
+    params = {'sample': sample}
 
     with pytest.raises(MissingFieldError) as exc_info:
         Stream(params)
 
     err = exc_info.value
-    assert err.stream_id == 'sx'
-    assert len(err.fields) >= 1
+    assert err.fields == ['stream_id']
+    assert err.stream_id == 'unknown'
+
+
+def test_stream_builds_with_the_two_existence_conditions_alone():
+    """stream_id + sample bastano: nessun altro campo di contesto e' preteso.
+
+    Il rovescio del test precedente, e la ragione per cui ha dovuto cambiare
+    forma: `duration` (issue #205) e `onset` (issue #220) hanno un default.
+    """
+    import os
+    from pge.shared.utils import PATHSAMPLES
+    samples = [f for f in os.listdir(PATHSAMPLES) if f.endswith('.wav')]
+    if not samples:
+        pytest.skip("nessun sample disponibile")
+    sample = samples[0]
+
+    stream = Stream({'stream_id': 'sx', 'sample': sample})
+
+    assert stream.stream_id == 'sx'
+    assert stream.onset == 0.0
+    assert stream.duration == stream.sample_dur_sec
 
 
 def test_stream_invalid_grain_reverse_raises_invalid_field_value_error():

--- a/tests/core/test_stream_duration_default.py
+++ b/tests/core/test_stream_duration_default.py
@@ -6,7 +6,11 @@ Test per `duration` opzionale nello stream (issue #205).
 
 A riposo lo stream risintetizza il sample: se `duration` non e' dichiarata,
 la durata dello stream e' quella del file audio in `sample`. Le condizioni
-di esistenza di uno stream passano da quattro a tre: stream_id, onset, sample.
+di esistenza di uno stream passavano cosi' da quattro a tre.
+
+Da #220 sono due — stream_id e sample: anche `onset` ha un default (l'origine
+della timeline). Il default di `onset` e' coperto da
+test_stream_onset_default.py; qui resta la parte che riguarda `duration`.
 """
 import numpy as np
 import pytest
@@ -28,7 +32,12 @@ def _write_wav(directory, name='tone.wav', seconds=2.0):
 
 
 def _params(**overrides):
-    """Stream minimo SENZA `duration`: solo le tre condizioni di esistenza."""
+    """Stream minimo SENZA `duration`.
+
+    `onset` e' dichiarato di proposito, pur essendo opzionale da #220: qui
+    l'oggetto del test e' il default di `duration`, e a muoversi deve essere
+    una cosa sola.
+    """
     params = {
         'stream_id': 'test_stream',
         'onset': 0.0,
@@ -118,23 +127,35 @@ class TestDurationDefaultsToSampleDuration:
 
 
 class TestStreamExistenceConditions:
-    """Le condizioni di esistenza di uno stream sono tre: stream_id, onset,
-    sample. `duration` non e' piu' fra queste."""
+    """Le condizioni di esistenza di uno stream sono due: stream_id e sample.
+    Ne' `duration` (issue #205) ne' `onset` (issue #220) sono fra queste."""
 
-    def test_missing_onset_still_fails_and_does_not_name_duration(self, tmp_path):
+    def test_missing_sample_still_fails_and_does_not_name_duration(self, tmp_path):
         _write_wav(tmp_path)
-        params = {'stream_id': 'test_stream', 'sample': 'tone.wav'}
+        params = {'stream_id': 'test_stream', 'onset': 0.0}
 
         with pytest.raises(MissingFieldError) as exc_info:
             Stream(params, samples_dir=str(tmp_path))
 
         err = exc_info.value
-        assert err.fields == ['onset']
+        assert err.fields == ['sample']
         assert err.stream_id == 'test_stream'
 
     def test_missing_stream_id_still_fails(self, tmp_path):
         _write_wav(tmp_path)
         params = {'onset': 0.0, 'sample': 'tone.wav'}
+
+        with pytest.raises(MissingFieldError) as exc_info:
+            Stream(params, samples_dir=str(tmp_path))
+
+        assert exc_info.value.fields == ['stream_id']
+
+    def test_missing_stream_id_names_neither_duration_nor_onset(self, tmp_path):
+        """Con i due default in vigore, l'unico campo mancante e' quello che
+        manca davvero: l'errore non deve trascinarsi dietro le chiavi che
+        adesso hanno un valore neutro."""
+        _write_wav(tmp_path)
+        params = {'sample': 'tone.wav'}
 
         with pytest.raises(MissingFieldError) as exc_info:
             Stream(params, samples_dir=str(tmp_path))

--- a/tests/core/test_stream_onset_default.py
+++ b/tests/core/test_stream_onset_default.py
@@ -17,7 +17,7 @@ import pytest
 import soundfile as sf
 
 from pge.core.stream import Stream
-from pge.shared.exceptions import MissingFieldError
+from pge.core.stream_config import StreamContext, stream_onset_is_implicit
 
 
 SR = 48000
@@ -77,6 +77,70 @@ class TestOnsetDefaultsToOrigin:
         assert min(onsets) == pytest.approx(0.0, abs=0.05)
         assert max(onsets) < 1.0, (
             "i grani devono stare dentro la duration dichiarata, a partire da 0")
+
+
+class TestOnsetDeclarationForms:
+    """Le forme in cui `onset` puo' presentarsi, e cosa vale ciascuna."""
+
+    def test_explicit_null_behaves_as_absent_key(self, tmp_path):
+        """`onset: null` e' una dichiarazione vuota, non un valore: vale
+        l'origine come se la chiave non ci fosse. Senza la risoluzione prima
+        della costruzione, quel None arriverebbe intatto fino all'aritmetica
+        dei grani."""
+        _write_wav(tmp_path, seconds=2.0)
+
+        stream = _build(tmp_path, onset=None)
+
+        assert stream.onset == pytest.approx(0.0)
+        assert min(g.onset for g in stream.grains) == pytest.approx(0.0, abs=0.05)
+
+    def test_explicit_onset_still_wins(self, tmp_path):
+        """Nessuna regressione sugli YAML esistenti: la posizione dichiarata
+        prevale sull'origine."""
+        _write_wav(tmp_path, seconds=2.0)
+
+        stream = _build(tmp_path, onset=5.0)
+
+        assert stream.onset == pytest.approx(5.0)
+        onsets = [g.onset for g in stream.grains]
+        assert min(onsets) >= 5.0
+        assert max(onsets) < 6.0
+
+    def test_zero_is_a_declaration_not_an_absence(self):
+        """`onset: 0` e il default sono indistinguibili nel risultato ma
+        distinti nell'intenzione: il predicato scatta sull'assenza, non sulla
+        truthiness. E' l'unico punto in cui la differenza e' osservabile — al
+        livello dello stream i due casi producono lo stesso numero."""
+        assert stream_onset_is_implicit({}) is True
+        assert stream_onset_is_implicit({'onset': None}) is True
+        assert stream_onset_is_implicit({'onset': 0}) is False
+        assert stream_onset_is_implicit({'onset': 0.0}) is False
+
+
+class TestStreamContextResolution:
+    """La risoluzione avviene prima di costruire il dataclass frozen, in
+    entrambi i rami di allow_none: dopo, `onset` non sarebbe piu' scrivibile."""
+
+    @pytest.mark.parametrize('allow_none', [True, False])
+    def test_absent_onset_becomes_the_origin(self, allow_none):
+        ctx = StreamContext.from_yaml(
+            {'stream_id': 's1', 'duration': 5.0, 'sample': 'test.wav'},
+            sample_dur_sec=2.0, allow_none=allow_none,
+        )
+
+        assert ctx.onset == pytest.approx(0.0)
+
+    @pytest.mark.parametrize('allow_none', [True, False])
+    def test_null_onset_never_reaches_the_dataclass(self, allow_none):
+        """allow_none=True lo includerebbe come None, allow_none=False lo
+        escluderebbe lasciando il campo senza valore: entrambi i rami passano
+        per la risoluzione e nessuno dei due arriva a cls(**kwargs) con None."""
+        ctx = StreamContext.from_yaml(
+            {'stream_id': 's1', 'onset': None, 'duration': 5.0, 'sample': 'test.wav'},
+            sample_dur_sec=2.0, allow_none=allow_none,
+        )
+
+        assert ctx.onset == pytest.approx(0.0)
 
 
 class TestRenderWithoutOnset:

--- a/tests/core/test_stream_onset_default.py
+++ b/tests/core/test_stream_onset_default.py
@@ -77,3 +77,38 @@ class TestOnsetDefaultsToOrigin:
         assert min(onsets) == pytest.approx(0.0, abs=0.05)
         assert max(onsets) < 1.0, (
             "i grani devono stare dentro la duration dichiarata, a partire da 0")
+
+
+class TestRenderWithoutOnset:
+    """La pipeline completa YAML -> audio con lo stream minimo assoluto."""
+
+    def test_minimal_yaml_renders_from_the_origin(self, tmp_path):
+        """Le due condizioni di esistenza e basta: stream_id e sample (piu' il
+        blocco grain). Lo stream parte da 0 e dura quanto il sample, quindi
+        l'audio reso e' lungo quanto il file: se `onset` avesse un default
+        diverso da 0 il rendering sarebbe piu' lungo di quel tanto."""
+        from pge import api
+
+        _write_wav(tmp_path, seconds=2.0)
+        yaml_path = tmp_path / 'senza_onset.yml'
+        yaml_path.write_text(
+            "composition:\n"
+            "  title: \"onset default\"\n"
+            "\n"
+            "streams:\n"
+            "  - stream_id: \"s1\"\n"
+            "    sample: \"tone.wav\"\n"
+            "    grain:\n"
+            "      duration: 0.05\n"
+        )
+        output_path = tmp_path / 'out.wav'
+
+        generator = api.load_generator(str(yaml_path), samples_dir=str(tmp_path))
+        result = api.render(
+            generator, str(output_path),
+            renderer='numpy', samples_dir=str(tmp_path),
+        )
+
+        assert result.audio_paths
+        rendered = sf.info(result.audio_paths[0])
+        assert rendered.duration == pytest.approx(2.0, abs=0.2)

--- a/tests/core/test_stream_onset_default.py
+++ b/tests/core/test_stream_onset_default.py
@@ -1,0 +1,79 @@
+# =============================================================================
+# tests/core/test_stream_onset_default.py
+# =============================================================================
+"""
+Test per `onset` opzionale nello stream (issue #220).
+
+Uno stream che non dichiara nulla comincia all'origine della timeline: 0 non
+e' "nulla", e' l'origine. Le condizioni di esistenza di uno stream passano da
+tre a due: stream_id, sample.
+
+Specchio di test_stream_duration_default.py (issue #205), con una asimmetria
+da tenere presente: il default di `duration` e' derivato da un dato (il file
+audio), quello di `onset` e' la costante 0.0.
+"""
+import numpy as np
+import pytest
+import soundfile as sf
+
+from pge.core.stream import Stream
+from pge.shared.exceptions import MissingFieldError
+
+
+SR = 48000
+
+
+def _write_wav(directory, name='tone.wav', seconds=2.0):
+    """Scrive un wav silenzioso di durata nota: la generazione dei grani e'
+    simbolica, conta solo la durata dichiarata dall'header."""
+    sf.write(str(directory / name),
+             np.zeros(int(SR * seconds), dtype='float32'), SR)
+    return name
+
+
+def _params(**overrides):
+    """Stream minimo SENZA `onset`: solo le due condizioni di esistenza.
+
+    `duration` e' dichiarata di proposito, per isolare il default di `onset`
+    da quello di `duration` (issue #205): qui a muoversi deve essere una cosa
+    sola.
+    """
+    params = {
+        'stream_id': 'test_stream',
+        'duration': 1.0,
+        'sample': 'tone.wav',
+        'grain': {'duration': 0.05, 'envelope': 'hanning'},
+    }
+    params.update(overrides)
+    return params
+
+
+def _build(tmp_path, **overrides):
+    """Stream vero attraverso __init__, pronto a generare grani.
+
+    I riferimenti Csound (`sample_table_num`, `window_table_map`) in produzione
+    li assegna il Generator: qui vanno iniettati a mano, come negli altri test
+    che generano grani da uno Stream costruito direttamente.
+    """
+    stream = Stream(_params(**overrides), samples_dir=str(tmp_path))
+    stream.sample_table_num = 1
+    stream.window_table_map = {'hanning': 2}
+    return stream
+
+
+class TestOnsetDefaultsToOrigin:
+    """Senza `onset`, lo stream parte dall'origine della timeline."""
+
+    def test_grains_start_at_the_timeline_origin(self, tmp_path):
+        """Il default e' visibile sui grani, non solo sull'attributo: la
+        generazione e' lazy, quindi il test legge `.grains` (issue #220)."""
+        _write_wav(tmp_path, seconds=2.0)
+
+        stream = _build(tmp_path)
+
+        assert stream.onset == pytest.approx(0.0)
+        onsets = [g.onset for g in stream.grains]
+        assert onsets, "senza onset lo stream deve comunque generare grani"
+        assert min(onsets) == pytest.approx(0.0, abs=0.05)
+        assert max(onsets) < 1.0, (
+            "i grani devono stare dentro la duration dichiarata, a partire da 0")

--- a/tests/e2e/test_engine_errors_e2e.py
+++ b/tests/e2e/test_engine_errors_e2e.py
@@ -41,14 +41,14 @@ streams:
       duration_range: 0.01
 """
 
-# Manca `onset`. `duration` e' opzionale (issue #205): ometterla non e' un
-# errore, quindi qui il campo mancante e' uno solo -> messaggio singolare.
+# Mancano `stream_id`, `onset` e `duration`. Le ultime due sono opzionali
+# (issue #205 e #220): ometterle non e' un errore, quindi qui il campo
+# mancante e' uno solo -> messaggio singolare.
 YAML_MISSING_CONTEXT = """\
 composition:
   title: "test missing context"
 streams:
-  - stream_id: "stream_no_ctx"
-    sample: "pino.wav"
+  - sample: "pino.wav"
     distribution_mode: 'gaussian'
     density: 5
     distribution: [[0,1],[1,1]]
@@ -59,13 +59,12 @@ streams:
       duration_range: 0.01
 """
 
-# Mancano `stream_id` e `onset`: due campi obbligatori -> messaggio plurale.
-YAML_MISSING_TWO_CONTEXT = """\
+# Mancano entrambe le condizioni di esistenza rimaste: `stream_id` e `sample`.
+YAML_MISSING_BOTH_CONDITIONS = """\
 composition:
-  title: "test missing two context fields"
+  title: "test missing both existence conditions"
 streams:
-  - sample: "pino.wav"
-    distribution_mode: 'gaussian'
+  - distribution_mode: 'gaussian'
     density: 5
     distribution: [[0,1],[1,1]]
     pointer:
@@ -264,26 +263,33 @@ def test_e2e_missing_context_fields(tmp_path, cleanup_log):
     result = _run(yaml_abs)
     _assert_clean_user_output(result)
     assert "Campo obbligatorio mancante" in result.stdout
-    assert "'onset'" in result.stdout
-    # duration omessa non e' un errore (issue #205): non deve comparire
-    # fra i campi mancanti.
+    assert "'stream_id'" in result.stdout
+    # duration (issue #205) e onset (issue #220) omesse non sono un errore:
+    # non devono comparire fra i campi mancanti.
     assert "'duration'" not in result.stdout
-    assert "stream_no_ctx" in result.stdout
-    _assert_log_contains(yaml_abs, "MissingFieldError", ["onset"])
+    assert "'onset'" not in result.stdout
+    _assert_log_contains(yaml_abs, "MissingFieldError", ["stream_id"])
 
 
 @pytest.mark.e2e
-def test_e2e_missing_two_context_fields(tmp_path, cleanup_log):
-    """Con piu' campi mancanti il messaggio e' plurale e li elenca tutti."""
-    yaml_abs = _write_yaml(tmp_path, '02b_missing_two_context.yml',
-                           YAML_MISSING_TWO_CONTEXT)
+def test_e2e_missing_both_existence_conditions_reports_sample_first(tmp_path, cleanup_log):
+    """Con `stream_id` e `sample` entrambi assenti l'errore nomina `sample`.
+
+    Il controllo su `sample` in Stream.__init__ precede quello sui campi di
+    contesto e si ferma li'. Da #220 le condizioni di esistenza sono due e una
+    delle due e' proprio `sample`, quindi dalla CLI il messaggio plurale di
+    MissingFieldError non e' piu' raggiungibile: resta esercitato dove nasce
+    (tests/shared/test_engine_exceptions.py) e sul percorso che bypassa
+    __init__ (tests/core/test_stream.py).
+    """
+    yaml_abs = _write_yaml(tmp_path, '02b_missing_both_conditions.yml',
+                           YAML_MISSING_BOTH_CONDITIONS)
     cleanup_log.append(_log_path_for(yaml_abs))
     result = _run(yaml_abs)
     _assert_clean_user_output(result)
-    assert "Campi obbligatori mancanti" in result.stdout
-    assert "'onset'" in result.stdout
-    assert "'stream_id'" in result.stdout
-    _assert_log_contains(yaml_abs, "MissingFieldError", ["onset", "stream_id"])
+    assert "Campo obbligatorio mancante" in result.stdout
+    assert "'sample'" in result.stdout
+    _assert_log_contains(yaml_abs, "MissingFieldError", ["sample"])
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
Implementa la issue #220. `onset` esce dai campi obbligatori dello stream: se
assente o `null`, lo stream comincia all'origine della timeline.

Closes #220

## Cosa cambia per chi scrive YAML

Le condizioni di esistenza di uno stream passano da tre a due — `stream_id` e
`sample`:

```yaml
streams:
  - stream_id: risintesi     # parte da 0, dura quanto il sample
    sample: file.wav
```

Si chiude l'enunciato che #205 lasciava a metà: uno stream a riposo **è** il
sample — stessa origine, stessa durata, contenuto risintetizzato. Tutto il
resto è override compositivo.

| Dichiarazione | Posizione |
|---|---|
| chiave assente | `0.0` s |
| `onset: null` | `0.0` s (come chiave assente) |
| `onset: 12.5` | 12.5 s (l'esplicito vince sempre) |
| `onset: 0` | `0.0` s — dichiarazione esplicita, stesso risultato del default |

Nessuno YAML valido cambia comportamento: cambia solo il verdetto su input che
prima erano rifiutati. Costo accettato e documentato: un `onset` cancellato per
sbaglio non produce più un errore, lo stream si impila silenziosamente a `t=0`.

## I due punti di rottura, coperti dai test

1. **Risoluzione prima del dataclass frozen.** `StreamContext.from_yaml`
   risolve `onset` prima di `cls(**kwargs)`. Senza, `onset: null` entra nel
   dataclass come `None` e l'errore riemerge lontano, come `TypeError`
   nell'aritmetica dei grani. Nessun default nel dataclass: `onset` è
   dichiarato prima di `duration`/`sample`/`sample_dur_sec`, che ne
   resterebbero obbligati ad averne uno.
   → `TestStreamContextResolution`, parametrizzata su entrambi i rami di
   `allow_none` (uno includerebbe il `None`, l'altro lascerebbe il campo senza
   valore).

2. **Assegnazione esplicita in `_init_stream_context`.** Il loop `setattr`
   itera sui campi obbligatori: tolto `onset` da quell'insieme l'attributo non
   esisterebbe più, e la prima generazione di grani alzerebbe `AttributeError`
   — a cascata su `page_layout`, `score_visualizer`, i due renderer,
   `sv_exporter`, `reaper_project_writer`, `grain_json_writer`.
   → `TestOnsetDefaultsToOrigin` e `TestRenderWithoutOnset` leggono `.grains` e
   rendono l'audio, non solo l'attributo.

Il predicato è `is None`, non la truthiness: `onset: 0` resta una
dichiarazione. È distinguibile solo nel predicato — al livello dello stream i
due casi producono lo stesso numero — e lì è fissato
(`test_zero_is_a_declaration_not_an_absence`).

Entrambi i test sul default sono stati verificati per mordente con una
mutazione del sorgente (costante `1.0` al posto di `0.0`, e `'onset' not in`
al posto di `is None`): falliscono in entrambi i casi.

## Perché la cache non si muove

In #205 la durata risolta doveva entrare nel fingerprint perché derivava da un
file audio mutabile, mai entrato nell'hash: sostituire il sample a YAML fermo
avrebbe lasciato montato uno stem della lunghezza vecchia. Qui il default è la
costante `0.0` — nessuna dipendenza esterna da registrare, `stream_cache_manager`
resta invariato. `onset` resta nell'hash com'è oggi, fuori da
`FINGERPRINT_IGNORE_KEYS` (divergenza nota col lato JS, PGE-ui #39). Che
`onset` assente e `onset: 0.0` producano fingerprint diversi è il normale
effetto di una chiave in più: un re-render una tantum.

## Perché niente bump di `VARIATION_SEMANTICS_VERSION`

Quella versione traccia le modifiche che cambiano i **valori prodotti a parità
di YAML**, dove l'hash resterebbe identico e si continuerebbe ad ascoltare
audio vecchio senza nessun errore. Qui nessuno YAML valido cambia
comportamento: se `onset` c'è, vince come prima. Cambia solo il verdetto su
input che prima erano rifiutati, e quelli non hanno uno stem in cache.

## Punti della issue che sul sorgente sono risultati diversi

Tre cose che l'analisi della issue non aveva previsto. Nessuna cambia il
design, tutte hanno richiesto lavoro non elencato.

1. **Il messaggio plurale di `MissingFieldError` non è più raggiungibile dalla
   CLI.** Con due sole condizioni di esistenza, e una delle due `sample`, il
   controllo su `sample` in `Stream.__init__` precede sempre quello sui campi
   di contesto e si ferma lì: `stream_id` e `sample` entrambi assenti danno
   «Campo obbligatorio mancante: `'sample'`», non l'elenco dei due. Il test e2e
   sul plurale non era più producibile: ora fissa quell'ordine. Il messaggio
   plurale resta esercitato dove nasce (`tests/shared/test_engine_exceptions.py`)
   e sul percorso che bypassa `__init__` (`tests/core/test_stream.py`).

2. **Due test su `allow_none` usavano `onset` come vettore**
   (`tests/core/test_stream_config.py`): entrambi i rami ora passano dalla
   risoluzione e non arrivano mai al dataclass con `None`. Il vettore è
   diventato `stream_id`, unico campo rimasto senza default né risoluzione. Il
   contratto di `allow_none` resta verificato identico.

3. **`test_stream_missing_context_fields_raises_missing_field_error` era
   skippato dove `refs/` è vuota**, quindi l'inversione non si vedeva: teneva
   presenti `stream_id` e `sample` e contava su `onset` per far scattare
   l'errore. Su una macchina con i sample sarebbe stato rosso. Diventa il test
   su `stream_id` mancante, affiancato dal suo rovescio — `stream_id` + `sample`
   bastano a costruire uno stream.

Nota di processo: la issue indicava il branch `feature/onset-default`, ma la
sessione era vincolata al branch assegnato `claude/github-issue-220-g9y138` e
ho tenuto quello. Il CHANGELOG è sotto `## [Unreleased]` e non sotto una nuova
intestazione di versione: è la pratica del repo, la voce di #205 è nata così e
il bump l'ha fatto poi `chore(release): v7.1.0`.

## Test

`make tests`: **5688 passed** (exit 0), verde prima di ogni commit.

I due test prima skippati ora girano: ho generato un `refs/pino.wav` locale
(untracked, `*.wav` è gitignored) per poter eseguire davvero la suite e2e, che
senza sample era rossa per ragioni ambientali. Con quello:
`pytest tests/e2e/ -m e2e` → **62 passed, 15 skipped** (gli skip sono i test
che richiedono csound, assente in questo ambiente).

`make docs-index` + `make docs-lint`: OK (19 docs). `last_synced_commit` di
`docs/reference/yaml.md` aggiornato.

## Impatto cross-repo

- **PGE-ui: nessun impatto**, verificato sul sorgente. `serializeStream` emette
  sempre la chiave (`onset: s.onset ?? 0`) e `parseStream` già tollera
  l'assenza (`onset: y.onset ?? 0`); nel proprio fingerprint `onset` è
  ignorato.
- **PGE-ls: impatto reale, issue gemella già aperta** —
  DMGiulioRomano/PGE-ls#46, che è più completa dei punti elencati in #220:
  oltre a `_MANDATORY_FIELDS` e `_STREAM_VALUE_REQUIRED` in
  `diagnostic_provider.py` copre anche gli snippet, la skip-list, i `detail` e
  i `documentation` di `completion_provider.py` e il `_STREAM_CONTEXT_DOCS` di
  `hover_provider.py`. Non ne ho aperta una seconda. Quella issue si dichiara
  bloccata dal merge di questa PR.
- **cim2026-granular-engine-paper: nessun bump proposto.** Gli esempi del
  paper dichiarano tutti `onset` e nessuno YAML valido cambia comportamento:
  il rendering degli esempi è identico.