### PR TITLE
L'altezza del grano può dire quanto sample percorre davvero (--grain-height read-span)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,9 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   l'errore da cui nasce questa distinzione. `configs/PGE_grain_height_demo.yml`
   è la demo: un `pitch.ratio` che spazza gli estremi dell'unità (0.001 → 3) con
   la testina ferma, così l'unica cosa che si muove nel disegno è quanto sample
-  il grano attraversa.
+  il grano attraversa. Densità bassa e finestra asimmetrica (`expodec`) perché
+  la stessa demo si legga anche con `grain_shape: window`, dove il bordo del
+  grano traccia la curva della propria finestra invece della freccia.
 
 ### Documentazione
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,71 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ---
 
+## [Non rilasciato]
+
+### Aggiunto
+
+- **`--grain-height duration|read-span`: l'altezza del grano nella mappa può
+  ora misurare la porzione di sample che il grano percorre davvero.** Sull'asse
+  Y della mappa (`Read position (s)`) l'altezza disegnata era `grain.duration`,
+  cioè la porzione che il grano percorrerebbe **leggendo a velocità 1**. La
+  porzione che percorre è `duration × pitch_ratio`, ed è il conto che fanno
+  entrambe le pipeline: nel renderer NumPy i campioni sorgente consumati sono
+  `n_out × increment` con `increment = pitch_ratio × file_sr / output_sr`, in
+  Csound la fase percorsa in `duration` secondi è
+  `duration × pitch_ratio / iSampleLen`. Le due coincidono solo a
+  `|pitch_ratio| = 1`, ed è per questo che la geometria sbagliata non si
+  vedeva: a `pitch: semitones: 12` la freccia dichiarava metà del buffer che il
+  renderer legge, e la pendenza apparente restava 45 gradi qualunque fosse la
+  trasposizione (issue #223).
+
+  ```bash
+  python src/main.py configs/brano.yml --visualize --grain-height read-span
+  make all FILE=brano AUTOVISUAL=true GRAIN_HEIGHT=read-span
+  ```
+
+  **Non è un fix silenzioso, è un modo**, e il default resta quello storico
+  (`duration`): la geometria fedele cambia l'aspetto di **ogni** partitura già
+  generata con un `pitch` diverso da zero o una voce con `pitch_factor ≠ 1`, e
+  una figura che cambia forma sotto i piedi di chi l'ha stampata è un'altra
+  figura, non la stessa più corretta. Per la stessa ragione la mappa dichiara
+  la propria geometria: con `read-span` l'etichetta dell'asse porta
+  `(grain height = read span)`, così due mappe della stessa composizione nei
+  due modi non sono indistinguibili fuori contesto.
+
+  Il modo vale per entrambe le forme del grano (`grain_shape: arrow` e
+  `window`) e per il contenuto della lente, che passa dallo stesso disegno.
+  Due conseguenze della separazione fra altezza e larghezza:
+
+  - la **testa della freccia** è ora metà dell'**altezza** e non metà della
+    larghezza: erano lo stesso numero finché l'altezza era la durata;
+  - un grano veloce vicino alla fine del sample supera `sample_duration` più
+    spesso e viene **tagliato** dal bordo del subplot, mentre il renderer
+    wrappa (`read_indices % n_source`). Il taglio resta, dichiarato invece che
+    corretto (issue #223, punto 2).
+
+  Superficie: `grain_visuals.grain_height` con le costanti
+  `GRAIN_HEIGHT_DURATION` / `GRAIN_HEIGHT_READ_SPAN` / `GRAIN_HEIGHT_MODES`;
+  `arrow_vertices` e `window_vertices` prendono `height_mode` keyword-only; la
+  config del visualizer ha la chiave `grain_height`; la variabile Make è
+  `GRAIN_HEIGHT`. Un modo sconosciuto solleva `ValueError` col nome del refuso
+  invece di ripiegare in silenzio sulla geometria storica — che è esattamente
+  l'errore da cui nasce questa distinzione. `configs/PGE_grain_height_demo.yml`
+  è la demo: un `pitch.ratio` che spazza gli estremi dell'unità (0.001 → 3) con
+  la testina ferma, così l'unica cosa che si muove nel disegno è quanto sample
+  il grano attraversa.
+
+### Documentazione
+
+- `docs/reference/cli.md`: flag `--grain-height`, vincoli e nota sul taglio ai
+  bordi del sample.
+- `docs/explanation/score-visualizer-layout.md`: sezione «Due letture dello
+  stesso asse» — perché l'altezza è una porzione di buffer, perché il modo
+  fedele non è il default, e le tre conseguenze della separazione fra altezza
+  e larghezza.
+
+---
+
 ## [v8.0.0] — "Timeline Origin" — 2026-08-17
 
 ### Aggiunto

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,10 @@ SHOWSTATIC ?= false
 PLOT_ENVELOPES ?=
 # Durata (secondi) di una pagina nel plot della partitura (richiede AUTOVISUAL=true)
 PAGE_DURATION ?= 15
+# Che cosa misura l'altezza del grano nella partitura (issue #223):
+# duration = la durata (storico), read-span = la porzione di sample che il
+# grano percorre davvero (durata x |pitch_ratio|). Vuoto = duration.
+GRAIN_HEIGHT ?=
 FILE ?= PGE_test
 TEST ?= false
 PRECLEAN ?=true
@@ -134,6 +138,7 @@ help:
 	@echo "  AUTOPEN=true/false   - Auto-apri file generati"
 	@echo "  AUTOVISUAL=true/false- Genera visualizzazioni PDF"
 	@echo "  PAGE_DURATION=secondi - Durata pagina nel plot partitura (default: 15, richiede AUTOVISUAL=true)"
+	@echo "  GRAIN_HEIGHT=duration|read-span - Altezza del grano nella partitura: durata (default) o porzione di sample letta davvero (richiede AUTOVISUAL=true)"
 	@echo "  TEST=true/false      - Build tutti i file o solo FILE"
 	@echo "  CLEAN_RPP=true/false - make clean rimuove anche .rpp (default: false, preserva lavoro REAPER)"
 	@echo "  REAPER=true/false        - Esporta progetto Reaper .rpp"

--- a/configs/PGE_grain_height_demo.yml
+++ b/configs/PGE_grain_height_demo.yml
@@ -10,6 +10,11 @@
 # altezza, qualunque sia il ratio; con --grain-height read-span l'altezza
 # segue la porzione letta, che e' quella che il renderer percorre davvero.
 #
+# La densita' e' bassa e la finestra e' asimmetrica (`expodec`) apposta: cosi'
+# i grani restano staccati e la demo si legge anche con la forma `window`
+# (config del visualizer `grain_shape: window`), dove il bordo del grano
+# traccia la curva della sua finestra invece della freccia.
+#
 #   python src/main.py configs/PGE_grain_height_demo.yml output/demo.wav \
 #       --renderer numpy --format wav --visualize --grain-height read-span
 #
@@ -29,10 +34,10 @@ streams:
     duration: 12
     sample: demo_pulses.wav
     time_mode: normalized
-    density: 9
+    density: 3.5
     grain:
       duration: 0.25
-      envelope: hanning
+      envelope: expodec
     pointer:
       start: 0.12
       speed_ratio: 0
@@ -53,10 +58,10 @@ streams:
     duration: 12
     sample: demo_pulses.wav
     time_mode: normalized
-    density: 9
+    density: 3.5
     grain:
       duration: 0.25
-      envelope: hanning
+      envelope: expodec
       reverse:
     pointer:
       start: 0.88

--- a/configs/PGE_grain_height_demo.yml
+++ b/configs/PGE_grain_height_demo.yml
@@ -1,0 +1,72 @@
+# Demo dell'altezza del grano nella mappa (issue #223).
+#
+# L'asse Y della mappa e' la posizione di lettura nel sample, quindi l'altezza
+# di un grano e' una porzione di buffer. Qui il pitch e' scritto in `ratio` —
+# il moltiplicatore diretto della velocita' di lettura dentro il grano — e
+# spazza gli estremi dell'unita': da 0.001 (il grano resta quasi fermo su un
+# punto del file) a 3 (in un quarto di secondo ne attraversa tre quarti).
+#
+# Renderizzata con --grain-height duration tutti i grani hanno la stessa
+# altezza, qualunque sia il ratio; con --grain-height read-span l'altezza
+# segue la porzione letta, che e' quella che il renderer percorre davvero.
+#
+#   python src/main.py configs/PGE_grain_height_demo.yml output/demo.wav \
+#       --renderer numpy --format wav --visualize --grain-height read-span
+#
+# Il sample `demo_pulses.wav` non e' versionato (refs/ e' gitignored): un file
+# qualunque di ~4 s va bene, basta cambiare la chiave `sample`.
+
+title: altezza del grano - durata contro porzione letta
+duration: 12
+seed: 223
+
+streams:
+  # Testina ferma: l'unica cosa che si muove nel disegno e' quanto sample il
+  # grano attraversa. La scala di colore racconta la stessa cosa in altezza
+  # percepita, la forma la racconta in estensione.
+  - stream_id: sweep_forward
+    onset: 0
+    duration: 12
+    sample: demo_pulses.wav
+    time_mode: normalized
+    density: 9
+    grain:
+      duration: 0.25
+      envelope: hanning
+    pointer:
+      start: 0.12
+      speed_ratio: 0
+    pitch:
+      ratio:
+        - [0, 0.001]
+        - [0.25, 0.25]
+        - [0.5, 1.0]
+        - [0.75, 2.0]
+        - [1, 3.0]
+    pan: -30
+    volume: -6
+
+  # Stesso sweep letto all'indietro: il verso resta questione di segno, e la
+  # porzione letta si estende sotto la posizione di lettura invece che sopra.
+  - stream_id: sweep_reverse
+    onset: 0
+    duration: 12
+    sample: demo_pulses.wav
+    time_mode: normalized
+    density: 9
+    grain:
+      duration: 0.25
+      envelope: hanning
+      reverse:
+    pointer:
+      start: 0.88
+      speed_ratio: 0
+    pitch:
+      ratio:
+        - [0, 0.001]
+        - [0.25, 0.25]
+        - [0.5, 1.0]
+        - [0.75, 2.0]
+        - [1, 3.0]
+    pan: 30
+    volume: -6

--- a/docs/explanation/score-visualizer-layout.md
+++ b/docs/explanation/score-visualizer-layout.md
@@ -99,6 +99,48 @@ questa.
 config, è l'adapter a leggerlo e a passarne i valori. È anche ciò che rende
 possibile tipizzare la config senza toccare le regole.
 
+### Due letture dello stesso asse
+
+L'asse Y della mappa è la posizione di lettura nel sample, quindi l'altezza di
+un grano non è una quantità astratta: è **una porzione di buffer**. Quale,
+però, non è ovvio, e per anni il disegno ne ha usata una senza dirlo.
+
+Il grano ha una durata nel tempo dello stream, e una velocità di lettura al
+proprio interno — il blocco `pitch`, che in Csound si chiama letteralmente
+`iSpeed` (p5). La porzione di sample che attraversa è il prodotto delle due:
+`durata × pitch_ratio`. Il disegno usava la sola durata, cioè la porzione che
+il grano percorrerebbe leggendo a velocità 1. Le due coincidono solo a
+`|ratio| = 1` — e siccome è il caso più comune, l'errore non si vedeva: a
+un'ottava sopra la freccia dichiarava metà del buffer che il renderer legge, e
+la pendenza apparente restava 45 gradi qualunque fosse la trasposizione,
+mentre la pendenza *è* l'informazione che quella forma porta (issue #223).
+
+La correzione è una riga, ma non è un fix: è un **modo**. `grain_visuals.grain_height`
+espone le due letture — `duration` (storica) e `read_span` (fedele al
+rendering) — e la config `grain_height` sceglie, con la CLI che la accende
+(`--grain-height read-span`). Il default resta la lettura storica per una
+ragione che non è prudenza: la geometria nuova cambia l'aspetto di **ogni**
+partitura già generata, e una figura che cambia forma sotto i piedi di chi
+l'ha stampata è un'altra figura, non la stessa più corretta. Per lo stesso
+motivo l'etichetta dell'asse dichiara il modo attivo: due mappe della stessa
+composizione, una per modo, altrimenti sarebbero indistinguibili fuori
+contesto.
+
+Tre conseguenze cadono dove il modo si separa dalla durata:
+
+- **la testa della freccia è metà dell'altezza, non metà della larghezza.**
+  Erano lo stesso numero finché l'altezza era la durata; slegate, la
+  proporzione che rende la freccia leggibile è quella verticale.
+- **`grain_shape: window` si scala sulla stessa altezza**, ma lì l'asse porta
+  l'ampiezza della finestra, non la porzione letta: la silhouette resta
+  iscritta nell'estensione che il grano occupa davvero, e il picco della curva
+  è il massimo della finestra disegnato a quell'altezza, non un punto del
+  buffer.
+- **un grano veloce può uscire dal file**, e il subplot lo taglia. Il renderer
+  invece wrappa (`read_indices % n_source`), come `_draw_loop_mask` già fa
+  spezzando la banda in due: qui il taglio resta, dichiarato invece che
+  corretto.
+
 ### Una decisione che deve precedere il disegno
 
 Non tutto quello che il visualizer chiede ai moduli riguarda un artista già

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -5,6 +5,8 @@ status: stable
 tags: [cli, flags, make, rendering, export]
 sources:
   - src/main.py
+  - src/pge/cli.py
+  - src/pge/rendering/grain_visuals.py
   - make/build.mk
 last_synced_commit: 95fd483
 entry_for: [cli-flags, build-flags]
@@ -77,6 +79,7 @@ Senza argomenti: stampa usage ed esce con codice 1.
 | `--sco-dir DIR` | `generated` | — | destinazione `.sco` (attivo solo con `--keep-sco`) |
 | `--reaper-path FILE` | `{yaml_basename}.rpp` | `REAPER_PATH` | percorso del progetto Reaper |
 | `--plot-envelopes nomi` | tutti | `PLOT_ENVELOPES` | filtro selettivo degli envelope nella partitura: nomi comma-separated (es. `pitch,density,volume_prob`); nome non valido: messaggio con elenco dei validi + exit 1 |
+| `--grain-height duration\|read-span` | `duration` | `GRAIN_HEIGHT` | che cosa misura l'**altezza** del grano sull'asse del buffer nella partitura: `duration` = la durata (la porzione che il grano percorrerebbe leggendo a velocità 1, geometria storica), `read-span` = la porzione che percorre davvero (`durata × |pitch_ratio|`). Valore fuori dai due: messaggio + exit 1 |
 | `--magnify-at SPEC` | — | `MAGNIFY_AT` | lente/i di ingrandimento esplicite nella partitura. `SPEC` = target separati da `;`, ciascuno coppie `chiave=valore` separate da `,`. Chiave `t` (tempo s) obbligatoria; opzionali `y` (posizione di lettura), `zoom` (fattore), `out` (raggio cerchio di uscita, frazione figura), `src` (raggio cerchio di partenza, frazione figura; default `out/zoom`), `stream` (stream_id). SPEC malformato (`t` mancante, valore non numerico, chiave ignota): messaggio + exit 1 |
 
 ## Bounds
@@ -143,6 +146,20 @@ Vincoli tra flag e comportamento nelle combinazioni non valide:
   `markersize`/`labels` per lo stile). Niente da proiettare, niente
   disegnato: stream senza curve dinamiche, o istante fuori dall'estensione
   dello stream.
+- **`--grain-height`** ha effetto solo insieme a `--visualize`; la
+  validazione del valore avviene comunque (valore ignoto → exit 1 anche
+  senza `--visualize`), come per `--plot-envelopes`. Il valore è un modo di
+  lettura dell'asse Y, non una correzione da applicare sempre: `read-span`
+  cambia la geometria di **ogni** grano trasposto, quindi due partiture
+  della stessa composizione nei due modi non sono confrontabili a occhio —
+  per questo il modo attivo è scritto nell'etichetta dell'asse
+  (`Read position (s)` / `(grain height = read span)`). Vale per entrambe
+  le forme del grano (`grain_shape: arrow` e `window`) e per il contenuto
+  della lente, che passa dallo stesso disegno. Con `read-span` un grano
+  veloce vicino alla fine del sample supera `sample_duration` più spesso di
+  prima e viene **tagliato** dal bordo del subplot: il renderer invece
+  wrappa (`read_indices % n_source`), quindi lì la figura tace su una
+  porzione che l'audio contiene (vedi issue #223, punto 2).
 - Le flag con valore leggono il token successivo in `sys.argv`; se manca,
   la flag viene ignorata senza errore.
 
@@ -173,6 +190,12 @@ python src/main.py configs/brano.yml --visualize --plot-envelopes pitch,density
 
 # Equivalente via Make
 make all FILE=brano AUTOVISUAL=true PLOT_ENVELOPES=pitch,density
+
+# Partitura in cui l'altezza del grano e' la porzione di sample letta davvero
+python src/main.py configs/brano.yml --visualize --grain-height read-span
+
+# Equivalente via Make
+make all FILE=brano AUTOVISUAL=true GRAIN_HEIGHT=read-span
 
 # Partitura con lente automatica sul cluster piu' denso di ogni pagina
 python src/main.py configs/brano.yml --visualize --magnify

--- a/make/build.mk
+++ b/make/build.mk
@@ -53,6 +53,13 @@ ifneq ($(strip $(PAGE_DURATION)),)
 PYFLAGS += --page-duration $(PAGE_DURATION)
 endif
 
+# 2c-bis. Se GRAIN_HEIGHT e' non-vuoto, aggiungi --grain-height (issue #223):
+# che cosa misura l'altezza del grano sull'asse del buffer nella partitura.
+# Vuoto = default 'duration' di main.py (geometria storica).
+ifneq ($(strip $(GRAIN_HEIGHT)),)
+PYFLAGS += --grain-height $(GRAIN_HEIGHT)
+endif
+
 # 2d. Se MAGNIFY e' true, aggiungi --magnify (lente automatica sul cluster denso)
 ifeq ($(MAGNIFY), true)
 PYFLAGS += --magnify

--- a/src/pge/api.py
+++ b/src/pge/api.py
@@ -403,6 +403,7 @@ def export_score_pdf(
         'envelope_filter': None,
         'magnify_auto': False,
         'magnify_targets': [],
+        'grain_height': 'duration',
     }
     if config:
         merged.update(config)

--- a/src/pge/cli.py
+++ b/src/pge/cli.py
@@ -113,6 +113,16 @@ def _parse_jobs(argv):
     return value
 
 
+# Valori di --grain-height, e il modo di grain_visuals a cui corrispondono.
+# Sulla CLI il valore composto si scrive col trattino, come i flag; nella
+# config del visualizer resta snake_case, come ogni altra chiave. Un dict e non
+# una coppia di frozenset: la traduzione fra le due grafie e' proprio il dato.
+_GRAIN_HEIGHT_CLI_MODES = {
+    'duration': 'duration',
+    'read-span': 'read_span',
+}
+
+
 # Chiavi ammesse in un target di --magnify-at. Numeriche (float) e stringa.
 _MAGNIFY_NUMERIC_KEYS = frozenset({'t', 'y', 'zoom', 'out', 'src'})
 _MAGNIFY_STR_KEYS = frozenset({'stream'})
@@ -178,6 +188,7 @@ def main():
             "[--plot-envelopes nomi,csv] "
             "[--magnify] [--magnify-at SPEC] "
             "[--page-duration SECONDI] "
+            "[--grain-height duration|read-span] "
             "[--per-stream] "
             "[--renderer csound|numpy] "
             "[--jobs N|auto] "
@@ -238,6 +249,23 @@ def main():
                     f"Validi: {', '.join(sorted(PLOT_ENVELOPE_KEYS))}"
                 )
                 sys.exit(1)
