### PR TITLE
refactor(pointer): loop_unit non eredita più da time_mode (#222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,15 +138,15 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
   **`loop_unit` ha ora un vocabolario**: `seconds` (canonico, allineato a
   `grain.duration_unit` — l'unità nata «sul modello di `loop_unit`»),
-  `absolute` (alias storico, quello che `configs/PGE_cim.yml` scrive in undici
-  blocchi pointer) e `normalized`. Fuori di lì è `InvalidFieldValueError` con
-  `stream_id` e hint, come per `grain.duration_unit`. Prima qualunque stringa
-  diversa da `normalized` voleva dire "assoluto": `normalised`, `Normalized`,
-  `loop_unite` spegnevano la conversione senza un errore — e sotto
-  l'ereditarietà il refuso era peggio che inerte, perché su uno stream
-  `normalized` *cambiava* il risultato invece di lasciarlo com'era. Cambia
-  anche `loop_unit:` scritto e lasciato vuoto: era `None`, cioè falsy, cioè
-  ereditarietà; ora è un errore.
+  `absolute` (alias storico, quello che `configs/PGE_cim.yml` scrive in dieci
+  dei suoi ventuno blocchi pointer) e `normalized`. Fuori di lì è
+  `InvalidFieldValueError` con `stream_id` e hint, come per
+  `grain.duration_unit`. Prima qualunque stringa diversa da `normalized` voleva
+  dire "assoluto": `normalised`, `Normalized`, `loop_unite` spegnevano la
+  conversione senza un errore — e sotto l'ereditarietà il refuso era peggio che
+  inerte, perché su uno stream `normalized` *cambiava* il risultato invece di
+  lasciarlo com'era. Cambia anche `loop_unit:` scritto e lasciato vuoto: era
+  `None`, cioè falsy, cioè ereditarietà; ora è un errore.
 
   `start` resta legato a `loop_unit`, come prima e come documentato: è una
   posizione nel sample come `loop_start`, stesso dominio e stessa unità.
@@ -157,10 +157,11 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
   **Migrazione:** scrivere `loop_unit: normalized` nel blocco pointer. Per una
   release il motore lo dice da sé — un warning `[LOOP_UNIT]` che nomina le
-  chiavi interessate e la riga da aggiungere; poi si toglie. A differenza degli
-  altri avvisi del clip logger l'avviso esce su **stderr** anche quando la
-  console del clip logger è spenta, com'è sotto la CLI: un avviso che vive solo
-  in `./logs/` non raggiungerebbe chi lancia `make` e sente un suono diverso. In `configs/` i
+  chiavi interessate e la riga da aggiungere; poi si toglie, e la rimozione è
+  tracciata dalla issue #242. A differenza degli altri avvisi del clip logger
+  l'avviso esce su **stderr** anche quando la console del clip logger è spenta,
+  com'è sotto la CLI: un avviso che vive solo in `./logs/` non raggiungerebbe
+  chi lancia `make` e sente un suono diverso. In `configs/` i
   cinque stream interessati sono già stati resi espliciti
   (`PGE_pino3.yml`, `PGE_grain_height_demo.yml` ×2, `PGE_cim.yml` stream24,
   `PGE_pino4.yml`), quindi il corpus rende identico a prima.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,7 +157,10 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
   **Migrazione:** scrivere `loop_unit: normalized` nel blocco pointer. Per una
   release il motore lo dice da sé — un warning `[LOOP_UNIT]` che nomina le
-  chiavi interessate e la riga da aggiungere; poi si toglie. In `configs/` i
+  chiavi interessate e la riga da aggiungere; poi si toglie. A differenza degli
+  altri avvisi del clip logger l'avviso esce su **stderr** anche quando la
+  console del clip logger è spenta, com'è sotto la CLI: un avviso che vive solo
+  in `./logs/` non raggiungerebbe chi lancia `make` e sente un suono diverso. In `configs/` i
   cinque stream interessati sono già stati resi espliciti
   (`PGE_pino3.yml`, `PGE_grain_height_demo.yml` ×2, `PGE_cim.yml` stream24,
   `PGE_pino4.yml`), quindi il corpus rende identico a prima.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,64 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   passava inosservato: stava in una demo del repo, e si presentava come uno
   stream silenzioso invece che come un errore.
 
+### Modificato (breaking)
+
+- **`loop_unit` non eredita più da `time_mode`: il default è `seconds`**
+  (issue #222). Le due chiavi governavano due assi con due riferimenti diversi
+  e una sola parola: `time_mode: normalized` scala l'asse **X** (tempo) degli
+  envelope sulla `duration` dello stream, `loop_unit: normalized` scala l'asse
+  **Y** (valore) delle posizioni nel sample sulla `sample_dur_sec` del file
+  audio. La reference lo diceva già — §10.1, «I due possono coesistere» — e
+  trenta righe più su documentava che, se non dichiaravi `loop_unit`, la
+  seconda decisione la prendeva la prima.
+
+  **Il guasto peggiore non riguardava il loop.** La pre-normalizzazione scalava
+  `pointer.start` «indipendentemente dalla presenza di `loop_start`», e `start`
+  è `is_smart=False`, quindi non ha bounds: su uno stream `normalized` con un
+  sample da 8 secondi, `start: 2.0` diventava 16.0, wrappava modularmente e
+  rendeva un suono diverso da quello scritto — nessun errore, nessun log.
+  Uno stream che dichiara `time_mode` per i propri envelope non ha detto niente
+  sulla testina di lettura. Sui parametri di loop il bound dinamico
+  (`max_val = sample_dur_sec`) intercettava almeno il caso grosso; i valori che
+  restavano dentro il file passavano silenziosi.
+
+  **`loop_unit` ha ora un vocabolario**: `seconds` (canonico, allineato a
+  `grain.duration_unit` — l'unità nata «sul modello di `loop_unit`»),
+  `absolute` (alias storico, quello che `configs/PGE_cim.yml` scrive in undici
+  blocchi pointer) e `normalized`. Fuori di lì è `InvalidFieldValueError` con
+  `stream_id` e hint, come per `grain.duration_unit`. Prima qualunque stringa
+  diversa da `normalized` voleva dire "assoluto": `normalised`, `Normalized`,
+  `loop_unite` spegnevano la conversione senza un errore — e sotto
+  l'ereditarietà il refuso era peggio che inerte, perché su uno stream
+  `normalized` *cambiava* il risultato invece di lasciarlo com'era. Cambia
+  anche `loop_unit:` scritto e lasciato vuoto: era `None`, cioè falsy, cioè
+  ereditarietà; ora è un errore.
+
+  `start` resta legato a `loop_unit`, come prima e come documentato: è una
+  posizione nel sample come `loop_start`, stesso dominio e stessa unità.
+
+  **Chi lo vede:** solo gli stream con `time_mode: normalized`, **senza**
+  `loop_unit`, che dichiarano `pointer.start` o un parametro di loop con un
+  valore diverso da zero. Uno zero resta zero sotto qualunque fattore di scala.
+
+  **Migrazione:** scrivere `loop_unit: normalized` nel blocco pointer. Per una
+  release il motore lo dice da sé — un warning `[LOOP_UNIT]` che nomina le
+  chiavi interessate e la riga da aggiungere; poi si toglie. In `configs/` i
+  cinque stream interessati sono già stati resi espliciti
+  (`PGE_pino3.yml`, `PGE_grain_height_demo.yml` ×2, `PGE_cim.yml` stream24,
+  `PGE_pino4.yml`), quindi il corpus rende identico a prima.
+
+  `VARIATION_SEMANTICS_VERSION` passa da 2 a 3: il fingerprint di uno stem gira
+  sul dict YAML grezzo, quindi a YAML invariato l'hash non si muoverebbe, lo
+  stem resterebbe `clean` e si continuerebbe ad ascoltare l'audio con la
+  semantica vecchia. Un bump marca dirty ogni stream di ogni progetto: un
+  re-render completo al primo run, poi la cache incrementale riparte normalmente.
+
+  Fuori dal cambiamento: `stream.loop_start` espone il `Parameter` già
+  convertito, quindi `ScoreVisualizer` e i renderer non toccano mai il valore
+  grezzo. `PointerController` resta l'unico lettore di `loop_unit`, come
+  `Stream._pre_normalize_grain_params` è l'unico di `duration_unit`.
+
 ### Modificato
 
 - **Il renderer NumPy ignora `envelope` sotto i 10 campioni (208.3 µs).** A

--- a/configs/PGE_cim.yml
+++ b/configs/PGE_cim.yml
@@ -581,6 +581,10 @@ streams:
       duration: [[0, 0.01], [0.1222, 0.0098], [0.2231, 0.0099], [0.2564, 0.3972], [0.2604, 0.0001], [0.3468, 0.0001], [0.3623, 0.1063], [0.3664, 0.0107], [0.4966, 0.0148], [0.533, 0.0071], [1, 0.001]]
       envelope: rexporise
     pointer:
+      # loop_unit esplicito da #222: `start` e' una frazione del sample, come
+      # il pointer_range delle voci qui sotto (normalized: true). Prima lo
+      # ereditava da time_mode; renderlo esplicito tiene il render identico.
+      loop_unit: normalized
       start: 0.6
       speed_ratio: 0.25
     pitch:

--- a/configs/PGE_grain_height_demo.yml
+++ b/configs/PGE_grain_height_demo.yml
@@ -39,6 +39,9 @@ streams:
       duration: 0.25
       envelope: expodec
     pointer:
+      # loop_unit esplicito da #222: `start` e' una frazione del sample (il
+      # file di demo dura ~4 s), non secondi. Prima lo ereditava da time_mode.
+      loop_unit: normalized
       start: 0.12
       speed_ratio: 0
     pitch:
@@ -64,6 +67,9 @@ streams:
       envelope: expodec
       reverse:
     pointer:
+      # loop_unit esplicito da #222: `start` e' una frazione del sample (il
+      # file di demo dura ~4 s), non secondi. Prima lo ereditava da time_mode.
+      loop_unit: normalized
       start: 0.88
       speed_ratio: 0
     pitch:

--- a/configs/PGE_pino3.yml
+++ b/configs/PGE_pino3.yml
@@ -34,6 +34,9 @@ streams:
       duration_range: 0.02
       reverse: null
     pointer:
+      # loop_unit esplicito da #222: loop_start e loop_dur sono frazioni del
+      # sample, non secondi. Prima lo ereditavano da time_mode.
+      loop_unit: normalized
       speed_ratio: "-.03"
       loop_start: 0.25
       loop_dur: [[[0, 0.6], [100, 0.1]], 1, 5]

--- a/configs/PGE_pino4.yml
+++ b/configs/PGE_pino4.yml
@@ -34,6 +34,11 @@ streams:
     #range_always_active:
     sample: "002-34_468-3_219.wav"
     pointer:
+      # loop_unit esplicito da #222: `start` e' una frazione del sample. La
+      # riga qui sotto e' commentata (e ha un refuso nel nome), quindi non ha
+      # mai avuto effetto: quel che si sente e' sempre stato normalized,
+      # ereditato da time_mode.
+      loop_unit: normalized
       #loop_unite: absolute
       speed_ratio: -.03
       offset_range: [[[0,.02], [100,.6]],1,5]

--- a/docs/plans/2026-08-26-001-refactor-loop-unit-independent-plan.md
+++ b/docs/plans/2026-08-26-001-refactor-loop-unit-independent-plan.md
@@ -186,19 +186,35 @@ La issue elenca tre config. Il corpus completo ne conta **dieci** stream con
 `time_mode: normalized` e una posizione dichiarata senza `loop_unit`; di questi,
 quelli in cui il numero si muove sono quattro:
 
-| config / stream | valore | cosa cambia |
+| config / stream | valore | perche' e' una frazione |
 |---|---|---|
-| `PGE_pino3.yml` / `texture1#2` | `loop_start: 0.25`, `loop_dur` envelope | **va corretto**: e' una frazione |
-| `PGE_grain_height_demo.yml` / `sweep_forward` | `start: 0.12` | **va corretto**: 12% del file, con `speed_ratio: 0` |
-| `PGE_grain_height_demo.yml` / `sweep_reverse` | `start: 0.88` | **va corretto**: 88% del file, e' la coppia del precedente |
-| `PGE_cim.yml` / `stream24` | `start: 0.6` | si lascia: in `PGE_cim` `start` e' scritto in secondi ovunque (`1.47`, `0.35`, `1.1`), la nuova lettura e' quella giusta |
-| `PGE_pino4.yml` / `texture1` (2°) | `start: 0.6` | si lascia: accanto c'e' `#loop_unite: absolute` commentato, cioe' l'intenzione dichiarata dall'autore e' proprio "assoluto" |
+| `PGE_pino3.yml` / `texture1#2` | `loop_start: 0.25`, `loop_dur` envelope | il caso che la issue aveva gia' censito |
+| `PGE_grain_height_demo.yml` / `sweep_forward` | `start: 0.12` | 12% di un file che l'intestazione dichiara «~4 s», con `speed_ratio: 0` |
+| `PGE_grain_height_demo.yml` / `sweep_reverse` | `start: 0.88` | 88%, ed e' la coppia speculare del precedente: in secondi i due sweep collasserebbero nel primo secondo del file |
+| `PGE_cim.yml` / `stream24` | `start: 0.6` | tutto il blocco pointer di quello stream ragiona in frazioni: `voices.pointer` ha `normalized: true` con `pointer_range: 1` |
+| `PGE_pino4.yml` / `texture1` (2°) | `start: .6` | il `#loop_unite: absolute` accanto e' commentato **e** ha un refuso nel nome, quindi non ha mai avuto effetto: quel che si sente e' sempre stato normalized |
 
 Gli altri sei hanno `start: 0` e non si accorgono di niente.
+
+A tutti e cinque si aggiunge `loop_unit: normalized`, cioe' si scrive l'unita'
+che era in vigore: il corpus rende identico a prima e nessuno dei suoi stream
+emette l'avviso di migrazione. E' la direzione conservativa — questo piano
+toglie un accoppiamento implicito, non ridiscute le scelte di nessuno — ed e'
+la ragione per cui tocca anche i due config che la issue dava per invariati:
+la issue li dava per tali perche' «dichiarano gia' la chiave», che e' vero per
+undici blocchi pointer di `PGE_cim.yml` e falso per il dodicesimo.
 
 `PGE_grain_height_demo.yml` e' il caso che la issue non aveva visto, ed e' il
 piu' netto: `0.88` secondi su un file di demo non e' un numero che qualcuno
 scrive, `88%` si'.
+
+### Un refuso che resta fuori portata
+
+`configs/PGE_pino4.yml` scrive `loop_unite` (commentato). Il vocabolario nuovo
+intercetta il valore sbagliato di una chiave giusta, non il nome sbagliato di
+una chiave: `loop_unite` resta una chiave ignota che il blocco pointer accetta
+in silenzio. Validare le chiavi ignote e' un lavoro suo — vale per ogni blocco,
+non solo per questo — e non entra qui.
 
 ### Fuori dal cambiamento
 

--- a/docs/plans/2026-08-26-001-refactor-loop-unit-independent-plan.md
+++ b/docs/plans/2026-08-26-001-refactor-loop-unit-independent-plan.md
@@ -1,0 +1,276 @@
+---
+title: "refactor(pointer): loop_unit non eredita piu' da time_mode"
+type: refactor
+status: active
+date: 2026-08-26
+issue: 222
+---
+
+# refactor(pointer): `loop_unit` non eredita piu' da `time_mode`
+
+## Overview
+
+Una riga sola, `pointer_controller.py:208`:
+
+```python
+loop_unit = params.get('loop_unit') or self._config.time_mode
+```
+
+Da qui un keyword governa due assi con due riferimenti diversi. `time_mode`
+scala l'asse **X** (tempo) degli envelope sulla `duration` dello stream;
+`loop_unit` scala l'asse **Y** (valore) delle posizioni nel sample sulla
+`sample_dur_sec` del file audio. Asse diverso, grandezza diversa, dominio
+diverso — la timeline della composizione contro la lunghezza di un file su
+disco. La reference lo dice gia' (§10.1, «I due possono coesistere») e trenta
+righe piu' su documenta che, se non dichiari `loop_unit`, la seconda decisione
+la prende la prima.
+
+Il piano stacca le due chiavi: default `seconds` indipendente, vocabolario
+esplicito, unita' sconosciuta che diventa errore.
+
+---
+
+## Problem Frame
+
+Misurato su `PointerController` con `sample_dur_sec = 8.0`:
+
+```
+time_mode='absolute'  (il default)
+  start: 2.0, NESSUN loop                      -> start=2.0
+  loop_start: 2.0 / loop_dur: 1.0              -> loop_start=2.0
+  loop_start: 0.25 (+ loop_unit: normalised)   -> loop_start=0.25
+
+time_mode='normalized'  (dichiarato per gli envelope)
+  start: 2.0, NESSUN loop                      -> start=16.0
+  loop_start: 2.0 / loop_dur: 1.0              -> ParameterBoundError: 16.0
+  loop_start: 0.25 (+ loop_unit: normalised)   -> loop_start=0.25
+```
+
+Tre guasti, in ordine di gravita':
+
+1. **`pointer.start` viene spostato in silenzio, anche senza nessun loop.** La
+   pre-normalizzazione scala `start` «indipendentemente dalla presenza di
+   `loop_start`». `start` e' `is_smart=False`, quindi non ha bounds: 16.0 su un
+   file da 8 secondi non solleva niente, wrappa modularmente e rende un suono
+   diverso da quello scritto. Uno stream che dichiara `time_mode` per i propri
+   envelope non ha detto niente sulla testina di lettura.
+2. **I valori loop cambiano dominio senza che nessuno l'abbia chiesto.** Qui il
+   bound dinamico `max_val = sample_dur_sec` intercetta il caso grosso; i
+   valori che restano dentro il file passano silenziosi.
+3. **`loop_unit` non ha vocabolario.** Qualunque stringa diversa da
+   `'normalized'` significa "assoluto": `normalised`, `Normalized`,
+   `loop_unite` (il refuso sta scritto in `configs/PGE_pino4.yml:12`) spengono
+   la conversione senza un errore. Sotto l'ereditarieta' il refuso e' peggio
+   che inerte: su uno stream `normalized` *cambia* il risultato invece di
+   lasciarlo com'era.
+
+C'e' un quarto caso, che la issue non nomina: `loop_unit:` scritto **vuoto**.
+Lo `or` lo tratta come assente (`None` e' falsy) e fa scattare l'ereditarieta',
+quindi anche una chiave dichiarata a meta' finisce per farsi decidere da
+`time_mode`.
+
+### L'ereditarieta' non sta risparmiando niente a nessuno
+
+Nel corpus dei config, chi combina le due chiavi o riscrive `loop_unit` a mano
+o non se ne accorge:
+
+| config | cosa dichiara | perche' |
+|---|---|---|
+| `PGE_cim.yml` | `time_mode: normalized` + `loop_unit: absolute` (11 volte) | l'autore vuole i secondi e deve **annullare** l'ereditarieta' a mano |
+| `PGE_pino2.yml` | `time_mode: normalized` + `loop_unit: normalized` | ridondante: lo erediterebbe comunque |
+| `PGE_pino3.yml` | `time_mode: normalized`, nessun `loop_unit` | l'unico che ci si appoggia davvero per il loop |
+
+### Il precedente che decide la questione
+
+`grain.duration_unit` e' nato dopo, dichiaratamente «sul modello di
+`loop_unit`» (CHANGELOG v5.1.0), e ha fatto le tre scelte opposte:
+
+| | `loop_unit` | `grain.duration_unit` |
+|---|---|---|
+| default | eredita da `time_mode` | `seconds`, indipendente |
+| vocabolario | implicito (`!= 'normalized'`) | `('seconds', 'samples', 'milliseconds')` |
+| unita' sconosciuta | silenzio, vale "assoluto" | `InvalidFieldValueError` con hint |
+
+Il meccanismo di conversione e' gia' condiviso (`scale_raw_param_values`).
+Quel che manca a `loop_unit` e' solo il contorno che `duration_unit` si e'
+portato dietro: non e' un'invenzione, e' allineare la chiave piu' vecchia a
+quella che l'ha copiata.
+
+---
+
+## Design
+
+### 1. Default indipendente
+
+`loop_unit` smette di leggere `self._config.time_mode`. Assente = `seconds`.
+
+### 2. Vocabolario esplicito
+
+```python
+LOOP_UNITS = ('seconds', 'absolute', 'normalized')
+```
+
+`seconds` e' la grafia canonica (allineata a `duration_unit`), `absolute`
+l'alias storico — quello che `PGE_cim.yml`, la reference e gli hover di PGE-ls
+hanno sempre scritto. Sono la stessa lettura: valori gia' in secondi assoluti.
+Tenere l'alias costa una voce di tupla e tiene validi 11 blocchi pointer del
+config di punta; toglierlo avrebbe voluto dire riscriverli tutti per guadagnare
+una grafia in meno.
+
+### 3. Unita' sconosciuta -> errore
+
+`InvalidFieldValueError(field='pointer.loop_unit', ...)` con `stream_id` e hint
+che elenca le unita', sulla forma di `Stream._pre_normalize_grain_params`. La
+validazione scatta **quando la chiave e' presente**, non quando serve: un
+`loop_unit` scritto su uno stream che non ha ancora parametri di posizione e'
+comunque un refuso da segnalare. Di riflesso il `loop_unit:` vuoto diventa
+errore invece che ereditarieta' silenziosa.
+
+### 4. `start` resta legato a `loop_unit`
+
+Non cambia: `start` e' una posizione nel sample come `loop_start`, stesso
+dominio, stessa unita' (§10.1 della reference lo documenta gia'). Dopo la
+modifica smette semplicemente di essere scalato da una chiave che parla d'altro.
+Il nome `loop_unit` resta imperfetto — governa anche una chiave che loop non e'
+— ma rinominarlo e' un breaking piu' largo di questo, e non e' quello che la
+issue chiede.
+
+### 5. Warning di migrazione
+
+Una release, poi si toglie (marcato `# ponytail:`). Con `time_mode: normalized`,
+nessun `loop_unit` e una posizione dichiarata, il motore nomina il cambio di
+semantica e dice cosa scrivere per riavere il comportamento precedente.
+
+**Divergenza deliberata dalla issue.** Il warning parla solo a chi cambia
+davvero: un valore `0` vale zero sotto qualunque fattore di scala, quindi
+`start: 0` non ha niente da migrare. Senza questo filtro il corpus di `configs/`
+emetterebbe **undici** avvisi (`PGE_cim` ×5, `PGE_test` ×4,
+`PGE_cubic_smoothstep_demo` ×2) su stream in cui non si muove un campione, e i
+tre veri finirebbero in mezzo al rumore.
+
+**Seconda divergenza deliberata.** La issue propone di usare `log_config_warning`
+perche' e' «gia' importato» in `pointer_controller.py`. Non e' riusabile: la sua
+firma e' `(stream_id, param_name, raw_value, clipped_value, min_val, max_val,
+value_type)` e formatta un valore clippato contro un bound
+(`raw={:>12.6f} -> clip={:>12.6f}`). Un messaggio di migrazione non ha nessuna
+di quelle grandezze. Va aggiunta invece una `log_loop_unit_migration_warning`
+in `shared/logger.py`, sulla forma di `log_window_curve_warning`: e' la
+convenzione del modulo — una funzione per tipo di avviso, tag `[NOME]`,
+`stream_id` in testa, `get_clip_logger()` che puo' tornare `None`.
+
+### 6. Cache incrementale
+
+Il fingerprint si calcola sul dict YAML grezzo: a YAML invariato l'hash non si
+muove, lo stem resta `clean` e si continuerebbe ad ascoltare l'audio
+renderizzato con la semantica vecchia. E' esattamente il caso per cui
+`VARIATION_SEMANTICS_VERSION` esiste: bump 2 -> 3.
+
+---
+
+## Impatto
+
+| file | cosa cambia |
+|---|---|
+| `src/pge/controllers/pointer_controller.py` | il default, `LOOP_UNITS`, la validazione, il warning |
+| `src/pge/shared/logger.py` | nuova `log_loop_unit_migration_warning` |
+| `src/pge/rendering/stream_cache_manager.py` | `VARIATION_SEMANTICS_VERSION` 2 -> 3 |
+| `configs/PGE_pino3.yml` | `loop_unit: normalized` su `texture1#2` |
+| `configs/PGE_grain_height_demo.yml` | `loop_unit: normalized` sui due sweep |
+| `tests/controllers/test_pointer_controller.py` | tre test da ripilotare, sei nuovi |
+| `docs/reference/yaml.md` | Blocco Pointer, §3.3(c), §10.1, tabella delle forme |
+| `CHANGELOG.md` | voce breaking semantico |
+
+### Config: il raggio reale e' piu' largo di quello della issue
+
+La issue elenca tre config. Il corpus completo ne conta **dieci** stream con
+`time_mode: normalized` e una posizione dichiarata senza `loop_unit`; di questi,
+quelli in cui il numero si muove sono quattro:
+
+| config / stream | valore | cosa cambia |
+|---|---|---|
+| `PGE_pino3.yml` / `texture1#2` | `loop_start: 0.25`, `loop_dur` envelope | **va corretto**: e' una frazione |
+| `PGE_grain_height_demo.yml` / `sweep_forward` | `start: 0.12` | **va corretto**: 12% del file, con `speed_ratio: 0` |
+| `PGE_grain_height_demo.yml` / `sweep_reverse` | `start: 0.88` | **va corretto**: 88% del file, e' la coppia del precedente |
+| `PGE_cim.yml` / `stream24` | `start: 0.6` | si lascia: in `PGE_cim` `start` e' scritto in secondi ovunque (`1.47`, `0.35`, `1.1`), la nuova lettura e' quella giusta |
+| `PGE_pino4.yml` / `texture1` (2°) | `start: 0.6` | si lascia: accanto c'e' `#loop_unite: absolute` commentato, cioe' l'intenzione dichiarata dall'autore e' proprio "assoluto" |
+
+Gli altri sei hanno `start: 0` e non si accorgono di niente.
+
+`PGE_grain_height_demo.yml` e' il caso che la issue non aveva visto, ed e' il
+piu' netto: `0.88` secondi su un file di demo non e' un numero che qualcuno
+scrive, `88%` si'.
+
+### Fuori dal cambiamento
+
+`stream.loop_start` (`core/stream.py:867`) espone il `Parameter` gia'
+convertito, quindi `ScoreVisualizer` (`score_visualizer.py:983-985`) e i
+renderer non toccano mai il valore grezzo. `pointer_controller` resta l'unico
+lettore di `loop_unit`, come `Stream._pre_normalize_grain_params` e' l'unico di
+`duration_unit`.
+
+---
+
+## Test
+
+Criterio d'accettazione, con `sample_dur_sec = 8.0` e `time_mode: normalized`
+dichiarato sullo stream:
+
+| caso | oggi | atteso dopo |
+|---|---|---|
+| `start: 2.0`, nessun loop | 16.0 | 2.0 |
+| `loop_start: 2.0`, `loop_dur: 1.0` | ParameterBoundError (16.0) | 2.0 / 1.0 |
+| `loop_start: 0.25` + `loop_unit: normalized` | 2.0 | 2.0 |
+| `loop_start: 0.25` + `loop_unit: absolute` | 0.25 | 0.25 |
+| `loop_start: 0.25` + `loop_unit: seconds` | 0.25 | 0.25 |
+| `loop_unit: normalised` (refuso) | 0.25, silenzioso | `InvalidFieldValueError` |
+| `loop_unit:` vuoto | eredita da `time_mode` | `InvalidFieldValueError` |
+
+Piu' il test che conta: su uno stream `time_mode: normalized` **e**
+`loop_unit: normalized`, un envelope su `loop_start` deve avere l'asse X ancora
+scalato sulla `duration` dello stream e l'asse Y sulla `sample_dur_sec`. E' la
+coesistenza documentata in §10.1, e non deve regredire. Va scritto contro un
+`StreamConfig` e un `ParameterOrchestrator` **reali**: i test di
+`TestPreNormalization` mockano l'orchestratore, quindi vedono solo meta' della
+pipeline (la Y) e non potrebbero accorgersi della X.
+
+---
+
+## Non-goal
+
+- La semantica di `time_mode` sugli envelope non si tocca (ne' X, ne'
+  `time_unit`, ne' lo scaling del formato compatto).
+- Nessuna rinomina di `loop_unit`.
+- PGE-ls e PGE-ui non si toccano: hanno le loro issue di follow-up.
+
+## Follow-up cross-repo
+
+La regola `.claude/rules/cross-repo-impact.md` chiede una issue per repo
+interessato. Qui ce ne sono due, e la seconda e' piu' grave di quanto la issue
+#222 lasci intendere (che PGE-ui non lo nomina affatto).
+
+- **PGE-ls** — documentazione dell'ereditarieta' nei suggerimenti
+  (`completion_provider.py`, `clients/vscode/README.md`, secondo i riferimenti
+  raccolti nella issue #222) e vocabolario nelle completion dei valori.
+  Impatto: testi di hover disallineati. Nessun rischio sull'audio.
+
+- **PGE-ui** — non e' solo documentazione: il fallback e' **ricalcato in
+  codice**, e ci scrive dentro.
+
+  `loopUnitInfo` (`src/lib/envelope-utils.js:507`) dichiara di essere lo
+  specchio della riga che questo piano cambia, e ne eredita il ramo
+  `source: "time_mode"`. Due conseguenze concrete:
+
+  1. `Inspector.jsx:1066` — `if (u === loopUnitInherited) delete np.loopUnit;
+     else np.loopUnit = u;`. Su uno stream `time_mode: normalized`, scegliere
+     "normalized" **cancella** la chiave perche' la crede ridondante. Dopo
+     questo piano quello YAML significa secondi: l'editor mostrerebbe una
+     scelta e ne scriverebbe l'opposta.
+  2. `app.jsx:1001` (`splitAtPlayhead`) scrive `pointer.start` come
+     `ptr.pos / sampleDur` quando l'unita' risolve a `normalized`. Ogni stream
+     che l'editor crea nasce `time_mode: normalized` senza `loop_unit`, quindi
+     e' il caso ordinario: dopo il cambio la coda dello split riprenderebbe da
+     una posizione sbagliata.
+
+  Va aggiunto anche il vocabolario: oggi il commento dice «anything other than
+  "normalized" means absolute seconds — the engine only ever tests
+  `!= 'normalized'`», che dopo questo piano non e' piu' vero.

--- a/docs/plans/done/2026-08-26-001-refactor-loop-unit-independent-plan.md
+++ b/docs/plans/done/2026-08-26-001-refactor-loop-unit-independent-plan.md
@@ -137,7 +137,8 @@ issue chiede.
 
 ### 5. Warning di migrazione
 
-Una release, poi si toglie (marcato `# ponytail:`). Con `time_mode: normalized`,
+Una release, poi si toglie (marcato `# ponytail:`, rimozione tracciata
+dalla issue #242). Con `time_mode: normalized`,
 nessun `loop_unit` e una posizione dichiarata, il motore nomina il cambio di
 semantica e dice cosa scrivere per riavere il comportamento precedente.
 
@@ -202,7 +203,9 @@ emette l'avviso di migrazione. E' la direzione conservativa — questo piano
 toglie un accoppiamento implicito, non ridiscute le scelte di nessuno — ed e'
 la ragione per cui tocca anche i due config che la issue dava per invariati:
 la issue li dava per tali perche' «dichiarano gia' la chiave», che e' vero per
-undici blocchi pointer di `PGE_cim.yml` e falso per il dodicesimo.
+quindici dei ventuno blocchi pointer di `PGE_cim.yml` (dieci `absolute`, cinque
+`normalized`) e falso per i sei restanti — uno dei quali, `stream24`, ha una
+posizione non nulla e va migrato.
 
 `PGE_grain_height_demo.yml` e' il caso che la issue non aveva visto, ed e' il
 piu' netto: `0.88` secondi su un file di demo non e' un numero che qualcuno

--- a/docs/plans/done/2026-08-26-001-refactor-loop-unit-independent-plan.md
+++ b/docs/plans/done/2026-08-26-001-refactor-loop-unit-independent-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "refactor(pointer): loop_unit non eredita piu' da time_mode"
 type: refactor
-status: active
+status: done
 date: 2026-08-26
 issue: 222
 ---

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -13,7 +13,7 @@ sources:
   - src/pge/shared/seeding.py
   - src/pge/shared/distribution_strategy.py
   - src/pge/rendering/numpy_window_registry.py
-last_synced_commit: 8bbfd75
+last_synced_commit: fb01d7f
 entry_for: [yaml-syntax, envelope-syntax]
 ---
 
@@ -704,7 +704,7 @@ nel sample, stesso dominio. Il vocabolario è chiuso — `seconds`, `absolute`,
 `normalized` — e un'unità fuori da quello è `InvalidFieldValueError`, non un
 silenzioso "assoluto".
 
-Fino alla v7.2.0 `loop_unit` assente ereditava da `time_mode`: uno stream
+Fino alla v8.0.0 inclusa `loop_unit` assente ereditava da `time_mode`: uno stream
 `normalized` vedeva `start` e i parametri di loop scalati per `sample_dur_sec`
 anche senza nessun loop dichiarato. Le due chiavi parlano di assi diversi (vedi
 §10.1) e ora sono indipendenti. (issue #222)
@@ -2091,7 +2091,7 @@ pointer:
 Con un sample da 8 secondi: a `t=0` il loop parte da 2.0 s del file, a `t=20`
 da 6.0 s, a metà stream da 4.0 s.
 
-**`loop_unit` non eredita da `time_mode`** (issue #222). Fino alla v7.2.0 lo
+**`loop_unit` non eredita da `time_mode`** (issue #222). Fino alla v8.0.0 inclusa lo
 faceva, e un solo keyword finiva per governare i due assi: uno stream che
 dichiarava `time_mode` per i propri envelope si vedeva spostare anche la
 testina di lettura, `start` compreso, senza aver detto niente al riguardo.

--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -6,13 +6,14 @@ tags: [yaml, syntax, parameters, envelopes]
 sources:
   - src/pge/engine/generator.py
   - src/pge/core/stream.py
+  - src/pge/controllers/
   - src/pge/parameters/
   - src/pge/strategies/
   - src/pge/envelopes/
   - src/pge/shared/seeding.py
   - src/pge/shared/distribution_strategy.py
   - src/pge/rendering/numpy_window_registry.py
-last_synced_commit: 8bd9d21
+last_synced_commit: 8bbfd75
 entry_for: [yaml-syntax, envelope-syntax]
 ---
 
@@ -692,10 +693,21 @@ pointer:
   loop_start: [[0, 1.0], [30, 5.0]]   # finestra di loop mobile
   loop_dur: [[0, 0.5], [30, 3.0]]
 
-  # Unità per i valori loop (opzionale)
+  # Unità delle posizioni nel sample (opzionale)
   loop_unit: normalized   # "normalized": valori [0,1] scalati su sample_dur_sec
-                          # default: eredita da time_mode dello stream
+                          # "seconds" (canonico) / "absolute" (alias): secondi
+                          # default: seconds — NON eredita da time_mode
 ```
+
+`loop_unit` governa i tre parametri di loop **e** `start`: sono tutte posizioni
+nel sample, stesso dominio. Il vocabolario è chiuso — `seconds`, `absolute`,
+`normalized` — e un'unità fuori da quello è `InvalidFieldValueError`, non un
+silenzioso "assoluto".
+
+Fino alla v7.2.0 `loop_unit` assente ereditava da `time_mode`: uno stream
+`normalized` vedeva `start` e i parametri di loop scalati per `sample_dur_sec`
+anche senza nessun loop dichiarato. Le due chiavi parlano di assi diversi (vedi
+§10.1) e ora sono indipendenti. (issue #222)
 
 Bounds: `pointer_speed_ratio` ∈ [-100, 100], `pointer_deviation` ∈ [-1, 1].
 
@@ -1546,12 +1558,13 @@ density:
   time_unit: normalized
 ```
 
-**(c) Solo per i parametri loop del pointer: `loop_unit`**
+**(c) Solo per le posizioni nel sample: `loop_unit`**
 
 I parametri `loop_start`, `loop_end`, `loop_dur` (e `start`, che è scalare ma
 segue la stessa unità) hanno una semantica aggiuntiva: `loop_unit: normalized`
 scala i **valori** (asse Y) da `[0, 1]` a `[0, sample_dur_sec]`. Non agisce
-sull'asse X. È documentato nella sezione 10.
+sull'asse X, e **non** si deduce da `time_mode`: il suo default è `seconds`. È
+documentato nella sezione 10.
 
 #### 3.3 Scaling del formato compatto
 
@@ -2036,6 +2049,10 @@ pointer:
   loop_dur:   0.5                    # = 0.5 * sample_dur_sec
 ```
 
+Unità ammesse: `seconds` (canonico), `absolute` (alias di `seconds`),
+`normalized`. **Default `seconds`**, indipendente da qualsiasi altra chiave;
+un'unità fuori vocabolario è `InvalidFieldValueError`.
+
 Con envelope normalizzato sui valori:
 
 ```yaml
@@ -2049,13 +2066,44 @@ Internamente `PointerController._pre_normalize_loop_params` usa
 `sample_dur_sec` prima di costruire l'`Envelope`. Funziona anche su formati
 compatti: il pattern `[x%, y]` viene scalato sul valore.
 
-Differenza chiave da `time_mode`:
+### Differenza chiave da `time_mode`
 
-- `time_mode: normalized` scala l'asse **X** (tempo) usando la `duration` dello stream
-- `loop_unit: normalized` scala l'asse **Y** (valore) usando la `sample_dur_sec`
-  del file audio caricato
+Sono due chiavi indipendenti, e la ragione è che parlano di grandezze che non
+hanno niente in comune:
 
-I due possono coesistere.
+|  | `time_mode: normalized` | `loop_unit: normalized` |
+|---|---|---|
+| asse | **X** (tempo) | **Y** (valore) |
+| riferimento | `duration` dello stream | `sample_dur_sec` del file audio |
+| dominio | la timeline della composizione | la lunghezza di un file su disco |
+
+I due **coesistono**, e su uno stesso envelope agiscono insieme senza toccarsi:
+
+```yaml
+duration: 20
+time_mode: normalized
+pointer:
+  loop_unit: normalized
+  loop_start: [[0, 0.25], [1, 0.75]]   # X: 0..1 → 0..20 s di stream
+                                       # Y: 0.25..0.75 → 25%..75% del sample
+```
+
+Con un sample da 8 secondi: a `t=0` il loop parte da 2.0 s del file, a `t=20`
+da 6.0 s, a metà stream da 4.0 s.
+
+**`loop_unit` non eredita da `time_mode`** (issue #222). Fino alla v7.2.0 lo
+faceva, e un solo keyword finiva per governare i due assi: uno stream che
+dichiarava `time_mode` per i propri envelope si vedeva spostare anche la
+testina di lettura, `start` compreso, senza aver detto niente al riguardo.
+`start` è `is_smart=False` e quindi non ha bounds, per cui lo spostamento non
+sollevava nulla: wrappava modularmente e rendeva un suono diverso da quello
+scritto.
+
+**Migrazione:** per riavere il comportamento precedente basta scrivere
+`loop_unit: normalized` nel blocco pointer. Per una release il motore lo dice
+da sé — con `time_mode: normalized`, nessun `loop_unit` e almeno una posizione
+diversa da zero, emette un warning `[LOOP_UNIT]` che nomina le chiavi
+interessate.
 
 #### 10.2 `deviation_probability` come envelope
 
@@ -2254,7 +2302,7 @@ Sintesi di tutte le forme accettate. `T` indica il tempo, `V` il valore.
 | Formato misto                                 | `[[0, 10], [5, 10], [[[0, 30], [100, 50]], 25, 4]]`| Offset automatico |
 | BP group diretto                              | `[[[0, 0], [0.5, 30], [1, 5]], 'cubic']`           | Macrozona unica con interp proprio (§2.7) |
 | BP group in misto                             | `[[[[0, 0], [0.4, 8]], 'cubic'], [[[0.75, 6], [1, 0]], 'step']]` | Macrozone con interp diversi; tempi assoluti |
-| Loop pointer normalizzato (valori)            | `loop_unit: normalized` + `loop_start: 0.0`        | Scala Y per sample_dur_sec |
+| Loop pointer normalizzato (valori)            | `loop_unit: normalized` + `loop_start: 0.0`        | Scala Y per sample_dur_sec; default `seconds`, indipendente da `time_mode` |
 | Time mode globale                             | `time_mode: normalized` a livello stream           | Scala X per stream duration |
 | Espressione matematica                        | `[[0, 0], [(pi*5), 1]]`                            | Valutata a parse-time |
 | deviation_probability globale envelope                      | `deviation_probability: [[0, 0], [30, 80]]`                      | Probabilità time-varying |
@@ -2321,9 +2369,9 @@ un envelope dal YAML al runtime è:
 | `read_direction` | -1 | +1 | — | solo `-1` e `+1`; assente = modalità `auto` |
 | `pointer_speed_ratio` | -100 | 100 | 1.0 | negativo = indietro |
 | `pointer_deviation` | -1 | 1 | 0.0 | offset per-grano |
-| `loop_start` | 0 | sample_dur | — | secondi |
-| `loop_end` | 0 | sample_dur | — | secondi |
-| `loop_dur` | 0.005 | sample_dur | — | secondi |
+| `loop_start` | 0 | sample_dur | — | secondi; `loop_unit: normalized` li scrive come frazione |
+| `loop_end` | 0 | sample_dur | — | secondi; `loop_unit: normalized` li scrive come frazione |
+| `loop_dur` | 0.005 | sample_dur | — | secondi; `loop_unit: normalized` li scrive come frazione |
 | `num_voices` | 1 | 256 | 1 | intero |
 | `scatter` | 0 | 1 | 0.0 | 0=sync, 1=indip. |
 

--- a/src/pge/controllers/pointer_controller.py
+++ b/src/pge/controllers/pointer_controller.py
@@ -40,17 +40,22 @@ _LOOP_UNIT_SCOPE = ('start', 'loop_start', 'loop_end', 'loop_dur')
 
 
 def _rescaling_would_change(value) -> bool:
-    """True se moltiplicare `value` per `sample_dur_sec` ne cambierebbe il senso.
+    """True se la conversione a secondi muoverebbe `value`.
 
-    Serve solo all'avviso di migrazione di #222: uno zero e' zero in tutt'e due
-    le letture, quindi non c'e' niente da migrare. Envelope, dict e formati
-    compatti li tocca la conversione, quindi contano.
+    Serve solo all'avviso di migrazione di #222, e per essere utile deve essere
+    lo specchio di cio' che `scale_raw_param_values` tocca davvero: numeri ed
+    envelope-like, e nient'altro. Due esclusioni, per due motivi diversi:
+
+    - uno zero e' zero sotto qualunque fattore di scala, quindi non ha niente
+      da migrare (ed e' la forma piu' comune nel corpus dei config);
+    - quel che la conversione lascia passare invariato — una stringa, per dire
+      — non si muoveva nemmeno prima.
     """
     if value is None or isinstance(value, bool):
         return False
     if isinstance(value, (int, float)):
         return value != 0
-    return True
+    return Envelope.is_envelope_like(value)
 
 
 
@@ -281,11 +286,10 @@ class PointerController:
 
         return scaled
 
+    # ponytail: si toglie dopo una release, quando il vecchio comportamento
+    # di loop_unit non e' piu' memoria viva di nessuno.
     def _warn_loop_unit_migration(self, params: dict) -> None:
         """Avvisa gli stream a cui #222 cambia il significato dei numeri.
-
-        # ponytail: si toglie dopo una release, quando il vecchio
-        # comportamento non e' piu' memoria viva di nessuno.
 
         Prima di #222 un `loop_unit` mancante ereditava da `time_mode`: su uno
         stream `normalized` queste posizioni venivano scalate per

--- a/src/pge/controllers/pointer_controller.py
+++ b/src/pge/controllers/pointer_controller.py
@@ -287,7 +287,9 @@ class PointerController:
         return scaled
 
     # ponytail: si toglie dopo una release, quando il vecchio comportamento
-    # di loop_unit non e' piu' memoria viva di nessuno.
+    # di loop_unit non e' piu' memoria viva di nessuno. Il conto lo tiene la
+    # issue #242, che elenca tutto cio' che va via insieme a questo metodo:
+    # il marcatore da solo non lo greperebbe nessuno.
     def _warn_loop_unit_migration(self, params: dict) -> None:
         """Avvisa gli stream a cui #222 cambia il significato dei numeri.
 

--- a/src/pge/controllers/pointer_controller.py
+++ b/src/pge/controllers/pointer_controller.py
@@ -16,8 +16,44 @@ from pge.envelopes.envelope import Envelope, scale_raw_param_values
 from pge.parameters.parameter_schema import POINTER_PARAMETER_SCHEMA
 from pge.parameters.parameter_orchestrator import ParameterOrchestrator
 from pge.core.stream_config import StreamConfig
-from pge.shared.logger import log_config_warning, log_loop_drift_warning, log_loop_dynamic_mode, log_loop_init
+from pge.shared.logger import (
+    log_config_warning,
+    log_loop_drift_warning,
+    log_loop_dynamic_mode,
+    log_loop_init,
+    log_loop_unit_migration_warning,
+)
 from pge.shared.exceptions import InvalidFieldValueError
+
+# Vocabolario di 'loop_unit' (issue #222). Fuori di qui e' un errore.
+#
+# 'seconds' e' la grafia canonica — allinea loop_unit a grain.duration_unit,
+# l'unita' nata «sul modello di loop_unit» (CHANGELOG v5.1.0) — e 'absolute'
+# l'alias storico, quello che i config e la reference hanno sempre scritto.
+# Sono la stessa lettura: valori gia' in secondi assoluti, nessuna conversione.
+LOOP_UNITS = ('seconds', 'absolute', 'normalized')
+
+# Le chiavi del blocco pointer che 'loop_unit' interpreta. 'start' e' fra
+# queste benche' loop non sia: e' una posizione nel sample come loop_start,
+# stesso dominio e stessa unita' (reference §10.1).
+_LOOP_UNIT_SCOPE = ('start', 'loop_start', 'loop_end', 'loop_dur')
+
+
+def _rescaling_would_change(value) -> bool:
+    """True se moltiplicare `value` per `sample_dur_sec` ne cambierebbe il senso.
+
+    Serve solo all'avviso di migrazione di #222: uno zero e' zero in tutt'e due
+    le letture, quindi non c'e' niente da migrare. Envelope, dict e formati
+    compatti li tocca la conversione, quindi contano.
+    """
+    if value is None or isinstance(value, bool):
+        return False
+    if isinstance(value, (int, float)):
+        return value != 0
+    return True
+
+
+
 class PointerController:
     """
     Gestisce il posizionamento della testina di lettura nel sample.
@@ -192,11 +228,20 @@ class PointerController:
 
     def _pre_normalize_loop_params(self, params: dict) -> dict:
         """
-        Conversione di unita' per i parametri loop.
-        
-        Se loop_unit == 'normalized', scala i valori dei parametri loop
-        da [0.0-1.0] a secondi assoluti usando sample_dur_sec dal context.
-        
+        Conversione di unita' per le posizioni nel sample.
+
+        `loop_unit: normalized` scala i valori di `start`, `loop_start`,
+        `loop_end` e `loop_dur` da [0.0-1.0] a secondi assoluti usando
+        `sample_dur_sec` dal context. Il default e' `seconds`: nessuna
+        conversione.
+
+        `loop_unit` NON eredita da `time_mode` (issue #222). Le due chiavi
+        governano assi diversi con riferimenti diversi: `time_mode` scala
+        l'asse X (tempo) degli envelope sulla `duration` dello stream,
+        `loop_unit` scala l'asse Y (valore) sulla `sample_dur_sec` del file
+        audio. Restano indipendenti e possono coesistere sullo stesso
+        envelope — e' la coesistenza documentata in §10.1 della reference.
+
         Questo metodo e' l'unico punto nel sistema che legge 'loop_unit'
         dal dizionario grezzo, ed e' il motivo legittimo: loop_unit e' un
         meta-parametro che controlla l'interpretazione degli altri, non un
@@ -205,25 +250,65 @@ class PointerController:
         if params is None:
             return {}
 
-        loop_unit = params.get('loop_unit') or self._config.time_mode
+        if 'loop_unit' not in params:
+            self._warn_loop_unit_migration(params)
+            return params  # default 'seconds': valori gia' in secondi assoluti
+
+        loop_unit = params['loop_unit']
+        if loop_unit not in LOOP_UNITS:
+            # Stessa forma di Stream._pre_normalize_grain_params: la chiave
+            # e' scritta, quindi il refuso va nominato invece di ricadere in
+            # silenzio su "assoluto".
+            err = InvalidFieldValueError(
+                field='pointer.loop_unit',
+                value=loop_unit,
+                hint=f"unità disponibili: {list(LOOP_UNITS)}",
+            )
+            err.stream_id = self._config.context.stream_id
+            raise err
+
         if loop_unit != 'normalized':
-            return params  # Valori gia' in secondi assoluti
+            return params  # 'seconds'/'absolute': gia' in secondi assoluti
 
         scale = self._sample_dur_sec
 
         # Copia superficiale: non modificare il dizionario originale
+        # (il fingerprint della cache e stream_data_map leggono i dati grezzi).
         scaled = dict(params)
-
-        # Scala start (indipendente dalla presenza di loop_start)
-        if 'start' in scaled and scaled['start'] is not None:
-            scaled['start'] = self._scale_value(scaled['start'], scale)
-
-        # Scala i parametri loop
-        for key in ('loop_start', 'loop_end', 'loop_dur'):
-            if key in scaled and scaled[key] is not None:
+        for key in _LOOP_UNIT_SCOPE:
+            if scaled.get(key) is not None:
                 scaled[key] = self._scale_value(scaled[key], scale)
 
         return scaled
+
+    def _warn_loop_unit_migration(self, params: dict) -> None:
+        """Avvisa gli stream a cui #222 cambia il significato dei numeri.
+
+        # ponytail: si toglie dopo una release, quando il vecchio
+        # comportamento non e' piu' memoria viva di nessuno.
+
+        Prima di #222 un `loop_unit` mancante ereditava da `time_mode`: su uno
+        stream `normalized` queste posizioni venivano scalate per
+        `sample_dur_sec`. Ora non piu'.
+
+        Avvisa solo chi cambia davvero: uno zero resta zero sotto qualunque
+        fattore di scala, e `start: 0` e' la forma piu' comune nel corpus dei
+        config — senza il filtro sarebbero undici avvisi su stream in cui non
+        si muove un campione, con i tre casi veri in mezzo al rumore.
+        """
+        if self._config.time_mode != 'normalized':
+            return
+
+        affected = [key for key in _LOOP_UNIT_SCOPE
+                    if _rescaling_would_change(params.get(key))]
+        if not affected:
+            return
+
+        log_loop_unit_migration_warning(
+            stream_id=self._config.context.stream_id,
+            keys=affected,
+            sample_dur_sec=self._sample_dur_sec,
+        )
 
 
     def _scale_value(self, value, scale: float):

--- a/src/pge/rendering/stream_cache_manager.py
+++ b/src/pge/rendering/stream_cache_manager.py
@@ -50,7 +50,10 @@ FINGERPRINT_IGNORE_KEYS = frozenset({"solo", "mute"})
 # 1 -> semantica storica (uniform ±range/2, gaussian con range = sigma)
 # 2 -> range e' sempre la larghezza della banda; gaussian troncata con
 #      sigma = larghezza/6; introdotta l'ancora range_anchor
-VARIATION_SEMANTICS_VERSION = 2
+# 3 -> loop_unit non eredita piu' da time_mode (issue #222): su uno stream
+#      'normalized' senza loop_unit, pointer.start e i parametri di loop
+#      restano in secondi invece di essere scalati per sample_dur_sec
+VARIATION_SEMANTICS_VERSION = 3
 
 
 class StreamCacheManager:

--- a/src/pge/shared/logger.py
+++ b/src/pge/shared/logger.py
@@ -427,6 +427,41 @@ def log_unreadable_curve_warning(
     )
 
 
+def log_loop_unit_migration_warning(
+    stream_id: str,
+    keys,
+    sample_dur_sec: float,
+):
+    """
+    Logga il cambio di semantica di `loop_unit` (issue #222).
+
+    Prima di #222 un `loop_unit` mancante ereditava da `time_mode`: su uno
+    stream `normalized` le posizioni nel sample venivano scalate per
+    `sample_dur_sec`. Ora il default e' `seconds` e vengono lette come sono.
+
+    Parla solo a chi cambia davvero — `time_mode: normalized`, nessun
+    `loop_unit`, almeno un valore che la conversione muoveva. Uno zero resta
+    zero sotto qualunque fattore di scala.
+
+    Args:
+        stream_id:      ID dello stream
+        keys:           chiavi del blocco pointer che cambiano lettura
+        sample_dur_sec: durata del sample, il fattore che non si applica piu'
+    """
+    logger = get_clip_logger()
+    if logger is None:
+        return
+
+    logger.warning(
+        f"[LOOP_UNIT] [{stream_id}] "
+        f"{', '.join(keys)}: ora in secondi. 'loop_unit' non eredita piu' da "
+        f"'time_mode' (issue #222); prima questi valori venivano scalati per "
+        f"sample_dur_sec={sample_dur_sec}. "
+        f"Per il comportamento precedente aggiungi 'loop_unit: normalized' al "
+        f"blocco pointer."
+    )
+
+
 def log_loop_init(
     stream_id: str,
     loop_start: float,

--- a/src/pge/shared/logger.py
+++ b/src/pge/shared/logger.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 from datetime import datetime
 import os
 
@@ -448,11 +449,7 @@ def log_loop_unit_migration_warning(
         keys:           chiavi del blocco pointer che cambiano lettura
         sample_dur_sec: durata del sample, il fattore che non si applica piu'
     """
-    logger = get_clip_logger()
-    if logger is None:
-        return
-
-    logger.warning(
+    message = (
         f"[LOOP_UNIT] [{stream_id}] "
         f"{', '.join(keys)}: ora in secondi. 'loop_unit' non eredita piu' da "
         f"'time_mode' (issue #222); prima questi valori venivano scalati per "
@@ -460,6 +457,18 @@ def log_loop_unit_migration_warning(
         f"Per il comportamento precedente aggiungi 'loop_unit: normalized' al "
         f"blocco pointer."
     )
+
+    logger = get_clip_logger()
+    if logger is not None:
+        logger.warning(message)
+
+    # A differenza degli altri avvisi del clip logger, questo annuncia un
+    # cambio di semantica che altera l'audio in silenzio: deve arrivare
+    # all'utente anche quando la console del clip logger e' spenta — come la
+    # configura la CLI (cli.py: console_enabled=False). Il file di log da
+    # solo non lo raggiungerebbe.
+    if not CLIP_LOG_CONFIG['console_enabled'] or logger is None:
+        print(f"CLIP: {message}", file=sys.stderr)
 
 
 def log_loop_init(

--- a/tests/controllers/test_pointer_controller.py
+++ b/tests/controllers/test_pointer_controller.py
@@ -2884,6 +2884,14 @@ class TestLoopUnitMigrationWarning:
 
         assert self._warn_calls(mock_config, {'start': 0.6}) == []
 
+    def test_silent_on_what_the_conversion_never_touched(self, mock_config):
+        """`scale_raw_param_values` lascia passare invariato quel che non e'
+        ne' un numero ne' un envelope: una stringa non si muoveva nemmeno
+        prima, quindi non ha niente da migrare."""
+        mock_config.time_mode = 'normalized'
+
+        assert self._warn_calls(mock_config, {'start': '0.6'}) == []
+
     def test_warns_on_envelope_values(self, mock_config):
         """Un envelope veniva scalato punto per punto: cambia anche lui."""
         mock_config.time_mode = 'normalized'

--- a/tests/controllers/test_pointer_controller.py
+++ b/tests/controllers/test_pointer_controller.py
@@ -1424,45 +1424,50 @@ class TestPreNormalization:
 
         assert pointer.has_loop is False
 
-    def test_time_mode_normalized_as_fallback(self, mock_config):
-        """Se loop_unit non specificato, usa config.time_mode come fallback."""
+    def test_time_mode_normalized_does_not_scale_loop_params(self, mock_config):
+        """Senza loop_unit i valori loop restano in secondi, anche su uno
+        stream 'normalized' (issue #222).
+
+        Era il contrario: `loop_unit` mancante ereditava da `time_mode`, e
+        `loop_start: 2.0` su uno stream normalized diventava 16.0 — fuori dal
+        bound dinamico (max_val = sample_dur_sec), quindi un render che si
+        ferma su un valore che l'utente non ha mai scritto.
+        """
         mock_config.time_mode = 'normalized'
         mock_config.context.sample_dur_sec = 8.0
 
-        raw_params = {
-            'loop_start': 0.25,
-            'loop_end': 0.75,
-            # Nessun loop_unit esplicito -> fallback a config.time_mode
-        }
-        # 0.25*8=2.0, 0.75*8=6.0
-        real = _build_real_params(loop_start=2.0, loop_end=6.0)
-        pointer = _make_pointer(mock_config, real, raw_params)
+        real = _build_real_params(start=0.0)
+        pointer = _make_pointer(mock_config, real, {})
 
-        assert pointer.has_loop is True
+        result = pointer._pre_normalize_loop_params(
+            {'loop_start': 2.0, 'loop_dur': 1.0}
+        )
 
-    def test_start_normalized_scales_with_sample_dur(self, mock_config):
+        assert result['loop_start'] == pytest.approx(2.0)
+        assert result['loop_dur'] == pytest.approx(1.0)
+
+    def test_start_scales_with_loop_unit_normalized(self, mock_config):
+        """La scala di 'start' la chiede `loop_unit`, non `time_mode`.
+
+        `start` e' una posizione nel sample come `loop_start`: stesso dominio,
+        stessa unita' (reference §10.1).
         """
-        RED: con time_mode='normalized', il valore di 'start' deve essere
-        moltiplicato per sample_dur_sec.
-        BUG ATTUALE: _pre_normalize_loop_params scala solo i parametri loop,
-        non 'start'. Il metodo scalera' start solo dopo il fix.
-        """
-        mock_config.time_mode = 'normalized'
+        mock_config.time_mode = 'absolute'
         mock_config.context.sample_dur_sec = 10.0
 
         real = _build_real_params(start=0.0)
         pointer = _make_pointer(mock_config, real, {})
 
-        result = pointer._pre_normalize_loop_params({'start': 0.5})
+        result = pointer._pre_normalize_loop_params(
+            {'start': 0.5, 'loop_unit': 'normalized'}
+        )
 
         assert result['start'] == pytest.approx(5.0)
 
 
     def test_start_absolute_mode_no_scaling(self, mock_config):
         """
-        Con time_mode='absolute', 'start' NON deve essere scalato.
-        Questo test deve rimanere GREEN sia prima che dopo il fix:
-        verifica che la modalita' assoluta non introduca regressioni.
+        Con loop_unit assente (default 'seconds'), 'start' NON viene scalato.
         """
         mock_config.time_mode = 'absolute'
         mock_config.context.sample_dur_sec = 10.0
@@ -1475,13 +1480,14 @@ class TestPreNormalization:
         assert result['start'] == pytest.approx(2.0)
 
 
-    def test_start_normalized_without_loop_params(self, mock_config):
-        """
-        RED: con time_mode='normalized' e nessun 'loop_start' nel dict,
-        'start' deve essere comunque scalato.
-        BUG ATTUALE: il return anticipato su 'loop_start' not in params
-        blocca tutta la normalizzazione prima ancora di arrivare a 'start'.
-        Questo e' il caso piu' comune: start senza loop.
+    def test_start_not_scaled_by_time_mode_alone(self, mock_config):
+        """Il guasto piu' grave di #222: `start` spostato in silenzio.
+
+        Uno stream che dichiara `time_mode` per i propri envelope non ha detto
+        niente sulla testina di lettura. `start` e' `is_smart=False`, quindi
+        non ha bounds: 2.0 che diventa 16.0 su un file da 8 secondi non solleva
+        niente, wrappa modularmente e rende un suono diverso da quello scritto.
+        Nessun `loop_start` in gioco: e' il caso piu' comune, start senza loop.
         """
         mock_config.time_mode = 'normalized'
         mock_config.context.sample_dur_sec = 8.0
@@ -1489,11 +1495,10 @@ class TestPreNormalization:
         real = _build_real_params(start=0.0)
         pointer = _make_pointer(mock_config, real, {})
 
-        # Nessun 'loop_start' nel dict: il bug si manifesta qui
-        result = pointer._pre_normalize_loop_params({'start': 0.25})
+        result = pointer._pre_normalize_loop_params({'start': 2.0})
 
-        assert result['start'] == pytest.approx(2.0)  # 0.25 * 8.0 = 2.0
-        
+        assert result['start'] == pytest.approx(2.0)
+
 # =============================================================================
 # GRUPPO 11: DEVIATION SCALING
 # =============================================================================
@@ -2692,3 +2697,265 @@ class TestStartMustBeScalar:
         il pointer parte da loop_start."""
         stream = build_stream(pointer={'speed_ratio': 1.0})
         assert stream._pointer.start == pytest.approx(0.0)
+
+
+# =============================================================================
+# GRUPPO 21: LOOP_UNIT NON EREDITA DA TIME_MODE (issue #222)
+# =============================================================================
+
+from pge.controllers.pointer_controller import LOOP_UNITS
+
+
+def _real_config(time_mode='absolute', sample_dur_sec=8.0, duration=20.0,
+                 stream_id='s1'):
+    """StreamConfig VERO, non mockato.
+
+    `TestPreNormalization` e i suoi vicini mockano l'orchestratore, quindi
+    vedono solo meta' del lavoro: la pre-normalizzazione dei valori (asse Y).
+    Lo scaling temporale (asse X) lo fa il parser, a valle. Per osservare i due
+    assi insieme serve la pipeline intera.
+    """
+    context = StreamContext(
+        stream_id=stream_id,
+        onset=0.0,
+        duration=duration,
+        sample='x.wav',
+        sample_dur_sec=sample_dur_sec,
+    )
+    return StreamConfig(context=context, time_mode=time_mode)
+
+
+class TestLoopUnitVocabulary:
+    """`loop_unit` ha un vocabolario, e fuori di li' e' un errore.
+
+    Prima qualunque stringa diversa da 'normalized' voleva dire "assoluto":
+    `normalised`, `Normalized`, `loop_unite` (il refuso e' scritto davvero, in
+    `configs/PGE_pino4.yml`) spegnevano la conversione senza un errore. Sotto
+    l'ereditarieta' il refuso era peggio che inerte: su uno stream
+    `time_mode: normalized` *cambiava* il risultato invece di lasciarlo com'era.
+    """
+
+    @pytest.mark.parametrize('unit', ['normalised', 'Normalized', 'assoluto',
+                                      'absolut', '', 'SECONDS'])
+    def test_unknown_unit_raises(self, mock_config, unit):
+        real = _build_real_params(loop_start=0.25)
+
+        with pytest.raises(InvalidFieldValueError) as exc_info:
+            _make_pointer(mock_config, real,
+                          {'loop_start': 0.25, 'loop_unit': unit})
+
+        err = exc_info.value
+        assert err.field == 'pointer.loop_unit'
+        assert err.value == unit
+        assert err.stream_id == 'test_stream'
+        # L'hint elenca le unita', come quello di grain.duration_unit.
+        for known in LOOP_UNITS:
+            assert known in err.hint
+
+    def test_empty_key_raises_instead_of_inheriting(self, mock_config):
+        """`loop_unit:` scritto e lasciato vuoto e' None, non "assente".
+
+        Era il quarto caso, quello che la issue non nomina: lo `or` trattava
+        None come falsy e faceva scattare l'ereditarieta'. Una chiave
+        dichiarata a meta' finiva per farsela decidere da `time_mode`.
+        """
+        mock_config.time_mode = 'normalized'
+        real = _build_real_params(loop_start=0.25)
+
+        with pytest.raises(InvalidFieldValueError) as exc_info:
+            _make_pointer(mock_config, real,
+                          {'loop_start': 0.25, 'loop_unit': None})
+
+        assert exc_info.value.field == 'pointer.loop_unit'
+
+    def test_unknown_unit_raises_even_with_nothing_to_convert(self, mock_config):
+        """La validazione guarda la chiave, non il suo lavoro.
+
+        Un `loop_unit` scritto su un blocco pointer che non ha ancora posizioni
+        e' comunque un refuso: segnalarlo solo quando c'e' qualcosa da scalare
+        renderebbe l'errore dipendente dal resto del blocco.
+        """
+        real = _build_real_params()
+
+        with pytest.raises(InvalidFieldValueError):
+            _make_pointer(mock_config, real, {'loop_unit': 'normalised'})
+
+    @pytest.mark.parametrize('unit', ['seconds', 'absolute'])
+    def test_seconds_and_absolute_are_the_same_reading(self, mock_config, unit):
+        """`seconds` e' la grafia canonica, `absolute` l'alias storico.
+
+        `absolute` e' quel che `configs/PGE_cim.yml` scrive in undici blocchi
+        pointer e quel che la reference ha sempre documentato; `seconds` allinea
+        `loop_unit` a `grain.duration_unit`, l'unita' nata «sul modello di
+        loop_unit». Le due grafie devono dare lo stesso numero.
+        """
+        mock_config.time_mode = 'normalized'   # non deve contare piu'
+        mock_config.context.sample_dur_sec = 8.0
+        real = _build_real_params(start=0.0)
+        pointer = _make_pointer(mock_config, real, {})
+
+        result = pointer._pre_normalize_loop_params(
+            {'start': 0.25, 'loop_start': 0.25, 'loop_unit': unit}
+        )
+
+        assert result['start'] == pytest.approx(0.25)
+        assert result['loop_start'] == pytest.approx(0.25)
+
+    def test_normalized_still_scales(self, mock_config):
+        """La controprova: l'unita' che fa qualcosa continua a farlo."""
+        mock_config.time_mode = 'absolute'
+        mock_config.context.sample_dur_sec = 8.0
+        real = _build_real_params(start=0.0)
+        pointer = _make_pointer(mock_config, real, {})
+
+        result = pointer._pre_normalize_loop_params({
+            'start': 0.25, 'loop_start': 0.25, 'loop_end': 0.75,
+            'loop_dur': 0.1, 'loop_unit': 'normalized',
+        })
+
+        assert result['start'] == pytest.approx(2.0)
+        assert result['loop_start'] == pytest.approx(2.0)
+        assert result['loop_end'] == pytest.approx(6.0)
+        assert result['loop_dur'] == pytest.approx(0.8)
+
+
+class TestLoopUnitMigrationWarning:
+    """L'avviso di migrazione parla solo a chi cambia davvero.
+
+    `# ponytail:` nel sorgente: si toglie dopo una release.
+    """
+
+    def _warn_calls(self, mock_config, params):
+        # L'orchestratore e' mockato: se il dict grezzo dichiara un loop, il
+        # Parameter corrispondente deve esistere o `has_loop` trova None.
+        real = _build_real_params(
+            start=0.0,
+            loop_start=1.0 if 'loop_start' in params else None,
+            loop_dur=1.0 if 'loop_dur' in params else None,
+        )
+        with patch('pge.controllers.pointer_controller'
+                   '.log_loop_unit_migration_warning') as warn:
+            _make_pointer(mock_config, real, params)
+        return warn.call_args_list
+
+    def test_warns_when_the_reading_changes(self, mock_config):
+        mock_config.time_mode = 'normalized'
+        mock_config.context.sample_dur_sec = 8.0
+
+        calls = self._warn_calls(mock_config, {'start': 0.6})
+
+        assert len(calls) == 1
+        assert calls[0].kwargs['stream_id'] == 'test_stream'
+        assert calls[0].kwargs['keys'] == ['start']
+
+    def test_warns_on_loop_params_too(self, mock_config):
+        mock_config.time_mode = 'normalized'
+
+        calls = self._warn_calls(mock_config,
+                                 {'loop_start': 0.25, 'loop_dur': 0.1})
+
+        assert len(calls) == 1
+        assert calls[0].kwargs['keys'] == ['loop_start', 'loop_dur']
+
+    def test_silent_on_zero(self, mock_config):
+        """Uno zero resta zero sotto qualunque fattore di scala.
+
+        Non e' un dettaglio: `start: 0` e' la forma piu' comune nel corpus dei
+        config (`PGE_cim` ×5, `PGE_test` ×4, `PGE_cubic_smoothstep_demo` ×2).
+        Avvisarli sarebbe undici righe di rumore attorno ai tre casi veri.
+        """
+        mock_config.time_mode = 'normalized'
+
+        assert self._warn_calls(mock_config, {'start': 0}) == []
+        assert self._warn_calls(mock_config, {'start': 0.0}) == []
+
+    def test_silent_when_loop_unit_is_declared(self, mock_config):
+        """Chi ha gia' dichiarato l'unita' non ha niente da migrare."""
+        mock_config.time_mode = 'normalized'
+
+        assert self._warn_calls(
+            mock_config, {'start': 0.6, 'loop_unit': 'normalized'}) == []
+        assert self._warn_calls(
+            mock_config, {'start': 0.6, 'loop_unit': 'seconds'}) == []
+
+    def test_silent_on_absolute_streams(self, mock_config):
+        """`time_mode: absolute` non ereditava niente: nulla cambia."""
+        mock_config.time_mode = 'absolute'
+
+        assert self._warn_calls(mock_config, {'start': 0.6}) == []
+
+    def test_warns_on_envelope_values(self, mock_config):
+        """Un envelope veniva scalato punto per punto: cambia anche lui."""
+        mock_config.time_mode = 'normalized'
+
+        calls = self._warn_calls(
+            mock_config, {'loop_start': [[0, 0.25], [1, 0.75]]})
+
+        assert len(calls) == 1
+        assert calls[0].kwargs['keys'] == ['loop_start']
+
+
+class TestLoopUnitAxesCoexist:
+    """Il test che conta: i due assi restano indipendenti.
+
+    `time_mode: normalized` scala l'asse X (tempo) sulla `duration` dello
+    stream; `loop_unit: normalized` scala l'asse Y (valore) sulla
+    `sample_dur_sec` del file audio. Sono la coesistenza documentata in §10.1
+    della reference, ed e' la ragione per cui #222 stacca le due chiavi invece
+    di fonderle. Non deve regredire.
+    """
+
+    def test_x_on_stream_duration_y_on_sample_dur(self):
+        config = _real_config(time_mode='normalized',
+                              sample_dur_sec=8.0, duration=20.0)
+        pointer = PointerController(
+            {
+                'loop_start': [[0, 0.25], [1, 0.75]],
+                'loop_dur': 0.1,
+                'loop_unit': 'normalized',
+            },
+            config,
+        )
+
+        # Asse Y: 0.25 e 0.75 della durata del SAMPLE (8.0).
+        # Asse X: i tempi 0 e 1 sulla durata dello STREAM (20.0).
+        assert pointer.loop_start.get_value(0.0) == pytest.approx(2.0)
+        assert pointer.loop_start.get_value(20.0) == pytest.approx(6.0)
+        # Il punto di mezzo prova che la X e' stata scalata: senza, l'envelope
+        # sarebbe gia' finito a t=1 e terrebbe 6.0 per tutto il resto.
+        assert pointer.loop_start.get_value(10.0) == pytest.approx(4.0)
+        assert pointer.loop_dur.get_value(0.0) == pytest.approx(0.8)
+
+    def test_y_alone_without_time_mode(self):
+        """La controprova sull'asse X: senza `time_mode` l'envelope resta in
+        secondi assoluti, e la Y si scala lo stesso."""
+        config = _real_config(time_mode='absolute',
+                              sample_dur_sec=8.0, duration=20.0)
+        pointer = PointerController(
+            {
+                'loop_start': [[0, 0.25], [20, 0.75]],
+                'loop_dur': 0.1,
+                'loop_unit': 'normalized',
+            },
+            config,
+        )
+
+        assert pointer.loop_start.get_value(0.0) == pytest.approx(2.0)
+        assert pointer.loop_start.get_value(20.0) == pytest.approx(6.0)
+
+    def test_time_mode_normalized_alone_leaves_values_in_seconds(self):
+        """Lo stesso stream senza `loop_unit`: la X si scala, la Y no.
+
+        Sulla pipeline vera, non sul mock. Prima, `loop_start: 2.0` diventava
+        16.0 e sfondava il bound dinamico (max_val = sample_dur_sec = 8.0).
+        """
+        config = _real_config(time_mode='normalized',
+                              sample_dur_sec=8.0, duration=20.0)
+        pointer = PointerController(
+            {'loop_start': [[0, 2.0], [1, 6.0]], 'loop_dur': 1.0},
+            config,
+        )
+
+        assert pointer.loop_start.get_value(0.0) == pytest.approx(2.0)
+        assert pointer.loop_start.get_value(20.0) == pytest.approx(6.0)
+        assert pointer.loop_dur.get_value(0.0) == pytest.approx(1.0)

--- a/tests/controllers/test_pointer_controller.py
+++ b/tests/controllers/test_pointer_controller.py
@@ -2784,10 +2784,10 @@ class TestLoopUnitVocabulary:
     def test_seconds_and_absolute_are_the_same_reading(self, mock_config, unit):
         """`seconds` e' la grafia canonica, `absolute` l'alias storico.
 
-        `absolute` e' quel che `configs/PGE_cim.yml` scrive in undici blocchi
-        pointer e quel che la reference ha sempre documentato; `seconds` allinea
-        `loop_unit` a `grain.duration_unit`, l'unita' nata «sul modello di
-        loop_unit». Le due grafie devono dare lo stesso numero.
+        `absolute` e' quel che `configs/PGE_cim.yml` scrive in dieci dei suoi
+        ventuno blocchi pointer e quel che la reference ha sempre documentato;
+        `seconds` allinea `loop_unit` a `grain.duration_unit`, l'unita' nata
+        «sul modello di loop_unit». Le due grafie devono dare lo stesso numero.
         """
         mock_config.time_mode = 'normalized'   # non deve contare piu'
         mock_config.context.sample_dur_sec = 8.0

--- a/tests/controllers/test_pointer_controller.py
+++ b/tests/controllers/test_pointer_controller.py
@@ -2822,7 +2822,8 @@ class TestLoopUnitVocabulary:
 class TestLoopUnitMigrationWarning:
     """L'avviso di migrazione parla solo a chi cambia davvero.
 
-    `# ponytail:` nel sorgente: si toglie dopo una release.
+    `# ponytail:` nel sorgente: si toglie dopo una release, insieme a questa
+    classe. Rimozione tracciata dalla issue #242.
     """
 
     def _warn_calls(self, mock_config, params):

--- a/tests/shared/test_logger.py
+++ b/tests/shared/test_logger.py
@@ -16,6 +16,7 @@ from pge.shared.logger import (
     log_loop_drift_warning,
     log_loop_dynamic_mode,
     log_loop_init,
+    log_loop_unit_migration_warning,
     log_unreadable_curve_warning,
     CLIP_LOG_CONFIG,
 
@@ -1182,3 +1183,64 @@ class TestLogUnreadableCurveWarning:
             h.flush()
         content = (tmp_path / 'envelope_clips_curvefile.log').read_text()
         assert '[UNREADABLE_CURVE]' in content
+
+
+# =============================================================================
+# TEST: log_loop_unit_migration_warning — canale visibile
+# =============================================================================
+
+class TestLoopUnitMigrationWarningIsVisible:
+    """
+    L'avviso di migrazione di `loop_unit` (issue #222) e' l'unico segnale di
+    una modifica che cambia l'audio in silenzio. La CLI configura il clip
+    logger con `console_enabled=False`: se l'avviso vivesse solo li', chi
+    lancia `make` sentirebbe un suono diverso senza vedere nulla.
+    """
+
+    def test_stderr_even_when_clip_console_disabled(self, tmp_path, capsys):
+        configure_clip_logger(
+            enabled=True,
+            file_enabled=True,
+            console_enabled=False,
+            log_dir=str(tmp_path),
+            yaml_name='loopunitcli'
+        )
+        get_clip_logger()
+        log_loop_unit_migration_warning('s1', ['loop_start'], 2.5)
+        err = capsys.readouterr().err
+        assert '[LOOP_UNIT]' in err
+        assert 's1' in err
+
+    def test_stderr_even_when_clip_logger_disabled(self, capsys):
+        configure_clip_logger(enabled=False)
+        log_loop_unit_migration_warning('s2', ['loop_end'], 1.0)
+        assert '[LOOP_UNIT]' in capsys.readouterr().err
+
+    def test_still_written_to_file(self, tmp_path):
+        configure_clip_logger(
+            enabled=True,
+            file_enabled=True,
+            console_enabled=False,
+            log_dir=str(tmp_path),
+            yaml_name='loopunitfile'
+        )
+        l = get_clip_logger()
+        log_loop_unit_migration_warning('s1', ['loop_start'], 2.5)
+        for h in l.handlers:
+            h.flush()
+        content = (tmp_path / 'envelope_clips_loopunitfile.log').read_text()
+        assert '[LOOP_UNIT]' in content
+
+    def test_no_duplicate_on_console_enabled(self, tmp_path, capsys):
+        """Con la console del clip logger attiva l'avviso resta uno solo: su
+        stderr passa dal logger, non anche dal print."""
+        configure_clip_logger(
+            enabled=True,
+            file_enabled=True,
+            console_enabled=True,
+            log_dir=str(tmp_path),
+            yaml_name='loopunitdup'
+        )
+        get_clip_logger()
+        log_loop_unit_migration_warning('s1', ['loop_start'], 2.5)
+        assert capsys.readouterr().err.count('[LOOP_UNIT]') == 1


### PR DESCRIPTION
Chiude #222.

Un keyword governava due assi con due riferimenti diversi. `time_mode: normalized` scala l'asse **X** (tempo) degli envelope sulla `duration` dello stream; `loop_unit: normalized` scala l'asse **Y** (valore) delle posizioni nel sample sulla `sample_dur_sec` del file audio. La reference lo diceva già — §10.1, «I due possono coesistere» — e trenta righe più su documentava che, se non dichiaravi `loop_unit`, la seconda decisione la prendeva la prima.

## Cosa cambia

| | prima | dopo |
|---|---|---|
| default | eredita da `time_mode` | `seconds`, indipendente |
| vocabolario | implicito (`!= 'normalized'`) | `('seconds', 'absolute', 'normalized')` |
| unità sconosciuta | silenzio, vale "assoluto" | `InvalidFieldValueError` con `stream_id` e hint |
| `loop_unit:` vuoto | `None` è falsy → eredita | errore |

`seconds` è la grafia canonica (allinea `loop_unit` a `grain.duration_unit`, l'unità nata «sul modello di `loop_unit`»), `absolute` l'alias storico — è quel che `configs/PGE_cim.yml` scrive in dieci dei suoi ventuno blocchi pointer. `start` resta legato a `loop_unit`, come prima e come documentato: è una posizione nel sample come `loop_start`, stesso dominio.

**Il guasto peggiore non riguardava il loop.** La pre-normalizzazione scalava `pointer.start` «indipendentemente dalla presenza di `loop_start`», e `start` è `is_smart=False`, quindi senza bounds: su uno stream `normalized` con un sample da 8 secondi, `start: 2.0` diventava 16.0, wrappava modularmente e rendeva un suono diverso da quello scritto — nessun errore, nessun log.

Verificato su `Stream` reali (`sample_dur_sec = 8.0`, stream `time_mode: normalized`):

```
start 0.6 senza loop_unit :  0.6000   (prima: 4.8)
start 0.6 + normalized    :  4.8000   (il comportamento precedente, dichiarato)
start 0.6 + seconds       :  0.6000
start 0.6 + absolute      :  0.6000
loop_unit: 'normalised'   ->  InvalidFieldValueError
loop_unit:  (vuoto)       ->  InvalidFieldValueError
```

E i due assi restano indipendenti — un envelope su `loop_start` con entrambe le chiavi attive, stream da 4 s su sample da 8 s: `pos(t=0)=2.0`, `pos(t=2)=4.0`. X scalata sulla `duration`, Y sulla `sample_dur_sec`.

`VARIATION_SEMANTICS_VERSION` 2 → 3: il fingerprint gira sul dict YAML grezzo, quindi senza bump gli stem resterebbero `clean` e si continuerebbe ad ascoltare l'audio con la semantica vecchia.

## Tre punti dove ho divergito dalla issue

La issue è stata trattata come specifica, ma tre cose non tornavano.

**1. `log_config_warning` non è riusabile.** La issue propone di usarla «perché è già importata». La sua firma è `(stream_id, param_name, raw_value, clipped_value, min_val, max_val, value_type)` e formatta un valore clippato contro un bound (`raw={:>12.6f} → clip={:>12.6f}`): un messaggio di migrazione non ha nessuna di quelle grandezze, e passarci delle stringhe la fa esplodere sul format spec. La convenzione del modulo `logger.py` è una funzione per tipo di avviso — `log_window_curve_warning`, `log_unreadable_curve_warning`, `log_loop_init` — quindi ho aggiunto `log_loop_unit_migration_warning` sulla loro forma.

**2. Il warning parla solo a chi cambia davvero.** La issue lo fa scattare su `time_mode: normalized` + qualunque posizione dichiarata senza `loop_unit`. Ma uno zero resta zero sotto qualunque fattore di scala: con quella regola il corpus di `configs/` emetterebbe **undici** avvisi (`PGE_cim` ×5, `PGE_test` ×4, `PGE_cubic_smoothstep_demo` ×2) su stream in cui non si muove un campione, con i casi veri in mezzo al rumore. Il predicato è lo specchio di ciò che `scale_raw_param_values` tocca davvero: numeri diversi da zero ed envelope-like.

**3. I config interessati sono cinque, non uno.** La issue ne censisce uno (`PGE_pino3.yml`) e dà `PGE_cim.yml` e `PGE_pino2.yml` per invariati «perché dichiarano già la chiave». Vero per quindici dei ventuno blocchi pointer di `PGE_cim` (dieci `absolute`, cinque `normalized`), falso per i sei restanti — e uno di quei sei, `stream24`, ha una posizione non nulla. Il corpus completo:

| config / stream | valore | perché è una frazione |
|---|---|---|
| `PGE_pino3.yml` / `texture1#2` | `loop_start: 0.25` + `loop_dur` envelope | il caso già censito |
| `PGE_grain_height_demo.yml` / `sweep_forward` | `start: 0.12` | 12% di un file che l'intestazione dichiara «~4 s», con `speed_ratio: 0` |
| `PGE_grain_height_demo.yml` / `sweep_reverse` | `start: 0.88` | 88%, ed è la coppia speculare: in secondi i due sweep collasserebbero entrambi nel primo secondo del file e la demo perderebbe il suo punto |
| `PGE_cim.yml` / `stream24` | `start: 0.6` | tutto il suo blocco pointer ragiona in frazioni: `voices.pointer` ha `normalized: true` con `pointer_range: 1` |
| `PGE_pino4.yml` / `texture1` | `start: .6` | il `#loop_unite: absolute` accanto è commentato **e** ha un refuso nel nome, quindi non ha mai avuto effetto |

A tutti e cinque si aggiunge `loop_unit: normalized`, cioè si scrive l'unità che era già in vigore: **il corpus rende identico a prima** e nessuno dei suoi stream emette l'avviso di migrazione. Un repo che avvisa sui propri config è un repo che non ha finito di migrare.

Gli altri sei stream con `time_mode: normalized` e una posizione dichiarata hanno `start: 0` e non si accorgono di niente.

## Test

Rosso prima, verde poi: 17 test rossi sul comportamento nuovo, più sei che passavano già e restano come guardia di non-regressione.

Il test che conta è la **coesistenza dei due assi**, e va scritto sulla pipeline vera: `TestPreNormalization` mocka l'orchestratore, quindi vede solo metà del lavoro (la Y, fatta in pre-normalizzazione) e non si accorgerebbe se lo scaling temporale smettesse di funzionare. `TestLoopUnitAxesCoexist` costruisce `StreamConfig` e `PointerController` reali.

`pytest` completo verde a ogni commit (1200+ test, gli unici skip sono i dieci preesistenti di `test_envelope_scaling.py`). Verificato anche un render reale end-to-end con il renderer NumPy.

## Fuori scope

- La semantica di `time_mode` sugli envelope non si tocca (né X, né `time_unit`, né lo scaling del formato compatto).
- Nessuna rinomina di `loop_unit`: il nome resta imperfetto (governa anche `start`, che loop non è) ma cambiarlo è un breaking più largo di questo.
- **Il refuso `loop_unite` resta fuori portata.** Il vocabolario nuovo intercetta il valore sbagliato di una chiave giusta, non il nome sbagliato di una chiave: `loop_unite` è una chiave ignota che il blocco pointer continua ad accettare in silenzio. Validare le chiavi ignote vale per ogni blocco, non solo per questo, e merita una issue sua.

## Impatto cross-repo

Per `.claude/rules/cross-repo-impact.md`, due repo sono interessati. In entrambi il fallback non è documentazione: è **codice ricalcato**, più grave di quanto la issue #222 lasci intendere (PGE-ui non lo nomina affatto).

- **[DMGiulioRomano/PGE-ui#149](https://github.com/DMGiulioRomano/PGE-ui/issues/149)** — `loopUnitInfo` (`src/lib/envelope-utils.js`) dichiara di essere lo specchio di questa riga e ne eredita il ramo `source: "time_mode"`. Due conseguenze. La grave: l'Inspector (`Inspector.jsx:1066`) **cancella** `loop_unit` quando l'utente sceglie il valore che crede ereditato, e siccome `loopUnitInherited` vale `normalized` su uno stream `normalized`, toccare quel selettore butta via la chiave esplicita e trasforma uno stream sano in uno esposto. La seconda: `splitAtPlayhead` (`app.jsx`) scrive `pointer.start` come `ptr.pos / sampleDur` risolvendo l'unità con lo stesso fallback — corretto sugli stream nati nell'editor, sbagliato di 8× sullo YAML importato.
- **[DMGiulioRomano/PGE-ls#49](https://github.com/DMGiulioRomano/PGE-ls/issues/49)** — `_get_effective_unit_mode` (`hover_provider.py`) è un mirror verbatim della riga, e `_check_pointer_param_bounds` ci decide sopra i bounds: dopo questa PR applicherebbe `[0.0, 1.0]` a valori che sono in secondi. Diagnostiche false nei due versi — un `loop_start: 2.0` valido segnalato come fuori range, e un valore oltre la durata del sample non più controllato.

### Rettifiche dopo la review

Tre correzioni, nessuna al codice del motore (commit `b9011c7`).

- **La stima d'impatto su PGE-ui era rovesciata.** La prima stesura diceva che ogni stream nato nell'editor è esposto perché nasce `time_mode: normalized` senza `loop_unit`. Falso: `32591ea` scrive già `loopUnit: "normalized"` nel template (`app.jsx:1314`), `yaml-bridge.js:465` lo serializza, la coda dello split lo eredita via spread. Il caso ordinario si salva; a rompersi è lo YAML che l'editor non ha creato. Il punto sopra è stato riscritto e [PGE-ui#149](https://github.com/DMGiulioRomano/PGE-ui/issues/149) aggiornata: i due punti sono in ordine invertito rispetto a prima, e il suo punto 5 («l'editor deve materializzare la chiave») risulta già chiuso da `32591ea`.
- **Il conteggio dei blocchi pointer.** Dieci `absolute`, non undici; quindici su ventuno dichiaravano già la chiave. Corretto qui, nel CHANGELOG e nel plan. Il numero undici resta dov'è giusto — nel commento di `_warn_loop_unit_migration`, dove conta gli avvisi che il corpus emetterebbe senza il filtro.
- **Il marcatore `# ponytail:` ora ha un posto dove il conto resta**: [#242](https://github.com/DMGiulioRomano/PythonGranularEngine/issues/242) elenca tutto ciò che va via con l'avviso di migrazione, ed è citata dalle tre occorrenze e dal CHANGELOG.

`make tests` verde (5838 passed, 10 skipped), `make docs-lint` OK.

## Nota sul diff

Il branch è stato creato su uno stato locale che portava già il lavoro di #234 (issue chiusa il 2026-08-23, mai pushata su `main`): i commit da `010206b` a `855f00e` non sono di questa PR. Il lavoro di #222 sono i **sette commit da `03f44dc` in poi**. Li ho tenuti invece di resettare il branch perché quei commit esistevano solo in questo container e resettare li avrebbe persi.

Merge e release restano all'utente: nessun bump di versione, nessun `chore(release)`.
