### PR TITLE
fix(192): il dominio di ParameterCurve e' cio' che float() legge, e lo scarto del lettore lascia una traccia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,34 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   la stessa demo si legga anche con `grain_shape: window`, dove il bordo del
   grano traccia la curva della propria finestra invece della freccia.
 
+### Corretto
+
+- **Un `np.float32` non è più una curva che sparisce dalla partitura.**
+  `ParameterCurve.classify` filtrava con `isinstance(raw, (int, float))`, e la
+  linea che tracciava non era il dominio che dichiara: era un dettaglio di
+  ereditarietà di numpy. `np.float64` passava perché è sottoclasse di `float`;
+  `np.float32`, `np.int64`, `Decimal` e `Fraction` no, pur essendo numeri che
+  `float()` legge da sempre — ed erano numeri che `float()` leggeva anche qui,
+  prima del refactor delle facce. Il criterio è ora quello dichiarato:
+  «numero» è ciò che `float()` sa leggere, cioè chi espone `__float__`. Le
+  stringhe restano fuori, ed è per loro che il controllo esiste
+  (`grain_envelope` è il nome di una finestra, non una curva); chi espone
+  `__float__` e poi rifiuta la conversione — un array a più elementi — viene
+  rifiutato con lo stesso errore di dominio, non con la formulazione di numpy.
+  Stesso allargamento in `envelope_extractor._readable`, dove però il predicato
+  è `numbers.Real`: lì il valore non è *dato* ma *trovato* su un attributo
+  qualunque di un oggetto qualunque, e la tolleranza ha il costo opposto
+  (issue #192).
+
+- **Lo scarto di una faccia illeggibile non è più muto.** Il lettore delle
+  curve salta la faccia fuori dominio invece di far cadere l'estrazione — le
+  curve di uno stream sono decine, e un parametro malformato non deve portarsi
+  via la partitura intera — ma farlo in silenzio rendeva indistinguibile
+  «questo parametro non ha una curva» da «questo parametro ha un valore che non
+  so leggere». Ora `log_unreadable_curve_warning` emette `[UNREADABLE_CURVE]`
+  sul clip logger, nominando stream, chiave pubblicata, faccia e motivo
+  (issue #192).
+
 ### Documentazione
 
 - `docs/reference/cli.md`: flag `--grain-height`, vincoli e nota sul taglio ai
@@ -70,6 +98,9 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   stesso asse» — perché l'altezza è una porzione di buffer, perché il modo
   fedele non è il default, e le tre conseguenze della separazione fra altezza
   e larghezza.
+- `docs/explanation/parameter-curve.md`: l'implicazione «Il dominio lo dichiara
+  il value object, la tolleranza è di chi legge» dice ora dov'è la linea del
+  dominio e perché la tolleranza del lettore lascia una traccia.
 
 ---
 

--- a/docs/explanation/parameter-curve.md
+++ b/docs/explanation/parameter-curve.md
@@ -9,7 +9,8 @@ sources:
   - src/pge/controllers/voice_manager.py
   - src/pge/shared/probability_gate.py
   - src/pge/rendering/envelope_extractor.py
-last_synced_commit: 33aed88
+  - src/pge/shared/logger.py
+last_synced_commit: d0d40c6
 ---
 
 # ParameterCurve: come si legge il comportamento nel tempo di un parametro
@@ -197,6 +198,28 @@ il modulo dei parametri.
   Le curve di uno stream sono decine: un parametro malformato non deve
   portarsi via anche le altre, cioè la partitura intera o l'intera sessione
   Sonic Visualiser.
+- **Dov'è la linea del dominio, e perché non è la stessa nei due punti.**
+  «Numero» è ciò che `float()` sa leggere — chi espone `__float__` — non ciò
+  che eredita da `float`. Un `isinstance(raw, (int, float))` tracciava la linea
+  dove passa l'ereditarietà di numpy, non dove passa il dominio: `np.float64`
+  dentro perché sottoclasse di `float`, `np.float32` fuori, pur essendo lo
+  stesso numero scritto con meno bit (issue #192). Esporre `__float__` non
+  garantisce però la conversione — un array a più elementi ce l'ha e poi
+  rifiuta — e in quel caso l'errore torna quello del dominio, o il chiamante
+  tollerante catturerebbe la formulazione di numpy senza sapere di che
+  parametro parla. `envelope_extractor._readable` si ferma un passo prima, a
+  `numbers.Real`, e la differenza è voluta: lì il valore non è *dato* ma
+  *trovato* su un attributo qualunque di un oggetto qualunque, e la tolleranza
+  ha il costo opposto — un duck-typing su `__float__` accetterebbe qualsiasi
+  cosa sappia fingersi un numero.
+- **La tolleranza del lettore lascia una traccia.** Saltare in silenzio rende
+  indistinguibile «questo parametro non ha una curva» da «questo parametro ha
+  un valore che non so leggere»: la partitura esce senza la riga e non c'è modo
+  di sapere perché. `_curve_of` chiama `log_unreadable_curve_warning`
+  (`shared/logger.py`), che emette `[UNREADABLE_CURVE]` sul clip logger con
+  stream, chiave pubblicata, faccia e il messaggio di `classify`. Il
+  comportamento non cambia — la faccia resta `absent` — cambia che se ne sappia
+  qualcosa.
 - `envelope_extractor` è passato da 394 a 287 righe: i sei blocchi duplicati e
   i tre meccanismi di accesso sono una tabella sola, con **un unico punto di
   appiattimento** — l'unico che ha bisogno di `stream.duration`.

--- a/src/pge/parameters/parameter_curve.py
+++ b/src/pge/parameters/parameter_curve.py
@@ -18,6 +18,13 @@ CONSTANT = 'constant'
 ABSENT = 'absent'
 
 
+def _not_a_number(raw) -> TypeError:
+    """L'errore di dominio, in un posto solo: lo alzano due rami di classify."""
+    return TypeError(
+        "ParameterCurve.classify accetta Envelope, numero o None; "
+        f"ricevuto {type(raw).__name__}: {raw!r}")
+
+
 @dataclass(frozen=True)
 class ParameterCurve:
     """Classificazione di una faccia di Parameter: curva, costante o assente."""
@@ -29,6 +36,15 @@ class ParameterCurve:
     @classmethod
     def classify(cls, raw) -> 'ParameterCurve':
         """Classifica un valore grezzo (Envelope, numero o None).
+
+        "Numero" e' cio' che `float()` sa leggere — chi espone `__float__` —
+        non cio' che eredita da `float`. Un `isinstance(raw, (int, float))`
+        traccerebbe la linea dove passa l'ereditarieta' di numpy, non dove
+        passa il dominio: `np.float64` dentro perche' sottoclasse di `float`,
+        `np.float32` fuori, pur essendo lo stesso numero scritto con meno bit
+        (issue #192). Le stringhe restano fuori perche' non hanno `__float__`,
+        ed e' per loro che il controllo esiste: `grain_envelope` e' il nome di
+        una finestra, non una curva.
 
         Raises:
             TypeError: se `raw` non e' nessuno dei tre. Il dominio e' scritto
@@ -45,11 +61,17 @@ class ParameterCurve:
                 # Costante travestita: breakpoint tutti uguali.
                 return cls(kind=CONSTANT, value=float(values[0]))
             return cls(kind=VARYING, envelope=raw)
-        if not isinstance(raw, (int, float)):
-            raise TypeError(
-                "ParameterCurve.classify accetta Envelope, numero o None; "
-                f"ricevuto {type(raw).__name__}: {raw!r}")
-        return cls(kind=CONSTANT, value=float(raw))
+        if not hasattr(type(raw), '__float__'):
+            raise _not_a_number(raw)
+        try:
+            return cls(kind=CONSTANT, value=float(raw))
+        except (TypeError, ValueError) as exc:
+            # Esporre `__float__` non garantisce la conversione: un array a
+            # piu' elementi ce l'ha e poi rifiuta. Il rifiuto torna quello del
+            # dominio — stesso tipo, stesso messaggio parlante — cosi' il
+            # chiamante tollerante non si trova a catturare la formulazione di
+            # numpy senza sapere di che parametro parla.
+            raise _not_a_number(raw) from exc
 
     @classmethod
     def from_gate(cls, gate) -> 'ParameterCurve':

--- a/src/pge/rendering/envelope_extractor.py
+++ b/src/pge/rendering/envelope_extractor.py
@@ -18,6 +18,7 @@ offset sull'onset globale e' responsabilita' del consumatore.
 """
 from __future__ import annotations
 
+import numbers
 import re
 from dataclasses import dataclass
 from typing import Callable
@@ -192,13 +193,38 @@ def _readable(obj):
 
     Tutto il resto — stringhe (grain_envelope), None dei gruppi esclusivi,
     attributi che non esistono — non lo e'.
+
+    "Numero" e' `numbers.Real`, non `(int, float)`: un `np.float32` sullo
+    Stream e' un numero come il suo `np.float64`, che passava per la sola
+    ragione di ereditare da `float` (issue #192). Non e' pero' il duck-typing
+    su `__float__` che usa ParameterCurve, e la differenza e' voluta: li' il
+    valore e' *dato*, qui e' *trovato* — questa funzione guarda un attributo
+    qualunque di un oggetto qualunque, e la tolleranza ha il costo opposto.
     """
     from pge.envelopes.envelope import Envelope
     from pge.parameters.parameter import Parameter
 
-    if isinstance(obj, (Parameter, Envelope, int, float)):
+    if isinstance(obj, (Parameter, Envelope, numbers.Real)):
         return obj
     return None
+
+
+def _unreadable(source, stream, exc):
+    """Lo scarto di una faccia fuori dominio: assente, ma non in silenzio.
+
+    Saltarla e' l'unica reazione proporzionata — far cadere questa faccia vuol
+    dire far cadere tutte le altre curve dello stream, cioe' la partitura
+    intera, o l'intera sessione Sonic Visualiser. Il warning e' il resto della
+    reazione: senza, "questo parametro non ha una curva" e "questo parametro
+    ha un valore che non so leggere" arrivano identici a chi guarda la
+    partitura (issue #192).
+    """
+    from pge.parameters.parameter_curve import ParameterCurve
+    from pge.shared.logger import log_unreadable_curve_warning
+
+    log_unreadable_curve_warning(
+        getattr(stream, 'stream_id', None), source.key, source.face, exc)
+    return ParameterCurve(kind='absent')
 
 
 def _curve_of(source, stream):
@@ -217,19 +243,22 @@ def _curve_of(source, stream):
         }[source.face]
         try:
             return face(obj)
-        except TypeError:
+        except TypeError as exc:
             # Dentro un Parameter puo' esserci un valore fuori dal dominio di
-            # ParameterCurve: Parameter non valida al costruttore. Qui non e'
-            # una curva e non se ne pubblica nessuna — ma saltarla e' l'unica
-            # reazione proporzionata, perche' far cadere questa faccia vuol
-            # dire far cadere tutte le altre curve dello stream, cioe' la
-            # partitura intera. Il value object resta stretto: e' il lettore a
-            # essere tollerante, come lo era prima del refactor.
-            return ParameterCurve(kind='absent')
+            # ParameterCurve: Parameter non valida al costruttore. Il value
+            # object resta stretto: e' il lettore a essere tollerante, come lo
+            # era prima del refactor.
+            return _unreadable(source, stream, exc)
     # Sorgente grezza (pitch_value): ha solo il valore, niente range ne' gate.
     if source.face != 'value':
         return ParameterCurve(kind='absent')
-    return ParameterCurve.classify(obj)
+    try:
+        return ParameterCurve.classify(obj)
+    except TypeError as exc:
+        # `_readable` ha gia' detto che e' un numero, ma `numbers.Real` non
+        # promette che la conversione riesca. Stessa tolleranza dell'altro
+        # ramo: una riga in meno, non una partitura in meno.
+        return _unreadable(source, stream, exc)
 
 
 def _voice_curves(stream):

--- a/src/pge/shared/logger.py
+++ b/src/pge/shared/logger.py
@@ -391,6 +391,42 @@ def log_window_curve_warning(
     )
 
 
+def log_unreadable_curve_warning(
+    stream_id: str,
+    curve_key: str,
+    face: str,
+    reason,
+):
+    """
+    Logga lo scarto di una faccia che non e' una curva.
+
+    Dentro un Parameter puo' esserci un valore fuori dal dominio di
+    ParameterCurve: `Parameter.__init__` non valida, e chi lo costruisce a
+    mano puo' metterci dentro qualunque cosa. Il lettore delle curve
+    (rendering.envelope_extractor) lo salta invece di far cadere l'estrazione
+    — le curve di uno stream sono decine, e un parametro malformato non deve
+    portarsi via la partitura intera. Saltarlo in silenzio pero' rende
+    indistinguibile "questo parametro non ha una curva" da "questo parametro
+    ha un valore che non so leggere" (issue #192).
+
+    Args:
+        stream_id:  ID dello stream
+        curve_key:  nome pubblicato della riga (--plot-envelopes, layer SV)
+        face:       'value', 'range' o 'probability'
+        reason:     il TypeError di ParameterCurve.classify, che nomina tipo
+                    e valore
+    """
+    logger = get_clip_logger()
+    if logger is None:
+        return
+
+    logger.warning(
+        f"[UNREADABLE_CURVE] [{stream_id}] "
+        f"'{curve_key}' (faccia '{face}') non e' una curva: {reason}. "
+        f"La riga non viene pubblicata; le altre curve dello stream restano."
+    )
+
+
 def log_loop_init(
     stream_id: str,
     loop_start: float,

--- a/tests/parameters/test_parameter_curve.py
+++ b/tests/parameters/test_parameter_curve.py
@@ -9,6 +9,10 @@ di essere ripetuta da ogni consumatore che legge i privati di Parameter.
 
 Qui si testa il modello puro: niente Stream, niente matplotlib, niente mock.
 """
+from decimal import Decimal
+from fractions import Fraction
+
+import numpy as np
 import pytest
 
 from pge.envelopes.envelope import Envelope
@@ -72,6 +76,57 @@ class TestClassifyScalarAndAbsent:
         arrivi."""
         with pytest.raises(TypeError, match="str.*hanning"):
             ParameterCurve.classify('hanning')
+
+
+class TestTheNumericDomain:
+    """"Numero" e' cio' che `float()` sa leggere, non cio' che eredita da
+    `float` (issue #192).
+
+    Il filtro era `isinstance(raw, (int, float))`, e la linea che tracciava non
+    era il dominio del value object: era un dettaglio di ereditarieta' di
+    numpy. `np.float64` passava perche' e' sottoclasse di `float`, `np.float32`
+    no — pur essendo lo stesso numero scritto con meno bit. Prima del refactor
+    la riga era `float(raw)`, e li leggeva tutti.
+    """
+
+    @pytest.mark.parametrize('raw, expected', [
+        (np.float32(1.5), 1.5),
+        (np.float64(1.5), 1.5),
+        (np.int64(3), 3.0),
+        (np.int32(3), 3.0),
+        (Decimal('1.5'), 1.5),
+        (Fraction(3, 2), 1.5),
+    ])
+    def test_any_numeric_type_is_a_constant(self, raw, expected):
+        curve = ParameterCurve.classify(raw)
+        assert (curve.kind, curve.value) == ('constant', expected)
+
+    def test_the_payload_is_a_python_float(self):
+        """Il value object normalizza: chi legge `value` non deve sapere da
+        quale libreria arrivava il numero."""
+        assert type(ParameterCurve.classify(np.float32(1.5)).value) is float
+
+    def test_float32_and_float64_are_the_same_curve(self):
+        """La regressione in una riga: due scritture dello stesso numero
+        davano due esiti diversi."""
+        assert (ParameterCurve.classify(np.float32(2.0))
+                == ParameterCurve.classify(np.float64(2.0)))
+
+    def test_a_string_is_still_outside(self):
+        """L'allargamento non e' una resa: il caso per cui il controllo esiste
+        — `grain_envelope`, che e' il nome di una finestra — resta fuori,
+        perche' una stringa non sa diventare un float."""
+        with pytest.raises(TypeError):
+            ParameterCurve.classify('hanning')
+
+    def test_something_that_only_looks_like_a_number_is_rejected_the_same_way(self):
+        """Un array a piu' elementi espone `__float__` e poi fallisce la
+        conversione. Il rifiuto deve restare quello del dominio — stesso tipo,
+        stesso messaggio parlante — o il chiamante tollerante si troverebbe a
+        catturare la formulazione di numpy senza sapere di che parametro
+        parla."""
+        with pytest.raises(TypeError, match="ndarray"):
+            ParameterCurve.classify(np.array([1.0, 2.0]))
 
 
 class TestFromGate:

--- a/tests/rendering/test_envelope_extractor.py
+++ b/tests/rendering/test_envelope_extractor.py
@@ -15,8 +15,9 @@ Copre:
 
 import sys
 
+import numpy as np
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from pge.envelopes.envelope import Envelope
 from pge.parameters.parameter import Parameter
@@ -746,6 +747,67 @@ class TestValueOutsideTheDomain:
         from pge.parameters.parameter_curve import ParameterCurve
         with pytest.raises(TypeError):
             ParameterCurve.classify('rumore')
+
+    def test_the_skip_leaves_a_trace(self, tmp_path):
+        """Saltare in silenzio rende indistinguibile "questo parametro non ha
+        una curva" da "questo parametro ha un valore che non so leggere":
+        la partitura esce senza la riga, e nessuno sa perche' (issue #192)."""
+        import pge.shared.logger as logger_module
+        from pge.shared.logger import configure_clip_logger, get_clip_logger
+
+        configure_clip_logger(enabled=True, file_enabled=True,
+                              console_enabled=False, log_dir=str(tmp_path),
+                              yaml_name='unreadable')
+        logger = get_clip_logger()
+        captured = []
+        try:
+            with patch.object(logger, 'warning',
+                              side_effect=lambda msg: captured.append(msg)):
+                get_stream_envelopes(self._stream_with('rumore'), show_static=True)
+        finally:
+            for handler in logger.handlers[:]:
+                handler.close()
+                logger.removeHandler(handler)
+            logger_module._clip_logger = None
+            logger_module._clip_logger_initialized = False
+            configure_clip_logger()
+
+        assert any('volume' in msg for msg in captured)
+
+
+class TestANumberInAnyWriting:
+    """Un numero resta una curva costante comunque sia scritto (issue #192).
+
+    Il dominio di ParameterCurve filtrava con `isinstance(raw, (int, float))`:
+    `np.float64` passava perche' e' sottoclasse di `float`, `np.float32` no, e
+    la faccia spariva dalla partitura per un dettaglio di ereditarieta' di
+    numpy. Qui si guarda dal lato di chi legge: la riga deve esserci.
+    """
+
+    def _keys(self, value):
+        s = make_stream('s1', onset=0.0, duration=10.0)
+        s.volume = Parameter('volume', value, GRANULAR_PARAMETERS['volume'])
+        return get_stream_envelopes(s, show_static=True)
+
+    @pytest.mark.parametrize('value', [
+        np.float32(-6.0), np.float64(-6.0), np.int64(-6), np.int32(-6),
+    ])
+    def test_a_numpy_scalar_is_published(self, value):
+        assert 'volume' in self._keys(value)
+
+    def test_the_published_curve_carries_the_value(self):
+        """Non basta che la chiave ci sia: la costante appiattita deve valere
+        quel numero, o la partitura disegna una riga sbagliata."""
+        env = self._keys(np.float32(-6.0))['volume']
+        assert env.breakpoints[0][1] == pytest.approx(-6.0)
+
+    def test_a_raw_numpy_source_is_published_too(self):
+        """La stessa domanda sul path senza Parameter: `pitch` arriva allo
+        Stream gia' risolto (Envelope o scalare), e il filtro che decide se
+        e' leggibile e' un secondo isinstance, con la stessa linea storta."""
+        s = make_stream('s1', onset=0.0, duration=10.0)
+        s.pitch_value = np.float32(3.0)
+        assert 'pitch' in get_stream_envelopes(s, show_static=True)
 
 
 class TestFlattenSpansTheStream:

--- a/tests/shared/test_logger.py
+++ b/tests/shared/test_logger.py
@@ -16,6 +16,7 @@ from pge.shared.logger import (
     log_loop_drift_warning,
     log_loop_dynamic_mode,
     log_loop_init,
+    log_unreadable_curve_warning,
     CLIP_LOG_CONFIG,
 
 )
@@ -1094,3 +1095,90 @@ class TestIntegration:
         content = log_file.read_text()
         assert '[CONFIG]' in content
 
+
+
+# =============================================================================
+# TEST: log_unreadable_curve_warning (issue #192)
+# =============================================================================
+
+class TestLogUnreadableCurveWarning:
+    """Dentro un Parameter puo' esserci un valore che non e' una curva:
+    l'estrattore lo salta invece di far cadere la partitura intera. Saltarlo
+    in silenzio pero' rende indistinguibile "questo parametro non ha una
+    curva" da "questo parametro ha un valore che non so leggere".
+    """
+
+    def _capture(self, tmp_path, yaml_name, *args):
+        configure_clip_logger(
+            enabled=True,
+            file_enabled=True,
+            console_enabled=False,
+            log_dir=str(tmp_path),
+            yaml_name=yaml_name
+        )
+        l = get_clip_logger()
+        captured = []
+        with patch.object(l, 'warning', side_effect=lambda msg: captured.append(msg)):
+            log_unreadable_curve_warning(*args)
+        return captured
+
+    def test_does_not_raise_when_logger_none(self):
+        configure_clip_logger(enabled=False)
+        get_clip_logger()
+        log_unreadable_curve_warning('s1', 'volume', 'value', 'motivo')
+
+    def test_calls_logger_warning(self, tmp_path):
+        configure_clip_logger(
+            enabled=True,
+            file_enabled=True,
+            console_enabled=False,
+            log_dir=str(tmp_path),
+            yaml_name='curvewarn'
+        )
+        l = get_clip_logger()
+        with patch.object(l, 'warning') as mock_warn:
+            log_unreadable_curve_warning('s1', 'volume', 'value', 'motivo')
+            mock_warn.assert_called_once()
+
+    def test_message_contains_unreadable_curve_tag(self, tmp_path):
+        captured = self._capture(tmp_path, 'curvetag', 's1', 'volume', 'value', 'motivo')
+        assert '[UNREADABLE_CURVE]' in captured[0]
+
+    def test_message_contains_stream_id(self, tmp_path):
+        captured = self._capture(tmp_path, 'curvestream', 'STREAM_X', 'volume', 'value', 'motivo')
+        assert 'STREAM_X' in captured[0]
+
+    def test_message_contains_curve_key(self, tmp_path):
+        """La chiave e' il nome pubblicato della riga (--plot-envelopes, layer
+        SV): senza, il warning non dice quale curva manca dalla partitura."""
+        captured = self._capture(tmp_path, 'curvekey', 's1', 'pointer_deviation_range', 'range', 'motivo')
+        assert 'pointer_deviation_range' in captured[0]
+
+    def test_message_contains_the_face(self, tmp_path):
+        """Un Parameter ha tre facce: quella fuori dominio va nominata, o si
+        cerca il valore sbagliato."""
+        captured = self._capture(tmp_path, 'curveface', 's1', 'volume', 'probability', 'motivo')
+        assert 'probability' in captured[0]
+
+    def test_message_contains_the_reason(self, tmp_path):
+        """E' il messaggio di ParameterCurve.classify, che nomina tipo e
+        valore: e' li' che sta l'informazione utile a correggere lo YAML."""
+        captured = self._capture(
+            tmp_path, 'curvereason', 's1', 'volume', 'value',
+            "ricevuto str: 'rumore'")
+        assert "ricevuto str: 'rumore'" in captured[0]
+
+    def test_message_written_to_file(self, tmp_path):
+        configure_clip_logger(
+            enabled=True,
+            file_enabled=True,
+            console_enabled=False,
+            log_dir=str(tmp_path),
+            yaml_name='curvefile'
+        )
+        l = get_clip_logger()
+        log_unreadable_curve_warning('s1', 'volume', 'value', 'motivo')
+        for h in l.handlers:
+            h.flush()
+        content = (tmp_path / 'envelope_clips_curvefile.log').read_text()
+        assert '[UNREADABLE_CURVE]' in content


### PR DESCRIPTION
Chiude #192.

## Il dominio era piu' stretto di quello che dichiarava

`ParameterCurve.classify` diceva in docstring «accetta Envelope, **numero** o None» e poi filtrava con `isinstance(raw, (int, float))`. La linea che quel controllo tracciava non era il dominio del value object: era un dettaglio di ereditarieta' di numpy.

| prima | dopo |
|---|---|
| `np.float64` -> constant (solo perche' sottoclasse di `float`) | constant |
| `np.float32` -> TypeError | constant |
| `np.int64` / `np.int32` -> TypeError | constant |
| `Decimal` / `Fraction` -> TypeError | constant |
| `'hanning'` -> TypeError | TypeError |

Prima del refactor delle facce la riga era `float(raw)`, e li leggeva tutti. Il criterio diventa quello dichiarato: **«numero» e' cio' che `float()` sa leggere**, cioe' chi espone `__float__`. Le stringhe restano fuori — non ce l'hanno — ed e' per loro che il controllo esiste: `grain_envelope` e' il nome di una finestra, non una curva.

Esporre `__float__` non promette pero' che la conversione riesca: un array a piu' elementi ce l'ha e poi rifiuta. In quel caso l'errore torna **quello del dominio**, con lo stesso messaggio parlante, cosi' il chiamante tollerante non si trova a catturare la formulazione di numpy senza sapere di che parametro parla.

## E il rifiuto non produceva nessun messaggio

`envelope_extractor._curve_of` cattura il `TypeError` e risponde `absent`. La scelta e' giusta nel merito — far cadere una faccia vuol dire far cadere l'intera partitura — ma in silenzio «questo parametro non ha una curva» e «questo parametro ha un valore che non so leggere» arrivano identici a chi guarda la partitura.

`log_unreadable_curve_warning` (in `shared/logger.py`, stessa forma di `log_window_curve_warning`) emette ora `[UNREADABLE_CURVE]` sul clip logger — lo stesso canale dei clip, console piu' file — nominando stream, chiave pubblicata, faccia e il messaggio di `classify`, che a sua volta nomina tipo e valore. Il comportamento non cambia: la faccia resta `absent`.

Scelto il clip logger e non l'engine logger perche' quest'ultimo e' configurato a livello `ERROR` e solo su file: un `.warning()` li' non verrebbe emesso affatto.

## La stessa linea storta c'era due volte

`_readable` — il filtro che decide se un attributo dello Stream puo' essere una curva — usava lo stesso `isinstance(obj, (..., int, float))`: un `np.float32` trovato sul path grezzo (`pitch_value`) spariva prima ancora di arrivare al value object. Anche quello e' allargato, ma con un predicato **diverso**, `numbers.Real`:

- in `classify` il valore e' **dato** dal chiamante, e il duck-typing su `__float__` e' il criterio giusto;
- in `_readable` il valore e' **trovato** su un attributo qualunque di un oggetto qualunque, e la tolleranza ha il costo opposto — `__float__` accetterebbe qualsiasi cosa sappia fingersi un numero (un `MagicMock`, per dire, ce l'ha).

Con `numbers.Real` che non promette la conversione, anche il ramo della sorgente grezza passa ora dallo scarto tollerante invece di poter alzare.

## Test

TDD, rosso prima di verde. Aggiunti:

- `tests/parameters/test_parameter_curve.py::TestTheNumericDomain` — i sei tipi numerici come costanti, il payload normalizzato a `float`, `float32` e `float64` che danno la stessa curva, la stringa ancora fuori, e l'array multi-elemento rifiutato con l'errore del dominio.
- `tests/shared/test_logger.py::TestLogUnreadableCurveWarning` — tag, stream, chiave, faccia, motivo, scrittura su file, e il no-op a logger disabilitato.
- `tests/rendering/test_envelope_extractor.py::TestANumberInAnyWriting` — lo scalare numpy **pubblicato** (chiave e valore) sia dal path `Parameter` sia da quello grezzo; piu' `TestValueOutsideTheDomain::test_the_skip_leaves_a_trace`.

`make tests`: **5744 passed, 78 deselected**. `make docs-lint`: OK (19 docs).

## Impatto cross-repo

**Nessuno** su `PGE-ls` e `PGE-ui`, quindi nessuna issue aperta: la sintassi YAML non cambia, non nascono errori nuovi nella gerarchia `EngineError` (il `TypeError` e' interno al value object e resta catturato dal lettore), CLI, flag e formati di output sono invariati, e l'insieme delle chiavi pubblicate (`ENVELOPE_COLORS`, `--plot-envelopes`, layer SV) e' lo stesso. La riga di protocollo su stdout letta da PGE-ui non e' toccata: il warning nuovo esce sul canale del clip logger, dove escono gia' i clip warning.

Fuori portata anche per gli esempi del paper CIM: `pitch_value` viene da `PitchController.value`, che il parser YAML risolve in float Python, e i `Parameter` passano da `_validate_and_clip` — nessun esempio produce oggi un valore che il vecchio filtro scartava, quindi nessuna partitura gia' generata cambia aspetto.