+    # --grain-height duration|read-span (issue #223): che cosa misura
+    # l'altezza del grano sull'asse del buffer nella partitura. 'duration' e'
+    # la geometria storica (la porzione che il grano percorrerebbe a velocita'
+    # 1), 'read-span' quella che percorre davvero (durata x |pitch_ratio|).
+    # Come --plot-envelopes la validazione e' sempre attiva: il refuso non
+    # resta muto solo perche' manca --visualize.
+    grain_height = _GRAIN_HEIGHT_CLI_MODES['duration']
+    if '--grain-height' in sys.argv:
+        idx = sys.argv.index('--grain-height')
+        if idx + 1 < len(sys.argv):
+            raw = sys.argv[idx + 1]
+            if raw not in _GRAIN_HEIGHT_CLI_MODES:
+                print(f"--grain-height non valido: '{raw}'. "
+                      f"Valori: {', '.join(_GRAIN_HEIGHT_CLI_MODES)}")
+                sys.exit(1)
+            grain_height = _GRAIN_HEIGHT_CLI_MODES[raw]
+
     # --magnify: lente automatica sul cluster piu' denso (una per pagina).
     # Effetto solo con --visualize, come --show-static. Token esatto: '--magnify'
     # non collide con '--magnify-at' (sono elementi distinti di sys.argv).
