### PR TITLE
fix(rendering): sotto i 10 campioni la finestra non si applica (#225)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,48 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ## [Non rilasciato]
 
+### Corretto
+
+- **Grani muti: la finestra collassata a 1-2 campioni ora è piatta, non zero**
+  (issue #225). Con `grain.duration` dentro la banda `round(dur * output_sr) == 2`
+  — **31.25-52.08 µs a 48 kHz**, estremi inclusi perché `round()` in Python è
+  half-to-even — il renderer NumPy produceva **silenzio digitale assoluto**. A
+  quelle lunghezze il campionamento discreto non riesce a rappresentare la
+  forma della finestra: le simmetriche cadono sui due estremi, che valgono zero
+  (`np.hanning(2) == [0, 0]`), e le asimmetriche che partono da zero cadono sul
+  solo punto di partenza (`exporise(1) == [0]`). Il grano veniva generato
+  regolarmente, moltiplicato per la finestra e reso come silenzio: non veniva
+  scartato e non loggava nulla. Con `duration_range` attivo si azzerava solo la
+  frazione di grani che cadeva nella banda — buchi sparsi e irregolari; con la
+  curva `duration` stabilmente dentro la banda, un buco continuo (nel caso di
+  riproduzione: **296 ms** a zero assoluto, con tutti i grani presenti).
+
+  `NumpyWindowRegistry` riconosce ora la finestra collassata — picco sotto
+  -60 dB rispetto all'1.0 di progetto di ogni finestra del catalogo — e la
+  sostituisce con la piatta: sotto i 3 campioni non c'è salita, picco e discesa
+  da rappresentare, quindi è l'unica lettura onesta. Riguarda `hanning`,
+  `bartlett`/`triangle`, `blackman`, `blackman_harris`, `sinc`, `half_sine` a
+  N≤2 e `exporise`, `exporise_strong`, `rexporise` a N=1.
+
+  **La guardia sta sul risultato, non su `n`**, ed è la differenza che conta: si
+  ripara la finestra collassata, non ogni finestra corta. `expodec` e `rexpodec`
+  a N=2 valgono `[1, 0]` — una decadenza vera, non un caso degenere — e restano
+  come sono; così `hamming` (0.08), `gaussian` (0.044) e `kaiser` (0.015),
+  attenuate ma udibili. Un grano piano porta ancora informazione, e alzarlo
+  significherebbe inventare un livello che nessuno dei due renderer produce. La
+  soglia non è critica: fra il picco più alto fra i riparati (`blackman_harris`,
+  6e-5) e il più basso fra i lasciati stare (`kaiser`, 0.0149) c'è un vuoto di
+  248x, e -60 dB ci sta in mezzo con due ordini di grandezza di margine per lato.
+
+  **Non allinea NumPy e Csound**, e non era possibile: Csound legge la ftable
+  con `poscil` a fase 0 ed è muto a N=1 su nove finestre (tutte quelle che
+  partono da zero) mentre a N=2 sta bene — l'opposto di NumPy. I due renderer
+  erano e restano diversi ai due estremi; quello che cambia è che nessuno dei
+  due tace più dove l'altro suona per un accidente aritmetico.
+
+  Il clamp `min_val = 1/output_sr` su `grain_duration` continua a garantire
+  N ≥ 1 e non c'entra: impediva N=0, non intercettava N=2.
+
 ### Aggiunto
 
 - **`--grain-height duration|read-span`: l'altezza del grano nella mappa può
@@ -64,6 +106,12 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Documentazione
 
+- `docs/reference/yaml.md`, note sui grani a precisione di campione: riscritte
+  per la issue #225. La nota diceva che il silenzio a 2 campioni era «la
+  matematica della finestra, non un bug» — ora non lo è più, e il testo dichiara
+  la banda fatale corretta (31.25-52.08 µs, non 35-52), l'elenco completo delle
+  finestre interessate, quali restano attenuate di proposito, e in che modo
+  esatto NumPy e Csound divergono ai due estremi.
 - `docs/reference/cli.md`: flag `--grain-height`, vincoli e nota sul taglio ai
   bordi del sample.
 - `docs/explanation/score-visualizer-layout.md`: sezione «Due letture dello

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,19 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   Il clamp `min_val = 1/output_sr` su `grain_duration` continua a garantire
   N ≥ 1 e non c'entra: impediva N=0, non intercettava N=2.
 
+- **`configs/PGE_grain_duration_samples_demo.yml`: lo stream `s2_short_512samples`
+  scriveva `duration: 2` invece di `512`.** Difetto indipendente dal precedente,
+  trovato indagandolo. Con `duration_unit: samples` quei 2 campioni sono 41.7 µs
+  — dentro la banda fatale — e con `envelope: hanning` lo stream era
+  **completamente muto**. Tre indizi nel file concordavano sul valore giusto: lo
+  `stream_id`, il commento inline (`# ~10.7 ms`, che è 512/48000 s, non 2
+  campioni) e lo stream 4, dichiarato «controprova retrocompatibile: stessi ~512
+  campioni ma in secondi» con `duration: 0.01067`. Corretto: s2 e s4 rendono ora
+  lo stesso picco (0.5637) e sono di nuovo la coppia di controprova che il file
+  dichiara di essere. È anche la prova che il bug della finestra collassata
+  passava inosservato: stava in una demo del repo, e si presentava come uno
+  stream silenzioso invece che come un errore.
+
 ### Aggiunto
 
 - **`--grain-height duration|read-span`: l'altezza del grano nella mappa può

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,42 +10,24 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Corretto
 
-- **Grani muti: la finestra collassata a 1-2 campioni ora è piatta, non zero**
-  (issue #225). Con `grain.duration` dentro la banda `round(dur * output_sr) == 2`
-  — **31.25-52.08 µs a 48 kHz**, estremi inclusi perché `round()` in Python è
+- **Grani muti: sotto i 10 campioni non si finestra più** (issue #225). Con
+  `grain.duration` dentro la banda `round(dur * output_sr) == 2` —
+  **31.25-52.08 µs a 48 kHz**, estremi inclusi perché `round()` in Python è
   half-to-even — il renderer NumPy produceva **silenzio digitale assoluto**. A
   quelle lunghezze il campionamento discreto non riesce a rappresentare la
-  forma della finestra: le simmetriche cadono sui due estremi, che valgono zero
-  (`np.hanning(2) == [0, 0]`), e le asimmetriche che partono da zero cadono sul
-  solo punto di partenza (`exporise(1) == [0]`). Il grano veniva generato
-  regolarmente, moltiplicato per la finestra e reso come silenzio: non veniva
-  scartato e non loggava nulla. Con `duration_range` attivo si azzerava solo la
-  frazione di grani che cadeva nella banda — buchi sparsi e irregolari; con la
-  curva `duration` stabilmente dentro la banda, un buco continuo (nel caso di
-  riproduzione: **296 ms** a zero assoluto, con tutti i grani presenti).
+  forma della finestra: le simmetriche cadono sui due estremi, che valgono
+  zero (`np.hanning(2) == [0, 0]`), e le asimmetriche che partono da zero
+  cadono sul solo punto di partenza (`exporise(1) == [0]`). Il grano veniva
+  generato regolarmente, moltiplicato per la finestra e reso come silenzio:
+  non veniva scartato e non loggava nulla. Con `duration_range` attivo si
+  azzerava solo la frazione di grani che cadeva nella banda — buchi sparsi e
+  irregolari; con la curva `duration` stabilmente dentro la banda, un buco
+  continuo (nel caso di riproduzione: **4 secondi** a zero assoluto, con tutti
+  i grani presenti).
 
-  `NumpyWindowRegistry` riconosce ora la finestra collassata — picco sotto
-  -60 dB rispetto all'1.0 di progetto di ogni finestra del catalogo — e la
-  sostituisce con la piatta: sotto i 3 campioni non c'è salita, picco e discesa
-  da rappresentare, quindi è l'unica lettura onesta. Riguarda `hanning`,
-  `bartlett`/`triangle`, `blackman`, `blackman_harris`, `sinc`, `half_sine` a
-  N≤2 e `exporise`, `exporise_strong`, `rexporise` a N=1.
-
-  **La guardia sta sul risultato, non su `n`**, ed è la differenza che conta: si
-  ripara la finestra collassata, non ogni finestra corta. `expodec` e `rexpodec`
-  a N=2 valgono `[1, 0]` — una decadenza vera, non un caso degenere — e restano
-  come sono; così `hamming` (0.08), `gaussian` (0.044) e `kaiser` (0.015),
-  attenuate ma udibili. Un grano piano porta ancora informazione, e alzarlo
-  significherebbe inventare un livello che nessuno dei due renderer produce. La
-  soglia non è critica: fra il picco più alto fra i riparati (`blackman_harris`,
-  6e-5) e il più basso fra i lasciati stare (`kaiser`, 0.0149) c'è un vuoto di
-  248x, e -60 dB ci sta in mezzo con due ordini di grandezza di margine per lato.
-
-  **Non allinea NumPy e Csound**, e non era possibile: Csound legge la ftable
-  con `poscil` a fase 0 ed è muto a N=1 su nove finestre (tutte quelle che
-  partono da zero) mentre a N=2 sta bene — l'opposto di NumPy. I due renderer
-  erano e restano diversi ai due estremi; quello che cambia è che nessuno dei
-  due tace più dove l'altro suona per un accidente aritmetico.
+  La correzione non guarda il caso degenere, guarda la lunghezza: sotto i
+  **10 campioni (208.3 µs)** la finestra non viene applicata. Vedi la voce in
+  «Modificato» per il perché e per cosa cambia.
 
   Il clamp `min_val = 1/output_sr` su `grain_duration` continua a garantire
   N ≥ 1 e non c'entra: impediva N=0, non intercettava N=2.
@@ -62,6 +44,39 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   dichiara di essere. È anche la prova che il bug della finestra collassata
   passava inosservato: stava in una demo del repo, e si presentava come uno
   stream silenzioso invece che come un errore.
+
+### Modificato
+
+- **Il renderer NumPy ignora `envelope` sotto i 10 campioni (208.3 µs).** A
+  quelle lunghezze la finestra non taglia i bordi: decima il grano.
+  `hanning(3)` è `[0, 1, 0]` — tiene un campione su tre e paga tre campioni di
+  budget; a 4 ne tiene due su quattro. Non c'è una forma con un interno, ci
+  sono due zeri agli estremi e uno o due punti in mezzo. E l'effetto spettrale
+  è l'opposto di quello per cui la finestra esiste: su un tono a 440 Hz la
+  quota di energia sopra 2 kHz — lo sporco da troncamento — vale 0.767 per il
+  grano non finestrato a 3 campioni contro 0.917 per lo stesso grano con
+  `hanning`. Finestrare accorcia il grano più di quanto ne smussi i bordi. Il
+  pareggio arriva intorno ai 30 campioni; 10 è la linea scelta, conservativa
+  rispetto alla misura.
+
+  **Cosa cambia in pratica.** I grani sotto i 208.3 µs che oggi si sentono
+  diventano più forti, di quanto dipende dalla finestra: +36.6 dB per `kaiser`
+  a 2 campioni, +27.1 dB per `gaussian`, +21.9 dB per `hamming`, +2 e +7 dB
+  per il resto a 3-4 campioni. Sono le stesse lunghezze a cui la scelta della
+  finestra decideva un livello e non una forma: adesso il livello è uno solo,
+  e `kaiser` e `hanning` non differiscono più di 36 dB sullo stesso grano di
+  2 campioni. Nel repo l'unica config toccata è
+  `PGE_grain_duration_samples_demo.yml`, stream `s1_click_train_1sample`.
+
+  **Il salto alla soglia è dichiarato**: attraversando i 208.3 µs il livello
+  scende di colpo, da −0.4 dB (`expodec_strong`) a −7.3 dB (`rexpodec`),
+  −4.3 dB con `hanning`. È la finestra che entra in funzione. Con `rectangle`
+  non c'è salto, perché è piatta da entrambi i lati.
+
+  **Non allinea NumPy e Csound**, li allontana: Csound la finestra la applica
+  comunque, leggendo la ftable con `poscil` a fase 0, ed è muto a N=1 sulle
+  nove finestre che partono da zero. Sotto i 10 campioni la scelta del
+  renderer domina il risultato più della scelta della finestra.
 
 ### Aggiunto
 
@@ -121,10 +136,10 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 - `docs/reference/yaml.md`, note sui grani a precisione di campione: riscritte
   per la issue #225. La nota diceva che il silenzio a 2 campioni era «la
-  matematica della finestra, non un bug» — ora non lo è più, e il testo dichiara
-  la banda fatale corretta (31.25-52.08 µs, non 35-52), l'elenco completo delle
-  finestre interessate, quali restano attenuate di proposito, e in che modo
-  esatto NumPy e Csound divergono ai due estremi.
+  matematica della finestra, non un bug» — ora non lo è più. Il testo dichiara
+  la soglia dei 10 campioni e la misura che la motiva, la banda fatale corretta
+  (31.25-52.08 µs, non 35-52), il salto di livello alla soglia finestra per
+  finestra, e in che modo NumPy e Csound divergono là sotto.
 - `docs/reference/cli.md`: flag `--grain-height`, vincoli e nota sul taglio ai
   bordi del sample.
 - `docs/explanation/score-visualizer-layout.md`: sezione «Due letture dello

--- a/configs/PGE_grain_duration_samples_demo.yml
+++ b/configs/PGE_grain_duration_samples_demo.yml
@@ -32,7 +32,7 @@ streams:
     sample: "sinus.wav"
     density: 40.0
     grain:
-      duration: 2         # ~10.7 ms
+      duration: 512       # ~10.7 ms
       duration_unit: samples
       envelope: hanning
 

--- a/configs/PGE_issue225_loop_probe.yml
+++ b/configs/PGE_issue225_loop_probe.yml
@@ -1,0 +1,149 @@
+# PGE_issue225_loop_probe.yml
+# Prova empirica per la PR #226 (issue #225): grani cortissimi dentro una
+# finestra di loop stretta, fill_factor 1, renderer NumPy.
+#
+# Banda fatale a 48 kHz: round(dur * 48000) == 2, cioe' 31.25-52.08 us.
+#   n=1 -> dur < 31.25 us      n=2 -> 31.25-52.08 us      n=3 -> 52.08-72.9 us
+#
+# Lancia con:  make FILE=PGE_issue225_loop_probe RENDERER=numpy STEMS=true
+seed: 20250822
+
+streams:
+
+  # 1. Sweep attraverso la banda: 100 us -> 21 us. Attraversa n=4,3,2,1.
+  #    Con hanning il tratto n=2 e' il buco.
+  - stream_id: "s1_sweep_hanning"
+    onset: 0.0
+    duration: 4.0
+    sample: "sinus.wav"
+    fill_factor: 1.0
+    pointer:
+      loop_start: 1.0
+      loop_end: 1.05
+      speed_ratio: 1.0
+    grain:
+      duration: [[0.0, 0.0001], [4.0, 0.000021]]
+      envelope: hanning
+
+  # 2. Stesso sweep, envelope expodec: controllo, la fix non lo tocca.
+  - stream_id: "s2_sweep_expodec"
+    onset: 0.0
+    duration: 4.0
+    sample: "sinus.wav"
+    fill_factor: 1.0
+    pointer:
+      loop_start: 1.0
+      loop_end: 1.05
+      speed_ratio: 1.0
+    grain:
+      duration: [[0.0, 0.0001], [4.0, 0.000021]]
+      envelope: expodec
+
+  # 3. Fisso dentro la banda fatale: 2 campioni esatti, hanning.
+  #    Pre-fix: stream interamente muto.
+  - stream_id: "s3_fixed_n2_hanning"
+    onset: 0.0
+    duration: 4.0
+    sample: "sinus.wav"
+    fill_factor: 1.0
+    pointer:
+      loop_start: 1.0
+      loop_end: 1.05
+      speed_ratio: 1.0
+    grain:
+      duration: 2
+      duration_unit: samples
+      envelope: hanning
+
+  # 4. Un campione: NumPy sano prima e dopo (hanning(1) == [1.0]).
+  - stream_id: "s4_fixed_n1_hanning"
+    onset: 0.0
+    duration: 4.0
+    sample: "sinus.wav"
+    fill_factor: 1.0
+    pointer:
+      loop_start: 1.0
+      loop_end: 1.05
+      speed_ratio: 1.0
+    grain:
+      duration: 1
+      duration_unit: samples
+      envelope: hanning
+
+  # 5. Loop mobile + durata dentro la banda: il buco si muove col loop.
+  - stream_id: "s5_loop_mobile_n2"
+    onset: 0.0
+    duration: 4.0
+    sample: "sinus.wav"
+    fill_factor: 1.0
+    pointer:
+      loop_start: [[0.0, 0.5], [4.0, 3.5]]
+      loop_dur: 0.05
+      speed_ratio: 1.0
+    grain:
+      duration: 2
+      duration_unit: samples
+      envelope: hanning
+
+  # 6. Riferimento sano: 480 campioni (10 ms), stesso loop, stesso fill_factor.
+  - stream_id: "s6_reference_10ms"
+    onset: 0.0
+    duration: 4.0
+    sample: "sinus.wav"
+    fill_factor: 1.0
+    pointer:
+      loop_start: 1.0
+      loop_end: 1.05
+      speed_ratio: 1.0
+    grain:
+      duration: 480
+      duration_unit: samples
+      envelope: hanning
+
+  # 7. Stessa banda, envelope kaiser: la fix non lo tocca (picco 0.0149).
+  #    Confronto di livello con s3 (hanning riparata a 1.0).
+  - stream_id: "s7_fixed_n2_kaiser"
+    onset: 0.0
+    duration: 4.0
+    sample: "sinus.wav"
+    fill_factor: 1.0
+    pointer:
+      loop_start: 1.0
+      loop_end: 1.05
+      speed_ratio: 1.0
+    grain:
+      duration: 2
+      duration_unit: samples
+      envelope: kaiser
+
+  # 8. Idem con gaussian (picco 0.0439).
+  - stream_id: "s8_fixed_n2_gaussian"
+    onset: 0.0
+    duration: 4.0
+    sample: "sinus.wav"
+    fill_factor: 1.0
+    pointer:
+      loop_start: 1.0
+      loop_end: 1.05
+      speed_ratio: 1.0
+    grain:
+      duration: 2
+      duration_unit: samples
+      envelope: gaussian
+
+  # 9. Sweep attraverso la soglia: 5 -> 20 campioni (104 -> 417 us).
+  #    A 10 campioni (208.3 us, meta' esatta dello stream) la finestra entra
+  #    in funzione e il livello scende di colpo.
+  - stream_id: "s9_sweep_threshold"
+    onset: 0.0
+    duration: 4.0
+    sample: "sinus.wav"
+    fill_factor: 1.0
+    pointer:
+      loop_start: 1.0
+      loop_end: 1.05
+      speed_ratio: 1.0
+    grain:
+      duration: [[0.0, 5], [4.0, 20]]
+      duration_unit: samples
+      envelope: hanning

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -11,6 +11,7 @@ sources:
   - src/pge/envelopes/
   - src/pge/shared/seeding.py
   - src/pge/shared/distribution_strategy.py
+  - src/pge/rendering/numpy_window_registry.py
 last_synced_commit: 8bd9d21
 entry_for: [yaml-syntax, envelope-syntax]
 ---
@@ -624,17 +625,37 @@ in ogni unità: il renderer arrotonda al campione più vicino
 
 Note sui grani a precisione di campione:
 
-- **Finestre simmetriche su grani di 2-3 campioni**: `hanning`, `bartlett`,
-  `blackman`, `half_sine`, `sinc` hanno estremi nulli — a 2 campioni il grano
-  è silenzio, a 3 sopravvive solo il campione centrale. È la matematica della
-  finestra, non un bug. Per grani ultra-corti usare `rectangle` (piatta),
-  `hamming` (estremi 0.08) o la famiglia `expodec` (parte da 1.0).
-- **Divergenza NumPy/Csound**: il renderer NumPy campiona la finestra a
-  `n_out` punti (`hanning` a 1 campione = `[1.0]`, impulso pieno); Csound
-  legge la tabella finestra con `poscil` a `1/p3` Hz e su un grano di 1
-  campione ne legge solo il primo punto (per `hanning` = 0, grano silente).
-  I due renderer non sono mai stati dichiarati bit-equivalenti; a queste
-  durate la scelta della finestra domina il risultato.
+- **Nessun grano è muto** (issue #225). A 1-2 campioni il campionamento
+  discreto non riesce a rappresentare la forma della finestra: le simmetriche
+  cadono sui due estremi, che valgono zero (`np.hanning(2) == [0, 0]`), e le
+  asimmetriche che partono da zero cadono sul solo punto di partenza
+  (`exporise(1) == [0]`). Il renderer NumPy riconosce la finestra collassata —
+  picco sotto -60 dB rispetto all'1.0 di progetto — e la sostituisce con la
+  piatta: sotto i 3 campioni non c'è salita, picco e discesa da rappresentare.
+  Riguarda `hanning`, `bartlett`/`triangle`, `blackman`, `blackman_harris`,
+  `sinc`, `half_sine` a N≤2 e `exporise`, `exporise_strong`, `rexporise` a N=1.
+  Prima della fix questi grani venivano generati, moltiplicati per zero e resi
+  come silenzio digitale, senza scarto e senza log: con `grain.duration` dentro
+  la banda `round(dur * output_sr) == 2` — **31.25-52.08 µs a 48 kHz**, estremi
+  inclusi perché `round()` in Python è half-to-even — il risultato era un buco
+  di centinaia di ms.
+- **Finestre attenuate, non riparate**: `hamming` (estremi 0.08), `gaussian`
+  (0.044) e `kaiser` (0.015) a N≤2 restano come sono. Sono basse ma udibili, e
+  un grano piano porta ancora informazione: alzarle significherebbe inventare
+  un livello che nessuno dei due renderer produce. Stesso discorso per
+  `expodec`/`rexpodec`, che a N=2 valgono `[1, 0]` — una decadenza vera, non un
+  caso degenere. Per grani ultra-corti con livello pieno resta consigliata
+  `rectangle` (piatta) o la famiglia `expodec` (parte da 1.0).
+- **Divergenza NumPy/Csound**: i due renderer non sono mai stati dichiarati
+  bit-equivalenti e a queste durate restano diversi ai due estremi — la fix
+  sopra non li allinea, toglie il silenzio. Csound legge la tabella finestra
+  con `poscil` a `1/p3` Hz e fase iniziale 0: su un grano di 1 campione ne
+  legge solo il primo punto, quindi è **muto a N=1** su tutte le finestre che
+  partono da zero (nove: `hanning`, `bartlett`/`triangle`, `blackman`,
+  `blackman_harris`, `sinc`, `half_sine`, `exporise`, `exporise_strong`,
+  `rexporise`), mentre a N=2 legge gli indici 0 e 512 della tabella e sta
+  bene. NumPy è l'opposto: sano a N=1, collassato a N=2. A queste durate la
+  scelta della finestra e del renderer domina il risultato.
 - **Densità derivata**: con `fill_factor` e grani da 1 campione la density
   `fill_factor/duration` satura al bound massimo (4000 g/s).
 

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -625,37 +625,39 @@ in ogni unità: il renderer arrotonda al campione più vicino
 
 Note sui grani a precisione di campione:
 
-- **Nessun grano è muto** (issue #225). A 1-2 campioni il campionamento
-  discreto non riesce a rappresentare la forma della finestra: le simmetriche
-  cadono sui due estremi, che valgono zero (`np.hanning(2) == [0, 0]`), e le
-  asimmetriche che partono da zero cadono sul solo punto di partenza
-  (`exporise(1) == [0]`). Il renderer NumPy riconosce la finestra collassata —
-  picco sotto -60 dB rispetto all'1.0 di progetto — e la sostituisce con la
-  piatta: sotto i 3 campioni non c'è salita, picco e discesa da rappresentare.
-  Riguarda `hanning`, `bartlett`/`triangle`, `blackman`, `blackman_harris`,
-  `sinc`, `half_sine` a N≤2 e `exporise`, `exporise_strong`, `rexporise` a N=1.
-  Prima della fix questi grani venivano generati, moltiplicati per zero e resi
-  come silenzio digitale, senza scarto e senza log: con `grain.duration` dentro
-  la banda `round(dur * output_sr) == 2` — **31.25-52.08 µs a 48 kHz**, estremi
-  inclusi perché `round()` in Python è half-to-even — il risultato era un buco
-  di centinaia di ms.
-- **Finestre attenuate, non riparate**: `hamming` (estremi 0.08), `gaussian`
-  (0.044) e `kaiser` (0.015) a N≤2 restano come sono. Sono basse ma udibili, e
-  un grano piano porta ancora informazione: alzarle significherebbe inventare
-  un livello che nessuno dei due renderer produce. Stesso discorso per
-  `expodec`/`rexpodec`, che a N=2 valgono `[1, 0]` — una decadenza vera, non un
-  caso degenere. Per grani ultra-corti con livello pieno resta consigliata
-  `rectangle` (piatta) o la famiglia `expodec` (parte da 1.0).
+- **Sotto i 10 campioni non si finestra** (issue #225). Il renderer NumPy
+  ignora `envelope` per i grani più corti di **208.3 µs** (10 campioni a
+  48 kHz) e li rende piatti. A quelle lunghezze la finestra non taglia i
+  bordi: decima il grano. `hanning(3)` è `[0, 1, 0]` — tiene un campione su
+  tre e paga tre campioni di budget; a 4 ne tiene due su quattro. E l'effetto
+  spettrale è l'opposto di quello per cui la finestra esiste: su un tono a
+  440 Hz la quota di energia sopra 2 kHz (lo sporco da troncamento) vale
+  0.767 per il grano non finestrato a 3 campioni contro 0.917 per lo stesso
+  grano con `hanning`. Il pareggio arriva intorno ai 30 campioni; 10 è la
+  linea scelta, conservativa rispetto alla misura.
+- **Il grano muto non esiste più.** Era il caso degenere della stessa
+  faccenda: a 1-2 campioni le finestre simmetriche cadono sui due estremi,
+  che valgono zero (`np.hanning(2) == [0, 0]`), e le asimmetriche che partono
+  da zero cadono sul solo punto di partenza (`exporise(1) == [0]`). Il grano
+  veniva generato, moltiplicato per zero e reso come **silenzio digitale
+  assoluto**, senza scarto e senza log: con `grain.duration` dentro la banda
+  `round(dur * output_sr) == 2` — **31.25-52.08 µs**, estremi inclusi perché
+  `round()` in Python è half-to-even — il risultato era un buco di centinaia
+  di ms. Ora quelle lunghezze stanno sotto la soglia e non vengono finestrate.
+- **Il salto alla soglia è dichiarato**: attraversando i 208.3 µs il livello
+  del grano scende di colpo, da −0.4 dB (`expodec_strong`) a −7.3 dB
+  (`rexpodec`), −4.3 dB con `hanning`. È la finestra che entra in funzione.
+  Con una `duration` che sweepa attraverso la soglia si sente uno scalino:
+  se dà fastidio, usare `rectangle`, che è piatta da entrambi i lati.
 - **Divergenza NumPy/Csound**: i due renderer non sono mai stati dichiarati
-  bit-equivalenti e a queste durate restano diversi ai due estremi — la fix
-  sopra non li allinea, toglie il silenzio. Csound legge la tabella finestra
-  con `poscil` a `1/p3` Hz e fase iniziale 0: su un grano di 1 campione ne
-  legge solo il primo punto, quindi è **muto a N=1** su tutte le finestre che
-  partono da zero (nove: `hanning`, `bartlett`/`triangle`, `blackman`,
-  `blackman_harris`, `sinc`, `half_sine`, `exporise`, `exporise_strong`,
-  `rexporise`), mentre a N=2 legge gli indici 0 e 512 della tabella e sta
-  bene. NumPy è l'opposto: sano a N=1, collassato a N=2. A queste durate la
-  scelta della finestra e del renderer domina il risultato.
+  bit-equivalenti e sotto i 10 campioni divergono di più di prima, perché
+  Csound la finestra la applica comunque. Legge la tabella con `poscil` a
+  `1/p3` Hz e fase iniziale 0: su un grano di 1 campione ne legge solo il
+  primo punto, quindi è **muto a N=1** su tutte le finestre che partono da
+  zero (`hanning`, `bartlett`/`triangle`, `blackman`, `blackman_harris`,
+  `sinc`, `half_sine`, `exporise`, `exporise_strong`, `rexporise`). Sotto i
+  10 campioni la scelta del renderer domina il risultato più della scelta
+  della finestra.
 - **Densità derivata**: con `fill_factor` e grani da 1 campione la density
   `fill_factor/duration` satura al bound massimo (4000 g/s).
 

--- a/src/pge/rendering/numpy_window_registry.py
+++ b/src/pge/rendering/numpy_window_registry.py
@@ -21,13 +21,23 @@ from typing import Dict, List, Tuple
 from pge.controllers.window_registry import WindowRegistry
 
 
-# Soglia di collasso della finestra (issue #225). Ogni finestra del catalogo e'
-# per costruzione una forma normalizzata con picco 1.0; sotto -60 dB da quel
-# picco non e' piu' attenuata, e' collassata. Non e' un numero critico: fra il
-# picco piu' alto fra i casi degeneri (blackman_harris a N<=2, 6e-5) e il piu'
-# basso fra quelli sani (kaiser a N=2, 0.0149) c'e' un vuoto di 248x, e la
-# soglia ci sta in mezzo con due ordini di grandezza di margine per lato.
-WINDOW_COLLAPSE_FLOOR = 1e-3
+# Sotto quanti campioni la finestra non viene applicata (issue #225).
+#
+# A queste lunghezze la finestra non taglia i bordi: decima il grano.
+# `hanning(3)` e' `[0, 1, 0]` -- tiene un campione su tre e paga tre campioni
+# di budget; a 4 ne tiene due su quattro. Non c'e' una forma con un interno:
+# ci sono due zeri agli estremi e uno o due punti in mezzo.
+#
+# E l'effetto spettrale e' l'opposto di cio' per cui la finestra esiste. Su un
+# tono a 440 Hz la quota di energia sopra 2 kHz -- lo sporco da troncamento --
+# vale 0.767 per il grano non finestrato a 3 campioni contro 0.917 per lo
+# stesso grano con `hanning`: finestrare accorcia il grano piu' di quanto ne
+# smussi i bordi. Il pareggio arriva intorno ai 30 campioni; 10 e' la linea
+# scelta, conservativa rispetto alla misura.
+#
+# Il caso degenere della issue (`np.hanning(2) == [0, 0]`, grano reso come
+# silenzio digitale assoluto) e' un sottocaso: sta sotto la soglia.
+WINDOW_MIN_SHAPE_SAMPLES = 10
 
 
 class NumpyWindowRegistry:
@@ -102,11 +112,16 @@ class NumpyWindowRegistry:
             from pge.shared.exceptions import InvalidWindowError
             raise InvalidWindowError(name=name, available=self.available_windows())
 
+        # Sotto la soglia non c'e' forma da rappresentare: nessuna finestra,
+        # e nemmeno il costo di generarla. Vedi WINDOW_MIN_SHAPE_SAMPLES.
+        if n < WINDOW_MIN_SHAPE_SAMPLES:
+            return np.ones(n, dtype=np.float64)
+
         key = (canonical, n)
         if key in self._cache:
             return self._cache[key]
 
-        window = self._repair_if_collapsed(self._generate(canonical, n), n)
+        window = self._generate(canonical, n)
         self._cache[key] = window
         return window
 
@@ -131,39 +146,6 @@ class NumpyWindowRegistry:
     # =========================================================================
     # GENERAZIONE
     # =========================================================================
-
-    @staticmethod
-    def _repair_if_collapsed(window: np.ndarray, n: int) -> np.ndarray:
-        """Un grano valido non e' mai silenzio: ripara la finestra collassata.
-
-        A N piccolissimi il campionamento discreto non riesce a rappresentare
-        la forma. Le simmetriche cadono sui due estremi, che valgono zero
-        (`np.hanning(2) == [0, 0]`); le asimmetriche che partono da zero
-        cadono sul solo punto di partenza (`exporise(1) == [0]`). Il grano
-        viene generato regolarmente, moltiplicato per la finestra e reso come
-        silenzio digitale: non viene scartato e non logga nulla. Con
-        `grain.duration` dentro la banda `round(dur * sr) == 2` (31.25-52.08 us
-        a 48 kHz) il risultato e' un buco di centinaia di ms.
-
-        La guardia sta sul risultato, non su `n`, e questa e' la differenza che
-        conta: si ripara la finestra che e' collassata, non ogni finestra
-        corta. `expodec` a N=2 e' `[1, 0]` -- una decadenza vera, non un caso
-        degenere -- e resta com'e'; cosi' `hamming` (0.08), `gaussian` (0.044)
-        e `kaiser` (0.015), attenuate ma udibili. Un grano piano porta ancora
-        informazione, e alzarlo significherebbe inventare un livello che
-        nessuno dei due renderer produce.
-
-        Il rimpiazzo e' la finestra piatta: sotto i 3 campioni non c'e' forma
-        da rappresentare -- niente salita, picco e discesa -- quindi e'
-        l'unica lettura onesta. Non allinea a Csound, che a queste lunghezze
-        legge la ftable con `poscil` a fase 0 ed e' muto a N=1 su nove
-        finestre e sano a N=2: i due renderer restano diversi ai due estremi,
-        come dice docs/reference/yaml.md, ma nessuno dei due tace dove l'altro
-        suona per un accidente aritmetico.
-        """
-        if np.max(np.abs(window)) > WINDOW_COLLAPSE_FLOOR:
-            return window
-        return np.ones(n, dtype=np.float64)
 
     def _generate(self, name: str, n: int) -> np.ndarray:
         """Genera l'array finestra per il nome dato."""

--- a/src/pge/rendering/numpy_window_registry.py
+++ b/src/pge/rendering/numpy_window_registry.py
@@ -21,6 +21,15 @@ from typing import Dict, List, Tuple
 from pge.controllers.window_registry import WindowRegistry
 
 
+# Soglia di collasso della finestra (issue #225). Ogni finestra del catalogo e'
+# per costruzione una forma normalizzata con picco 1.0; sotto -60 dB da quel
+# picco non e' piu' attenuata, e' collassata. Non e' un numero critico: fra il
+# picco piu' alto fra i casi degeneri (blackman_harris a N<=2, 6e-5) e il piu'
+# basso fra quelli sani (kaiser a N=2, 0.0149) c'e' un vuoto di 248x, e la
+# soglia ci sta in mezzo con due ordini di grandezza di margine per lato.
+WINDOW_COLLAPSE_FLOOR = 1e-3
+
+
 class NumpyWindowRegistry:
     """
     Registry con caching per finestre grano come array NumPy.
@@ -97,7 +106,7 @@ class NumpyWindowRegistry:
         if key in self._cache:
             return self._cache[key]
 
-        window = self._generate(canonical, n)
+        window = self._repair_if_collapsed(self._generate(canonical, n), n)
         self._cache[key] = window
         return window
 
@@ -122,6 +131,39 @@ class NumpyWindowRegistry:
     # =========================================================================
     # GENERAZIONE
     # =========================================================================
+
+    @staticmethod
+    def _repair_if_collapsed(window: np.ndarray, n: int) -> np.ndarray:
+        """Un grano valido non e' mai silenzio: ripara la finestra collassata.
+
+        A N piccolissimi il campionamento discreto non riesce a rappresentare
+        la forma. Le simmetriche cadono sui due estremi, che valgono zero
+        (`np.hanning(2) == [0, 0]`); le asimmetriche che partono da zero
+        cadono sul solo punto di partenza (`exporise(1) == [0]`). Il grano
+        viene generato regolarmente, moltiplicato per la finestra e reso come
+        silenzio digitale: non viene scartato e non logga nulla. Con
+        `grain.duration` dentro la banda `round(dur * sr) == 2` (31.25-52.08 us
+        a 48 kHz) il risultato e' un buco di centinaia di ms.
+
+        La guardia sta sul risultato, non su `n`, e questa e' la differenza che
+        conta: si ripara la finestra che e' collassata, non ogni finestra
+        corta. `expodec` a N=2 e' `[1, 0]` -- una decadenza vera, non un caso
+        degenere -- e resta com'e'; cosi' `hamming` (0.08), `gaussian` (0.044)
+        e `kaiser` (0.015), attenuate ma udibili. Un grano piano porta ancora
+        informazione, e alzarlo significherebbe inventare un livello che
+        nessuno dei due renderer produce.
+
+        Il rimpiazzo e' la finestra piatta: sotto i 3 campioni non c'e' forma
+        da rappresentare -- niente salita, picco e discesa -- quindi e'
+        l'unica lettura onesta. Non allinea a Csound, che a queste lunghezze
+        legge la ftable con `poscil` a fase 0 ed e' muto a N=1 su nove
+        finestre e sano a N=2: i due renderer restano diversi ai due estremi,
+        come dice docs/reference/yaml.md, ma nessuno dei due tace dove l'altro
+        suona per un accidente aritmetico.
+        """
+        if np.max(np.abs(window)) > WINDOW_COLLAPSE_FLOOR:
+            return window
+        return np.ones(n, dtype=np.float64)
 
     def _generate(self, name: str, n: int) -> np.ndarray:
         """Genera l'array finestra per il nome dato."""

--- a/tests/rendering/test_numpy_window_registry.py
+++ b/tests/rendering/test_numpy_window_registry.py
@@ -573,3 +573,87 @@ class TestCatalogueParity:
         from pge.controllers.window_registry import WindowRegistry
 
         assert set(registry.available_windows()) == set(WindowRegistry.all_names())
+
+
+# =============================================================================
+# NESSUNA FINESTRA E' MUTA (issue #225)
+# =============================================================================
+
+class TestNeverSilentWindow:
+    """Un grano valido non e' mai silenzio.
+
+    A N piccolissimi il campionamento discreto della finestra collassa: le
+    simmetriche vengono campionate sugli estremi (`np.hanning(2) == [0, 0]`)
+    e le asimmetriche sul solo punto di partenza (`exporise(1) == [0]`). Il
+    grano viene generato, moltiplicato per zero e reso come silenzio, senza
+    scarto e senza log. Con `grain.duration` che entra nella banda fatale
+    (31.25-52.08 us a 48 kHz, cioe' `round(dur*sr) == 2`) il risultato e' un
+    buco di silenzio digitale largo centinaia di ms.
+
+    La guardia sta sul RISULTATO, non su `n`: si ripara la finestra che e'
+    collassata, non ogni finestra corta. Cosi' `expodec` a N=2 resta `[1, 0]`
+    -- una decadenza vera, non un caso degenere -- e le finestre solo
+    attenuate (`hamming` 0.08, `gaussian` 0.044, `kaiser` 0.015) restano come
+    sono: un grano piano porta ancora informazione, e alzarlo significherebbe
+    inventare un livello che nessuno dei due renderer produce.
+    """
+
+    # Soglia di collasso: -60 dB rispetto al picco di progetto (1.0) di ogni
+    # finestra del catalogo. Non e' un numero critico -- fra il picco piu' alto
+    # fra quelli riparati (blackman_harris, 6e-5) e il piu' basso fra quelli
+    # lasciati stare (kaiser, 0.0149) c'e' un vuoto di 248x, e la soglia ci sta
+    # in mezzo con due ordini di grandezza di margine per lato.
+    FLOOR = 1e-3
+
+    @pytest.mark.parametrize("n", list(range(1, 17)))
+    def test_no_window_collapses_at_small_n(self, registry, n):
+        """Nessun nome del catalogo produce una finestra sotto la soglia di
+        collasso, per nessun N fra 1 e 16.
+
+        Il criterio e' il PICCO, non la somma: `sum() > 0` passerebbe per
+        `sinc` a N=1 (somma 3.9e-17, inudibile) e fallirebbe per `blackman` a
+        N=2 per il motivo sbagliato (somma negativa, -2.8e-17). Quello che
+        conta e' se il grano si sente.
+        """
+        for name in registry.available_windows():
+            window = registry.get(name, n)
+            peak = float(np.max(np.abs(window)))
+            assert peak > self.FLOOR, f"{name} n={n}: picco {peak:.4g}, grano muto"
+
+    @pytest.mark.parametrize("name,n", [
+        ('hanning', 2), ('bartlett', 2), ('triangle', 2), ('blackman', 2),
+        ('sinc', 1), ('sinc', 2), ('half_sine', 1), ('half_sine', 2),
+        ('blackman_harris', 1), ('blackman_harris', 2),
+        ('exporise', 1), ('exporise_strong', 1), ('rexporise', 1),
+    ])
+    def test_collapsed_window_becomes_flat_unit(self, registry, name, n):
+        """I casi degeneri noti diventano la finestra piatta a 1.0.
+
+        Sotto i 3 campioni non c'e' forma da rappresentare: niente salita,
+        picco e discesa. La finestra piatta e' l'unica lettura onesta.
+        """
+        np.testing.assert_array_equal(registry.get(name, n), np.ones(n))
+
+    @pytest.mark.parametrize("name,n,expected", [
+        # asimmetriche: a N=2 [1, 0] e' una decadenza vera, non un collasso
+        ('expodec', 2, [1.0, 0.0]),
+        ('expodec_strong', 2, [1.0, 0.0]),
+        ('rexpodec', 2, [1.0, 0.0]),
+        # attenuate ma udibili: restano intatte
+        ('hamming', 2, [0.08, 0.08]),
+        ('gaussian', 1, [0.043937]),
+        ('rectangle', 2, [1.0, 1.0]),
+    ])
+    def test_informative_small_windows_are_untouched(self, registry, name, n, expected):
+        """La guardia ripara solo cio' che e' collassato.
+
+        Se la finestra corta porta ancora informazione -- una decadenza, o
+        semplicemente un livello basso ma udibile -- resta esattamente com'e'.
+        """
+        np.testing.assert_allclose(registry.get(name, n), expected, atol=1e-6)
+
+    def test_repair_does_not_touch_normal_lengths(self, registry):
+        """A lunghezze normali le finestre restano la loro matematica: la
+        guardia non deve poter scattare su una finestra sana."""
+        w = registry.get('hanning', 1024)
+        np.testing.assert_array_almost_equal(w, np.hanning(1024))

--- a/tests/rendering/test_numpy_window_registry.py
+++ b/tests/rendering/test_numpy_window_registry.py
@@ -576,84 +576,76 @@ class TestCatalogueParity:
 
 
 # =============================================================================
-# NESSUNA FINESTRA E' MUTA (issue #225)
+# SOTTO I 10 CAMPIONI NON SI FINESTRA (issue #225)
 # =============================================================================
 
-class TestNeverSilentWindow:
-    """Un grano valido non e' mai silenzio.
+class TestNoWindowingBelowShapeThreshold:
+    """Sotto i 10 campioni la finestra non viene applicata.
 
-    A N piccolissimi il campionamento discreto della finestra collassa: le
-    simmetriche vengono campionate sugli estremi (`np.hanning(2) == [0, 0]`)
-    e le asimmetriche sul solo punto di partenza (`exporise(1) == [0]`). Il
-    grano viene generato, moltiplicato per zero e reso come silenzio, senza
-    scarto e senza log. Con `grain.duration` che entra nella banda fatale
-    (31.25-52.08 us a 48 kHz, cioe' `round(dur*sr) == 2`) il risultato e' un
-    buco di silenzio digitale largo centinaia di ms.
+    A quelle lunghezze non taglia i bordi: decima il grano. `hanning(3)` e'
+    `[0, 1, 0]` -- tiene un campione su tre e paga tre campioni di budget;
+    a 4 ne tiene due su quattro. Non c'e' una forma con un interno, ci sono
+    due zeri agli estremi e uno o due punti in mezzo.
 
-    La guardia sta sul RISULTATO, non su `n`: si ripara la finestra che e'
-    collassata, non ogni finestra corta. Cosi' `expodec` a N=2 resta `[1, 0]`
-    -- una decadenza vera, non un caso degenere -- e le finestre solo
-    attenuate (`hamming` 0.08, `gaussian` 0.044, `kaiser` 0.015) restano come
-    sono: un grano piano porta ancora informazione, e alzarlo significherebbe
-    inventare un livello che nessuno dei due renderer produce.
+    La conseguenza spettrale e' l'opposto di cio' per cui la finestra esiste.
+    Su un tono a 440 Hz la quota di energia sopra 2 kHz -- lo sporco da
+    troncamento -- vale 0.767 per il grano non finestrato a 3 campioni contro
+    0.917 per lo stesso grano con `hanning`: finestrare accorcia il grano piu'
+    di quanto ne smussi i bordi, e il risultato e' piu' sporco. Il pareggio
+    arriva intorno ai 30 campioni; 10 e' la linea scelta.
+
+    Il caso degenere della issue -- `np.hanning(2) == [0, 0]`, grano generato,
+    moltiplicato per zero e reso come silenzio digitale assoluto senza scarto
+    e senza log -- e' un sottocaso: sta sotto la soglia e non si finestra.
     """
 
-    # Soglia di collasso: -60 dB rispetto al picco di progetto (1.0) di ogni
-    # finestra del catalogo. Non e' un numero critico -- fra il picco piu' alto
-    # fra quelli riparati (blackman_harris, 6e-5) e il piu' basso fra quelli
-    # lasciati stare (kaiser, 0.0149) c'e' un vuoto di 248x, e la soglia ci sta
-    # in mezzo con due ordini di grandezza di margine per lato.
-    FLOOR = 1e-3
+    @pytest.mark.parametrize("n", list(range(1, 10)))
+    def test_every_window_is_flat_below_threshold(self, registry, n):
+        """Ogni nome del catalogo, sotto i 10 campioni, e' la finestra piatta.
+
+        Il livello del grano non dipende piu' dalla finestra scelta a queste
+        lunghezze: non c'e' forma da rappresentare, quindi non c'e' scelta da
+        rispettare. E' la differenza rispetto a una guardia sul solo caso
+        degenere, che avrebbe lasciato `kaiser` a 0.0149 e `hanning` a 1.0
+        sullo stesso grano di 2 campioni -- 36 dB di scarto deciso da una
+        parola nello YAML.
+        """
+        for name in registry.available_windows():
+            np.testing.assert_array_equal(
+                registry.get(name, n), np.ones(n),
+                err_msg=f"{name} n={n}: finestrato sotto la soglia"
+            )
+
+    def test_threshold_boundary_is_windowed(self, registry):
+        """A 10 campioni esatti la finestra torna a essere la sua matematica.
+
+        E' il confine: sotto non si finestra, da qui in su si' -- e il salto
+        di livello che ne segue (circa 4 dB fra 9 e 10 campioni) e' dichiarato
+        in docs/reference/yaml.md.
+        """
+        np.testing.assert_array_almost_equal(
+            registry.get('hanning', 10), np.hanning(10)
+        )
+
+    def test_normal_lengths_are_untouched(self, registry):
+        """A lunghezze normali nulla cambia: la soglia non deve poter scattare
+        su una finestra che una forma ce l'ha."""
+        np.testing.assert_array_almost_equal(
+            registry.get('hanning', 1024), np.hanning(1024)
+        )
 
     @pytest.mark.parametrize("n", list(range(1, 17)))
-    def test_no_window_collapses_at_small_n(self, registry, n):
-        """Nessun nome del catalogo produce una finestra sotto la soglia di
-        collasso, per nessun N fra 1 e 16.
+    def test_no_window_is_ever_silent(self, registry, n):
+        """L'invariante che la issue #225 chiedeva: nessun nome del catalogo
+        produce un grano muto, per nessun N.
 
         Il criterio e' il PICCO, non la somma: `sum() > 0` passerebbe per
         `sinc` a N=1 (somma 3.9e-17, inudibile) e fallirebbe per `blackman` a
         N=2 per il motivo sbagliato (somma negativa, -2.8e-17). Quello che
-        conta e' se il grano si sente.
+        conta e' se il grano si sente. Sotto la soglia lo garantisce la
+        finestra piatta; sopra, il fatto che ogni finestra del catalogo abbia
+        picco 1.0 gia' da 3 campioni.
         """
         for name in registry.available_windows():
-            window = registry.get(name, n)
-            peak = float(np.max(np.abs(window)))
-            assert peak > self.FLOOR, f"{name} n={n}: picco {peak:.4g}, grano muto"
-
-    @pytest.mark.parametrize("name,n", [
-        ('hanning', 2), ('bartlett', 2), ('triangle', 2), ('blackman', 2),
-        ('sinc', 1), ('sinc', 2), ('half_sine', 1), ('half_sine', 2),
-        ('blackman_harris', 1), ('blackman_harris', 2),
-        ('exporise', 1), ('exporise_strong', 1), ('rexporise', 1),
-    ])
-    def test_collapsed_window_becomes_flat_unit(self, registry, name, n):
-        """I casi degeneri noti diventano la finestra piatta a 1.0.
-
-        Sotto i 3 campioni non c'e' forma da rappresentare: niente salita,
-        picco e discesa. La finestra piatta e' l'unica lettura onesta.
-        """
-        np.testing.assert_array_equal(registry.get(name, n), np.ones(n))
-
-    @pytest.mark.parametrize("name,n,expected", [
-        # asimmetriche: a N=2 [1, 0] e' una decadenza vera, non un collasso
-        ('expodec', 2, [1.0, 0.0]),
-        ('expodec_strong', 2, [1.0, 0.0]),
-        ('rexpodec', 2, [1.0, 0.0]),
-        # attenuate ma udibili: restano intatte
-        ('hamming', 2, [0.08, 0.08]),
-        ('gaussian', 1, [0.043937]),
-        ('rectangle', 2, [1.0, 1.0]),
-    ])
-    def test_informative_small_windows_are_untouched(self, registry, name, n, expected):
-        """La guardia ripara solo cio' che e' collassato.
-
-        Se la finestra corta porta ancora informazione -- una decadenza, o
-        semplicemente un livello basso ma udibile -- resta esattamente com'e'.
-        """
-        np.testing.assert_allclose(registry.get(name, n), expected, atol=1e-6)
-
-    def test_repair_does_not_touch_normal_lengths(self, registry):
-        """A lunghezze normali le finestre restano la loro matematica: la
-        guardia non deve poter scattare su una finestra sana."""
-        w = registry.get('hanning', 1024)
-        np.testing.assert_array_almost_equal(w, np.hanning(1024))
+            peak = float(np.max(np.abs(registry.get(name, n))))
+            assert peak > 1e-3, f"{name} n={n}: picco {peak:.4g}, grano muto"


### PR DESCRIPTION
Chiude #225 — ma dove la issue chiedeva di riparare la finestra collassata, qui si toglie la finestra: **sotto i 10 campioni (208.3 µs) il renderer NumPy non finestra il grano.**

## Il difetto, confermato

Riprodotto end-to-end. Strumentando `GrainRenderer.render`, il meccanismo è quello descritto nella issue: a N=2 il campionamento discreto della finestra cade sui due estremi, che valgono zero (`np.hanning(2) == [0, 0]`), il grano viene moltiplicato per zero e reso come **silenzio digitale assoluto**. Nessun grano scartato, nessun log.

Confermato anche `n_out = max(1, round(...))`, il clamp `min_val = 1/output_sr` che impedisce N=0 ma non N=2, e l'esclusione del wrap del pointer.

**La banda fatale è 31.25-52.08 µs, non 35-52.** `round()` in Python è half-to-even: `round(1.5) == 2` e `round(2.5) == 2`, quindi la banda `round(dur*sr) == 2` prende entrambi gli estremi. Verificato sul grain-json di un rendering vero: i grani a N=2 stanno esattamente fra 52.082 e 31.250 µs, estremo incluso.

## Perché la guardia sul picco non bastava

La prima versione di questa PR riconosceva la finestra **collassata** (picco sotto -60 dB) e la sostituiva con la piatta. Riparava il sintomo e lasciava in piedi la domanda vera: a quelle lunghezze la finestra sta facendo il suo mestiere?

No. Lunghezza efficace (`sum/max`: quanti campioni passano davvero) contro quelli dichiarati:

| n dichiarati | 1 | 2 | 3 | 4 | 5 | 8 |
|---|---|---|---|---|---|---|
| `hanning` | 1.00 | **0.00** | **1.00** | 2.00 | 2.00 | 3.68 |
| `blackman` | 1.00 | **0.00** | **1.00** | 2.00 | 1.68 | 3.19 |
| `rectangle` | 1.00 | 2.00 | 3.00 | 4.00 | 5.00 | 8.00 |

A 3 campioni `hanning` è `[0, 1, 0]`: tiene **un** campione su tre e paga tre campioni di budget. A 4 ne tiene due su quattro. Non taglia i bordi, decima il grano.

E l'effetto spettrale è l'opposto di quello per cui la finestra esiste. Tono a 440 Hz, fase random, quota di energia sopra 2 kHz (lo sporco da troncamento — meno è meglio):

| n | µs | rettangolo | hanning | |
|---|---|---|---|---|
| 3 | 62 | 0.767 | 0.917 | **la finestra peggiora** |
| 4 | 83 | 0.695 | 0.837 | peggiora |
| 8 | 167 | 0.462 | 0.644 | peggiora |
| 16 | 333 | 0.221 | 0.344 | peggiora |
| 32 | 667 | 0.097 | 0.067 | aiuta |
| 480 | 10000 | 0.005 | 0.000 | aiuta |

Finestrare accorcia il grano più di quanto ne smussi i bordi: il pareggio arriva intorno ai **30 campioni**. La soglia scelta è 10, conservativa rispetto alla misura.

## La fix

Una riga in testa a `get()`, prima ancora di generare la finestra:

```python
if n < WINDOW_MIN_SHAPE_SAMPLES:   # 10
    return np.ones(n, dtype=np.float64)
```

Sparisce `WINDOW_COLLAPSE_FLOOR`, sparisce `_repair_if_collapsed`, sparisce la scansione del picco: il modulo perde 9 righe nette. La soglia sta su `n` e dice una cosa vera sul dominio — sotto i 10 campioni non c'è forma da rappresentare — invece di misurare un sintomo. Il silenzio della issue è un sottocaso che ci cade dentro.

Cade anche un'incoerenza che la guardia sul picco lasciava in piedi: `kaiser` a 2 campioni valeva 0.0149 e `hanning` 1.0, **36 dB di scarto sullo stesso grano** decisi da una parola nello YAML. Adesso sotto la soglia il livello è uno solo.

## Il prezzo, dichiarato

**I grani corti che oggi si sentono salgono di livello** (variazione in dB sull'energia del grano):

| | n=1 | n=2 | n=3 | n=4 |
|---|---|---|---|---|
| `kaiser` | 0 | **+36.6** | +4.8 | +5.7 |
| `gaussian` | +27.1 | +27.1 | +4.8 | +6.0 |
| `hamming` | 0 | +21.9 | +4.7 | +5.2 |
| `expodec` | 0 | +3.0 | +2.3 | +2.1 |
| `hanning`, `blackman`, `bartlett` | 0 | (era muta) | +4.8 | +5.5..+7.0 |

Nel repo l'unica config toccata è `PGE_grain_duration_samples_demo.yml`, stream `s1_click_train_1sample`.

**Attraversando la soglia il livello scende di colpo**, da -0.4 dB (`expodec_strong`) a -7.3 dB (`rexpodec`), -4.3 dB con `hanning`: è la finestra che entra in funzione. Misurato sul rendering (stream `s9`, sweep 5→20 campioni): **-4.25 dB contro i -4.26 previsti**. Con `rectangle` non c'è scalino, perché è piatta da entrambi i lati.

**Non allinea NumPy e Csound, li allontana.** Csound la finestra la applica comunque: legge la ftable con `poscil` a fase 0 ed è muto a N=1 sulle nove finestre che partono da zero. Sotto i 10 campioni la scelta del renderer domina il risultato più della scelta della finestra. Dichiarato in `docs/reference/yaml.md`.

## La prova empirica

`configs/PGE_issue225_loop_probe.yml`, nove stream, tutti con `fill_factor: 1` e una finestra di loop di 50 ms percorsa dal pointer venti volte al secondo, così il confinamento al loop e i suoi wrap stanno nel giro insieme ai grani cortissimi. Reso con il renderer NumPy su tre versioni del codice: `main`, la guardia sul picco, la soglia.

| stream | main | guardia picco | soglia n<10 |
|---|---|---|---|
| s1 sweep 100→21 µs, hanning | **1005.2 ms di silenzio** | 0.0 ms | 0.0 ms |
| s2 stesso sweep, expodec | rms 0.1530 | 0.1530 | 0.1965 (= s1) |
| s3 fisso 2 campioni, hanning | **4000.0 ms di silenzio** | 0.1632 | 0.1632 |
| s4 fisso 1 campione | 0.1154 | 0.1154 (bit-identico) | 0.1154 (bit-identico) |
| s5 loop mobile, 2 campioni | **4000.0 ms di silenzio** | 0.1632 | 0.1632 |
| s6 riferimento 480 campioni | 0.2447 | 0.2447 (bit-identico) | 0.2447 (bit-identico) |
| s7 kaiser 2 campioni | 0.0024 | 0.0024 | 0.1632 |
| s8 gaussian 2 campioni | 0.0072 | 0.0072 | 0.1632 |

Tre cose da leggere in questa tabella. Il difetto si riproduce dentro il loop, fisso e mobile: **4 secondi di zero digitale assoluto** con tutti i grani presenti. Sopra la soglia non cambia niente, bit per bit (s4, s6). E sotto la soglia s1 e s2 diventano identici, s7 e s8 raggiungono s3: è il punto della soglia — là sotto la finestra non decide più niente.

Un dettaglio verificato per non lasciarlo inspiegato: il buco misurato in s1 è 1005.2 ms contro i 1054.7 ms teorici della banda. La differenza sono i ±25 ms per bordo del DC blocker, FIR a fase lineare con kernel di 2400 campioni centrati. Tolto il filtro, teoria e misura coincidono al campione.

## Un secondo difetto, non nella issue

`configs/PGE_grain_duration_samples_demo.yml`, stream `s2_short_512samples`: scriveva `duration: 2` invece di `512`. Con `duration_unit: samples` sono 2 campioni (41.7 µs), dentro la banda fatale, e con `envelope: hanning` **lo stream era completamente muto**. Tre indizi nel file concordavano sul valore giusto: lo `stream_id`, il commento inline (`# ~10.7 ms`, che è 512/48000 s) e lo stream 4, dichiarato «controprova retrocompatibile: stessi ~512 campioni ma in secondi» con `duration: 0.01067`. Ora s2 e s4 rendono lo stesso picco (0.5637) e sono di nuovo la coppia di controprova che il file dichiara di essere.

È anche la prova che il bug passava inosservato: stava in una demo del repo, e si presentava come uno stream silenzioso invece che come un errore.

## Test

`TestNoWindowingBelowShapeThreshold`: ogni nome del catalogo × ogni N da 1 a 9 dev'essere esattamente la piatta; il confine a N=10 dev'essere di nuovo `np.hanning(10)`; a 1024 campioni nulla cambia. Resta l'invariante che la issue chiedeva — nessun nome del catalogo produce un grano muto, per nessun N fra 1 e 16 — perché è la garanzia, mentre la soglia è il modo di ottenerla.

Il criterio è il **picco**, non la somma: `sum() > 0` passerebbe per `sinc` a N=1 (somma 3.9e-17, inudibile) e fallirebbe per `blackman` a N=2 per il motivo sbagliato (somma negativa, -2.8e-17).

Suite completa verde: 5746 passed. `docs-lint` OK.

## Documentazione

`docs/reference/yaml.md` dichiarava il comportamento **intenzionale** («è la matematica della finestra, non un bug»), e va quindi riscritto, non solo esteso. La nota ora porta la soglia e la misura che la motiva, la banda fatale corretta, il salto di livello finestra per finestra, e in che modo NumPy e Csound divergono là sotto.

## Impatto cross-repo

Nessuna issue aperta. La sintassi YAML non cambia: nessun nome nuovo, nessun bound, nessun errore, nessuna CLI, nessun formato. Cambia il comportamento del renderer NumPy sotto i 10 campioni.

Verificata anche la regola `submodule-sync-cim`: **niente bump**. Il grano più corto negli esempi del paper CIM 2026 è `0.001` s (48 campioni, `complete_example.yml`), 4.8 volte sopra la soglia; l'unico `duration_range` presente (`PGE_voices.yml`) non scende sotto 0.02 s. Gli esempi del paper rendono identici.
