### PR TITLE
feat(cli): --samples-dir, e la directory dei sample smette di essere il cwd (#235)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ## [Non rilasciato]
 
+### Aggiunto
+
+- **`--samples-dir DIR`: la directory dei sample smette di essere il cwd**
+  (issue #235). `Generator(yaml, samples_dir=...)` e `api.build_renderer(...,
+  samples_dir=...)` accettavano una directory arbitraria da sempre, ma nessuno
+  gliela passava: la CLI costruiva `Generator(yaml_file)` e basta, e il
+  fallback e' il globale `PATHSAMPLES` (`'./refs/'`), **relativo al cwd del
+  processo**. Renderizzare da una directory di lavoro qualsiasi era
+  impossibile, e per PGE-ui era il motivo per cui il bridge deve scrivere i
+  progetti dentro `configs/` del motore e lanciare il processo con `cwd=`:
+  YAML, output e cache erano gia' parametrizzabili, i sample no.
+
+  Il flag raggiunge i **tre** posti da cui un run CLI legge i file audio
+  sorgente: il `Generator` (durata dello stream, via `Stream` ->
+  `get_sample_duration`), il renderer (`SampleRegistry` con numpy, SSDIR con
+  csound) e il visualizer (waveform in partitura). Assente, ogni default resta
+  quello di prima.
+
+  **`--ssdir` non copriva il caso csound**, benche' lo sembri. SSDIR dice a
+  Csound dove cercare i soundfile *in fase di render*, ma la durata del sample
+  la risolve `Stream.__init__` molto prima, e quel passo legge `PATHSAMPLES`:
+  con `--ssdir /altrove` da un cwd senza `refs/` il run muore in
+  `SampleNotFoundError` — stampando `./refs/...`, non SSDIR — prima ancora che
+  il renderer esista, identico al caso numpy. L'asimmetria fra i due renderer
+  non era quella che sembrava: il lato Python era hardcoded per entrambi.
+
+  La regola di precedenza `--ssdir` esplicito > `--samples-dir` > `refs`
+  esisteva gia' in `api.build_renderer` ma era **irraggiungibile dalla CLI**,
+  che passava sempre `ssdir='refs'`. Ora la CLI passa `None` quando `--ssdir`
+  non c'e'; senza nessuno dei due flag SSDIR resta `refs`, come sempre.
+
 ### Corretto
 
 - **Un envelope su tre grafie non veniva riconosciuto come envelope** (issue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   che passava sempre `ssdir='refs'`. Ora la CLI passa `None` quando `--ssdir`
   non c'e'; senza nessuno dei due flag SSDIR resta `refs`, come sempre.
 
+  **Presente senza valore, il flag stampa un messaggio ed esce con 1**: unica
+  eccezione all'idioma della CLI, dove una flag con valore mancante viene
+  ignorata in silenzio. Altrove il silenzio costa poco; qui il fallback
+  sarebbe `./refs/`, cioe' la directory da cui il flag serve ad andarsene, e
+  il fallimento somiglierebbe al successo.
+
 ### Corretto
 
 - **Un envelope su tre grafie non veniva riconosciuto come envelope** (issue

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -123,11 +123,16 @@ Vincoli tra flag e comportamento nelle combinazioni non valide:
   `--samples-dir` > `refs`. Senza nessuno dei due, SSDIR resta `refs`.
 - **`--samples-dir` non entra nel fingerprint della cache.** *Dove* stanno i
   sample non è un parametro dello stem: spostare la directory non marca
-  dirty nulla (vedi [[caching]]). Ne consegue anche il contrario: due
-  directory diverse con file omonimi e contenuto diverso condividono lo
-  stesso manifest e lo stesso stem, e la cache non se ne accorge — è la
-  stessa proprietà per cui il contenuto del file audio non è mai stato
-  nell'hash.
+  dirty nulla (vedi [[caching]]). Ne consegue che due directory diverse con
+  file omonimi possono condividere manifest e stem — ma la cecità non è
+  totale, e il confine è la durata dichiarata. Per gli stream **senza**
+  `duration` (issue #205) la durata risolta dal file audio *è* nell'hash
+  (`StreamCacheManager.compute_fingerprint` aggiunge `sample_dur_sec` quando
+  `stream_duration_is_implicit`), e quel valore lo risolve proprio
+  `samples_dir`: puntare a un omonimo di lunghezza diversa marca quello
+  stream dirty. Resta cieca su due casi: stream con `duration` esplicita, e
+  omonimi di pari durata con contenuto diverso — quest'ultimo è la stessa
+  proprietà per cui il contenuto del file audio non è mai stato nell'hash.
 - **`--show-static`** ha effetto solo insieme a `--visualize`.
 - **`--show-voice-offsets`** ha effetto solo insieme a `--visualize`. Gli
   offset per-voce vengono campionati dalle voice strategy

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -70,7 +70,7 @@ Senza argomenti: stampa usage ed esce con codice 1.
 | `--jobs N\|auto` | `auto` | `JOBS` | worker del rendering NumPy multi-processo. `auto` = core disponibili - 1 (min 1, via affinity dove disponibile); `1` = sequenziale, campioni bit-identici allo storico; `0`, negativi o non numerici: messaggio + exit 1. Ignorato con `--renderer csound` |
 | `--format aiff\|wav\|flac` | `aiff` | `FORMAT` | formato audio; valore non valido: messaggio + exit 1 |
 | `--cache-dir DIR` | `cache` | `CACHEDIR` | directory dei manifest di fingerprint |
-| `--samples-dir DIR` | `./refs/` (globale `PATHSAMPLES`) | — | directory dei file audio sorgente, per **entrambi** i renderer. Vale per i tre posti da cui un run legge i sample: durata dello stream (`Stream` → `get_sample_duration`), lettura in render (`SampleRegistry` con numpy, SSDIR con csound) e waveform in partitura. Assente: comportamento storico, `./refs/` **relativo al cwd** del processo |
+| `--samples-dir DIR` | `./refs/` (globale `PATHSAMPLES`) | — | directory dei file audio sorgente, per **entrambi** i renderer. Vale per i tre posti da cui un run legge i sample: durata dello stream (`Stream` → `get_sample_duration`), lettura in render (`SampleRegistry` con numpy, SSDIR con csound) e waveform in partitura. Assente: comportamento storico, `./refs/` **relativo al cwd** del processo. Presente senza valore: messaggio + exit 1 (vedi Bounds) |
 | `--orc-path PATH` | `csound/main.orc` | — | orchestra Csound |
 | `--incdir DIR` | `src` | — | include dir per Csound |
 | `--ssdir DIR` | `--samples-dir`, altrimenti `refs` | — | sample search dir di Csound (variabile d'ambiente SSDIR). Vince su `--samples-dir` quando è esplicito; **non basta da solo** (vedi Bounds) |
@@ -183,7 +183,11 @@ Vincoli tra flag e comportamento nelle combinazioni non valide:
   wrappa (`read_indices % n_source`), quindi lì la figura tace su una
   porzione che l'audio contiene (vedi issue #223, punto 2).
 - Le flag con valore leggono il token successivo in `sys.argv`; se manca,
-  la flag viene ignorata senza errore.
+  la flag viene ignorata senza errore. **Unica eccezione: `--samples-dir`**,
+  che con il valore mancante stampa un messaggio ed esce con 1. Il silenzio
+  costa poco sugli altri flag, mentre qui ricadrebbe su `./refs/` — cioè
+  proprio la directory da cui il flag serve ad andarsene — e il fallimento
+  somiglierebbe al successo.
 
 ## Esempi
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -8,7 +8,7 @@ sources:
   - src/pge/cli.py
   - src/pge/rendering/grain_visuals.py
   - make/build.mk
-last_synced_commit: 95fd483
+last_synced_commit: 9764017
 entry_for: [cli-flags, build-flags]
 ---
 
@@ -70,9 +70,10 @@ Senza argomenti: stampa usage ed esce con codice 1.
 | `--jobs N\|auto` | `auto` | `JOBS` | worker del rendering NumPy multi-processo. `auto` = core disponibili - 1 (min 1, via affinity dove disponibile); `1` = sequenziale, campioni bit-identici allo storico; `0`, negativi o non numerici: messaggio + exit 1. Ignorato con `--renderer csound` |
 | `--format aiff\|wav\|flac` | `aiff` | `FORMAT` | formato audio; valore non valido: messaggio + exit 1 |
 | `--cache-dir DIR` | `cache` | `CACHEDIR` | directory dei manifest di fingerprint |
+| `--samples-dir DIR` | `./refs/` (globale `PATHSAMPLES`) | — | directory dei file audio sorgente, per **entrambi** i renderer. Vale per i tre posti da cui un run legge i sample: durata dello stream (`Stream` → `get_sample_duration`), lettura in render (`SampleRegistry` con numpy, SSDIR con csound) e waveform in partitura. Assente: comportamento storico, `./refs/` **relativo al cwd** del processo |
 | `--orc-path PATH` | `csound/main.orc` | — | orchestra Csound |
 | `--incdir DIR` | `src` | — | include dir per Csound |
-| `--ssdir DIR` | `refs` | — | sample search dir (file sorgente audio) |
+| `--ssdir DIR` | `--samples-dir`, altrimenti `refs` | — | sample search dir di Csound (variabile d'ambiente SSDIR). Vince su `--samples-dir` quando è esplicito; **non basta da solo** (vedi Bounds) |
 | `--sfdir DIR` | `output` | `SFDIR` | sound file dir di Csound |
 | `--log-dir DIR` | `logs` | `LOGDIR` | directory dei log |
 | `--message-level N` | `134` | — | message level di Csound |
@@ -111,6 +112,22 @@ Vincoli tra flag e comportamento nelle combinazioni non valide:
   byte-identico tra run perché libsndfile scrive un timestamp wall-clock nel
   PEAK chunk dell'header; confronta i campioni (`soundfile.read`), non i byte
   grezzi.
+- **`--ssdir` non sostituisce `--samples-dir`, nemmeno con `--renderer
+  csound`.** SSDIR dice a Csound dove cercare i soundfile *in fase di
+  render*, ma la durata del sample la risolve `Stream.__init__` (via
+  `get_sample_duration`) prima che esista un renderer, e quel passo legge
+  `PATHSAMPLES`. Da un cwd senza `refs/`, `--ssdir /altrove` da solo muore
+  con `SampleNotFoundError` esattamente come il renderer numpy — il path
+  stampato è `./refs/…`, non SSDIR, e il render non è nemmeno iniziato. La
+  precedenza fra i due, quando entrambi contano: `--ssdir` esplicito >
+  `--samples-dir` > `refs`. Senza nessuno dei due, SSDIR resta `refs`.
+- **`--samples-dir` non entra nel fingerprint della cache.** *Dove* stanno i
+  sample non è un parametro dello stem: spostare la directory non marca
+  dirty nulla (vedi [[caching]]). Ne consegue anche il contrario: due
+  directory diverse con file omonimi e contenuto diverso condividono lo
+  stesso manifest e lo stesso stem, e la cache non se ne accorge — è la
+  stessa proprietà per cui il contenuto del file audio non è mai stato
+  nell'hash.
 - **`--show-static`** ha effetto solo insieme a `--visualize`.
 - **`--show-voice-offsets`** ha effetto solo insieme a `--visualize`. Gli
   offset per-voce vengono campionati dalle voice strategy
@@ -181,6 +198,13 @@ python src/main.py configs/brano.yml --renderer numpy --jobs 1
 
 # Numero esplicito di worker via Make (vuoto = auto = core-1)
 make all FILE=brano RENDERER=numpy JOBS=4
+
+# Sample fuori dal checkout del motore: render da una directory di lavoro
+# qualsiasi (nessun refs/ nel cwd), con entrambi i renderer
+python src/main.py brano.yml output/brano.wav \
+  --renderer numpy --format wav --samples-dir /media/wavs
+python src/main.py brano.yml output/brano.aif \
+  --renderer csound --samples-dir /media/wavs   # alimenta anche SSDIR
 
 # Debug csound: conserva gli .sco intermedi
 python src/main.py configs/brano.yml --renderer csound --keep-sco --sco-dir generated

--- a/src/pge/cli.py
+++ b/src/pge/cli.py
@@ -65,7 +65,9 @@ def _build_renderer(renderer_type: str, generator, **kwargs):
         csound_options = api.CsoundOptions(
             orc_path=kwargs.get('orc_path', 'csound/main.orc'),
             incdir=kwargs.get('incdir', 'src'),
-            ssdir=kwargs.get('ssdir', 'refs'),
+            # None (nessun --ssdir): la precedenza la risolve l'API,
+            # che ricade su samples_dir e poi sul default storico 'refs'.
+            ssdir=kwargs.get('ssdir'),
             sfdir=kwargs.get('sfdir', 'output'),
             log_dir=kwargs.get('log_dir', 'logs'),
             message_level=kwargs.get('message_level', 134),
@@ -78,6 +80,7 @@ def _build_renderer(renderer_type: str, generator, **kwargs):
         output_sr=kwargs.get('output_sr', DEFAULT_OUTPUT_SR),
         jobs=kwargs.get('jobs', 'auto'),
         audio_format=kwargs.get('audio_format', DEFAULT_FORMAT),
+        samples_dir=kwargs.get('samples_dir'),
         cache_manifest_path=cache_manifest_path,
         csound=csound_options,
     )
@@ -193,6 +196,7 @@ def main():
             "[--renderer csound|numpy] "
             "[--jobs N|auto] "
             "[--format aiff|wav|flac] "
+            "[--samples-dir DIR] "
             "[--orc-path PATH] [--incdir DIR] [--ssdir DIR] [--sfdir DIR] "
             "[--log-dir DIR] [--message-level N] "
             "[--keep-sco] [--sco-dir DIR] "
@@ -329,6 +333,19 @@ def main():
         if idx + 1 < len(sys.argv):
             cache_dir = sys.argv[idx + 1]
 
+    # --samples-dir DIR (issue #235): directory dei sample audio, per
+    # entrambi i renderer. Assente (None) -> fallback storico su PATHSAMPLES
+    # ('./refs/', relativo al cwd). Non e' un doppione di --ssdir: SSDIR dice
+    # a csound dove cercare i soundfile in fase di render, mentre la durata
+    # del sample la risolve il Generator (Stream -> get_sample_duration) prima
+    # che esista un renderer — senza questo flag quel passo cerca in './refs/'
+    # con entrambi i renderer.
+    samples_dir = None
+    if '--samples-dir' in sys.argv:
+        idx = sys.argv.index('--samples-dir')
+        if idx + 1 < len(sys.argv):
+            samples_dir = sys.argv[idx + 1]
+
     # --- Csound config args ---
 
     orc_path = 'csound/main.orc'
@@ -343,7 +360,10 @@ def main():
         if idx + 1 < len(sys.argv):
             incdir = sys.argv[idx + 1]
 
-    ssdir = 'refs'
+    # Default None e non 'refs': cosi' la regola di precedenza dell'API
+    # (--ssdir esplicito > --samples-dir > 'refs') e' raggiungibile dalla CLI.
+    # Senza nessuno dei due flag SSDIR resta 'refs', come sempre.
+    ssdir = None
     if '--ssdir' in sys.argv:
         idx = sys.argv.index('--ssdir')
         if idx + 1 < len(sys.argv):
@@ -403,7 +423,7 @@ def main():
     configure_engine_logger(yaml_name=yaml_basename, log_dir='./logs')
 
     try:
-        generator = Generator(yaml_file)
+        generator = Generator(yaml_file, samples_dir=samples_dir)
 
         print(f"Caricamento {yaml_file}...")
         generator.load_yaml()
@@ -427,6 +447,7 @@ def main():
             yaml_basename=yaml_basename,
             sco_dir=sco_dir,
             audio_format=audio_format,
+            samples_dir=samples_dir,
         )
 
         # Garbage collection: rimuove stream orfani (rimossi/rinominati nel YAML)
@@ -495,7 +516,7 @@ def main():
                 'magnify_auto': magnify_auto,
                 'magnify_targets': magnify_targets,
                 'grain_height': grain_height,
-            })
+            }, samples_dir=samples_dir)
 
         print(f"Log: {get_clip_log_path()}")
 

--- a/src/pge/cli.py
+++ b/src/pge/cli.py
@@ -340,11 +340,19 @@ def main():
     # del sample la risolve il Generator (Stream -> get_sample_duration) prima
     # che esista un renderer — senza questo flag quel passo cerca in './refs/'
     # con entrambi i renderer.
+    #
+    # Unico flag del file che rifiuta il valore mancante invece di ignorarlo:
+    # altrove il silenzio costa poco, qui chi scrive `--samples-dir` senza
+    # directory si sente rispondere './refs/', cioe' il posto da cui il flag
+    # serviva ad andarsene — un fallimento che somiglia troppo al successo.
     samples_dir = None
     if '--samples-dir' in sys.argv:
         idx = sys.argv.index('--samples-dir')
-        if idx + 1 < len(sys.argv):
-            samples_dir = sys.argv[idx + 1]
+        if idx + 1 >= len(sys.argv):
+            print("--samples-dir richiede una directory. "
+                  "Esempio: --samples-dir /percorso/ai/sample")
+            sys.exit(1)
+        samples_dir = sys.argv[idx + 1]
 
     # --- Csound config args ---
 

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -30,6 +30,7 @@ USAGE = (
     "[--renderer csound|numpy] "
     "[--jobs N|auto] "
     "[--format aiff|wav|flac] "
+    "[--samples-dir DIR] "
     "[--orc-path PATH] [--incdir DIR] [--ssdir DIR] [--sfdir DIR] "
     "[--log-dir DIR] [--message-level N] "
     "[--keep-sco] [--sco-dir DIR] "

--- a/tests/test_cli_samples_dir.py
+++ b/tests/test_cli_samples_dir.py
@@ -142,3 +142,34 @@ class TestSsdirIsNotEnoughForCsound:
         except SystemExit:
             pass
         assert "Sample non trovato" not in capsys.readouterr().out
+
+
+class TestMissingValueIsNotSilent:
+    """`--samples-dir` in coda, senza directory: messaggio + exit 1.
+
+    L'idioma `if idx + 1 < len(sys.argv)` senza `else` e' quello di tutti i
+    flag del file, e altrove costa poco. Qui no: chi scrive `--samples-dir`
+    e non gli da' un valore si sente rispondere `./refs/`, cioe' esattamente
+    la directory da cui il flag serviva ad andarsene. Il fallimento silenzioso
+    somiglia troppo al successo.
+    """
+
+    def test_exits_1_with_a_message(self, altrove, capsys):
+        with pytest.raises(SystemExit) as exc:
+            _run(['main.py', 'mini.yml', 'output/mini.wav',
+                  '--renderer', 'numpy', '--format', 'wav', '--samples-dir'])
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert '--samples-dir' in out
+        # Il messaggio parla del flag, non del sample: l'errore vero e' che
+        # la directory non e' stata scritta.
+        assert 'Sample non trovato' not in out
+
+    def test_it_does_not_reach_the_generator(self, altrove):
+        """Esce durante il parsing degli argomenti: nessun caricamento YAML,
+        nessuno stem, nessun log."""
+        work, _ = altrove
+        with pytest.raises(SystemExit):
+            _run(['main.py', 'mini.yml', 'output/mini.wav',
+                  '--renderer', 'numpy', '--format', 'wav', '--samples-dir'])
+        assert not (work / "output" / "mini.wav").exists()

--- a/tests/test_cli_samples_dir.py
+++ b/tests/test_cli_samples_dir.py
@@ -1,0 +1,144 @@
+# tests/test_cli_samples_dir.py
+"""
+Test di integrazione del flag CLI --samples-dir (issue #235).
+
+Niente mock: si invoca `pge.cli.main()` per davvero, da un cwd che **non**
+contiene `refs/`, con il sample scritto altrove. E' la verifica chiesta
+dalla issue, e l'unica che dimostra la cosa che conta — che `./refs/`
+smetta di essere un vincolo sulla directory di lavoro.
+
+Copre anche la premessa sbagliata della issue: `--ssdir` non basta al
+renderer csound. SSDIR dice a csound dove cercare i soundfile in fase di
+render, ma la durata del sample la risolve `Stream.__init__` molto prima,
+via `get_sample_duration` -> PATHSAMPLES. Il run muore li', identico al
+caso numpy, e per questo la prova non ha bisogno di csound installato.
+"""
+
+import sys
+
+import numpy as np
+import pytest
+import soundfile as sf
+from unittest.mock import patch
+
+
+_YAML = """\
+seed: 42
+streams:
+  - stream_id: s1
+    onset: 0
+    duration: 0.5
+    sample: pino.wav
+    time_mode: normalized
+    distribution_mode: uniform
+    density: 10
+    distribution: 0
+    grain:
+      duration: 0.05
+      envelope: hanning
+    pointer:
+      start: 0
+      speed_ratio: 1
+    pitch:
+      semitones: 0
+    pan: 0
+    volume: -6
+"""
+
+
+@pytest.fixture
+def altrove(tmp_path, monkeypatch):
+    """Un cwd senza `refs/` e una directory sample da tutt'altra parte.
+
+    Ritorna (work_dir, samples_dir): il processo gira dentro work_dir, dove
+    c'e' solo lo YAML.
+    """
+    samples_dir = tmp_path / "media" / "wavs"
+    samples_dir.mkdir(parents=True)
+    sr = 44100
+    t = np.linspace(0, 1.0, sr, endpoint=False)
+    sf.write(str(samples_dir / "pino.wav"),
+             (0.3 * np.sin(2 * np.pi * 220 * t)).astype(np.float32), sr)
+
+    work = tmp_path / "work"
+    (work / "output").mkdir(parents=True)
+    (work / "mini.yml").write_text(_YAML)
+
+    assert not (work / "refs").exists()
+    monkeypatch.chdir(work)
+    return work, samples_dir
+
+
+def _run(argv):
+    """Invoca la CLI reale con argv dato."""
+    from pge.cli import main
+    with patch.object(sys, 'argv', argv):
+        main()
+
+
+class TestNumpyRendersFromAnywhere:
+    """La verifica della issue, renderer numpy."""
+
+    def test_render_succeeds_with_samples_dir(self, altrove):
+        work, samples_dir = altrove
+        _run(['main.py', 'mini.yml', 'output/mini.wav',
+              '--renderer', 'numpy', '--format', 'wav', '--jobs', '1',
+              '--samples-dir', str(samples_dir)])
+        out = work / "output" / "mini.wav"
+        assert out.exists(), "nessun audio prodotto con --samples-dir"
+        audio, _ = sf.read(str(out))
+        assert np.any(audio != 0), "audio prodotto ma silenzioso"
+
+    def test_without_the_flag_still_fails_on_refs(self, altrove, capsys):
+        """Assente -> comportamento storico invariato: SampleNotFoundError
+        su './refs/', exit 1."""
+        with pytest.raises(SystemExit) as exc:
+            _run(['main.py', 'mini.yml', 'output/mini.wav',
+                  '--renderer', 'numpy', '--format', 'wav', '--jobs', '1'])
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "Sample non trovato" in out
+        assert "./refs/pino.wav" in out
+
+    def test_trailing_separator_is_not_required(self, altrove):
+        """`--samples-dir /dir` e `/dir/` sono la stessa directory: il
+        separatore lo mette l'API (SampleRegistry e get_sample_duration
+        concatenano base + filename)."""
+        work, samples_dir = altrove
+        _run(['main.py', 'mini.yml', 'output/mini.wav',
+              '--renderer', 'numpy', '--format', 'wav', '--jobs', '1',
+              '--samples-dir', str(samples_dir) + '/'])
+        assert (work / "output" / "mini.wav").exists()
+
+
+class TestSsdirIsNotEnoughForCsound:
+    """La premessa che la issue da' per buona — «con csound il caso e' gia'
+    coperto da --ssdir» — non regge: il run non arriva nemmeno al renderer.
+
+    Nessuno di questi test richiede csound installato: e' esattamente il
+    punto.
+    """
+
+    def test_ssdir_alone_dies_in_the_generator(self, altrove, capsys):
+        _, samples_dir = altrove
+        with pytest.raises(SystemExit) as exc:
+            _run(['main.py', 'mini.yml', 'output/mini.aif',
+                  '--renderer', 'csound', '--ssdir', str(samples_dir)])
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "Sample non trovato" in out
+        # Il path cercato e' PATHSAMPLES, non SSDIR: la lettura non e'
+        # passata dal renderer.
+        assert "./refs/pino.wav" in out
+
+    def test_samples_dir_gets_csound_past_the_generator(self, altrove, capsys):
+        """Con --samples-dir il Generator risolve, e il run prosegue: qui si
+        ferma sul csound assente (o produce audio, se c'e'), non piu' sul
+        sample."""
+        _, samples_dir = altrove
+        try:
+            _run(['main.py', 'mini.yml', 'output/mini.aif',
+                  '--renderer', 'csound', '--samples-dir', str(samples_dir)])
+        except SystemExit:
+            pass
+        assert "Sample non trovato" not in capsys.readouterr().out

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -66,9 +66,11 @@ class TestNormalFlow:
     """
 
     def test_generator_created_with_yaml_path(self, mocks):
+        """samples_dir e' sempre esplicito (issue #235); None = fallback
+        storico su PATHSAMPLES."""
         with patch.object(sys, 'argv', ['main.py', 'test.yml', 'out.aif']):
             mocks['main'].main()
-        mocks['Generator'].assert_called_once_with('test.yml')
+        mocks['Generator'].assert_called_once_with('test.yml', samples_dir=None)
 
     def test_load_yaml_called(self, mocks):
         with patch.object(sys, 'argv', ['main.py', 'test.yml', 'out.aif']):
@@ -745,14 +747,22 @@ class TestCsoundArgs:
         return build_mock.call_args.kwargs['csound']
 
     def test_default_csound_options(self, mocks):
-        """Senza flag: default storici della CLI, ssdir esplicito 'refs'."""
+        """Senza flag: default storici della CLI.
+
+        `ssdir=None` non e' un default perso: e' la CLI che smette di
+        imporre 'refs' per lasciare all'API la precedenza --ssdir >
+        --samples-dir > 'refs' (issue #235). Che SSDIR resti 'refs' senza
+        nessuno dei due flag lo verifica
+        TestSamplesDirFlag::test_csound_ssdir_unchanged_without_any_flag,
+        che guarda il valore risolto e non l'opzione.
+        """
         opts = self._get_csound_options(
             mocks, ['main.py', 'test.yml', 'out.aif'])
         api_mod = mocks['main'].api
         assert opts == api_mod.CsoundOptions(
             orc_path='csound/main.orc',
             incdir='src',
-            ssdir='refs',
+            ssdir=None,
             sfdir='output',
             log_dir='logs',
             message_level=134,
@@ -1341,3 +1351,115 @@ class TestExportSvFlag:
                 mocks['main'].main()
         sv_cls.return_value.export.assert_not_called()
         assert 'export-sv' in capsys.readouterr().out
+
+
+# =============================================================================
+# TEST FLAG --samples-dir (issue #235)
+# =============================================================================
+
+class TestSamplesDirFlag:
+    """
+    --samples-dir DIR: la directory dei sample smette di essere il globale
+    './refs/', relativo al cwd del processo.
+
+    In un run CLI i file audio sorgente vengono letti da tre posti diversi, e
+    il flag deve raggiungerli tutti:
+
+    - il **Generator**, che risolve la durata del sample dentro `Stream`
+      (`get_sample_duration`) prima ancora che esista un renderer — e' il
+      punto in cui oggi fallisce anche il renderer csound, che pure ha gia'
+      `--ssdir`;
+    - il **renderer**: `SampleRegistry(base_path=...)` con numpy, SSDIR con
+      csound (dove `--ssdir` esplicito resta prioritario);
+    - il **visualizer**, che disegna la waveform del sample in partitura.
+
+    Qui si verifica la mappa argv -> kwargs dell'API; la propagazione dentro
+    l'API e' coperta da tests/test_api.py.
+    """
+
+    def _build_call(self, mocks, argv):
+        """Esegue main() con api.build_renderer patchata; ritorna i kwargs."""
+        api_mod = mocks['main'].api
+        result = api_mod.RenderResult(
+            audio_paths=['/out/test.aif'], elapsed_seconds=0.0,
+            renderer_type='csound', per_stream=False)
+        with patch.object(api_mod, 'build_renderer') as build_mock, \
+             patch.object(api_mod, 'render', return_value=result):
+            with patch.object(sys, 'argv', argv):
+                mocks['main'].main()
+        return build_mock.call_args.kwargs
+
+    def _ssdir(self, mocks, argv):
+        """SSDIR risolto davvero: main() -> api.build_renderer (non
+        patchata) -> RendererFactory.create."""
+        with patch.object(sys, 'argv', argv):
+            mocks['main'].main()
+        kwargs = mocks['RendererFactory'].create.call_args.kwargs
+        return kwargs['csound_config']['env_vars']['SSDIR']
+
+    # --- Generator -----------------------------------------------------------
+
+    def test_flag_reaches_generator(self, mocks):
+        with patch.object(sys, 'argv', ['main.py', 'test.yml', 'out.aif',
+                                        '--samples-dir', '/media/wavs']):
+            mocks['main'].main()
+        mocks['Generator'].assert_called_once_with(
+            'test.yml', samples_dir='/media/wavs')
+
+    def test_absent_leaves_generator_on_the_historical_default(self, mocks):
+        """Assente -> samples_dir None: il Generator ricade su PATHSAMPLES."""
+        with patch.object(sys, 'argv', ['main.py', 'test.yml', 'out.aif']):
+            mocks['main'].main()
+        mocks['Generator'].assert_called_once_with('test.yml', samples_dir=None)
+
+    # --- Renderer ------------------------------------------------------------
+
+    def test_flag_reaches_build_renderer(self, mocks):
+        kwargs = self._build_call(
+            mocks, ['main.py', 'test.yml', 'out.aif',
+                    '--samples-dir', '/media/wavs'])
+        assert kwargs['samples_dir'] == '/media/wavs'
+
+    def test_absent_passes_none_to_build_renderer(self, mocks):
+        kwargs = self._build_call(mocks, ['main.py', 'test.yml', 'out.aif'])
+        assert kwargs['samples_dir'] is None
+
+    # --- SSDIR (csound): la regola di precedenza gia' scritta in api.py ------
+
+    def test_csound_ssdir_unchanged_without_any_flag(self, mocks):
+        """Parita' col comportamento storico: niente flag -> SSDIR 'refs'."""
+        assert self._ssdir(mocks, ['main.py', 'test.yml', 'out.aif']) == 'refs'
+
+    def test_csound_ssdir_follows_samples_dir(self, mocks):
+        """Senza --ssdir, --samples-dir alimenta SSDIR (senza slash finale,
+        convenzione csound)."""
+        ssdir = self._ssdir(mocks, ['main.py', 'test.yml', 'out.aif',
+                                    '--samples-dir', '/media/wavs/'])
+        assert ssdir == '/media/wavs'
+
+    def test_csound_explicit_ssdir_wins_over_samples_dir(self, mocks):
+        ssdir = self._ssdir(mocks, ['main.py', 'test.yml', 'out.aif',
+                                    '--samples-dir', '/media/wavs',
+                                    '--ssdir', '/altro/refs'])
+        assert ssdir == '/altro/refs'
+
+    # --- Visualizer ----------------------------------------------------------
+
+    def test_flag_reaches_the_visualizer_config(self, mocks):
+        """Il visualizer concatena base + filename: serve lo slash finale,
+        che api.export_score_pdf aggiunge."""
+        with patch.object(sys, 'argv', ['main.py', 'test.yml', 'out.aif',
+                                        '--visualize',
+                                        '--samples-dir', '/media/wavs']):
+            mocks['main'].main()
+        cfg = mocks['ScoreVisualizer'].call_args.kwargs['config']
+        assert cfg['samples_dir'] == '/media/wavs/'
+
+    def test_absent_leaves_the_visualizer_config_untouched(self, mocks):
+        """Nessuna chiave iniettata: il default None del VisualizerConfig
+        tiene il fallback storico su PATHSAMPLES."""
+        with patch.object(sys, 'argv',
+                          ['main.py', 'test.yml', 'out.aif', '--visualize']):
+            mocks['main'].main()
+        cfg = mocks['ScoreVisualizer'].call_args.kwargs['config']
+        assert 'samples_dir' not in cfg


### PR DESCRIPTION
Closes #235.

## Cosa cambia

Nuovo flag `--samples-dir DIR`, propagato ai **tre** posti da cui un run CLI legge i file audio sorgente:

| consumatore | come ci arriva | cosa faceva prima |
|---|---|---|
| `Generator` → `Stream` → `get_sample_duration` (durata dello stream) | `Generator(yaml, samples_dir=...)` | `PATHSAMPLES` = `./refs/` |
| renderer: `SampleRegistry` (numpy) / SSDIR (csound) | `api.build_renderer(samples_dir=...)` | `./refs/` / `refs` |
| `ScoreVisualizer` (waveform in partitura) | `api.export_score_pdf(samples_dir=...)` | `PATHSAMPLES` |

Più `StreamCacheManager`, che risolve la durata dal file audio per gli stream senza `duration` (#205) e riceve `samples_dir` da `build_renderer` — seam già esistente.

Assente il flag, **ogni default resta quello di prima**.

## La issue dava per coperto il caso csound. Non lo era

> «Con `csound` il caso e' gia' coperto da `--ssdir`»

Verificato: falso, e ora c'è un test che lo fissa (`TestSsdirIsNotEnoughForCsound`). SSDIR dice a Csound dove cercare i soundfile **in fase di render**, ma la durata del sample la risolve `Stream.__init__` via `get_sample_duration` molto prima che un renderer esista. Da un cwd senza `refs/`:

```
$ python src/main.py mini.yml out.aif --renderer csound --ssdir /altrove
[ERRORE] Sample non trovato: 'pino.wav'
  Path cercato: ./refs/pino.wav      <-- PATHSAMPLES, non SSDIR
```

Byte per byte lo stesso errore del renderer numpy. L'asimmetria fra i due renderer non era quella descritta: il **lato Python era hardcoded per entrambi**, e csound aveva in più un flag che copre solo la seconda metà del problema. Conseguenza pratica: `--samples-dir` non è un doppione di `--ssdir` nemmeno per chi usa csound — è l'unico modo di sganciare il run dal cwd, e i test csound qui non richiedono csound installato proprio perché il run non ci arriva.

## La regola di precedenza esisteva già, ma era irraggiungibile

`api.build_renderer` risolve SSDIR come `--ssdir` esplicito > `samples_dir` > `'refs'` (`api.py:197-203`). Quel ramo non è mai stato eseguito dalla CLI, che passava sempre `ssdir='refs'` — vincendo su tutto. Ora la CLI passa `None` quando `--ssdir` non c'è.

Il default della CLI si sposta da `'refs'` a `None`, ma **il valore risolto non cambia**: senza nessuno dei due flag SSDIR resta `refs`. Due test lo separano — `TestCsoundArgs::test_default_csound_options` guarda l'opzione (ora `None`), `TestSamplesDirFlag::test_csound_ssdir_unchanged_without_any_flag` guarda il valore che arriva a `RendererFactory.create` (ancora `refs`).

## `--samples-dir` senza valore esce con 1

Unico flag del file a rifiutare il valore mancante invece di ignorarlo. L'idioma `if idx + 1 < len(sys.argv)` senza `else` altrove costa poco; qui rispondeva `Path cercato: ./refs/pino.wav` a chi aveva appena scritto `--samples-dir`, accusando il sample di un errore che stava nella riga di comando. Gli altri flag restano com'erano — è un cambio a sé.

L'eccezione è dichiarata dove serve, sempre con la ragione e non solo con la regola: commento nel codice, riga della tabella e riga di Bounds in `docs/reference/cli.md`, paragrafo del CHANGELOG. La regola generale nel doc («se manca, la flag viene ignorata senza errore») ora nomina la sua eccezione invece di restare falsa.

Copre il valore **mancante** (flag in coda ad argv), non quello *malformato*: `--samples-dir --visualize` fa diventare `samples_dir` la stringa `'--visualize'` e fallisce con `Path cercato: --visualize/...`. È l'idioma di tutto il file, non una proprietà di questo flag, e a differenza del caso in coda non è silenzioso — il path stampato dice in chiaro cosa è andato storto. Sparisce col passaggio ad `argparse`, se e quando.

## Verifica

Quella chiesta dalla issue, da un cwd che non contiene `refs/`:

```
$ python src/main.py mini.yml output/mini.wav --renderer numpy --format wav \
    --samples-dir /altrove
 Generazione completata! 1 file generati:
    output/mini.wav

$ python src/main.py mini.yml output/mini.wav --renderer numpy --format wav
[ERRORE] Sample non trovato: 'pino.wav'
  Path cercato: ./refs/pino.wav
exit: 1
```

Provato anche `--per-stream --cache --visualize` con uno stream a durata implicita (#205): stem, manifest e PDF corretti, durata risolta dal file in `--samples-dir` (2.00 s) e non da `./refs/`.

## Test

TDD, rosso → verde. `make tests`: **5829 passed, 10 skipped** (+16).

- `tests/test_cli_samples_dir.py` (nuovo) — integrazione senza mock: `pge.cli.main()` invocata davvero da un cwd senza `refs/`. Contiene sia la verifica della issue sia i due test che fissano il comportamento attuale (`--ssdir` da solo muore nel Generator), che erano verdi prima della patch, sia il valore mancante (messaggio + exit code, e il fatto che esca durante il parsing senza arrivare al Generator).
- `tests/test_main.py::TestSamplesDirFlag` (nuovo, 10 test) — mappa argv → kwargs verso Generator / `build_renderer` / config del visualizer, più la risoluzione reale di SSDIR nei tre casi di precedenza.
- Due asserzioni aggiornate perché la modifica le cambia di proposito: `TestNormalFlow::test_generator_created_with_yaml_path` (`samples_dir` ora sempre esplicito) e `TestCsoundArgs::test_default_csound_options` (`ssdir=None`).
- `tests/test_cli_contract.py` — golden dell'usage: aggiungere un flag alla CLI cambia quella stringa per definizione.

## Fuori scope, di proposito

- **Nessuna variabile Make.** `--ssdir`, `--orc-path`, `--incdir` non ne hanno; `make` gira dalla root del repo, dove `./refs/` risolve già.
- **`PATHSAMPLES` resta** dov'è, deprecato come prima. Rimuoverlo è un cambio a sé.
- **Nessuna validazione dell'esistenza della directory.** Una `--samples-dir` inesistente dà `SampleNotFoundError` col path cercato in chiaro, che è già il messaggio giusto; nessun altro flag di path valida. Diverso dal valore *mancante*, che sopra invece esce con 1.

## Impatto cross-repo

Superficie pubblica toccata: CLI (un flag nuovo, nessuno rimosso o rinominato; nessun cambio a YAML, errori o formati).

- **PGE-ui — impatto sì.** È il motivo per cui la issue esiste: oggi il bridge risolve tutto come `root / "refs"` e lancia il processo con `cwd=root` proprio perché `./refs/` non è spostabile. Issue aperta: DMGiulioRomano/PGE-ui#148.
- **PGE-ls — nessun impatto.** È un language server sullo YAML: autocomplete, validazione, hover e diagnostica non vedono i flag della CLI. Nessuna issue aperta.
- **Paper CIM 2026 — nessun impatto.** `render_example.py` usa l'API Python (`Generator`, `RenderingEngine`, `ScoreVisualizer`), non la CLI, e nessuna firma dell'API cambia: `samples_dir` era già un parametro di tutte e tre. Il comportamento di rendering è invariato. Nessun bump del submodule proposto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTGgBni93qpPukU8ET1qpj