@@ -466,6 +494,7 @@ def main():
                 'envelope_filter': plot_envelopes,
                 'magnify_auto': magnify_auto,
                 'magnify_targets': magnify_targets,
+                'grain_height': grain_height,
             })
 
         print(f"Log: {get_clip_log_path()}")

--- a/src/pge/rendering/grain_visuals.py
+++ b/src/pge/rendering/grain_visuals.py
@@ -105,18 +105,72 @@ def visible_grains(stream, t_start, t_end):
     ]
 
 
-def arrow_vertices(grain):
+# =============================================================================
+# ALTEZZA DEL GRANO: due letture dello stesso asse
+# =============================================================================
+
+# Storico: l'altezza e' la durata, cioe' la porzione di buffer che il grano
+# percorrerebbe leggendo a velocita' 1. Resta il default perche' e' la
+# geometria di ogni partitura gia' generata.
+GRAIN_HEIGHT_DURATION = 'duration'
+# Fedele al rendering: la porzione che il grano percorre DAVVERO, durata
+# scalata per il rapporto di trasposizione.
+GRAIN_HEIGHT_READ_SPAN = 'read_span'
+
+GRAIN_HEIGHT_MODES = frozenset({GRAIN_HEIGHT_DURATION, GRAIN_HEIGHT_READ_SPAN})
+
+
+def grain_height(grain, height_mode=GRAIN_HEIGHT_DURATION):
+    """Quanto buffer occupa il grano sull'asse Y, secondo il modo scelto.
+
+    L'asse Y della mappa e' la posizione di lettura nel sample, quindi
+    l'altezza di un grano e' una porzione di buffer. Quale porzione, pero',
+    dipende da cosa si vuole leggere:
+
+    - `duration` — la porzione che il grano percorrerebbe a velocita' 1. E' il
+      tempo del grano riportato sull'asse del buffer, e coincide con la
+      porzione vera solo a |ratio| = 1.
+    - `read_span` — la porzione che il grano percorre davvero, `duration *
+      |pitch_ratio|`. E' il conto che fanno entrambe le pipeline: nel renderer
+      NumPy i campioni sorgente consumati sono `n_out * increment`, con
+      `increment = pitch_ratio * file_sr / output_sr`; in Csound la fase
+      percorsa in `duration` secondi e' `duration * pitch_ratio / iSampleLen`.
+
+    Valore assoluto: il verso lo decide gia' il segno del ratio, ribaltando la
+    forma sotto il pointer (come per il colore in `_visible_cents`). Un'altezza
+    e' una lunghezza, e una lunghezza non e' negativa.
+
+    Un modo sconosciuto e' un errore e non un default silenzioso: disegnare
+    di nascosto la geometria sbagliata e' esattamente il problema da cui
+    nasce questa distinzione (issue #223).
+    """
+    if height_mode == GRAIN_HEIGHT_DURATION:
+        return grain.duration
+    if height_mode == GRAIN_HEIGHT_READ_SPAN:
+        return grain.duration * abs(grain.pitch_ratio)
+    raise ValueError(
+        f"modo di altezza del grano sconosciuto: '{height_mode}'. "
+        f"Validi: {', '.join(sorted(GRAIN_HEIGHT_MODES))}")
+
+
+def arrow_vertices(grain, *, height_mode=GRAIN_HEIGHT_DURATION):
     """Vertici della freccia direzionale (forma storica del grano).
 
-    Rettangolo [onset, onset+duration] x [pointer, pointer+duration] con la
-    punta triangolare verso l'alto. L'altezza e' la durata: quanto sample il
-    grano consuma.
+    Rettangolo [onset, onset+duration] x [pointer, pointer+altezza] con la
+    punta triangolare verso l'alto. Sull'asse X il grano occupa il tempo che
+    dura; sull'asse Y l'altezza dice quanto sample attraversa, secondo
+    `height_mode` (vedi `grain_height`).
+
+    La testa occupa meta' dell'ALTEZZA. Era scritta come meta' della larghezza
+    perche' le due erano lo stesso numero finche' l'altezza era la durata; con
+    `read_span` si separano, e la proporzione che rende la freccia leggibile e'
+    quella verticale.
     """
     x = grain.onset
     width = grain.duration
     pointer_y = grain.pointer_pos
