### PR TITLE
fix(visualizer): la waveform della partitura disegna il segnale, non la griglia di lettura (#233)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,21 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   due volte per stream, una per la durata e una per il disegno — mentre il
   commento in cima al ciclo dichiarava il contrario.
 
+  Nella stessa passata, tre casi in cui il buffer reale non e' il buffer del
+  test: un **bucket piu' largo del sample** viene tagliato sulla lunghezza del
+  segnale (senza il taglio il padding cresceva con la manopola invece che con
+  l'audio, e `waveform_downsample` alto costava gigabyte su un sample da un
+  secondo); un **NaN isolato** non avvelena piu' il picco globale, che si
+  calcola nan-safe — prima bastava un campione a lasciare non normalizzata
+  *tutta* la curva, che finiva clippata contro i bordi; un **file di lunghezza
+  zero** torna al placeholder da un secondo invece di dare durata nulla, che
+  schiacciava grani, loop mask e label dello stream su un asse degenere.
+
+  E il `try` di `_load_waveform` copre di nuovo la sola apertura del file: un
+  guasto della riduzione (memoria, manopola fuori scala) non si traveste piu'
+  da «Impossibile caricare waveform», che lo avrebbe messo in cache e reso
+  silenzioso per il resto del rendering.
+
   **Cambia il disegno, non l'audio**: nessun renderer legge questo codice.
 
 - **Un envelope su tre grafie non veniva riconosciuto come envelope** (issue
@@ -185,7 +200,9 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
   L'avvertenza della issue resta vera per quella sola manopola:
   `waveform_downsample: 1` su un sample lungo produce ancora milioni di
-  vertici. E' l'unico modo rimasto per arrivarci, ed e' esplicito.
+  vertici. E' l'unico modo rimasto per arrivarci, ed e' esplicito. All'altro
+  capo la manopola e' invece tagliata sulla lunghezza del sample: un bucket
+  piu' largo del segnale *e'* il segnale, e non costa niente in piu'.
 
 - **Il renderer NumPy ignora `envelope` sotto i 10 campioni (208.3 µs).** A
   quelle lunghezze la finestra non taglia i bordi: decima il grano.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,54 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Corretto
 
+- **La waveform della partitura non era il segnale, era la griglia di lettura**
+  (issue #233). `ScoreVisualizer._load_waveform` riduceva il sample con
+  `audio[::200]` — un campione ogni duecento — e disegnava quello. Tre difetti,
+  che sono tre difetti diversi:
+
+  - **i transienti sparivano.** Un attacco largo meno del passo non veniva mai
+    pescato. Su un sample con un picco di 30 campioni a fondo scala la
+    partitura dichiarava un'ampiezza di meta' scala: non una versione
+    approssimata del segnale, un segnale che non esiste;
+  - **aliasing.** Sottocampionare senza filtrare ripiega le frequenze alte su
+    quelle basse. Una sinusoide a 220 Hz letta ogni 200 campioni (cioe' a
+    220.5 Hz) veniva disegnata come un'onda a 0.4 Hz. Su una nota pizzicata
+    l'effetto e' un lobo asimmetrico con un pettine di ondulazioni al posto del
+    decadimento: la forma che si legge sulla pagina non e' una semplificazione
+    di quella vera, e' un artefatto della griglia;
+  - **la scala verticale seguiva la manopola.** Si normalizzava su
+    `max(|audio[::ds]|)`, cioe' sul massimo dei campioni *sopravvissuti*.
+    Abbassare `waveform_downsample` per avere piu' dettaglio riscalava anche il
+    disegno, quindi due partiture generate a risoluzioni diverse non erano
+    confrontabili. E' il motivo per cui il «fix rapido» proposto nella issue
+    (200 -> 20) non era un fix: cambiava anche cio' che non doveva.
+
+  A questi si aggiungeva un asse temporale stirato — `linspace(0, duration, ...)`
+  mappava l'**ultimo campione pescato** sulla fine del sample, e su un sample
+  corto l'ultimo pescato e' lontano dalla fine — e un costo proporzionale alla
+  durata del file: un sample di dieci minuti produceva 132mila vertici, uno di
+  un secondo duecento.
+
+  Il rimedio e' l'inviluppo min/max, come disegna la waveform qualunque editor
+  audio: si legge **ogni** campione, il segnale si divide in bucket, e di ogni
+  bucket si tiene la coppia (minimo, massimo). Il picco c'e' sempre, perche' i
+  bucket partizionano il segnale. La lettura resta lineare nei campioni — deve
+  esserlo, e' il prezzo per non perderli — ma quel che arriva a matplotlib e'
+  limitato dal numero di bucket: **4000 vertici** che il sample duri cinque
+  secondi o dieci minuti (36 ms di riduzione sul secondo caso).
+
+  La regola vive nel modulo puro `rendering.waveform_peaks` (numpy e basta,
+  niente matplotlib e niente I/O); `_load_waveform` resta l'adapter che apre il
+  file, legge la config e tiene la cache.
+
+  Nella stessa passata: il **sample che non si apre** ora si prova una volta
+  sola. La waveform fittizia del ramo d'errore non finiva in cache, quindi ogni
+  subplot di ogni pagina ritentava l'apertura e ristampava lo stesso avviso —
+  due volte per stream, una per la durata e una per il disegno — mentre il
+  commento in cima al ciclo dichiarava il contrario.
+
+  **Cambia il disegno, non l'audio**: nessun renderer legge questo codice.
+
 - **Un envelope su tre grafie non veniva riconosciuto come envelope** (issue
   #234). `Envelope.is_envelope_like` era piu' stretta di quel che
   `EnvelopeBuilder` costruisce: una lista di **soli** breakpoint dict
@@ -116,6 +164,28 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   stream silenzioso invece che come un errore.
 
 ### Modificato
+
+- **La risoluzione della waveform si chiede in colonne, non in campioni**
+  (issue #233). Nuova chiave di config di `ScoreVisualizer`:
+  **`waveform_buckets`** (default `2000`), il numero di colonne min/max da
+  disegnare. E' una risoluzione, non un passo: il costo del disegno non dipende
+  piu' da quanto e' lungo il sample, e un sample corto viene disegnato intero
+  invece che a manciate di punti.
+
+  **`waveform_downsample` resta e non e' un errore passarla**, ma il default
+  scende da `200` a `None` e il significato si sposta di un passo: era il passo
+  del sottocampionamento, ora e' la **larghezza del bucket in campioni**, e se
+  data vince su `waveform_buckets`. Chi la passava ottiene la stessa densita' di
+  colonne di prima, con dentro il picco invece di un campione a caso. Assente
+  significa «derivala dal conteggio». Resta perche' fissare la risoluzione in
+  campioni e' legittimo — e' come si confrontano allo stesso dettaglio due
+  sample di lunghezza diversa — e perche' la config di `ScoreVisualizer` e'
+  superficie pubblica, che passa da `api.export_score_pdf` e dagli esempi del
+  paper.
+
+  L'avvertenza della issue resta vera per quella sola manopola:
+  `waveform_downsample: 1` su un sample lungo produce ancora milioni di
+  vertici. E' l'unico modo rimasto per arrivarci, ed e' esplicito.
 
 - **Il renderer NumPy ignora `envelope` sotto i 10 campioni (208.3 µs).** A
   quelle lunghezze la finestra non taglia i bordi: decima il grano.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,13 +58,22 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
   Nella stessa passata, tre casi in cui il buffer reale non e' il buffer del
   test: un **bucket piu' largo del sample** viene tagliato sulla lunghezza del
-  segnale (senza il taglio il padding cresceva con la manopola invece che con
-  l'audio, e `waveform_downsample` alto costava gigabyte su un sample da un
-  secondo); un **NaN isolato** non avvelena piu' il picco globale, che si
+  segnale, perche' un bucket piu' largo del segnale *e'* il segnale; un **NaN
+  isolato** non avvelena piu' il picco globale, che si
   calcola nan-safe — prima bastava un campione a lasciare non normalizzata
   *tutta* la curva, che finiva clippata contro i bordi; un **file di lunghezza
   zero** torna al placeholder da un secondo invece di dare durata nulla, che
   schiacciava grani, loop mask e label dello stream su un asse degenere.
+
+  E la riduzione non ricopia piu' il buffer. L'ultimo bucket veniva riempito
+  fino alla misura per poterlo reshapare con gli altri, e quella `concatenate`
+  costava una copia dell'**intero** segnale ogni volta che la lunghezza non era
+  multiplo esatto della larghezza — cioe' quasi sempre: **212 MB e 26 ms** su
+  dieci minuti di audio per aggiungere in coda meno di duemila campioni,
+  contro **0.1 MB e 7 ms** ora che i bucket pieni sono una view su una fetta e
+  l'ultimo si riduce da se'. Era l'unico punto in cui «il costo non dipende
+  piu' dalla durata» restava falso per la memoria. Il riempimento era comunque
+  un no-op semantico, quindi sparisce invece di essere documentato.
 
   E il `try` di `_load_waveform` copre di nuovo la sola apertura del file: un
   guasto della riduzione (memoria, manopola fuori scala) non si traveste piu'
@@ -198,11 +207,15 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   superficie pubblica, che passa da `api.export_score_pdf` e dagli esempi del
   paper.
 
-  L'avvertenza della issue resta vera per quella sola manopola:
+  L'avvertenza della issue resta vera, e vale per **entrambe** le manopole:
   `waveform_downsample: 1` su un sample lungo produce ancora milioni di
-  vertici. E' l'unico modo rimasto per arrivarci, ed e' esplicito. All'altro
-  capo la manopola e' invece tagliata sulla lunghezza del sample: un bucket
-  piu' largo del segnale *e'* il segnale, e non costa niente in piu'.
+  vertici, e `waveform_buckets` piu' grande della lunghezza del sample arriva
+  allo stesso tetto (`2 * len(audio)`) per la strada opposta. Nessuna delle due
+  e' tagliata verso l'alto: chiedere una risoluzione piu' fine del segnale e'
+  legittimo quanto chiederla piu' grossolana, ed e' esplicito in entrambi i
+  casi. Verso il basso invece `waveform_downsample` e' tagliata sulla lunghezza
+  del sample, perche' li' non c'e' niente da guadagnare: un bucket piu' largo
+  del segnale *e'* il segnale.
 
 - **Il renderer NumPy ignora `envelope` sotto i 10 campioni (208.3 µs).** A
   quelle lunghezze la finestra non taglia i bordi: decima il grano.

--- a/docs/explanation/score-visualizer-layout.md
+++ b/docs/explanation/score-visualizer-layout.md
@@ -11,7 +11,8 @@ sources:
   - src/pge/rendering/magnifier_projection.py
   - src/pge/rendering/score_visualizer.py
   - src/pge/rendering/visualizer_config.py
-last_synced_commit: 62ec803
+  - src/pge/rendering/waveform_peaks.py
+last_synced_commit: 41733f9
 ---
 
 # Il layout della partitura: separare i numeri dal disegno
@@ -90,9 +91,27 @@ costruire il `Polygon` è dell'adapter.
 `self.page_layouts` e stampa. Il modulo gli dà le pagine, lui le assegna: lo
 stato resta dell'oggetto, la regola no.
 
-**`_load_waveform` non si è mosso.** Non è geometria, è I/O con `soundfile` più
-una cache. Se ha una casa è `sample_registry`, ed è una domanda diversa da
-questa.
+**`_load_waveform` non si è mosso — ma metà di lui sì** (issue #233). Il metodo
+è I/O con `soundfile` più una cache, e quello resta dell'adapter: leggere il
+file, leggere la config, ricordarsi il risultato. Dentro però c'era anche una
+*regola* — come si riduce un buffer di centinaia di migliaia di campioni a una
+curva che sta in una colonna alta pochi centimetri — e quella è aritmetica pura,
+quindi è uscita in `waveform_peaks`, insieme agli altri moduli matplotlib-free.
+
+Non è stato un trasloco a costo zero, perché la regola era sbagliata. Riduceva
+con `audio[::200]`, un campione ogni duecento: i transienti più stretti del
+passo non venivano mai pescati, le frequenze alte aliasavano su quelle basse
+(una nota a 220 Hz letta a 220.5 Hz si disegnava come un'onda a 0.4 Hz), e la
+normalizzazione — fatta sul massimo dei campioni *sopravvissuti* — legava la
+scala verticale del disegno alla manopola della risoluzione. Ora è un inviluppo
+min/max: si legge ogni campione, si tiene la coppia (minimo, massimo) di ogni
+bucket, e il numero di vertici che arriva a matplotlib dipende dai bucket
+richiesti invece che dalla durata del file.
+
+Che questo sia diventato un modulo a sé è la stessa scelta del resto della
+famiglia, e si vede dal test: verificare che un picco di trenta campioni
+sopravviva alla riduzione non richiede più un `Generator` finto e la pila di
+plotting, richiede un array.
 
 **Le manopole di config diventano keyword argument.** `pad_ratio`, `samples`,
 `pan_range`, `hist_bins`, `page_duration`: i moduli non conoscono il dict di

--- a/docs/explanation/score-visualizer-layout.md
+++ b/docs/explanation/score-visualizer-layout.md
@@ -12,7 +12,7 @@ sources:
   - src/pge/rendering/score_visualizer.py
   - src/pge/rendering/visualizer_config.py
   - src/pge/rendering/waveform_peaks.py
-last_synced_commit: 41733f9
+last_synced_commit: 5fcfde7
 ---
 
 # Il layout della partitura: separare i numeri dal disegno

--- a/src/pge/rendering/score_visualizer.py
+++ b/src/pge/rendering/score_visualizer.py
@@ -54,6 +54,7 @@ from pge.rendering import grain_visuals  # noqa: E402
 from pge.rendering import magnifier_projection  # noqa: E402
 from pge.rendering import magnifier_targets  # noqa: E402
 from pge.rendering import page_layout  # noqa: E402
+from pge.rendering import waveform_peaks  # noqa: E402
 from pge.rendering.visualizer_config import VisualizerConfig  # noqa: E402
 
 
@@ -140,45 +141,44 @@ class ScoreVisualizer:
     # =========================================================================
 
     def _load_waveform(self, sample_path):
-        """Carica e processa waveform per visualizzazione."""
-        
+        """Carica il sample e lo riduce alla curva che si disegna.
+
+        Qui vive l'I/O e la cache; la riduzione e' di
+        rendering.waveform_peaks, che e' puro. Il risultato e'
+        `(time_axis, amplitude, duration)`: due array della stessa lunghezza
+        piu' la durata vera del file, con l'ampiezza normalizzata sul picco
+        del segnale intero.
+
+        La curva e' un inviluppo min/max, non un sottocampionamento a passo
+        fisso (issue #233): due punti per bucket, il minimo e il massimo dei
+        campioni che contiene. Il passo fisso perdeva i transienti piu'
+        stretti del passo, aliasava, e produceva un numero di vertici
+        proporzionale alla durata del file.
+        """
         if sample_path in self.waveform_cache:
             return self.waveform_cache[sample_path]
-        
+
         # Costruisci path completo (samples_dir iniettato o fallback globale)
         full_path = self.samples_dir + sample_path
-        
+
         try:
-            # Carica audio
             audio, sr = sf.read(full_path)
-            
-            # Mono mix se stereo
-            if audio.ndim > 1:
-                audio = np.mean(audio, axis=1)
-            
-            # Downsample per visualizzazione
-            ds = self.config['waveform_downsample']
-            audio_ds = audio[::ds]
-            
-            # Asse temporale
             duration = len(audio) / sr
-            time_axis = np.linspace(0, duration, len(audio_ds))
-            
-            # Normalizza ampiezza
-            max_amp = np.max(np.abs(audio_ds))
-            if max_amp > 0:
-                amplitude = audio_ds / max_amp
-            else:
-                amplitude = audio_ds
-            
+            time_axis, amplitude = waveform_peaks.peak_envelope(
+                audio, sr,
+                buckets=self.config['waveform_buckets'],
+                width=self.config['waveform_downsample'])
             result = (time_axis, amplitude, duration)
-            self.waveform_cache[sample_path] = result
-            return result
-            
+
         except Exception as e:
             print(f"⚠️  Impossibile caricare waveform {sample_path}: {e}")
-            # Ritorna waveform fittizia
-            return (np.array([0, 1]), np.array([0, 0]), 1.0)
+            # Waveform fittizia: piatta, lunga un secondo. Va in cache come le
+            # altre, altrimenti ogni subplot di ogni pagina ritenterebbe
+            # l'apertura di un file che non si apre e ristamperebbe l'avviso.
+            result = (np.array([0.0, 1.0]), np.array([0.0, 0.0]), 1.0)
+
+        self.waveform_cache[sample_path] = result
+        return result
     
     def _get_sample_duration(self, sample_path):
         """Ottiene la durata del sample."""

--- a/src/pge/rendering/score_visualizer.py
+++ b/src/pge/rendering/score_visualizer.py
@@ -161,21 +161,29 @@ class ScoreVisualizer:
         # Costruisci path completo (samples_dir iniettato o fallback globale)
         full_path = self.samples_dir + sample_path
 
+        # Il try copre l'apertura, non la riduzione: un guasto di quest'ultima
+        # (memoria, manopola fuori scala) non e' un file che non si apre, e
+        # travestirlo da tale lo renderebbe silenzioso — messo in cache, non
+        # ristampato piu'. Meglio che salga.
         try:
             audio, sr = sf.read(full_path)
-            duration = len(audio) / sr
-            time_axis, amplitude = waveform_peaks.peak_envelope(
-                audio, sr,
-                buckets=self.config['waveform_buckets'],
-                width=self.config['waveform_downsample'])
-            result = (time_axis, amplitude, duration)
-
+            if len(audio) == 0:
+                # La riduzione qui non solleva (torna curve vuote), ma una
+                # durata nulla schiaccerebbe l'intero subplot dello stream su
+                # un asse degenere: meglio il placeholder, che si legge.
+                raise ValueError('file audio di lunghezza zero')
         except Exception as e:
             print(f"⚠️  Impossibile caricare waveform {sample_path}: {e}")
             # Waveform fittizia: piatta, lunga un secondo. Va in cache come le
             # altre, altrimenti ogni subplot di ogni pagina ritenterebbe
             # l'apertura di un file che non si apre e ristamperebbe l'avviso.
             result = (np.array([0.0, 1.0]), np.array([0.0, 0.0]), 1.0)
+        else:
+            time_axis, amplitude = waveform_peaks.peak_envelope(
+                audio, sr,
+                buckets=self.config['waveform_buckets'],
+                width=self.config['waveform_downsample'])
+            result = (time_axis, amplitude, len(audio) / sr)
 
         self.waveform_cache[sample_path] = result
         return result

--- a/src/pge/rendering/visualizer_config.py
+++ b/src/pge/rendering/visualizer_config.py
@@ -193,7 +193,24 @@ class VisualizerConfig:
     waveform_alpha: float = 0.3
     waveform_color: str = 'steelblue'
     waveform_width_ratio: float = 0.06    # frazione della larghezza pagina
-    waveform_downsample: int = 200        # 1 punto ogni N campioni
+    # Risoluzione della waveform (issue #233). Il disegno e' un inviluppo
+    # min/max: il segnale si divide in bucket e di ognuno si tiene la coppia
+    # (minimo, massimo), come fa qualunque editor audio. Prima era un
+    # sottocampionamento a passo fisso, che perdeva i transienti, aliasava le
+    # frequenze alte su quelle basse, e costava in proporzione alla durata del
+    # file. Vedi rendering.waveform_peaks.
+    #
+    # Quante colonne min/max disegnare. E' una risoluzione, non un passo: il
+    # costo del disegno non dipende da quanto e' lungo il sample, e un sample
+    # corto viene disegnato intero invece che a manciate di punti.
+    waveform_buckets: int = 2000
+    # Larghezza del bucket in campioni. La manopola storica ("1 punto ogni N
+    # campioni"): se data vince su waveform_buckets. None = assente, cioe' la
+    # larghezza si deriva dal conteggio. Resta perche' fissare la risoluzione
+    # in campioni e' legittimo — e' come si confrontano allo stesso dettaglio
+    # due sample di lunghezza diversa — e perche' la config di ScoreVisualizer
+    # e' superficie pubblica.
+    waveform_downsample: Optional[int] = None
     # La colorbar del pitch vive in una colonna propria del GridSpec, cosi' i
     # subplot dei grani e quello degli envelope condividono la colonna centrale
     # e restano allineati sullo stesso bordo destro.

--- a/src/pge/rendering/waveform_peaks.py
+++ b/src/pge/rendering/waveform_peaks.py
@@ -70,8 +70,7 @@ def bucket_width(n_samples, buckets, width=None):
     """
     if width is not None:
         # Tagliata sulla lunghezza: un bucket piu' largo del segnale *e'* il
-        # segnale, e lasciarlo crescere costerebbe padding — memoria in
-        # proporzione alla manopola invece che all'audio.
+        # segnale, e lasciarlo crescere non aggiungerebbe niente al disegno.
         return max(1, min(int(width), int(n_samples) or 1))
     buckets = max(1, int(buckets))
     return max(1, -(-int(n_samples) // buckets))
@@ -113,20 +112,29 @@ def peak_envelope(audio, sr, *, buckets=DEFAULT_BUCKETS, width=None):
         return np.zeros(0), np.zeros(0)
 
     w = bucket_width(n, buckets, width)
+    n_full = n // w
     n_buckets = -(-n // w)
 
-    pad = n_buckets * w - n
-    if pad:
-        # Riempito con l'ultimo campione, che appartiene *gia'* all'ultimo
-        # bucket: min e max di quel bucket non si spostano di un capello.
-        # Con degli zeri, invece, la coda di un sample che finisce forte
-        # guadagnerebbe uno zero che il segnale non ha.
-        audio = np.concatenate(
-            [audio, np.full(pad, audio[-1], dtype=audio.dtype)])
+    mins = np.empty(n_buckets, dtype=np.float64)
+    maxs = np.empty(n_buckets, dtype=np.float64)
 
-    blocks = audio.reshape(n_buckets, w)
-    mins = blocks.min(axis=1).astype(np.float64)
-    maxs = blocks.max(axis=1).astype(np.float64)
+    # I bucket pieni sono una `reshape` di una *fetta*, che e' una view: non
+    # copia niente. L'alternativa — riempire l'ultimo bucket fino alla misura
+    # e reshapare tutto — costerebbe una copia dell'intero buffer ogni volta
+    # che la lunghezza non e' multiplo esatto della larghezza, cioe' quasi
+    # sempre: duecento megabyte su dieci minuti di audio per aggiungere in
+    # coda meno di duemila campioni.
+    if n_full:
+        blocks = audio[:n_full * w].reshape(n_full, w)
+        mins[:n_full] = blocks.min(axis=1)
+        maxs[:n_full] = blocks.max(axis=1)
+
+    # L'ultimo bucket, se parziale, si riduce da se': e' gia' una fetta, e min
+    # e max non hanno bisogno che sia della misura giusta.
+    if n_buckets > n_full:
+        tail = audio[n_full * w:]
+        mins[-1] = tail.min()
+        maxs[-1] = tail.max()
 
     # I bucket partizionano il segnale, quindi il picco globale e' gia' qui:
     # nessuna seconda passata sui campioni (su un sample lungo sarebbero

--- a/src/pge/rendering/waveform_peaks.py
+++ b/src/pge/rendering/waveform_peaks.py
@@ -1,0 +1,146 @@
+# src/pge/rendering/waveform_peaks.py
+"""
+Riduzione di un buffer audio a una curva disegnabile (issue #233).
+
+La partitura mette la waveform del sample su una colonna alta pochi
+centimetri. I campioni sono centinaia di migliaia, i pixel qualche centinaio:
+qualcosa va buttato, e la domanda non e' *quanto* ma *che cosa*.
+
+Il visualizer buttava a caso — `audio[::200]`, un campione ogni duecento — e
+questo modulo esiste per smettere. Il passo fisso ha tre difetti, e sono tre
+difetti diversi:
+
+**Perde i transienti.** Un attacco largo meno del passo non viene mai pescato.
+Su un sample con un picco di 30 campioni a fondo scala, la waveform disegnata
+dichiarava un'ampiezza di meta' scala: non era una versione approssimata del
+segnale, era un segnale che non esiste.
+
+**Aliasa.** Sottocampionare senza filtrare ripiega le frequenze alte su quelle
+basse. Una sinusoide a 220 Hz letta ogni 200 campioni (cioe' a 220.5 Hz)
+diventa un'onda lentissima a 0.4 Hz: la forma disegnata non e' una
+semplificazione di quella vera, e' un artefatto della griglia di lettura.
+
+**Costa in proporzione al file.** Il numero di vertici che arrivano a
+matplotlib e' `len(audio) / passo`: un sample di due minuti ne produceva
+ventiseimila, uno di un secondo duecento. Il primo e' lento da disegnare, il
+secondo e' illeggibile.
+
+Il rimedio e' l'inviluppo min/max, che e' come disegna la waveform qualunque
+editor audio: si legge **ogni** campione, si divide il segnale in bucket, e di
+ogni bucket si tiene la coppia (minimo, massimo). Il picco c'e' sempre, perche'
+i bucket partizionano il segnale e ogni campione cade in uno. La lettura resta
+lineare nei campioni — deve esserlo, e' il prezzo per non perderli — ma cio'
+che arriva al disegno e' limitato dal numero di bucket, non dalla durata.
+
+Il modulo e' puro: numpy e basta, niente matplotlib e niente I/O. Il file lo
+apre `ScoreVisualizer._load_waveform`, che resta l'adapter (legge la config e
+tiene la cache); qui vive solo la regola.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+
+# Quante colonne min/max disegnare per default. La colonna della waveform su
+# una pagina A4 stampata a 300 dpi e' alta al massimo un paio di migliaia di
+# pixel: sotto questa soglia il dettaglio si vedrebbe mancare, sopra si
+# pagherebbero vertici per pixel che non ci sono.
+DEFAULT_BUCKETS = 2000
+
+
+def bucket_width(n_samples, buckets, width=None):
+    """Quanti campioni entrano in un bucket.
+
+    Due modi di chiedere la risoluzione, e uno vince sull'altro:
+
+    - `buckets` fissa il **numero di colonne**, e la larghezza si deriva dalla
+      durata. E' il modo giusto per una pagina: il costo del disegno non
+      dipende da quanto e' lungo il sample.
+    - `width` fissa la **larghezza in campioni**, ignorando il conteggio. E' la
+      semantica storica di `waveform_downsample` ("un punto ogni N campioni"),
+      e serve quando due sample di lunghezza diversa vanno confrontati allo
+      stesso dettaglio temporale.
+
+    L'arrotondamento e' per eccesso: per difetto l'ultimo bucket resterebbe
+    fuori, e l'ultimo bucket e' la coda del sample.
+
+    Sotto il numero di bucket richiesti non c'e' niente da ridurre e la
+    larghezza scende a 1: il segnale si disegna intero. E' il caso dei sample
+    brevi, che col passo fisso erano i piu' maltrattati.
+    """
+    if width is not None:
+        return max(1, int(width))
+    buckets = max(1, int(buckets))
+    return max(1, -(-int(n_samples) // buckets))
+
+
+def peak_envelope(audio, sr, *, buckets=DEFAULT_BUCKETS, width=None):
+    """L'inviluppo min/max di `audio`, normalizzato, pronto per il disegno.
+
+    Ritorna `(time_axis, amplitude)`, due array della stessa lunghezza: per
+    ogni bucket una coppia di punti che condividono l'istante (il centro del
+    bucket) e portano il minimo e il massimo dei campioni che contiene. La
+    polilinea che ne esce e' la waveform; riempita fino allo zero e' la colonna
+    della partitura.
+
+    L'ampiezza e' normalizzata sul **picco vero del segnale intero**, non su
+    quello dei campioni sopravvissuti alla riduzione. Non e' un dettaglio: col
+    passo fisso si divideva per il massimo del sottoinsieme pescato, quindi
+    cambiare la manopola della risoluzione cambiava anche la scala verticale
+    del disegno. Qui la manopola cambia il dettaglio e basta — due partiture
+    generate a risoluzioni diverse restano confrontabili.
+
+    Args:
+        audio: campioni; mono o multicanale (i canali si mixano a mono).
+        sr: sample rate, per convertire gli indici in secondi.
+        buckets: numero di colonne min/max da produrre.
+        width: larghezza del bucket in campioni; se data, vince su `buckets`.
+
+    Returns:
+        (time_axis, amplitude): secondi e ampiezza in [-1, 1]. Vuoti se il
+        buffer e' vuoto — un file di lunghezza zero non deve far esplodere il
+        disegno.
+    """
+    audio = np.asarray(audio)
+    if audio.ndim > 1:
+        audio = audio.mean(axis=1)
+
+    n = audio.size
+    if n == 0:
+        return np.zeros(0), np.zeros(0)
+
+    w = bucket_width(n, buckets, width)
+    n_buckets = -(-n // w)
+
+    pad = n_buckets * w - n
+    if pad:
+        # Riempito con l'ultimo campione, che appartiene *gia'* all'ultimo
+        # bucket: min e max di quel bucket non si spostano di un capello.
+        # Con degli zeri, invece, la coda di un sample che finisce forte
+        # guadagnerebbe uno zero che il segnale non ha.
+        audio = np.concatenate(
+            [audio, np.full(pad, audio[-1], dtype=audio.dtype)])
+
+    blocks = audio.reshape(n_buckets, w)
+    mins = blocks.min(axis=1).astype(np.float64)
+    maxs = blocks.max(axis=1).astype(np.float64)
+
+    # I bucket partizionano il segnale, quindi il picco globale e' gia' qui:
+    # nessuna seconda passata sui campioni (su un sample lungo sarebbero
+    # milioni di letture per un numero che abbiamo in mano).
+    peak = max(maxs.max(), -mins.min())
+    if peak > 0:
+        mins /= peak
+        maxs /= peak
+
+    # Centro del bucket, calcolato sui bordi reali: l'ultimo bucket puo' essere
+    # parziale, e il suo centro deve dirlo. Il vecchio asse era un linspace
+    # fino alla durata, che mappava l'ultimo campione *pescato* sulla fine del
+    # sample e stirava la waveform — su un sample corto anche di un quarto.
+    edges = np.minimum(np.arange(n_buckets + 1) * w, n)
+    centers = (edges[:-1] + edges[1:]) / (2.0 * sr)
+
+    amplitude = np.empty(2 * n_buckets, dtype=np.float64)
+    amplitude[0::2] = mins
+    amplitude[1::2] = maxs
+    return np.repeat(centers, 2), amplitude

--- a/src/pge/rendering/waveform_peaks.py
+++ b/src/pge/rendering/waveform_peaks.py
@@ -69,7 +69,10 @@ def bucket_width(n_samples, buckets, width=None):
     brevi, che col passo fisso erano i piu' maltrattati.
     """
     if width is not None:
-        return max(1, int(width))
+        # Tagliata sulla lunghezza: un bucket piu' largo del segnale *e'* il
+        # segnale, e lasciarlo crescere costerebbe padding — memoria in
+        # proporzione alla manopola invece che all'audio.
+        return max(1, min(int(width), int(n_samples) or 1))
     buckets = max(1, int(buckets))
     return max(1, -(-int(n_samples) // buckets))
 
@@ -128,7 +131,9 @@ def peak_envelope(audio, sr, *, buckets=DEFAULT_BUCKETS, width=None):
     # I bucket partizionano il segnale, quindi il picco globale e' gia' qui:
     # nessuna seconda passata sui campioni (su un sample lungo sarebbero
     # milioni di letture per un numero che abbiamo in mano).
-    peak = max(maxs.max(), -mins.min())
+    # nan-safe: un solo campione NaN renderebbe NaN il picco, quindi falso il
+    # confronto qui sotto, quindi non normalizzata *tutta* la curva.
+    peak = max(np.nanmax(maxs), -np.nanmin(mins))
     if peak > 0:
         mins /= peak
         maxs /= peak

--- a/tests/rendering/test_score_visualizer.py
+++ b/tests/rendering/test_score_visualizer.py
@@ -1954,3 +1954,136 @@ class TestEnvelopeColorsConfig:
         assert PLOT_ENVELOPE_KEYS == frozenset(viz.config['envelope_colors'])
         assert 'pitch' in PLOT_ENVELOPE_KEYS
         assert 'volume_prob' in PLOT_ENVELOPE_KEYS
+
+
+# =============================================================================
+# GROUP - Risoluzione della waveform (issue #233)
+# =============================================================================
+
+class TestWaveformResolution:
+    """La waveform disegnata e' un inviluppo min/max, non un sottocampionamento.
+
+    La regola vive in rendering.waveform_peaks (modulo puro, testato a parte);
+    qui si verifica che _load_waveform la usi davvero e che le manopole di
+    config ci arrivino. La differenza si vede su un transiente: un picco largo
+    meno di un bucket, che il vecchio `audio[::200]` non pescava mai.
+    """
+
+    SPIKE_AT = 2.0
+    SPIKE_WIDTH = 30
+
+    def _audio_with_spike(self):
+        """Sinusoide a meta' scala con un transiente a fondo scala. Il picco
+        cade fuori dalla griglia del vecchio passo fisso: e' il caso che la
+        issue descrive, non uno costruito per essere gentile."""
+        audio = (0.5 * np.sin(
+            2 * np.pi * 220 * np.linspace(0, DUR, int(SR * DUR)))
+        ).astype(np.float64)
+        i = int(self.SPIKE_AT * SR) + 1
+        audio[i:i + self.SPIKE_WIDTH] = 1.0
+        return audio
+
+    def _load(self, config=None):
+        viz = make_viz(single_stream_scene(), config=config)
+        with patch('soundfile.read',
+                   return_value=(self._audio_with_spike(), SR)):
+            return viz._load_waveform('piano.wav')
+
+    def test_the_transient_reaches_the_drawing(self):
+        _, amplitude, _ = self._load()
+        assert np.max(np.abs(amplitude)) == pytest.approx(1.0)
+
+    def test_the_old_subsampling_would_have_lost_it(self):
+        """Regressione dichiarata: senza questa riga il test sopra passerebbe
+        anche su un'implementazione che il transiente lo pesca per fortuna."""
+        assert np.max(np.abs(self._audio_with_spike()[::200])) < 0.9
+
+    def test_the_transient_is_drawn_where_it_happens(self):
+        time_axis, amplitude, duration = self._load()
+        at_full_scale = time_axis[np.abs(amplitude) > 0.99]
+        assert at_full_scale.size > 0
+        assert np.all(np.abs(at_full_scale - self.SPIKE_AT) < duration / 2000)
+
+    def test_the_vertical_scale_does_not_follow_the_resolution(self):
+        """Il difetto silenzioso: si normalizzava sul massimo dei campioni
+        sopravvissuti al passo, quindi cambiare la manopola riscalava il
+        disegno invece di dettagliarlo. Due partiture generate a risoluzioni
+        diverse non erano confrontabili."""
+        peaks = [
+            np.max(np.abs(self._load({'waveform_buckets': b})[1]))
+            for b in (200, 2000, 20_000)
+        ]
+        assert peaks == pytest.approx([1.0, 1.0, 1.0])
+
+    def test_the_bucket_count_bounds_what_matplotlib_draws(self):
+        _, amplitude, _ = self._load({'waveform_buckets': 300})
+        assert len(amplitude) <= 2 * 300
+
+    def test_the_default_is_denser_than_the_old_fixed_stride(self):
+        """Il motivo per cui la issue e' aperta: su un sample di 4s a 44.1 kHz
+        il passo fisso disegnava ~880 punti."""
+        _, amplitude, _ = self._load()
+        assert len(amplitude) > 2 * len(self._audio_with_spike()[::200])
+
+    def test_the_historical_knob_still_sets_the_resolution(self):
+        """`waveform_downsample` sopravvive come larghezza del bucket: chi la
+        passava ottiene la stessa densita' di colonne di prima, con dentro il
+        picco invece di un campione a caso."""
+        audio = self._audio_with_spike()
+        _, amplitude, _ = self._load({'waveform_downsample': 200})
+        assert len(amplitude) == 2 * -(-len(audio) // 200)
+
+    def test_the_historical_knob_wins_over_the_bucket_count(self):
+        audio = self._audio_with_spike()
+        _, amplitude, _ = self._load(
+            {'waveform_buckets': 50, 'waveform_downsample': 200})
+        assert len(amplitude) == 2 * -(-len(audio) // 200)
+
+    def test_the_time_axis_stays_inside_the_sample(self):
+        """E' lo stesso asse su cui sono disegnati i grani: una waveform
+        stirata oltre la durata non ci si allinea piu'."""
+        time_axis, _, duration = self._load()
+        assert time_axis[0] >= 0.0
+        assert time_axis[-1] <= duration
+
+    def test_stereo_still_collapses_to_one_curve(self):
+        mono = self._audio_with_spike()
+        stereo = np.stack([mono, mono * 0.5], axis=1)
+        viz = make_viz(single_stream_scene())
+        with patch('soundfile.read', return_value=(stereo, SR)):
+            time_axis, amplitude, duration = viz._load_waveform('piano.wav')
+        assert len(time_axis) == len(amplitude)
+        assert duration == pytest.approx(DUR)
+
+
+class TestWaveformFailureIsCached:
+    """Il sample che non si apre si prova una volta sola.
+
+    Il commento in cima al ciclo dei subplot dice che _load_waveform fa cache,
+    quindi nessun re-read: sulla strada dell'errore era falso. Ogni subplot di
+    ogni pagina ritentava l'apertura e ristampava lo stesso avviso, due volte
+    per stream (una per la durata, una per il disegno).
+    """
+
+    def test_the_file_is_opened_once(self):
+        viz = make_viz(multi_page_scene(), config={'page_duration': 30.0})
+        with patch('soundfile.read',
+                   side_effect=OSError('file not found')) as mock_sf:
+            viz.render_all()
+        piano_calls = [c for c in mock_sf.call_args_list
+                       if 'piano.wav' in str(c)]
+        assert len(piano_calls) == 1
+
+    def test_the_warning_is_printed_once(self, capsys):
+        viz = make_viz(single_stream_scene(), config={'page_duration': 30.0})
+        with patch('soundfile.read', side_effect=OSError('file not found')):
+            viz.render_all()
+        printed = capsys.readouterr().out
+        assert printed.count('Impossibile caricare waveform') == 1
+
+    def test_the_fallback_curve_is_still_drawable(self):
+        viz = make_viz(single_stream_scene())
+        with patch('soundfile.read', side_effect=OSError('nope')):
+            time_axis, amplitude, duration = viz._load_waveform('piano.wav')
+        assert len(time_axis) == len(amplitude)
+        assert duration > 0

--- a/tests/rendering/test_score_visualizer.py
+++ b/tests/rendering/test_score_visualizer.py
@@ -2087,3 +2087,35 @@ class TestWaveformFailureIsCached:
             time_axis, amplitude, duration = viz._load_waveform('piano.wav')
         assert len(time_axis) == len(amplitude)
         assert duration > 0
+
+
+class TestWaveformOfADegenerateFile:
+    """Il file si apre ma non c'e' niente dentro, o la riduzione non riesce.
+
+    Sono due strade diverse da quella del file mancante, e prima di #233
+    finivano entrambe nello stesso `except`: la prima perche' `np.max` su un
+    array vuoto sollevava, la seconda perche' il try avvolgeva anche la
+    riduzione. Ora la riduzione non solleva piu' sul vuoto, quindi il vuoto va
+    riconosciuto; e un guasto della riduzione non e' un file che non si apre.
+    """
+
+    def test_a_zero_length_file_falls_back_to_the_placeholder(self):
+        """Senza fallback la durata scende a zero e l'intero subplot dello
+        stream — grani, loop mask, label — collassa su un asse degenere."""
+        viz = make_viz(single_stream_scene())
+        with patch('soundfile.read', return_value=(np.zeros(0), SR)):
+            time_axis, amplitude, duration = viz._load_waveform('piano.wav')
+        assert duration > 0
+        assert len(time_axis) == len(amplitude) > 0
+
+    def test_a_failing_reduction_is_not_reported_as_a_missing_file(self, capsys):
+        """Un guasto della riduzione (memoria, manopola fuori scala) non deve
+        travestirsi da errore di apertura e finire in cache: sarebbe silenzioso
+        per tutto il resto del rendering."""
+        viz = make_viz(single_stream_scene())
+        with patch('soundfile.read', return_value=(np.zeros(SR), SR)), \
+                patch('pge.rendering.waveform_peaks.peak_envelope',
+                      side_effect=MemoryError('too big')):
+            with pytest.raises(MemoryError):
+                viz._load_waveform('piano.wav')
+        assert 'Impossibile caricare waveform' not in capsys.readouterr().out

--- a/tests/rendering/test_visualizer_config.py
+++ b/tests/rendering/test_visualizer_config.py
@@ -282,3 +282,39 @@ class TestConfigMustBeAMapping:
     def test_none_is_still_the_empty_configuration(self):
         """None resta il default: nessuno scarto, tutti i valori dichiarati."""
         assert VisualizerConfig.from_overrides(None).as_dict()['page_duration'] == 30.0
+
+
+class TestWaveformResolution:
+    """Le due manopole della waveform (issue #233).
+
+    `waveform_buckets` chiede un numero di colonne min/max, cioe' una
+    risoluzione che non dipende da quanto e' lungo il sample.
+    `waveform_downsample` e' la manopola storica: fissa la larghezza del bucket
+    in campioni e vince sull'altra. Resta perche' e' superficie pubblica — la
+    config di ScoreVisualizer e' un dizionario che passa da api.py e dagli
+    esempi del paper — e perche' quel che chiede e' legittimo: due sample di
+    lunghezza diversa allo stesso dettaglio temporale.
+    """
+
+    def test_the_bucket_count_has_a_default(self):
+        config = VisualizerConfig.from_overrides(None).as_dict()
+        assert config['waveform_buckets'] == 2000
+
+    def test_the_historical_knob_defaults_to_absent(self):
+        """None, non 200: assente significa 'derivala dal conteggio', ed e' il
+        modo di distinguere chi la manopola non l'ha toccata."""
+        config = VisualizerConfig.from_overrides(None).as_dict()
+        assert config['waveform_downsample'] is None
+
+    def test_the_historical_knob_is_still_accepted(self):
+        """Retrocompatibilita': una config che la passa non deve morire sulla
+        guardia delle chiavi sconosciute."""
+        config = VisualizerConfig.from_overrides(
+            {'waveform_downsample': 50}).as_dict()
+        assert config['waveform_downsample'] == 50
+
+    def test_the_two_knobs_coexist(self):
+        config = VisualizerConfig.from_overrides(
+            {'waveform_buckets': 800, 'waveform_downsample': 20}).as_dict()
+        assert config['waveform_buckets'] == 800
+        assert config['waveform_downsample'] == 20

--- a/tests/rendering/test_waveform_peaks.py
+++ b/tests/rendering/test_waveform_peaks.py
@@ -247,3 +247,27 @@ class TestDefaultBuckets:
         massimo un paio di migliaia di pixel: sotto quella soglia il dettaglio
         si vedrebbe mancare, sopra si pagherebbe per pixel che non ci sono."""
         assert DEFAULT_BUCKETS >= 1000
+
+
+class TestDegenerateInput:
+    """Due modi in cui un buffer reale non e' il buffer del test."""
+
+    def test_a_bucket_wider_than_the_signal_is_the_signal(self):
+        """La manopola storica e' una larghezza in campioni, e chi vuole una
+        waveform grossolana la alza: niente le impedisce di superare la
+        lunghezza del sample. Il bucket va allora tagliato sul segnale, perche'
+        e' lui a dettare il padding: senza il taglio si allocano `width`
+        campioni di riempimento per un file che ne ha mille, e la memoria
+        finisce per dipendere dalla manopola invece che dall'audio."""
+        assert bucket_width(1000, buckets=2000, width=10 ** 9) == 1000
+
+    def test_a_single_nan_does_not_unnormalize_the_whole_curve(self):
+        """Un NaN nel buffer avvelena min e max del suo bucket, e da li' il
+        picco globale: la divisione salta e *tutta* la waveform resta in scala
+        assoluta, cioe' schiacciata o fuori dai bordi. Col passo fisso un NaN
+        isolato veniva quasi sempre saltato; ora si legge ogni campione, quindi
+        il caso va gestito invece che evitato per fortuna."""
+        audio = tone(1.0, amp=0.5).astype(np.float64)
+        audio[1000] = np.nan
+        _, amplitude = peak_envelope(audio, SR, buckets=200)
+        assert np.nanmax(np.abs(amplitude)) == pytest.approx(1.0)

--- a/tests/rendering/test_waveform_peaks.py
+++ b/tests/rendering/test_waveform_peaks.py
@@ -1,0 +1,249 @@
+# tests/rendering/test_waveform_peaks.py
+"""
+TDD suite per rendering.waveform_peaks (issue #233).
+
+Come si riduce un buffer audio a una curva disegnabile. La partitura mette la
+waveform del sample su una colonna alta pochi centimetri: i campioni sono
+centinaia di migliaia, i pixel qualche centinaio. Qualcosa va buttato, e la
+domanda e' *che cosa*.
+
+Il visualizer buttava a caso: `audio[::200]`, un campione ogni duecento. Tre
+conseguenze, tutte verificate qui sotto come regressione:
+
+1. i transienti sparivano — un picco largo meno di un bucket non veniva mai
+   pescato, e la waveform disegnata mostrava un'ampiezza che il segnale non ha;
+2. la normalizzazione dipendeva dal passo — si divideva per il massimo dei
+   campioni *sopravvissuti*, quindi cambiare la manopola cambiava la scala
+   verticale del disegno, non solo il suo dettaglio;
+3. il numero di vertici cresceva col file — un sample lungo ne produceva
+   decine di migliaia, uno corto poche centinaia.
+
+Il rimedio e' l'inviluppo min/max: si legge *ogni* campione, e per ogni bucket
+si tiene la coppia (minimo, massimo). Il costo della lettura resta lineare nei
+campioni — deve esserlo, e' il prezzo per non perdere i picchi — ma quello che
+arriva a matplotlib e' costante.
+"""
+
+import numpy as np
+import pytest
+
+from pge.rendering.waveform_peaks import (
+    DEFAULT_BUCKETS,
+    bucket_width,
+    peak_envelope,
+)
+
+
+SR = 44100
+
+
+def tone(seconds=1.0, freq=220.0, amp=0.5, sr=SR):
+    t = np.arange(int(sr * seconds)) / sr
+    return (amp * np.sin(2 * np.pi * freq * t)).astype(np.float32)
+
+
+class TestBucketWidth:
+    """Quanti campioni entrano in un bucket."""
+
+    def test_long_signal_is_divided_into_the_requested_buckets(self):
+        assert bucket_width(200_000, buckets=2000) == 100
+
+    def test_the_division_rounds_up_so_nothing_falls_outside(self):
+        """Con l'arrotondamento per difetto l'ultimo bucket resterebbe fuori:
+        e' la coda del sample, ed e' proprio dove sta la fine di una nota."""
+        assert bucket_width(2001, buckets=1000) == 3
+
+    def test_signal_shorter_than_the_buckets_is_not_reduced(self):
+        """Meno campioni che bucket: non c'e' niente da ridurre, il segnale si
+        disegna intero. E' il caso dei sample brevi, che col passo fisso erano
+        i piu' maltrattati."""
+        assert bucket_width(500, buckets=2000) == 1
+
+    def test_explicit_width_wins_over_the_bucket_count(self):
+        """La manopola storica (`waveform_downsample`) fissa la risoluzione in
+        campioni invece che in colonne: serve a confrontare due sample di
+        lunghezza diversa allo stesso dettaglio."""
+        assert bucket_width(200_000, buckets=2000, width=200) == 200
+
+    def test_a_degenerate_request_still_yields_a_usable_width(self):
+        """Lo schema di config non verifica i tipi (per scelta): uno zero non
+        deve arrivare fino a una divisione per zero. Zero colonne si legge come
+        una — l'intero segnale in un bucket solo: degenere ma coerente con cio'
+        che la manopola dice, mentre scendere a un campione per bucket darebbe
+        il *massimo* dettaglio a chi ne ha chiesto il minimo."""
+        assert bucket_width(1000, buckets=0) == 1000
+        assert bucket_width(1000, buckets=-5) == 1000
+        assert bucket_width(1000, buckets=2000, width=0) == 1
+
+
+class TestTransientSurvives:
+    """Il difetto che apre la issue: un picco piu' stretto di un bucket."""
+
+    def _signal_with_spike(self, sr=SR, seconds=5.0, spike_at=2.5, width=30):
+        audio = tone(seconds, sr=sr).astype(np.float64)
+        i = int(spike_at * sr)
+        audio[i:i + width] = 1.0
+        return audio
+
+    def test_subsampling_loses_it(self):
+        """La prova del difetto, non del rimedio: il vecchio `audio[::200]` non
+        pesca mai un transiente di 30 campioni, e la waveform disegnata
+        dichiara un picco di meta' scala su un segnale che arriva a fondo."""
+        audio = self._signal_with_spike()
+        assert np.max(np.abs(audio[::200])) < 0.9
+
+    def test_the_min_max_envelope_keeps_it(self):
+        audio = self._signal_with_spike()
+        _, amplitude = peak_envelope(audio, SR, buckets=2000)
+        assert np.max(np.abs(amplitude)) == pytest.approx(1.0)
+
+    def test_the_spike_lands_in_its_own_bucket_not_smeared_over_the_curve(self):
+        """Non basta che il picco compaia: deve comparire *dove sta*. Il bucket
+        che copre l'istante del transiente e' l'unico a toccare fondo scala."""
+        audio = self._signal_with_spike(spike_at=2.5)
+        time_axis, amplitude = peak_envelope(audio, SR, buckets=2000)
+        at_full_scale = time_axis[np.abs(amplitude) > 0.99]
+        assert at_full_scale.size > 0
+        assert np.all(np.abs(at_full_scale - 2.5) < 5.0 / 2000)
+
+
+class TestMatplotlibLoadIsBounded:
+    """Il secondo motivo del rimedio: quanto lavoro arriva al disegno."""
+
+    @pytest.mark.parametrize('seconds', [1.0, 10.0, 120.0])
+    def test_vertex_count_does_not_grow_with_the_file(self, seconds):
+        audio = tone(seconds)
+        time_axis, amplitude = peak_envelope(audio, SR, buckets=500)
+        assert len(amplitude) <= 2 * 500
+        assert len(time_axis) == len(amplitude)
+
+    def test_the_old_stride_did_grow_with_it(self):
+        """Regressione dichiarata: col passo fisso un sample di due minuti
+        produceva 26mila vertici, uno di un secondo 220."""
+        assert len(tone(120.0)[::200]) > 100 * len(tone(1.0)[::200])
+
+    def test_a_short_sample_is_drawn_whole(self):
+        """L'altra meta': sotto il numero di bucket non si butta niente, e i
+        valori disegnati sono quelli del segnale."""
+        audio = np.array([0.0, 0.5, -0.5, 1.0], dtype=np.float64)
+        _, amplitude = peak_envelope(audio, sr=4, buckets=2000)
+        assert len(amplitude) == 2 * len(audio)
+        assert amplitude[0::2] == pytest.approx(amplitude[1::2])
+        assert amplitude[1::2] == pytest.approx(audio)
+
+
+class TestNormalization:
+    """La scala verticale del disegno."""
+
+    def test_the_curve_touches_full_scale(self):
+        _, amplitude = peak_envelope(tone(1.0, amp=0.3), SR)
+        assert np.max(np.abs(amplitude)) == pytest.approx(1.0)
+
+    def test_the_scale_does_not_depend_on_the_resolution(self):
+        """Il difetto silenzioso del vecchio codice: si normalizzava sul massimo
+        dei campioni sopravvissuti al passo, quindi abbassare la manopola per
+        avere piu' dettaglio *riscalava anche il disegno*. Chi confrontava due
+        partiture generate con due risoluzioni confrontava due scale diverse."""
+        audio = tone(2.0, amp=0.4).astype(np.float64)
+        audio[10_020:10_040] = 0.9
+        peaks = [np.max(np.abs(peak_envelope(audio, SR, buckets=b)[1]))
+                 for b in (200, 2000, 20_000)]
+        assert peaks == pytest.approx([1.0, 1.0, 1.0])
+
+    def test_the_old_stride_did_depend_on_it(self):
+        audio = tone(2.0, amp=0.4).astype(np.float64)
+        audio[10_020:10_040] = 0.9
+        assert np.max(np.abs(audio[::200])) != pytest.approx(
+            np.max(np.abs(audio[::20])))
+
+    def test_silence_stays_silent_instead_of_dividing_by_zero(self):
+        time_axis, amplitude = peak_envelope(np.zeros(10_000), SR)
+        assert np.all(amplitude == 0.0)
+        assert np.all(np.isfinite(time_axis))
+
+    def test_an_all_positive_signal_is_normalized_on_its_own_peak(self):
+        """Un segnale senza parte negativa (una curva di inviluppo salvata come
+        audio) ha il minimo sopra lo zero: il picco e' il massimo, non il
+        maggiore fra i due in valore assoluto letto alla cieca."""
+        audio = np.linspace(0.1, 0.8, 5000)
+        _, amplitude = peak_envelope(audio, SR, buckets=100)
+        assert np.max(amplitude) == pytest.approx(1.0)
+        assert np.min(amplitude) > 0.0
+
+
+class TestTimeAxis:
+    """Dove cade, nel tempo del sample, ogni coppia min/max."""
+
+    def test_time_and_amplitude_are_paired(self):
+        """I due punti di un bucket condividono l'istante: la coppia disegna il
+        segmento verticale che nella partitura e' la colonna della waveform."""
+        time_axis, _ = peak_envelope(tone(3.0), SR, buckets=400)
+        assert time_axis[0::2] == pytest.approx(time_axis[1::2])
+
+    def test_it_is_non_decreasing(self):
+        time_axis, _ = peak_envelope(tone(3.0), SR, buckets=400)
+        assert np.all(np.diff(time_axis) >= 0)
+
+    def test_it_covers_the_sample_without_overflowing_it(self):
+        """L'asse deve stare dentro la durata vera: e' lo stesso asse su cui
+        sono disegnati i grani, e una waveform stirata non ci si allinea."""
+        seconds = 3.0
+        time_axis, _ = peak_envelope(tone(seconds), SR, buckets=400)
+        assert time_axis[0] >= 0.0
+        assert time_axis[-1] <= seconds
+        assert time_axis[0] < seconds / 400
+        assert time_axis[-1] > seconds - seconds / 400
+
+    def test_the_old_axis_overflowed_on_short_samples(self):
+        """Regressione: `linspace(0, duration, len(audio[::ds]))` mappava
+        l'ultimo campione *pescato* sulla fine del sample. Su un sample corto
+        l'ultimo pescato e' lontano dalla fine, e la waveform veniva stirata."""
+        n, ds, sr = 500, 200, SR
+        drawn = np.linspace(0, n / sr, len(np.zeros(n)[::ds]))
+        real_last = ((n - 1) // ds) * ds / sr
+        assert drawn[-1] > real_last * 1.2
+
+    def test_min_comes_before_max_in_each_bucket(self):
+        _, amplitude = peak_envelope(tone(2.0), SR, buckets=300)
+        assert np.all(amplitude[0::2] <= amplitude[1::2])
+
+
+class TestInputShapes:
+    """Che cosa accetta in ingresso."""
+
+    def test_stereo_is_mixed_down_to_mono(self):
+        left = tone(1.0, amp=1.0).astype(np.float64)
+        stereo = np.stack([left, np.zeros_like(left)], axis=1)
+        time_axis, amplitude = peak_envelope(stereo, SR, buckets=200)
+        assert len(amplitude) <= 400
+        assert time_axis[-1] <= 1.0
+
+    def test_an_empty_buffer_yields_an_empty_curve(self):
+        """Un file di lunghezza zero non deve far esplodere il disegno: torna
+        una curva vuota, che matplotlib sa disegnare (niente)."""
+        time_axis, amplitude = peak_envelope(np.zeros(0), SR)
+        assert len(time_axis) == 0
+        assert len(amplitude) == 0
+
+    def test_integer_pcm_is_normalized_like_float(self):
+        audio = np.array([-32768, 0, 16384, 32767], dtype=np.int16)
+        _, amplitude = peak_envelope(audio, sr=4, buckets=2000)
+        assert np.max(np.abs(amplitude)) == pytest.approx(1.0)
+
+    def test_every_sample_is_covered_by_some_bucket(self):
+        """La proprieta' che rende il rimedio un rimedio: i bucket partizionano
+        il segnale, quindi il minimo e il massimo globali ci sono sempre."""
+        rng = np.random.default_rng(0)
+        audio = rng.normal(size=12_345)
+        _, amplitude = peak_envelope(audio, SR, buckets=97)
+        peak = np.max(np.abs(audio))
+        assert np.max(amplitude) == pytest.approx(np.max(audio) / peak)
+        assert np.min(amplitude) == pytest.approx(np.min(audio) / peak)
+
+
+class TestDefaultBuckets:
+    def test_the_default_is_generous_enough_for_print(self):
+        """La colonna della waveform su una pagina A4 a 300 dpi e' alta al
+        massimo un paio di migliaia di pixel: sotto quella soglia il dettaglio
+        si vedrebbe mancare, sopra si pagherebbe per pixel che non ci sono."""
+        assert DEFAULT_BUCKETS >= 1000

--- a/tests/rendering/test_waveform_peaks.py
+++ b/tests/rendering/test_waveform_peaks.py
@@ -24,6 +24,8 @@ campioni — deve esserlo, e' il prezzo per non perdere i picchi — ma quello c
 arriva a matplotlib e' costante.
 """
 
+import tracemalloc
+
 import numpy as np
 import pytest
 
@@ -271,3 +273,20 @@ class TestDegenerateInput:
         audio[1000] = np.nan
         _, amplitude = peak_envelope(audio, SR, buckets=200)
         assert np.nanmax(np.abs(amplitude)) == pytest.approx(1.0)
+
+    def test_the_last_partial_bucket_does_not_copy_the_buffer(self):
+        """L'argomento di #233 e' che il costo smette di dipendere dalla
+        durata. Vale per i vertici, e deve valere anche per la memoria: se
+        l'ultimo bucket e' parziale — cioe' quasi sempre, perche' basta che la
+        lunghezza non sia multiplo esatto della larghezza — riempirlo con una
+        `concatenate` ricopia l'**intero** buffer per aggiungere in coda meno
+        di un bucket. Su dieci minuti sono duecento megabyte per duemila
+        campioni, e su uno stereo si sommano alla copia del mixdown."""
+        audio = np.zeros(2_000_001)  # non multiplo di w: ultimo bucket parziale
+        tracemalloc.start()
+        try:
+            peak_envelope(audio, SR, buckets=2000)
+            _, allocated = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+        assert allocated < audio.nbytes / 10


### PR DESCRIPTION
Chiude #233 con il **fix migliore** (inviluppo min/max per bucket), non con il fix rapido.

Il codice è stato riletto da capo senza fidarsi della diagnosi della issue, e il quadro è un po' più largo di come è scritto lì: il problema non è la *quantità* di dettaglio, è che la curva disegnata **non era una versione approssimata del segnale — era un artefatto della griglia di lettura**. Per questo il fix rapido proposto nella issue (`waveform_downsample` 200 → 20) non era un fix.

## Che cosa faceva

`ScoreVisualizer._load_waveform` riduceva il sample con `audio[::200]` e disegnava quello. Tre difetti, che sono tre difetti diversi (tutti verificati come regressione nei test, non solo asseriti):

**1. I transienti sparivano.** Un attacco largo meno del passo non veniva mai pescato. Misurato: un sample con un picco di 30 campioni a fondo scala veniva disegnato con ampiezza `0.51` invece di `1.00`.

**2. Aliasing.** Sottocampionare senza filtrare ripiega le frequenze alte su quelle basse. Una sinusoide a 220 Hz letta ogni 200 campioni (cioè a 220.5 Hz) veniva disegnata come un'onda a **0.4 Hz**. È questo il difetto che si vede sulla pagina, ed è il più grave dei tre perché non toglie informazione: ne aggiunge di falsa.

**3. La scala verticale seguiva la manopola.** Si normalizzava su `max(|audio[::ds]|)`, cioè sul massimo dei campioni *sopravvissuti*. Abbassare `waveform_downsample` per avere più dettaglio **riscalava anche il disegno** (picco `0.51` a ds=200, `1.00` a ds=50 sullo stesso file), quindi due partiture generate a risoluzioni diverse non erano confrontabili.

A questi si aggiungevano un asse temporale stirato (`linspace(0, duration, …)` mappava l'**ultimo campione pescato** sulla fine del sample — su un sample da 500 campioni la waveform veniva allungata di un quarto) e un costo proporzionale alla durata del file: 132mila vertici per un sample di dieci minuti, duecento per uno di un secondo.

## Prima / dopo, sulla pagina vera

Stesso sample (cinque note pizzicate: attacco netto, coda che decade), stessa pagina di partitura, stessa colonna. A sinistra il codice attuale, a destra questo branch:

| prima (`audio[::200]`) | dopo (min/max, 2000 bucket) |
| --- | --- |
| lobo asimmetrico, pettine di ondulazioni al posto del decadimento, attacchi invisibili | attacco netto e decadimento simmetrico attorno allo zero: si leggono cinque note pizzicate |

La forma a sinistra non è una semplificazione di quella a destra — è un'altra forma. La review in questo thread ha misurato quanto: errore medio `0.2597` contro `0.0000`, e i cinque attacchi letti a **zero** invece che al loro valore esatto. La descrizione qui sopra è se mai generosa.

## Il rimedio

Inviluppo **min/max per bucket**, come disegna la waveform qualunque editor audio: si legge **ogni** campione, il segnale si divide in bucket, e di ogni bucket si tiene la coppia (minimo, massimo). Il picco c'è sempre, perché i bucket partizionano il segnale.

La lettura resta lineare nei campioni — deve esserlo, è il prezzo per non perderli — ma **quel che arriva a matplotlib è limitato dai bucket, non dalla durata**:

| sample | campioni | vertici prima | vertici dopo | costo riduzione |
| --- | --- | --- | --- | --- |
| 5 s | 220 500 | 1 103 | 3 974 | 0.9 ms |
| 60 s | 2 646 000 | 13 230 | 4 000 | 4.3 ms |
| 600 s | 26 460 000 | 132 300 | 4 000 | 36 ms |
| 600 s + 1 campione | 26 460 001 | 132 300 | 4 000 | 16 ms, 0.1 MB extra |

L'ultima riga esiste per un motivo: le prime tre sono cadute tutte su lunghezze **multiple esatte** della larghezza del bucket, che è il caso in cui la prima stesura di questa PR saltava il ramo costoso. Vedi il punto 1 della review qui sotto.

Nota la seconda riga in giù: **più dettaglio e meno lavoro insieme**. E la prima riga è l'altra metà — sotto il numero di bucket non si butta niente, quindi un sample corto viene ora disegnato *intero* invece che a manciate di punti.

La regola vive nel modulo puro `rendering.waveform_peaks` (numpy e basta, niente matplotlib e niente I/O), come gli altri moduli della famiglia: `_load_waveform` resta l'adapter che apre il file, legge la config e tiene la cache. Verificare che un picco di trenta campioni sopravviva alla riduzione ora richiede un array, non un `Generator` finto e la pila di plotting.

## Superficie pubblica

**Nuova**: `waveform_buckets` (default `2000`) — quante colonne min/max disegnare. È una risoluzione, non un passo.

**`waveform_downsample` resta e non è un errore passarla**, ma il default scende da `200` a `None` e il significato si sposta di un passo: era il passo del sottocampionamento, ora è la **larghezza del bucket in campioni**, e se data vince su `waveform_buckets`. Chi la passava ottiene la stessa densità di colonne di prima, con dentro il picco invece di un campione a caso.

Non è stata rimossa di proposito: la config di `ScoreVisualizer` è superficie pubblica (passa da `api.export_score_pdf` e dagli esempi del paper), e chiedere la risoluzione in campioni è legittimo — è come si confrontano allo stesso dettaglio due sample di lunghezza diversa.

L'avvertenza della issue resta vera, e vale per **entrambe** le manopole: `waveform_downsample: 1` su un sample lungo produce ancora milioni di vertici, e `waveform_buckets` più grande della lunghezza del sample arriva allo stesso tetto (`2 * len(audio)`) per la strada opposta. Nessuna delle due è tagliata verso l'alto: chiedere una risoluzione più fine del segnale è legittimo quanto chiederla più grossolana, ed è esplicito in entrambi i casi.

## Extra nella stessa passata

Il **sample che non si apre** si prova ora una volta sola. La waveform fittizia del ramo d'errore non finiva in cache, quindi ogni subplot di ogni pagina ritentava l'apertura e ristampava lo stesso avviso — due volte per stream, una per la durata e una per il disegno — mentre il commento in cima al ciclo dichiarava il contrario.

## Test

`make tests` verde (nessun test preesistente modificato). **+55 test nuovi**:

- `tests/rendering/test_waveform_peaks.py` (31) — il modulo puro: bucketing e clamp della larghezza sulla lunghezza del segnale, transiente, limite sui vertici, normalizzazione nan-safe, asse temporale, stereo, PCM intero, buffer vuoto, e la regressione sulla memoria dell'ultimo bucket;
- `tests/rendering/test_score_visualizer.py` (+20) — che `_load_waveform` la usi davvero, che le manopole ci arrivino, il file di lunghezza zero, e la cache del ramo d'errore;
- `tests/rendering/test_visualizer_config.py` (+4) — le due chiavi e la retrocompatibilità.

Quattro test sono **regressioni dichiarate**: asseriscono che il *vecchio* codice sbagliava (il transiente perso, la scala che segue la manopola, l'asse stirato, i vertici che crescono col file). Senza, i test corrispondenti passerebbero anche su un'implementazione che azzecca il caso per fortuna.

## Impatto cross-repo

- **PGE-ls** — nessuno. La modifica non tocca sintassi YAML, bounds, nomi di strategy/window/renderer né la gerarchia degli errori.
- **PGE-ui** — nessuno. Verificato: né `waveform_downsample` né `waveform_buckets` compaiono nel repo, e la waveform dei clip in timeline è disegnata da `ClipWaveform` sui peak del proprio stem, senza passare dallo score visualizer.
- **`cim2026-granular-engine-paper`** — **da valutare**, ed è l'unico punto che richiede una decisione umana. La regola `submodule-sync-cim.md` scatta (il rendering della partitura cambia, e gli esempi del paper passano da `ScoreVisualizer`). Non è "rigenera le figure", è **riguarda le figure**: se gli attacchi passano da assenti a esatti, quello che il paper mostra oggi non è quello che mostrerà. Il repo del paper non è nello scope GitHub di questa sessione, quindi il bump non è stato proposto lì: va deciso a parte.

## Note per chi rilegge

- **Cambia il disegno, non l'audio.** Nessun renderer legge questo codice.
- **Non c'è padding.** I bucket pieni sono una `reshape` di una *fetta*, che è una view e non copia niente; l'ultimo bucket, se parziale, si riduce da sé — min e max non hanno bisogno che sia della misura giusta. Riempirlo fino alla misura costava una copia dell'**intero** buffer ogni volta che la lunghezza non è multiplo esatto della larghezza, cioè quasi sempre: 211 MB su dieci minuti di audio per aggiungere in coda meno di duemila campioni. Che la versione senza riempimento dia risultati identici bit per bit (verificato su centinaia di combinazioni di `(n, buckets, width)`) è anche la prova che il riempimento era un no-op semantico.
- Il picco per la normalizzazione si legge da `mins`/`maxs`, non con una seconda passata sui campioni: i bucket partizionano il segnale, quindi il picco globale è già lì (su un sample lungo sarebbero milioni di letture per un numero che abbiamo in mano). È `nanmax`/`nanmin`: un solo NaN renderebbe NaN il picco, quindi falso il confronto `peak > 0`, quindi non normalizzata *tutta* la curva.
- Il `try` di `_load_waveform` copre la sola apertura del file. Un guasto della riduzione (memoria, manopola fuori scala) non è un file che non si apre, e travestirlo da tale lo renderebbe silenzioso — messo in cache, non ristampato più.
- `_draw_waveform_full` non è stato toccato: la coppia min/max condivide l'istante, quindi `plot` + `fill_betweenx` disegnano la colonna esattamente come prima.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzuwND7bodJp6SFH16Eu6A