-    height = grain.duration
-    head_width = width * 0.5
+    height = grain_height(grain, height_mode)
+    head_height = height * 0.5
 
     if grain.pitch_ratio < 0:
         # Lettura all'indietro: la freccia si ribalta sotto il pointer. Il
@@ -125,36 +179,45 @@ def arrow_vertices(grain):
         return [
             (x, pointer_y),                     # base sinistra
             (x + width, pointer_y),             # base destra
-            (x + width, y_tip + head_width),    # spalla destra
+            (x + width, y_tip + head_height),   # spalla destra
             (x + width / 2, y_tip),             # punta
-            (x, y_tip + head_width),            # spalla sinistra
+            (x, y_tip + head_height),           # spalla sinistra
         ]
 
     y_tip = pointer_y + height
     return [
         (x, pointer_y),                         # base sinistra
         (x + width, pointer_y),                 # base destra
-        (x + width, y_tip - head_width),        # spalla destra
+        (x + width, y_tip - head_height),       # spalla destra
         (x + width / 2, y_tip),                 # punta
-        (x, y_tip - head_width),                # spalla sinistra
+        (x, y_tip - head_height),               # spalla sinistra
     ]
 
 
-def window_vertices(grain, xs, w):
+def window_vertices(grain, xs, w, *, height_mode=GRAIN_HEIGHT_DURATION):
     """Vertici della silhouette: base piatta sul pointer, bordo che segue la
     finestra.
 
     Args:
         grain: il grano da disegnare.
         xs, w: la curva normalizzata su [0,1] (vedi window_silhouette).
+        height_mode: su cosa si scala l'ampiezza della finestra (vedi
+            `grain_height`).
 
     Il verso segue il segno di pitch_ratio come per la freccia: sopra il
     pointer in avanti, sotto all'indietro.
+
+    Qui l'asse Y porta l'ampiezza della finestra, non la porzione letta: e'
+    una lettura diversa dello stesso asse, e vale la pena dirlo. Scalarla
+    sulla stessa altezza della freccia tiene le due forme coerenti — la
+    silhouette resta iscritta nell'estensione che il grano occupa davvero —
+    ma il picco della curva non e' un punto del buffer: e' il massimo della
+    finestra, disegnato all'altezza a cui il grano arriva.
     """
     x = grain.onset
     width = grain.duration
     pointer_y = grain.pointer_pos
-    height = grain.duration
+    height = grain_height(grain, height_mode)
 
     xs_abs = x + xs * width
     if grain.pitch_ratio < 0:

--- a/src/pge/rendering/score_visualizer.py
+++ b/src/pge/rendering/score_visualizer.py
@@ -488,7 +488,7 @@ class ScoreVisualizer:
             # Configura assi waveform
             ax_wave.set_ylim(-0.02, sample_duration+0.02)
             ax_wave.set_xlim(-1.1, 1.1)
-            ax_wave.set_ylabel(f"Read position (s)\n{sample_path}",
+            ax_wave.set_ylabel(f"{self._read_position_label()}\n{sample_path}",
                             fontsize=self._fs(self.config['label_fontsize']))
             ax_wave.set_xticks([])
             # Scarta i tick estremi dell'asse buffer: con le righe impilate
@@ -818,16 +818,36 @@ class ScoreVisualizer:
         )
 
 
-    def _grain_arrow_vertices(self, grain):
+    def _grain_height_mode(self):
+        """Che cosa misura l'altezza del grano sull'asse del buffer.
+
+        Config `grain_height`: 'duration' (storico) o 'read_span' (la porzione
+        che il grano percorre davvero). Vedi grain_visuals.grain_height."""
+        return self.config.get(
+            'grain_height', grain_visuals.GRAIN_HEIGHT_DURATION)
+
+    def _read_position_label(self):
+        """Etichetta dell'asse del buffer, che dichiara la propria geometria.
+
+        Con l'altezza fedele alla porzione letta la stessa figura racconta
+        un'altra cosa: due partiture della stessa composizione, una per modo,
+        sarebbero indistinguibili se l'asse non lo dicesse."""
+        if self._grain_height_mode() == grain_visuals.GRAIN_HEIGHT_READ_SPAN:
+            return "Read position (s)\n(grain height = read span)"
+        return "Read position (s)"
+
+    def _grain_arrow_vertices(self, grain, height_mode=None):
         """Vertici della freccia direzionale (forma storica del grano).
         Delega a rendering.grain_visuals.arrow_vertices."""
-        return grain_visuals.arrow_vertices(grain)
+        return grain_visuals.arrow_vertices(
+            grain, height_mode=height_mode or self._grain_height_mode())
 
-    def _grain_window_vertices(self, grain, xs, w):
+    def _grain_window_vertices(self, grain, xs, w, height_mode=None):
         """Vertici della silhouette "testa/bordo": base piatta sul pointer, il
         bordo superiore segue la curva della finestra w.
         Delega a rendering.grain_visuals.window_vertices."""
-        return grain_visuals.window_vertices(grain, xs, w)
+        return grain_visuals.window_vertices(
+            grain, xs, w, height_mode=height_mode or self._grain_height_mode())
 
     def _window_silhouette(self, name, resolution):
         """Curva finestra normalizzata su [0,1] in ampiezza e dominio.
@@ -877,6 +897,10 @@ class ScoreVisualizer:
         # volta per stream) e la risoluzione di campionamento.
         grain_shape = self.config.get('grain_shape', 'arrow')
         window_mode = grain_shape == 'window'
+        # Letto una volta per chiamata e non per grano: il modo e' una
+        # proprieta' della figura, non del singolo grano. Un modo ignoto
+        # solleva al primo grano, dentro grain_visuals.grain_height.
+        height_mode = self._grain_height_mode()
         if window_mode:
             name_map = self._window_name_map(stream)
             resolution = self.config['window_shape_resolution']
@@ -897,9 +921,10 @@ class ScoreVisualizer:
             if use_window:
                 xs, w = self._window_silhouette(
                     name_map[grain.envelope_table], resolution)
-                vertices = self._grain_window_vertices(grain, xs, w)
+                vertices = self._grain_window_vertices(
+                    grain, xs, w, height_mode)
             else:
-                vertices = self._grain_arrow_vertices(grain)
+                vertices = self._grain_arrow_vertices(grain, height_mode)
 
             # Crea poligono
             poly = mpatches.Polygon(vertices, closed=True)

--- a/src/pge/rendering/visualizer_config.py
+++ b/src/pge/rendering/visualizer_config.py
@@ -180,6 +180,14 @@ class VisualizerConfig:
     # grano ripiega sulla freccia: e' il cap al costo vettoriale sugli score
     # densi.
     window_shape_min_px: float = 3
+    # Che cosa misura l'ALTEZZA del grano sull'asse del buffer (issue #223).
+    # 'duration' -> la durata, cioe' la porzione che il grano percorrerebbe a
+    # velocita' 1 (comportamento storico); 'read_span' -> la porzione che
+    # percorre davvero, durata scalata per |pitch_ratio|. Il default resta
+    # 'duration' perche' il modo fedele cambia la geometria di ogni partitura
+    # gia' generata: e' una scelta di lettura, non un fix silenzioso.
+    # Valori ammessi: pge.rendering.grain_visuals.GRAIN_HEIGHT_MODES.
+    grain_height: str = 'duration'
 
     # --- WAVEFORM E COLORBAR -------------------------------------------------
     waveform_alpha: float = 0.3

--- a/tests/rendering/test_grain_height_mode.py
+++ b/tests/rendering/test_grain_height_mode.py
@@ -1,0 +1,161 @@
+# tests/rendering/test_grain_height_mode.py
+"""
+Suite per il modo di altezza del grano nella mappa (issue #223).
+
+Sull'asse Y della mappa (`Read position (s)`) l'altezza di un grano e' una
+porzione di buffer. Quella disegnata storicamente e' `grain.duration`: la
+porzione che il grano percorrerebbe leggendo a velocita' 1. La porzione che
+percorre davvero e' `duration * pitch_ratio` — le due coincidono solo a
+|ratio| = 1, e a ratio 2 la freccia disegna meta' di quello che il renderer
+legge.
+
+Correggerlo cambia la geometria di ogni partitura gia' generata, quindi non e'
+un fix silenzioso: e' un modo, `grain_height`, che si accende. Qui si verifica
+il cablaggio dal config al poligono disegnato — la geometria pura sta in
+test_grain_visuals.py.
+"""
+
+import pytest
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+from unittest.mock import MagicMock
+
+from pge.rendering.score_visualizer import ScoreVisualizer  # noqa: E402
+
+
+def make_grain(onset=0.0, duration=0.5, pointer_pos=0.5,
+               pitch_ratio=1.0, volume=-6.0, envelope_table=10):
+    g = MagicMock()
+    g.onset = onset
+    g.duration = duration
+    g.pointer_pos = pointer_pos
+    g.pitch_ratio = pitch_ratio
+    g.volume = volume
+    g.envelope_table = envelope_table
+    return g
+
+
+def make_stream(grains, window_table_map=None):
+    s = MagicMock()
+    s.voices = [grains]
+    s.stream_id = 's1'
+    s.onset = 0.0
+    s.duration = 6.0
+    if window_table_map is not None:
+        s.window_table_map = window_table_map
+    else:
+        del s.window_table_map
+    return s
+
+
+def make_viz(config=None):
+    gen = MagicMock()
+    gen.streams = []
+    return ScoreVisualizer(gen, config=config)
+
+
+@pytest.fixture(autouse=True)
+def close_figures():
+    yield
+    plt.close('all')
+
+
+def drawn_ys(config, grain):
+    """Le y del poligono disegnato per un grano, con la config data."""
+    viz = make_viz(config=config)
+    fig, ax = plt.subplots()
+    ax.set_xlim(0, 6)
+    ax.set_ylim(0, 2)
+    fig.canvas.draw()
+    viz._draw_grains_full(ax, make_stream([grain]), sample_duration=2.0,
+                          page_start=0.0, page_end=6.0)
+    return [y for _, y in ax.collections[0].get_paths()[0].vertices]
+
+
+# =============================================================================
+# GROUP 1 - Config: opt-in, default invariato
+# =============================================================================
+
+class TestConfigDefault:
+
+    def test_default_is_duration(self):
+        """Il default e' la geometria storica: le figure gia' pubblicate non
+        cambiano da sole."""
+        assert make_viz().config['grain_height'] == 'duration'
+
+    def test_override_read_span(self):
+        assert make_viz(
+            config={'grain_height': 'read_span'}).config['grain_height'] \
+            == 'read_span'
+
+
+# =============================================================================
+# GROUP 2 - Il modo arriva al poligono
+# =============================================================================
+
+class TestHeightReachesThePolygon:
+
+    def test_default_ignores_the_ratio(self):
+        """A ratio 3 la freccia storica resta alta quanto la durata: e'
+        proprio l'errore che il modo nuovo corregge."""
+        ys = drawn_ys(None, make_grain(onset=1.0, duration=0.5,
+                                       pointer_pos=0.4, pitch_ratio=3.0))
+        assert max(ys) == pytest.approx(0.9)
+
+    def test_read_span_scales_the_height(self):
+        """Ratio 3: il grano attraversa 1.5 s di buffer in 0.5 s di tempo."""
+        ys = drawn_ys({'grain_height': 'read_span'},
+                      make_grain(onset=1.0, duration=0.5, pointer_pos=0.4,
+                                 pitch_ratio=3.0))
+        assert max(ys) == pytest.approx(1.9)
+
+    def test_read_span_shrinks_a_slow_grain(self):
+        """Ratio 0.001: il grano resta quasi fermo sul punto di lettura."""
+        ys = drawn_ys({'grain_height': 'read_span'},
+                      make_grain(onset=1.0, duration=0.5, pointer_pos=0.4,
+                                 pitch_ratio=0.001))
+        assert max(ys) == pytest.approx(0.4005)
+
+    def test_read_span_keeps_the_reverse_below_the_pointer(self):
+        """Il verso resta questione di segno: la porzione letta si estende
+        sotto la posizione di lettura, non sopra."""
+        ys = drawn_ys({'grain_height': 'read_span'},
+                      make_grain(onset=1.0, duration=0.5, pointer_pos=1.9,
+                                 pitch_ratio=-3.0))
+        assert min(ys) == pytest.approx(0.4)
+        assert max(ys) == pytest.approx(1.9)
+
+    def test_window_shape_follows_the_same_mode(self):
+        """La silhouette della finestra si scala sulla stessa altezza: le due
+        forme non possono raccontare due geometrie diverse."""
+        ys = drawn_ys({'grain_height': 'read_span',
+                       'grain_shape': 'window',
+                       'window_shape_resolution': 32},
+                      make_grain(onset=1.0, duration=0.5, pointer_pos=0.4,
+                                 pitch_ratio=3.0, envelope_table=10))
+        assert max(ys) == pytest.approx(1.9)
+
+    def test_unknown_mode_is_refused_at_draw_time(self):
+        """Un refuso nel modo non produce una figura sbagliata in silenzio."""
+        with pytest.raises(ValueError, match='readspan'):
+            drawn_ys({'grain_height': 'readspan'}, make_grain())
+
+
+# =============================================================================
+# GROUP 3 - La figura dichiara la propria geometria
+# =============================================================================
+
+class TestAxisLabelDeclaresTheMode:
+    """Due partiture con geometrie diverse non devono essere indistinguibili
+    guardandole: chi legge una figura fuori contesto deve poter sapere quale
+    delle due altezze sta guardando."""
+
+    def test_read_span_is_announced_on_the_axis(self):
+        assert 'read span' in make_viz(
+            config={'grain_height': 'read_span'})._read_position_label()
+
+    def test_duration_mode_says_nothing_extra(self):
+        """Il modo storico non annuncia niente: le figure gia' generate
+        restano confrontabili con quelle nuove."""
+        assert make_viz()._read_position_label() == 'Read position (s)'

--- a/tests/rendering/test_grain_visuals.py
+++ b/tests/rendering/test_grain_visuals.py
@@ -18,8 +18,12 @@ from types import SimpleNamespace
 import pytest
 
 from pge.rendering.grain_visuals import (
+    GRAIN_HEIGHT_DURATION,
+    GRAIN_HEIGHT_MODES,
+    GRAIN_HEIGHT_READ_SPAN,
     WINDOW_SILHOUETTE_CACHE_SIZE,
     arrow_vertices,
+    grain_height,
     window_silhouette,
     window_vertices,
     visible_grains,
@@ -492,3 +496,134 @@ class TestWindowNameMap:
         interamente sulla freccia."""
         assert window_name_map(SimpleNamespace()) == {}
         assert window_name_map(SimpleNamespace(window_table_map=None)) == {}
+
+
+class TestGrainHeightMode:
+    """Quanto sample il grano percorre davvero (issue #223).
+
+    L'altezza sull'asse Y della mappa e' una porzione di buffer, e la porzione
+    che il grano percorre e' `duration * pitch_ratio`: `duration` da sola e' la
+    porzione che percorrerebbe leggendo a velocita' 1. Le due coincidono solo a
+    |ratio| = 1, ed e' per questo che il modo storico non si vedeva sbagliato.
+
+    Due modi, perche' la geometria giusta cambia l'aspetto di ogni partitura
+    gia' generata: `duration` resta il default, `read_span` e' la lettura
+    fedele al rendering.
+    """
+
+    def test_duration_mode_ignores_the_ratio(self):
+        """Modo storico: l'altezza e' la durata, qualunque sia la
+        trasposizione. Resta il default perche' e' la geometria di ogni figura
+        gia' pubblicata."""
+        for ratio in (0.5, 1.0, 2.0, -2.0):
+            assert grain_height(grain(duration=0.1, pitch_ratio=ratio),
+                                GRAIN_HEIGHT_DURATION) == pytest.approx(0.1)
+
+    def test_read_span_mode_scales_with_the_ratio(self):
+        """Un grano a un'ottava sopra legge il doppio di buffer nello stesso
+        tempo: e' il fattore `increment` del renderer NumPy, e la fase di
+        `poscil` in Csound, scritti come geometria."""
+        assert grain_height(grain(duration=0.1, pitch_ratio=2.0),
+                            GRAIN_HEIGHT_READ_SPAN) == pytest.approx(0.2)
+        assert grain_height(grain(duration=0.1, pitch_ratio=0.5),
+                            GRAIN_HEIGHT_READ_SPAN) == pytest.approx(0.05)
+
+    def test_read_span_mode_takes_the_absolute_ratio(self):
+        """Il verso lo decide gia' il segno, ribaltando la forma sotto il
+        pointer: l'altezza e' una lunghezza, e una lunghezza non e' negativa."""
+        assert grain_height(grain(duration=0.1, pitch_ratio=-2.0),
+                            GRAIN_HEIGHT_READ_SPAN) == pytest.approx(0.2)
+
+    def test_unknown_mode_is_refused_by_name(self):
+        """Un refuso nel modo non deve disegnare in silenzio la geometria
+        sbagliata: e' esattamente l'errore che questa issue chiude."""
+        with pytest.raises(ValueError, match='read-span'):
+            grain_height(grain(), 'read-span')
+
+    def test_the_two_modes_are_the_declared_set(self):
+        assert GRAIN_HEIGHT_MODES == frozenset(
+            {GRAIN_HEIGHT_DURATION, GRAIN_HEIGHT_READ_SPAN})
+
+
+class TestArrowVerticesReadSpan:
+    """La freccia in modo `read_span`: la punta cade dove il grano smette
+    davvero di leggere."""
+
+    def test_tip_reaches_the_read_span(self):
+        verts = arrow_vertices(
+            grain(onset=0.0, duration=0.1, pointer_pos=1.0, pitch_ratio=3.0),
+            height_mode=GRAIN_HEIGHT_READ_SPAN)
+        assert verts[3][1] == pytest.approx(1.3)
+
+    def test_head_still_takes_half_the_height(self):
+        """La testa resta meta' dell'altezza, non meta' della larghezza: le
+        due erano lo stesso numero solo finche' l'altezza era la durata."""
+        verts = arrow_vertices(
+            grain(onset=0.0, duration=0.1, pointer_pos=0.0, pitch_ratio=3.0),
+            height_mode=GRAIN_HEIGHT_READ_SPAN)
+        shoulders = [verts[2][1], verts[4][1]]
+        assert shoulders == [pytest.approx(0.15), pytest.approx(0.15)]
+
+    def test_reverse_head_still_takes_half_the_height(self):
+        verts = arrow_vertices(
+            grain(onset=0.0, duration=0.1, pointer_pos=0.0, pitch_ratio=-3.0),
+            height_mode=GRAIN_HEIGHT_READ_SPAN)
+        shoulders = [verts[2][1], verts[4][1]]
+        assert shoulders == [pytest.approx(-0.15), pytest.approx(-0.15)]
+
+    def test_width_stays_the_duration(self):
+        """Solo l'asse Y cambia significato: sull'asse X il grano occupa il
+        tempo che dura, trasposto o no."""
+        verts = arrow_vertices(
+            grain(onset=2.0, duration=0.1, pitch_ratio=3.0),
+            height_mode=GRAIN_HEIGHT_READ_SPAN)
+        xs = [x for x, _ in verts]
+        assert (min(xs), max(xs)) == pytest.approx((2.0, 2.1))
+
+    def test_a_nearly_still_grain_collapses_to_its_pointer(self):
+        """Ratio 0.001: il grano attraversa un millesimo del buffer che la
+        durata suggerisce. La freccia si appiattisce sulla posizione di
+        lettura, ed e' quello che il rendering fa davvero."""
+        verts = arrow_vertices(
+            grain(onset=0.0, duration=1.0, pointer_pos=0.5, pitch_ratio=0.001),
+            height_mode=GRAIN_HEIGHT_READ_SPAN)
+        assert len(verts) == 5
+        assert verts[3][1] == pytest.approx(0.501)
+
+    def test_duration_mode_is_the_default(self):
+        """Chi non chiede niente ha la geometria storica: il modo nuovo si
+        accende, non si subisce."""
+        g = grain(onset=0.0, duration=0.1, pointer_pos=0.0, pitch_ratio=3.0)
+        assert arrow_vertices(g) == arrow_vertices(
+            g, height_mode=GRAIN_HEIGHT_DURATION)
+        assert arrow_vertices(g)[3][1] == pytest.approx(0.1)
+
+
+class TestWindowVerticesReadSpan:
+    """La silhouette in modo `read_span`: l'asse Y porta l'ampiezza della
+    finestra scalata sulla porzione letta, non piu' sulla durata."""
+
+    def test_edge_peaks_at_the_read_span(self):
+        xs, w = window_silhouette('hanning', 33)
+        verts = window_vertices(
+            grain(onset=0.0, duration=0.1, pointer_pos=1.0, pitch_ratio=3.0),
+            xs, w, height_mode=GRAIN_HEIGHT_READ_SPAN)
+        ys = [y for _, y in verts]
+        assert max(ys) == pytest.approx(1.3)
+        assert min(ys) == pytest.approx(1.0)
+
+    def test_reverse_edge_falls_by_the_read_span(self):
+        xs, w = window_silhouette('hanning', 33)
+        verts = window_vertices(
+            grain(onset=0.0, duration=0.1, pointer_pos=1.0, pitch_ratio=-3.0),
+            xs, w, height_mode=GRAIN_HEIGHT_READ_SPAN)
+        ys = [y for _, y in verts]
+        assert min(ys) == pytest.approx(0.7)
+        assert max(ys) == pytest.approx(1.0)
+
+    def test_duration_mode_is_the_default(self):
+        xs, w = window_silhouette('hanning', 33)
+        g = grain(onset=0.0, duration=0.1, pointer_pos=1.0, pitch_ratio=3.0)
+        assert (window_vertices(g, xs, w)
+                == window_vertices(g, xs, w, height_mode=GRAIN_HEIGHT_DURATION))
+        assert max(y for _, y in window_vertices(g, xs, w)) == pytest.approx(1.1)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -716,6 +716,7 @@ class TestExportScorePdf:
         'envelope_filter': None,
         'magnify_auto': False,
         'magnify_targets': [],
+        'grain_height': 'duration',
     }
 
     def test_default_config_matches_cli(self, api_mocks):

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -25,6 +25,7 @@ USAGE = (
     "[--plot-envelopes nomi,csv] "
     "[--magnify] [--magnify-at SPEC] "
     "[--page-duration SECONDI] "
+    "[--grain-height duration|read-span] "
     "[--per-stream] "
     "[--renderer csound|numpy] "
     "[--jobs N|auto] "
@@ -169,6 +170,18 @@ class TestMagnifyAtValidationGolden:
         assert capsys.readouterr().out == (
             "--magnify-at: nessun target valido nello SPEC.\n"
         )
+
+
+class TestGrainHeightValidationGolden:
+    """Messaggio esatto di --grain-height (valore fuori dai due modi)."""
+
+    def test_unknown_mode_message(self, mocks, capsys):
+        _run_expect_exit(
+            mocks, ['main.py', 'test.yml', 'out.aif', '--visualize',
+                    '--grain-height', 'banana'])
+        assert capsys.readouterr().out == (
+            "--grain-height non valido: 'banana'. "
+            "Valori: duration, read-span\n")
 
 
 class TestSvLayoutValidationGolden:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -318,6 +318,71 @@ class TestPlotEnvelopesFlag:
 
 
 # =============================================================================
+# TEST FLAG --grain-height
+# =============================================================================
+
+class TestGrainHeightFlag:
+    """
+    --grain-height duration|read-span sceglie che cosa misura l'altezza del
+    grano sull'asse del buffer (issue #223): la durata (storico) o la porzione
+    di sample che il grano percorre davvero. Il valore arriva alla config di
+    ScoreVisualizer come `grain_height`, in snake_case. Valore ignoto: exit 1.
+    """
+
+    def _get_viz_config(self, mocks, argv):
+        with patch.object(sys, 'argv', argv):
+            mocks['main'].main()
+        _, kwargs = mocks['ScoreVisualizer'].call_args
+        return kwargs['config']
+
+    def test_default_is_duration(self, mocks):
+        """Senza flag la geometria e' quella storica: nessuna partitura gia'
+        generata cambia aspetto da sola."""
+        config = self._get_viz_config(
+            mocks, ['main.py', 'test.yml', 'out.aif', '--visualize'])
+        assert config.get('grain_height') == 'duration'
+
+    def test_read_span_reaches_the_config(self, mocks):
+        config = self._get_viz_config(
+            mocks, ['main.py', 'test.yml', 'out.aif', '--visualize',
+                    '--grain-height', 'read-span'])
+        assert config.get('grain_height') == 'read_span'
+
+    def test_duration_can_be_asked_explicitly(self, mocks):
+        config = self._get_viz_config(
+            mocks, ['main.py', 'test.yml', 'out.aif', '--visualize',
+                    '--grain-height', 'duration'])
+        assert config.get('grain_height') == 'duration'
+
+    def test_unknown_value_exits_with_1(self, mocks):
+        with patch.object(sys, 'argv',
+                          ['main.py', 'test.yml', 'out.aif', '--visualize',
+                           '--grain-height', 'banana']):
+            with pytest.raises(SystemExit) as exc_info:
+                mocks['main'].main()
+        assert exc_info.value.code == 1
+
+    def test_underscore_form_is_refused(self, mocks):
+        """Sulla CLI i valori composti si scrivono col trattino, come i flag:
+        una sola grafia, invece di due che passano entrambe."""
+        with patch.object(sys, 'argv',
+                          ['main.py', 'test.yml', 'out.aif', '--visualize',
+                           '--grain-height', 'read_span']):
+            with pytest.raises(SystemExit):
+                mocks['main'].main()
+
+    def test_validation_happens_without_visualize(self, mocks):
+        """Come --plot-envelopes: il valore si valida comunque, anche se senza
+        --visualize non ha effetto. Un refuso non resta muto."""
+        with patch.object(sys, 'argv',
+                          ['main.py', 'test.yml', 'out.aif',
+                           '--grain-height', 'banana']):
+            with pytest.raises(SystemExit) as exc_info:
+                mocks['main'].main()
+        assert exc_info.value.code == 1
+
+
+# =============================================================================
 # TEST FLAG --page-duration
 # =============================================================================
 


### PR DESCRIPTION
Chiude #223.

## Cosa cambia

Sull'asse Y della mappa (`Read position (s)`) l'altezza di un grano è una
porzione di buffer, e quella disegnata era `grain.duration`: la porzione che il
grano percorrerebbe **leggendo a velocità 1**. La porzione che percorre è
`duration × pitch_ratio` — le due coincidono solo a `|ratio| = 1`, ed è per
questo che la geometria sbagliata non si vedeva.

La correzione è una riga, ma non arriva come fix silenzioso: arriva come
**modo**, perché cambia l'aspetto di ogni partitura già generata con un `pitch`
diverso da zero.

```bash
python src/main.py configs/brano.yml --visualize --grain-height read-span
make all FILE=brano AUTOVISUAL=true GRAIN_HEIGHT=read-span
```

Default invariato (`duration`): a flag spenta ogni figura è byte per byte
quella di prima.

## Le quattro questioni aperte nella issue

1. **Testa della freccia** — è ora metà dell'**altezza**, non metà della
   larghezza: erano lo stesso numero finché l'altezza era la durata. Nessun cap
   ai ratio estremi: a 0.001 la freccia si appiattisce sulla posizione di
   lettura, ed è quello che il rendering fa davvero. Un tetto direbbe una
   proporzione falsa proprio dove la geometria è più informativa.
2. **Grani che escono dal file** — resta il taglio di `clip_on=True`, ma
   dichiarato invece che taciuto (nota in `docs/reference/cli.md` e nella
   explanation). Replicare lo split di `_draw_loop_mask` è lavoro a sé e non
   sta in questa PR.
3. **`grain_shape: window`** — si scala sulla stessa altezza, così le due forme
   non raccontano due geometrie diverse; il fatto che lì l'asse porti
   l'ampiezza della finestra e non la porzione letta è scritto nel docstring e
   nella explanation.
4. **Compatibilità delle figure** — in CHANGELOG, e l'etichetta dell'asse porta
   `(grain height = read span)` quando il modo è attivo: due mappe della stessa
   composizione nei due modi non sono indistinguibili fuori contesto. Sul bump
   del submodule nel repo del paper CIM 2026 decide l'autore (regola
   `submodule-sync-cim`): gli esempi rigenerati **non** cambiano finché la flag
   resta spenta.

## Superficie

- `grain_visuals.grain_height` + costanti `GRAIN_HEIGHT_DURATION` /
  `GRAIN_HEIGHT_READ_SPAN` / `GRAIN_HEIGHT_MODES`; `arrow_vertices` e
  `window_vertices` prendono `height_mode` keyword-only (default = storico).
- Config del visualizer: chiave `grain_height`. Un modo sconosciuto solleva
  `ValueError` col nome del refuso invece di ripiegare in silenzio sulla
  geometria storica — che è esattamente l'errore da cui nasce la distinzione.
- CLI: `--grain-height duration|read-span`, validato sempre (anche senza
  `--visualize`, come `--plot-envelopes`). Make: `GRAIN_HEIGHT`.
- Il modo è letto una volta per chiamata di `_draw_grains_full`, quindi vale
  anche per il contenuto della lente, che passa dallo stesso disegno.

## Test

`make tests`: 5719 passed. Nuovi:

- `tests/rendering/test_grain_visuals.py` — `TestGrainHeightMode`,
  `TestArrowVerticesReadSpan`, `TestWindowVerticesReadSpan` (geometria pura,
  incluso il caso ratio 0.001 e il default invariato).
- `tests/rendering/test_grain_height_mode.py` — cablaggio config → poligono
  disegnato, il reverse sotto il pointer, il modo ignoto rifiutato al disegno,
  l'etichetta dell'asse.
- `tests/test_main.py::TestGrainHeightFlag`,
  `tests/test_cli_contract.py::TestGrainHeightValidationGolden` (usage e
  messaggio d'errore golden), `tests/test_api.py` (default della config CLI).

## Demo

`configs/PGE_grain_height_demo.yml`: testina ferma e `pitch.ratio` che spazza
gli estremi dell'unità (0.001 → 3), così l'unica cosa che si muove nel disegno
è quanto sample il grano attraversa. Il sample non è versionato (`refs/` è
gitignored): va bene un file qualunque di ~4 s.

## Impatto cross-repo

- `PGE-ls` — nessuno: la superficie YAML non cambia.
- `PGE-ui` — la superficie CLI cambia (una flag nuova, opzionale). Il bridge
  non ne ha bisogno per rendere come oggi; se si vuole esporre il modo nel
  popover di render serve una issue lì, da aprire su decisione dell'autore.

---
_Generated by [Claude Code](https://claude.ai/code/session_014Bb2xQq3mC8MVeWA5mNJBN)_