### PR TITLE
fix(stream): .grains diventa una vista derivata e smette di ammutolire lo stream (#201)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,12 @@ jobs:
     name: docs lint + index check
     runs-on: ubuntu-latest
     steps:
+      # fetch-depth: 0 perche' lint_docs.py risolve ogni last_synced_commit
+      # contro la storia: col checkout shallow di default esiste un commit
+      # solo e non risolverebbe nessuno.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,31 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   intermedia esplicita. Lo script genera un sample sintetico se `refs/` e'
   vuota, quindi gira su un clone pulito.
 
+### Modificato (breaking)
+
+- **`Stream.grains` non ha piu' una setter** (issue #201). Assegnarla solleva
+  `AttributeError` nominando il rimpiazzo (`stream.voices = [[grano, ...],
+  ...]`). **Questo rende major la prossima release**: e' rimozione di
+  superficie pubblica senza ciclo di preavviso, al contrario della property in
+  lettura, che ne ottiene uno (vedi `### Deprecato`).
+
+  I due criteri divergono di proposito. La property in lettura restituisce
+  qualcosa di corretto, quindi puo' continuare a farlo per un ciclo. La setter
+  no: riusciva, lasciava `_voices` vuoto, marcava `generated = True` e
+  produceva un file di silenzio senza segnalare nulla (vedi `### Corretto`).
+  Non esiste una versione «che avvisa» di un comportamento cosi': avvisare e
+  poi ammutolire lo stream comunque non e' un preavviso, e' lo stesso guasto
+  con una riga di log. E delegare a `voices = [value]` sarebbe una
+  supposizione — una voce sola dove il chiamante ne intendeva N — cioe' un
+  rendering diverso da quello atteso, di nuovo in silenzio. Un
+  `AttributeError` rumoroso e' l'unica uscita che non inventa niente.
+
+  Nel repo la setter aveva cinque chiamanti, tutti in `tests/`: tre inerti su
+  `MagicMock`, due che rimettevano `generated = False` due righe sotto. Fuori
+  dal repo non se ne conoscono: `PGE-ls` non nomina `grains`, `PGE-ui` consuma
+  il JSON di `GrainJsonWriter` e nel repo del paper CIM 2026 nessuno script
+  Python la tocca.
+
 ### Corretto
 
 - **`Stream.grains` poteva ammutolire uno stream senza dire niente** (issue
@@ -85,10 +110,9 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   guasto di #225 e #234: non un errore, un file muto.
 
   `_voices` diventa l'unico backing field e `grains` una vista **derivata**,
-  ricalcolata a ogni lettura: la divergenza non e' piu' esprimibile. La setter
-  non c'e' piu' — assegnare solleva `AttributeError` nominando il rimpiazzo
-  (`stream.voices = [[grano, ...], ...]`) invece di riuscire e produrre
-  silenzio. `__repr__` conta da `_voices` e smette di mentire.
+  ricalcolata a ogni lettura: la divergenza non e' piu' esprimibile.
+  `__repr__` conta da `_voices` e smette di mentire. La setter e' rimossa —
+  breaking, vedi sotto.
 
   Il rendering non cambia: stesso `sha256` sull'audio di un config a seed
   fisso. Il flatten+sort eager che spariva dentro `generate_grains()` valeva

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,20 +46,22 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   il fallimento somiglierebbe al successo.
 - **`make bench` e `docs/explanation/costo-rendering.md`: quanto costa un
   rendering, e da cosa dipende.** Il costo si scompone in due termini
-  indipendenti, `t = a * N_grani + b * D_secondi`, con `a` circa 32 us per grano
-  e `b` circa 1,3 ms per secondo di uscita (Apple M2 Max, sequenziale). I due
-  termini pareggiano attorno ai 40 grani al secondo: sopra quella densita' —
+  indipendenti, `t = a * N_grani + b * D_secondi`, con `a` circa 34 us per grano
+  e `b` circa 1,4 ms per secondo di uscita (Apple M2 Max, sequenziale). I due
+  termini pareggiano attorno ai 42 grani al secondo: sopra quella densita' —
   cioe' nel regime d'uso — il costo lo governa la popolazione, sotto lo governa
   la durata del file. Il modello sta su 23 punti di misura fra 10^2 e 3*10^4
-  grani e fra 5 e 320 secondi, con errore mediano sotto l'1,5%.
+  grani e fra 5 e 320 secondi, con errore mediano sotto l'1%.
 
   Il nuovo `utils/bench_cost.py` produce le misure: tre sweep, il fit ai minimi
   quadrati e — con `make bench YAML=<file>` — la ripartizione delle fasi su
-  materiale reale. Su `configs/PGE_cim.yml` (994.291 grani, 92,5 s, 28,9 s
+  materiale reale. Su `configs/PGE_cim.yml` (994.555 grani, 92,5 s, 30,2 s
   totali) circa un terzo del tempo se ne va a costruire gli oggetti `Grain` e il
   resto a sommarli e scrivere il file: il prezzo della rappresentazione
   intermedia esplicita. Lo script genera un sample sintetico se `refs/` e'
-  vuota, quindi gira su un clone pulito.
+  vuota, ma **non basta a farlo girare su un clone pulito**: il sample
+  sintetico non raggiunge ne' il `Generator` ne' il `SampleRegistry`, che
+  ricadono entrambi sul globale `./refs/`. Difetto noto.
 
 ### Modificato (breaking)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,38 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Corretto
 
+- **`Stream.grains` poteva ammutolire uno stream senza dire niente** (issue
+  #201). `generate_grains()` teneva gli stessi eventi in due campi — `_voices`,
+  annidato per voce, e `_grains`, flat e ordinato per onset — allineati solo
+  lungo il percorso di generazione. Fuori da li' divergevano in silenzio, in
+  due direzioni, e la issue ne mostrava solo la prima:
+
+  - `stream.voices = [...]` lasciava `_grains` fermo al valore vecchio.
+    Innocuo: nessun backend legge `grains`;
+  - `stream.grains = [...]` lasciava `_voices` **vuoto** e marcava
+    `generated = True`. Non innocuo: *tutti* i backend leggono `voices`
+    (`score_writer`, `numpy_audio_renderer`, `grain_visuals`,
+    `grain_json_writer`), quindi lo stream restava senza grani da
+    renderizzare.
+
+  Misurato su uno stream da 1 s: 48 grani iniettati attraverso la setter
+  pubblica — documentata come «iniezione esplicita dei grani (test/consumer)» —
+  e un file di **silenzio puro**, picco 0.0000, uscita pulita, nessun avviso e
+  nessun log. Con `__repr__` che nel frattempo continuava a dichiarare
+  `grains=48`, cioe' confermava che i grani c'erano. E' la stessa classe di
+  guasto di #225 e #234: non un errore, un file muto.
+
+  `_voices` diventa l'unico backing field e `grains` una vista **derivata**,
+  ricalcolata a ogni lettura: la divergenza non e' piu' esprimibile. La setter
+  non c'e' piu' — assegnare solleva `AttributeError` nominando il rimpiazzo
+  (`stream.voices = [[grano, ...], ...]`) invece di riuscire e produrre
+  silenzio. `__repr__` conta da `_voices` e smette di mentire.
+
+  Il rendering non cambia: stesso `sha256` sull'audio di un config a seed
+  fisso. Il flatten+sort eager che spariva dentro `generate_grains()` valeva
+  il 2.9% del tempo di generazione e **8.1 MB ritenuti per milione di grani**,
+  per una lista che nessuno leggeva.
+
 - **Un envelope su tre grafie non veniva riconosciuto come envelope** (issue
   #234). `Envelope.is_envelope_like` era piu' stretta di quel che
   `EnvelopeBuilder` costruisce: una lista di **soli** breakpoint dict
@@ -114,6 +146,30 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   dichiara di essere. È anche la prova che il bug della finestra collassata
   passava inosservato: stava in una demo del repo, e si presentava come uno
   stream silenzioso invece che come un errore.
+
+### Deprecato
+
+- **`Stream.grains`**, rimozione prevista in **9.0.0** (issue #201). Resta
+  leggibile, come vista derivata di `stream.voices`, ed emette
+  `DeprecationWarning`. Rimpiazzo:
+
+  ```python
+  [g for voice in stream.voices for g in voice]          # voice-major
+  sorted(_, key=lambda g: g.onset)                       # per onset
+  ```
+
+  I due ordini non sono intercambiabili, ed e' la ragione per cui la property
+  se ne va invece di restare: `Grain` non porta l'indice di voce, quindi la
+  vista flat e' **lossy** rispetto a `voices`, e l'ordine per onset non e'
+  quello su cui i renderer sommano — l'ordine delle somme float e' quel che
+  rende un rendering riproducibile.
+
+  Nessun consumatore noto: i quattro backend di PGE iterano `voices`; `PGE-ls`
+  non nomina `grains`; `PGE-ui` consuma il JSON di `GrainJsonWriter`, dove
+  `grains` e' una chiave dello schema e non l'API Python; nel repo del paper
+  CIM 2026, che pinna PGE come submodule, nessuno degli script Python la legge.
+  Il ciclo di preavviso c'e' comunque perche' `pge` e' una libreria
+  installabile a SemVer.
 
 ### Modificato
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Questo progetto ha copertura test estensiva. Mantieni questo standard di qualit�
 - **Grain is a frozen dataclass** — never mutate after creation
 - **Window Registry:** WindowController pre-registers all window functions at Stream init — FtableManager table numbering depends on this; don't lazy-register
 - **Stream Cache:** active only with `STEMS=true CACHE=true RENDERER=csound`; StreamCacheManager fingerprints YAML per stream, only dirty streams re-render
-- **Voice System:** each voice generates its own grain list; interleaved into `self.grains` (flat, ordered by onset) for backward compatibility
+- **Voice System:** each voice generates its own grain list; `stream.voices` (`List[List[Grain]]`) is the single source of truth. `stream.grains` is a *derived* flat view, ordered by onset, deprecated since #201 (removal in 9.0.0) and with no setter — assigning it left `voices` empty and rendered silence. Flatten at the call site instead; note `voices` is voice-major and the renderers depend on that order
 - **Time Modes:** `time_mode: normalized` maps 0.0–1.0 to actual duration at grain generation time
 - **Math in YAML:** expressions like `(pi)` and `(10/2)` are evaluated via safe_eval before parsing
 

--- a/docs/explanation/costo-rendering.md
+++ b/docs/explanation/costo-rendering.md
@@ -7,7 +7,7 @@ sources:
   - src/pge/rendering/numpy_audio_renderer.py
   - src/pge/core/stream.py
   - utils/bench_cost.py
-last_synced_commit: 4f2708a
+last_synced_commit: f138d06
 ---
 
 # Costo del rendering — PythonGranularEngine
@@ -44,14 +44,19 @@ da 5 a 320 secondi), Apple M2 Max, Python 3.11, rendering sequenziale:
 
 | coefficiente | valore | cosa paga |
 |---|---|---|
-| `a` | ~32 µs per grano | costruire il `Grain`, finestrarlo, sommarlo nel buffer |
-| `b` | ~1,3 ms per secondo di uscita | allocare, normalizzare e scrivere il buffer |
+| `a` | ~34 µs per grano | costruire il `Grain`, finestrarlo, sommarlo nel buffer |
+| `b` | ~1,4 ms per secondo di uscita | allocare, normalizzare e scrivere il buffer |
 
-Errore relativo mediano sotto l'1,5%, massimo ~5%. Due parametri coprono tre
-ordini di grandezza di grani e due di durata. Fra run ripetute i coefficienti
-oscillano di qualche punto percentuale.
+Errore relativo mediano sotto l'1%, massimo ~9% (il punto peggiore è il più
+piccolo dello sweep, dove il costo fisso dell'avvio pesa). Due parametri coprono
+tre ordini di grandezza di grani e due di durata. Fra run ripetute i
+coefficienti oscillano di qualche punto percentuale: i valori qui vengono da una
+misura successiva alla issue #201, che ha tolto da `generate_grains()` il
+flatten+sort eager della vista `Stream.grains`, e restano gli stessi entro
+quell'oscillazione — il flatten valeva il ~3% della sola generazione, cioè meno
+del rumore fra run.
 
-**I due termini pareggiano attorno ai 40 grani al secondo.** Sotto quella
+**I due termini pareggiano attorno ai 42 grani al secondo.** Sotto quella
 densità comanda la durata dell'uscita; sopra comandano i grani. Il regime
 granulare d'uso sta sopra — a densità 100 il termine dei grani pesa 2,4 volte
 quello della durata, a densità 800 pesa venti volte — quindi *nella pratica* il
@@ -65,22 +70,26 @@ I grani sono **lazy**: `Stream.voices` è una property che chiama
 `generate_grains()` al primo accesso (`src/pge/core/stream.py`). Chi li tocca per
 primo è il render, quindi senza forzare la materializzazione il costo di
 costruire gli oggetti finisce dentro il tempo di rendering. Forzarla prima non
-cambia il totale — 1,071 s contro 1,085 s sullo stesso materiale — ma separa le
-due metà del lavoro:
+cambia il totale — è lo stesso lavoro, spostato — ma separa le due metà:
 
 | materiale | grani | durata | parse | costruzione dei `Grain` | overlap-add + scrittura | totale |
 |---|---|---|---|---|---|---|
-| esempio didattico multi-stream | 38 072 | 32,4 s | 0,008 s | 0,52 s (13,7 µs/grano) | 0,57 s | **1,10 s** |
-| `configs/PGE_cim.yml` | 994 291 | 92,5 s | 0,036 s | 8,87 s (8,9 µs/grano) | 19,94 s | **28,85 s** |
+| `configs/PGE_ff2_rassegna.yml` | 221 082 | 1 698 s | 0,12 s | 1,72 s (7,8 µs/grano) | 13,11 s | **14,95 s** |
+| `configs/PGE_cim.yml` | 994 555 | 92,5 s | 0,04 s | 9,73 s (9,8 µs/grano) | 20,45 s | **30,22 s** |
 
-Circa un terzo del costo, in un caso reale, è **materializzare la popolazione**,
-non il DSP. È il prezzo della rappresentazione intermedia esplicita: la lista di
+I due casi hanno il rapporto grani/durata rovesciato — 130 grani al secondo il
+primo, 10 700 il secondo — ed è il motivo per cui la quota di costruzione
+cambia: un ottavo del totale sul primo, quasi un terzo sul secondo. Nel regime
+denso **materializzare la popolazione** costa quanto una fetta consistente del
+DSP. È il prezzo della rappresentazione intermedia esplicita: la lista di
 `Grain` esiste come oggetto ispezionabile prima di diventare campioni, ed è
 quello che rende possibili la `map`, gli export e il debugging.
 
 In memoria quella lista costa poco: **~225 byte per grano** (`Grain` ha
 `__slots__` e 8 campi), cioè 8,5 MB per 38 000 grani. Il picco del processo è
-dominato da NumPy e dal buffer audio, non dai grani.
+dominato da NumPy e dal buffer audio, non dai grani. Se ne teneva una seconda
+copia — la vista flat, ~8 MB per milione di grani — finché la issue #201 non
+l'ha resa derivata.
 
 ## Trade-off
 
@@ -108,11 +117,17 @@ circa 0,3 s a invocazione, che su un rendering breve non è trascurabile.
 - `src/pge/rendering/numpy_audio_renderer.py` — `_overlap_add` sceglie fra il
   path sequenziale e `_overlap_add_parallel` in base a `jobs` e
   `min_parallel_grains`; è il termine `a` del modello.
-- `src/pge/core/stream.py` — la property `grains` e la generazione lazy; è la
-  metà del termine `a` che non è DSP.
+- `src/pge/core/stream.py` — la property `voices` e la generazione lazy; è la
+  metà del termine `a` che non è DSP. (`grains` è una vista derivata di
+  `voices`, deprecata dalla issue #201: non partecipa al costo se non la si
+  legge, e il benchmark non la legge.)
 - `utils/bench_cost.py` — produce tutte le misure di questa pagina. Non ha
   dipendenze oltre a quelle del motore e genera un sample sintetico se `refs/`
-  è vuota, quindi gira su un clone pulito.
+  è vuota, ma **su un clone pulito non gira lo stesso**: `_load()` costruisce
+  il `Generator` senza `samples_dir` e `_render()` passa il sample sintetico
+  come `ssdir`, che vale solo per Csound — entrambi i percorsi ricadono sul
+  globale `./refs/` e lo script muore in `SampleNotFoundError` prima di
+  misurare. Difetto noto, tracciato a parte.
 
 Un cambiamento che tocchi la costruzione del `Grain` o l'overlap-add si vede
 sul coefficiente `a`; uno che tocchi la scrittura del file si vede su `b`.

--- a/docs/explanation/costo-rendering.md
+++ b/docs/explanation/costo-rendering.md
@@ -85,11 +85,12 @@ DSP. È il prezzo della rappresentazione intermedia esplicita: la lista di
 `Grain` esiste come oggetto ispezionabile prima di diventare campioni, ed è
 quello che rende possibili la `map`, gli export e il debugging.
 
-In memoria quella lista costa poco: **~225 byte per grano** (`Grain` ha
-`__slots__` e 8 campi), cioè 8,5 MB per 38 000 grani. Il picco del processo è
-dominato da NumPy e dal buffer audio, non dai grani. Se ne teneva una seconda
-copia — la vista flat, ~8 MB per milione di grani — finché la issue #201 non
-l'ha resa derivata.
+In memoria quella lista costa **~225 byte per grano** (`Grain` ha `__slots__`
+e 8 campi): 50 MB per i 221 082 grani di `PGE_ff2_rassegna.yml`, 224 MB per i
+994 555 di `PGE_cim.yml`. Non è trascurabile nel regime denso, ma il picco del
+processo resta dominato da NumPy e dal buffer audio, non dai grani. Se ne
+teneva una seconda copia — la vista flat, ~8 MB per milione di grani — finché
+la issue #201 non l'ha resa derivata.
 
 ## Trade-off
 

--- a/docs/explanation/multi-voice.md
+++ b/docs/explanation/multi-voice.md
@@ -6,7 +6,7 @@ tags: [voices, strategy, dmx-1000, granular]
 sources:
   - src/pge/strategies/
   - src/pge/core/stream.py
-last_synced_commit: e829fc1
+last_synced_commit: 8249cdb
 ---
 
 # Sistema Multi-Voice — PythonGranularEngine
@@ -129,8 +129,7 @@ Stream._init_voice_manager()
 
     ▼
 Stream.generate_grains()
-    └─ voices: List[List[Grain]]   (indicizzati per voce)
-         + grains: List[Grain]     (flat, ordinato per onset — backward compat)
+    └─ voices: List[List[Grain]]   (indicizzati per voce — unica fonte di verità)
 ```
 
 ---
@@ -609,10 +608,25 @@ def _init_voice_manager(self, params: dict) -> None:
 ```python
 # Struttura restituita
 self.voices: List[List[Grain]]   # voices[voice_idx][grain_idx]
-self.grains: List[Grain]         # flat, ordinato per onset (backward compat)
 ```
 
-Con N voci e densità costante, `len(self.grains) == N × len(singola_voce)`.
+Con N voci e densità costante, `len(voices[i])` è uguale per ogni voce attiva:
+il totale dei grani è `N × len(singola_voce)`.
+
+`Stream.grains` esiste ancora — vista flat e ordinata per onset — ma è
+**derivata** da `voices` e **deprecata** (issue #201): sarà rimossa in 9.0.0.
+Non è memorizzata e non ha una setter: assegnarla lasciava `voices` vuoto e lo
+stream renderizzava silenzio senza segnalare nulla. Chi ha bisogno della lista
+piatta la costruisce dove serve:
+
+```python
+[g for voice in stream.voices for g in voice]                    # voice-major
+sorted(_, key=lambda g: g.onset)                                 # per onset
+```
+
+I due ordini non sono intercambiabili: `Grain` non porta l'indice di voce
+(la vista flat è lossy) e i renderer sommano in ordine voice-major, che è
+quel che rende un rendering riproducibile.
 
 ### Fade frazionario di `num_voices`
 
@@ -798,7 +812,7 @@ Risultato: range cresce da 0 a 8 semitoni nella durata dello stream, indipendent
 | Riproducibilità stochastic | Seed = `hash(stream_id + voice_index)` → stesso YAML → stesso output |
 | Pitch moltiplicativo | `pitch_ratio *= pitch_factor` (fattore materializzato dalla `PitchUnit`) → compatibile con ratio audio standard |
 | Fade frazionario voci | La parte decimale di `num_voices` interpolato attenua la voce di confine (`volume += 20·log10(frac)`); `step` con breakpoint interi → on/off netto come prima |
-| Backward compatibility | `self.grains` rimane piatto e ordinato per tutti i consumer esistenti; config scalari esistenti e `step` con breakpoint interi invariati |
+| Backward compatibility | `voices` è l'unica fonte di verità; `stream.grains` resta leggibile come vista derivata ma è deprecata (#201). Config scalari esistenti e `step` con breakpoint interi invariati |
 
 ---
 

--- a/docs/explanation/multi-voice.md
+++ b/docs/explanation/multi-voice.md
@@ -6,7 +6,7 @@ tags: [voices, strategy, dmx-1000, granular]
 sources:
   - src/pge/strategies/
   - src/pge/core/stream.py
-last_synced_commit: 8249cdb
+last_synced_commit: 8a8029c
 ---
 
 # Sistema Multi-Voice — PythonGranularEngine

--- a/docs/how-to/sonic-visualiser.md
+++ b/docs/how-to/sonic-visualiser.md
@@ -7,7 +7,7 @@ sources:
   - src/pge/export/sv_exporter.py
   - src/pge/rendering/envelope_extractor.py
   - src/main.py
-last_synced_commit: a730371
+last_synced_commit: 4c3069c
 entry_for: [export-sonic-visualiser]
 ---
 

--- a/src/pge/core/stream.py
+++ b/src/pge/core/stream.py
@@ -993,7 +993,11 @@ class Stream:
             "'[g for voice in stream.voices for g in voice]', aggiungendo "
             "un sorted(..., key=lambda g: g.onset) se serve l'ordine per "
             "onset.",
-            DeprecationWarning,
+            # FutureWarning, non DeprecationWarning: il secondo Python lo
+            # filtra di default fuori da __main__, quindi lo vedrebbe solo
+            # questo repo sotto pytest — cioe' nessuno dei consumatori a cui
+            # il preavviso serve.
+            FutureWarning,
             stacklevel=2,
         )
         # Il sort e' stabile: a parita' di onset i grani restano in ordine

--- a/src/pge/core/stream.py
+++ b/src/pge/core/stream.py
@@ -15,6 +15,7 @@ Ispirato al DMX-1000 di Barry Truax (1988).
 from __future__ import annotations
 
 import random
+import warnings
 from math import ceil, floor, log10
 from typing import List, Optional, Union
 
@@ -962,21 +963,39 @@ class Stream:
 
     @property
     def grains(self) -> List[Grain]:
-        """Vista flat dei grani, ordinata per onset (backward compat).
+        """DEPRECATA (issue #201), rimozione prevista in 9.0.0.
 
-        DERIVATA da `voices`, non memorizzata: ricalcolata a ogni lettura
-        (issue #201). Prima era un secondo campo, allineato solo lungo il
-        percorso `generate_grains()`; fuori da li' le due viste divergevano
-        in silenzio. Costruirla qui costa O(N log N) a chi la legge, e nulla
-        a chi non la legge — cioe' a tutti i backend, che iterano `voices`.
+        Vista flat dei grani, ordinata per onset. DERIVATA da `voices`, non
+        memorizzata: ricalcolata a ogni lettura. Prima era un secondo campo,
+        allineato solo lungo il percorso `generate_grains()`; fuori da li' le
+        due viste divergevano in silenzio.
 
-        Attenzione all'ordine: `voices` e' voice-major, questa e' per onset.
-        I renderer dipendono dal primo (l'ordine delle somme float e' quello
-        che rende un rendering riproducibile), quindi non e' un rimpiazzo di
-        `[g for voice in stream.voices for g in voice]`.
+        Rimpiazzo, a seconda di cosa serve:
+
+            [g for voice in stream.voices for g in voice]          # voice-major
+            sorted(..., key=lambda g: g.onset)                     # per onset
+
+        Non sono intercambiabili, ed e' il motivo per cui questa property se
+        ne va invece di restare: `Grain` non porta l'indice di voce, quindi la
+        vista flat e' lossy rispetto a `voices`, e l'ordine per onset non e'
+        quello su cui i renderer sommano (l'ordine delle somme float e' quel
+        che rende un rendering riproducibile). Nessun backend la legge —
+        score_writer, numpy_audio_renderer, grain_visuals e grain_json_writer
+        iterano tutti `voices`.
 
         Lazy come `voices`: la lettura genera i grani al primo accesso.
         """
+        warnings.warn(
+            "Stream.grains e' deprecata (issue #201) e sara' rimossa in "
+            "PGE 9.0.0: e' una vista derivata di Stream.voices, lossy "
+            "(il Grain non porta l'indice di voce) e ordinata per onset "
+            "invece che per voce. Usa "
+            "'[g for voice in stream.voices for g in voice]', aggiungendo "
+            "un sorted(..., key=lambda g: g.onset) se serve l'ordine per "
+            "onset.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         # Il sort e' stabile: a parita' di onset i grani restano in ordine
         # voice-major, come nella versione memorizzata.
         return sorted(
@@ -987,6 +1006,9 @@ class Stream:
     @grains.setter
     def grains(self, value: List[Grain]) -> None:
         """Sempre rifiutato: `voices` e' l'unico ingresso (issue #201).
+
+        Non deprecato ma rimosso subito, senza ciclo di preavviso: un setter
+        che riesce e produce silenzio non ha una versione "che avvisa".
 
         Il setter esisteva e marcava `generated = True` senza toccare
         `_voices`: lo stream restava senza grani da renderizzare e usciva

--- a/src/pge/core/stream.py
+++ b/src/pge/core/stream.py
@@ -98,8 +98,11 @@ class Stream:
     Mantiene compatibilità con Generator e ScoreVisualizer.
     
     Attributes:
-        voices: List[List[Grain]] - grani organizzati per voce
-        grains: List[Grain] - lista flattened (backward compatibility)
+        voices: List[List[Grain]] - grani organizzati per voce, unica
+                fonte di verita' su quali grani esistono
+        grains: List[Grain] - vista DERIVATA di voices, flat e ordinata per
+                onset (backward compatibility). Ricalcolata a ogni lettura:
+                non e' un secondo stato da tenere in sync (issue #201)
     """
     
     def __init__(self, params: dict, seed=None, samples_dir=None):
@@ -175,8 +178,9 @@ class Stream:
         # generate_grains() al primo accesso. Cosi' il Generator non genera i
         # grani per gli stream cache-clean (il renderer short-circuita su
         # is_dirty prima di leggere .voices), risparmiando il costo dominante.
+        # _voices e' l'unico backing field: la vista flat .grains e' derivata
+        # (issue #201), non un secondo campo da mantenere allineato.
         self._voices: List[List[Grain]] = []
-        self._grains: List[Grain] = []  # backward compatibility (flat)
         self.generated = False
 
     @staticmethod
@@ -703,10 +707,6 @@ class Stream:
         # Assegna ai backing field, non alle property: il getter di .voices
         # innescherebbe ricorsivamente generate_grains (generated ancora False).
         self._voices = clip_strategy.apply(all_voice_grains, self)
-        # Flatten e sort per onset (backward compatibility)
-        all_grains = [g for voice in self._voices for g in voice]
-        all_grains.sort(key=lambda g: g.onset)
-        self._grains = all_grains
         self.generated = True
 
         return self._voices
@@ -962,15 +962,42 @@ class Stream:
 
     @property
     def grains(self) -> List[Grain]:
-        """Vista flat dei grani (backward compat). Lazy: genera al primo accesso."""
-        if not self.generated:
-            self.generate_grains()
-        return self._grains
+        """Vista flat dei grani, ordinata per onset (backward compat).
+
+        DERIVATA da `voices`, non memorizzata: ricalcolata a ogni lettura
+        (issue #201). Prima era un secondo campo, allineato solo lungo il
+        percorso `generate_grains()`; fuori da li' le due viste divergevano
+        in silenzio. Costruirla qui costa O(N log N) a chi la legge, e nulla
+        a chi non la legge — cioe' a tutti i backend, che iterano `voices`.
+
+        Attenzione all'ordine: `voices` e' voice-major, questa e' per onset.
+        I renderer dipendono dal primo (l'ordine delle somme float e' quello
+        che rende un rendering riproducibile), quindi non e' un rimpiazzo di
+        `[g for voice in stream.voices for g in voice]`.
+
+        Lazy come `voices`: la lettura genera i grani al primo accesso.
+        """
+        # Il sort e' stabile: a parita' di onset i grani restano in ordine
+        # voice-major, come nella versione memorizzata.
+        return sorted(
+            (g for voice in self.voices for g in voice),
+            key=lambda g: g.onset,
+        )
 
     @grains.setter
     def grains(self, value: List[Grain]) -> None:
-        self._grains = value
-        self.generated = True
+        """Sempre rifiutato: `voices` e' l'unico ingresso (issue #201).
+
+        Il setter esisteva e marcava `generated = True` senza toccare
+        `_voices`: lo stream restava senza grani da renderizzare e usciva
+        muto, con `__repr__` che continuava a dichiararli presenti.
+        """
+        raise AttributeError(
+            "Stream.grains e' una vista derivata, in sola lettura (issue #201): "
+            "assegnarla lasciava .voices vuoto e lo stream renderizzava "
+            "silenzio senza segnalare nulla. Per iniettare i grani usa "
+            "'stream.voices = [[grano, ...], ...]', una lista per voce."
+        )
 
     # =========================================================================
     # REPR
@@ -980,6 +1007,9 @@ class Stream:
         mode = "fill_factor" if self.fill_factor is not None else "density"
         # NON innescare la generazione lazy: _create_streams stampa {stream} per
         # ogni stream; leggere la property .grains rigenererebbe tutto.
-        grain_count = len(self._grains) if self.generated else 'lazy'
+        # Il conteggio viene da _voices: leggerlo dal vecchio campo _grains
+        # faceva mentire il repr su ogni stream con le voci iniettate (#201).
+        grain_count = (sum(len(v) for v in self._voices)
+                       if self.generated else 'lazy')
         return (f"Stream(id={self.stream_id}, onset={self.onset}, "
                 f"dur={self.duration}, mode={mode}, grains={grain_count})")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,8 @@ Fixtures e helpers condivisi tra tutte le test suite.
 Contenuto:
 - mock_config: StreamConfig/StreamContext mockato per i controller tests
   Usato da: test_density_controller, test_pitch_controller, test_pointer_controller
+- build_stream: Stream veri, costruiti attraverso __init__
+- flat_grains: la vista flat dei grani, per i test che ne hanno bisogno
 """
 
 import pytest
@@ -99,3 +101,21 @@ def make_mock_stream_for_generator(stream_id='stream_01', sample='test.wav'):
     stream.__repr__ = Mock(return_value=f"Stream({stream_id})")
     stream.__str__ = Mock(return_value=f"Stream({stream_id})")
     return stream
+
+
+def flat_grains(stream):
+    """Tutti i grani dello stream, flat e ordinati per onset.
+
+    Rimpiazza le letture di `stream.grains`, deprecata (issue #201). La
+    vista
+    flat non e' uno stato dello Stream: e' una comodita' per chi guarda gli
+    eventi senza distinguere le voci, e questa e' la riga che la costruisce.
+
+    Stessa semantica della property: il sort e' stabile, quindi a parita' di
+    onset i grani restano in ordine voice-major. Chi ha bisogno DELL'ordine
+    voice-major (i renderer) itera `stream.voices` e non passa di qui.
+    """
+    return sorted(
+        (g for voice in stream.voices for g in voice),
+        key=lambda g: g.onset,
+    )

--- a/tests/core/test_grain_duration_unit.py
+++ b/tests/core/test_grain_duration_unit.py
@@ -24,6 +24,7 @@ from pge.shared.exceptions import (
     MissingFieldError,
     ParameterBoundError,
 )
+from conftest import flat_grains
 
 
 SAMPLE_DUR = 10.0
@@ -52,10 +53,10 @@ class TestDurationUnitSamples:
 
     def test_scalar_duration_in_samples(self):
         s = _make_stream({'duration': 480, 'duration_unit': 'samples'})
-        assert len(s.grains) > 0
+        assert len(flat_grains(s)) > 0
         assert all(
             g.duration == pytest.approx(480 / DEFAULT_OUTPUT_SR)
-            for g in s.grains
+            for g in flat_grains(s)
         )
 
     def test_one_sample_grain_is_valid(self):
@@ -63,9 +64,9 @@ class TestDurationUnitSamples:
         s = _make_stream({'duration': 1, 'duration_unit': 'samples'})
         assert all(
             g.duration == pytest.approx(1.0 / DEFAULT_OUTPUT_SR)
-            for g in s.grains
+            for g in flat_grains(s)
         )
-        assert len(s.grains) > 0
+        assert len(flat_grains(s)) > 0
 
     def test_envelope_duration_in_samples(self):
         """Envelope: i valori Y sono campioni, l'asse X resta tempo."""
@@ -73,9 +74,9 @@ class TestDurationUnitSamples:
             'duration': [[0.0, 48], [1.0, 4800]],
             'duration_unit': 'samples',
         })
-        first = s.grains[0]
+        first = flat_grains(s)[0]
         assert first.duration == pytest.approx(48 / DEFAULT_OUTPUT_SR, rel=1e-3)
-        assert max(g.duration for g in s.grains) > 10 * first.duration
+        assert max(g.duration for g in flat_grains(s)) > 10 * first.duration
 
     def test_duration_range_in_samples(self):
         """duration_range condivide l'unita' del blocco: i grani variano
@@ -85,7 +86,7 @@ class TestDurationUnitSamples:
              'duration_unit': 'samples'},
             range_always_active=True,
         )
-        durations = [g.duration for g in s.grains]
+        durations = [g.duration for g in flat_grains(s)]
         lo = (480 - 48) / DEFAULT_OUTPUT_SR
         hi = (480 + 48) / DEFAULT_OUTPUT_SR
         assert all(lo - 1e-12 <= d <= hi + 1e-12 for d in durations)
@@ -96,7 +97,7 @@ class TestDurationUnitSamples:
         s = _make_stream({'duration': 48.5, 'duration_unit': 'samples'})
         assert all(
             g.duration == pytest.approx(48.5 / DEFAULT_OUTPUT_SR)
-            for g in s.grains
+            for g in flat_grains(s)
         )
 
 
@@ -105,16 +106,16 @@ class TestDurationUnitMilliseconds:
 
     def test_scalar_duration_in_milliseconds(self):
         s = _make_stream({'duration': 10, 'duration_unit': 'milliseconds'})
-        assert len(s.grains) > 0
-        assert all(g.duration == pytest.approx(0.01) for g in s.grains)
+        assert len(flat_grains(s)) > 0
+        assert all(g.duration == pytest.approx(0.01) for g in flat_grains(s))
 
     def test_conversion_factor_is_fixed_not_sample_rate(self):
         """Il fattore e' 1e-3, non 1/output_sr: lo stesso numero letto come
         millisecondi e come campioni da' due durate diverse."""
         ms = _make_stream({'duration': 50, 'duration_unit': 'milliseconds'})
         smp = _make_stream({'duration': 50, 'duration_unit': 'samples'})
-        assert ms.grains[0].duration == pytest.approx(0.05)
-        assert smp.grains[0].duration == pytest.approx(50 / DEFAULT_OUTPUT_SR)
+        assert flat_grains(ms)[0].duration == pytest.approx(0.05)
+        assert flat_grains(smp)[0].duration == pytest.approx(50 / DEFAULT_OUTPUT_SR)
 
     def test_envelope_duration_in_milliseconds(self):
         """Envelope: i valori Y sono millisecondi, l'asse X resta tempo."""
@@ -122,9 +123,9 @@ class TestDurationUnitMilliseconds:
             'duration': [[0.0, 1], [1.0, 100]],
             'duration_unit': 'milliseconds',
         })
-        first = s.grains[0]
+        first = flat_grains(s)[0]
         assert first.duration == pytest.approx(0.001, rel=1e-3)
-        assert max(g.duration for g in s.grains) > 10 * first.duration
+        assert max(g.duration for g in flat_grains(s)) > 10 * first.duration
 
     def test_duration_range_in_milliseconds(self):
         """duration_range condivide l'unita' del blocco: i grani variano
@@ -134,7 +135,7 @@ class TestDurationUnitMilliseconds:
              'duration_unit': 'milliseconds'},
             range_always_active=True,
         )
-        durations = [g.duration for g in s.grains]
+        durations = [g.duration for g in flat_grains(s)]
         lo = (10 - 2) / 1000.0
         hi = (10 + 2) / 1000.0
         assert all(lo - 1e-12 <= d <= hi + 1e-12 for d in durations)
@@ -142,7 +143,7 @@ class TestDurationUnitMilliseconds:
 
     def test_fractional_milliseconds_allowed(self):
         s = _make_stream({'duration': 4.5, 'duration_unit': 'milliseconds'})
-        assert all(g.duration == pytest.approx(0.0045) for g in s.grains)
+        assert all(g.duration == pytest.approx(0.0045) for g in flat_grains(s))
 
     def test_below_one_sample_in_milliseconds_rejected(self):
         """Il bound minimo resta 1 campione: 0.001 ms sta sotto."""
@@ -177,18 +178,18 @@ class TestDurationUnitSeconds:
 
     def test_default_unit_is_seconds(self):
         s = _make_stream({'duration': 0.05})
-        assert all(g.duration == pytest.approx(0.05) for g in s.grains)
+        assert all(g.duration == pytest.approx(0.05) for g in flat_grains(s))
 
     def test_explicit_seconds_is_noop(self):
         s = _make_stream({'duration': 0.05, 'duration_unit': 'seconds'})
-        assert all(g.duration == pytest.approx(0.05) for g in s.grains)
+        assert all(g.duration == pytest.approx(0.05) for g in flat_grains(s))
 
     def test_seconds_down_to_one_sample_valid(self):
         """Anche in secondi la soglia minima e' ora 1 campione, non 1 ms."""
         s = _make_stream({'duration': 1.0 / DEFAULT_OUTPUT_SR})
         assert all(
             g.duration == pytest.approx(1.0 / DEFAULT_OUTPUT_SR)
-            for g in s.grains
+            for g in flat_grains(s)
         )
 
     def test_seconds_below_one_sample_rejected(self):
@@ -234,7 +235,7 @@ class TestDurationUnitValidation:
         s = _make_stream(
             {'duration': 480, 'duration_range': 96, 'duration_unit': 'samples'},
         )
-        assert len(s.grains) > 0
+        assert len(flat_grains(s)) > 0
 
 
 class TestDurationUnitDoesNotLeak:
@@ -277,8 +278,8 @@ class TestSamplesUnitRenderIntegration:
         renderer = GrainRenderer(reg, NumpyWindowRegistry(),
                                  output_sr=DEFAULT_OUTPUT_SR)
 
-        assert len(s.grains) > 0
-        for grain in s.grains[:10]:
+        assert len(flat_grains(s)) > 0
+        for grain in flat_grains(s)[:10]:
             buf = renderer.render(grain, 'test.wav', 'rectangle')
             assert buf.shape == (1, 2)          # esattamente 1 frame stereo
             assert np.abs(buf).max() > 0.5      # impulso non silente

--- a/tests/core/test_stream.py
+++ b/tests/core/test_stream.py
@@ -205,8 +205,9 @@ def stream_factory():
         s._clip_strategy = PassthroughClipStrategy()
 
         # Stato
+        # `voices` e' l'unico ingresso: `grains` e' una vista derivata
+        # e non ha piu' un setter (issue #201).
         s.voices = []
-        s.grains = []
         s.generated = False
 
         return s
@@ -550,11 +551,12 @@ class TestStreamInit:
 
             assert s.stream_id == 'test_stream'
             assert s.duration == 2.0
-            # Contratto lazy: la costruzione NON genera i grani. Si ispezionano i
-            # backing field grezzi, non le property voices/grains, che innescano
+            # Contratto lazy: la costruzione NON genera i grani. Si ispeziona il
+            # backing field grezzo, non la property voices, che innesca
             # generate_grains() al primo accesso.
             assert s._voices == []
-            assert s._grains == []
+            # Backing field unico (#201): la vista flat .grains e' derivata.
+            assert not hasattr(s, '_grains')
             assert s.generated is False
             assert s.sample_table_num is None
             assert s.envelope_table_num is None

--- a/tests/core/test_stream.py
+++ b/tests/core/test_stream.py
@@ -33,6 +33,7 @@ from unittest.mock import Mock, patch, MagicMock, PropertyMock, call
 from dataclasses import dataclass
 from pge.core.stream_config import StreamContext, StreamConfig
 from pge.core.stream import Stream
+from conftest import flat_grains
 
 
 # =============================================================================
@@ -576,7 +577,7 @@ class TestStreamInit:
 class TestLazyGrainGeneration:
     """
     Contratto lazy: i grani si materializzano alla PRIMA lettura di
-    .voices/.grains, non alla costruzione. Questo permette al Generator di
+    .voices, non alla costruzione. Questo permette al Generator di
     non generare i grani per gli stream cache-clean (il renderer short-circuita
     su is_dirty prima di leggere .voices), realizzando il risparmio di #117.
     """
@@ -591,16 +592,6 @@ class TestLazyGrainGeneration:
         assert s.generated is True
         assert len(voices) == 1            # max_voices=1
         assert len(voices[0]) > 0
-
-    def test_accessing_grains_triggers_generation(self, stream_factory):
-        """Leggere .grains su uno stream non generato innesca generate_grains."""
-        s = stream_factory(duration=0.5, inter_onset=0.1)
-        assert s.generated is False
-
-        grains = s.grains
-
-        assert s.generated is True
-        assert len(grains) > 0
 
     def test_voices_memoized_single_generation(self, stream_factory):
         """Accessi multipli a .voices generano i grani una sola volta."""
@@ -625,7 +616,7 @@ class TestLazyGrainGeneration:
         """__repr__ NON deve materializzare i grani.
 
         _create_streams stampa {stream} per ogni stream: se __repr__ leggesse la
-        property .grains, rigenererebbe tutti gli stream annullando il risparmio.
+        property .voices, rigenererebbe tutti gli stream annullando il risparmio.
         """
         s = stream_factory(duration=0.5, inter_onset=0.1)
 
@@ -683,15 +674,6 @@ class TestGenerateGrainsSingleVoice:
 
         assert len(s.voices) == 1
         assert len(s.voices[0]) in (10, 11)  # floating point accumulation
-
-    def test_grains_flattened_for_backward_compat(self, stream_factory):
-        """self.grains contiene versione flattened."""
-        s = stream_factory(duration=0.5, inter_onset=0.1)
-
-        s.generate_grains()
-
-        assert len(s.grains) == len(s.voices[0])
-        assert s.grains == s.voices[0]
 
     def test_generated_flag_set(self, stream_factory):
         """generated diventa True dopo generate_grains."""
@@ -765,10 +747,10 @@ class TestGenerateGrainsState:
         s = stream_factory(duration=0.3, inter_onset=0.1)
 
         s.generate_grains()
-        first_count = len(s.grains)
+        first_count = len(flat_grains(s))
 
         s.generate_grains()
-        second_count = len(s.grains)
+        second_count = len(flat_grains(s))
 
         # Deve aver resettato, non accumulato
         assert first_count == second_count
@@ -1123,7 +1105,7 @@ class TestStreamRepr:
 
         r = repr(s)
 
-        assert f'grains={len(s.grains)}' in r
+        assert f'grains={len(flat_grains(s))}' in r
 
     def test_repr_fill_factor_mode(self, stream_factory):
         """repr mostra mode=fill_factor se fill_factor presente."""
@@ -1221,7 +1203,7 @@ class TestStreamIntegration:
 
         s.generate_grains()
 
-        for grain in s.grains:
+        for grain in flat_grains(s):
             assert grain.onset >= 1.0
             assert grain.duration == pytest.approx(0.05)
             assert grain.volume == pytest.approx(-6.0)
@@ -1236,7 +1218,7 @@ class TestStreamIntegration:
         s.generate_grains()
 
         expected_total = sum(len(v) for v in s.voices)
-        assert len(s.grains) == expected_total
+        assert len(flat_grains(s)) == expected_total
 
     def test_onsets_monotonically_increasing_per_voice(self, stream_factory):
         """Dentro ogni voce, gli onset crescono."""
@@ -1254,7 +1236,7 @@ class TestStreamIntegration:
 
         s.generate_grains()
 
-        total_grains = len(s.grains)
+        total_grains = len(flat_grains(s))
         assert s._pitch.calculate.call_count == total_grains
 
     def test_pointer_controller_called_every_grain(self, stream_factory):
@@ -1263,7 +1245,7 @@ class TestStreamIntegration:
 
         s.generate_grains()
 
-        total_grains = len(s.grains)
+        total_grains = len(flat_grains(s))
         assert s._pointer.calculate.call_count == total_grains
 
     def test_window_selection_per_grain(self, stream_factory):
@@ -1272,7 +1254,7 @@ class TestStreamIntegration:
 
         s.generate_grains()
 
-        assert s._window_controller.select_window.call_count == len(s.grains)
+        assert s._window_controller.select_window.call_count == len(flat_grains(s))
 
 
 # =============================================================================

--- a/tests/core/test_stream_duration_default.py
+++ b/tests/core/test_stream_duration_default.py
@@ -18,6 +18,7 @@ import soundfile as sf
 
 from pge.core.stream import Stream
 from pge.shared.exceptions import MissingFieldError
+from conftest import flat_grains
 
 
 SR = 48000
@@ -66,12 +67,12 @@ class TestDurationDefaultsToSampleDuration:
 
     def test_grains_span_the_sample_duration(self, tmp_path):
         """Il default e' visibile sui grani, non solo sull'attributo: la
-        generazione e' lazy, quindi il test legge `.grains` (issue #205)."""
+        generazione e' lazy, quindi il test materializza i grani (issue #205)."""
         _write_wav(tmp_path, seconds=2.0)
 
         stream = _build(tmp_path)
 
-        onsets = [g.onset for g in stream.grains]
+        onsets = [g.onset for g in flat_grains(stream)]
         assert onsets, "senza duration lo stream deve comunque generare grani"
         assert max(onsets) < 2.0
         assert max(onsets) > 1.0, (
@@ -85,7 +86,7 @@ class TestDurationDefaultsToSampleDuration:
         stream = _build(tmp_path, duration=0.5)
 
         assert stream.duration == pytest.approx(0.5)
-        assert max(g.onset for g in stream.grains) < 0.5
+        assert max(g.onset for g in flat_grains(stream)) < 0.5
 
     def test_explicit_null_behaves_as_absent_key(self, tmp_path):
         """`duration: null` e' una dichiarazione vuota, non un valore: vale
@@ -95,7 +96,7 @@ class TestDurationDefaultsToSampleDuration:
         stream = _build(tmp_path, duration=None)
 
         assert stream.duration == pytest.approx(2.0)
-        assert max(g.onset for g in stream.grains) > 1.0
+        assert max(g.onset for g in flat_grains(stream)) > 1.0
 
     def test_zero_duration_is_not_replaced_by_the_sample(self, tmp_path):
         """`duration: 0` resta zero: il default scatta sull'assenza, non sulla
@@ -106,7 +107,7 @@ class TestDurationDefaultsToSampleDuration:
         stream = _build(tmp_path, duration=0)
 
         assert stream.duration == 0
-        assert stream.grains == []
+        assert flat_grains(stream) == []
 
     def test_normalized_time_mode_maps_onto_the_resolved_duration(self, tmp_path):
         """`time_mode: normalized` mappa 0.0-1.0 sulla duration risolta: senza
@@ -122,7 +123,7 @@ class TestDurationDefaultsToSampleDuration:
         # A meta' del sample l'envelope e' a meta' corsa. Se 0.0-1.0 fosse
         # mappato su una duration diversa (1 s, o un default arbitrario), qui
         # il valore sarebbe gia' saturo a 0.02.
-        midpoint = min(stream.grains, key=lambda g: abs(g.onset - 1.0))
+        midpoint = min(flat_grains(stream), key=lambda g: abs(g.onset - 1.0))
         assert midpoint.duration == pytest.approx(0.05, abs=1e-3)
 
 

--- a/tests/core/test_stream_grains_view.py
+++ b/tests/core/test_stream_grains_view.py
@@ -19,15 +19,17 @@ Qui si fissa il contratto che rende la divergenza impossibile per costruzione:
 una sola fonte di verita' (`_voices`) e `grains` calcolata a ogni lettura.
 """
 
+import warnings
+
 import pytest
 
 from pge.core.grain import Grain
 
 # Questo file esercita `.grains` di proposito: e' il file che ne fissa il
-# contratto finche' esiste. Il DeprecationWarning e' atteso ovunque tranne
+# contratto finche' esiste. Il FutureWarning e' atteso ovunque tranne
 # dove e' lui il soggetto (TestDeprecazione, che usa pytest.warns e vede
 # comunque il warning attraverso questo filtro).
-pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+pytestmark = pytest.mark.filterwarnings("ignore::FutureWarning")
 
 
 @pytest.fixture
@@ -175,15 +177,31 @@ class TestDeprecazione:
     """
 
     def test_leggerla_avvisa(self, stream):
-        with pytest.warns(DeprecationWarning, match="9.0.0"):
+        with pytest.warns(FutureWarning, match="9.0.0"):
             stream.grains
 
     def test_l_avviso_nomina_il_rimpiazzo(self, stream):
-        with pytest.warns(DeprecationWarning, match=r"stream\.voices"):
+        with pytest.warns(FutureWarning, match=r"stream\.voices"):
             stream.grains
+
+    def test_l_avviso_e_visibile_a_un_consumatore(self, stream):
+        """Il preavviso deve arrivare a chi importa `pge`, non solo a pytest.
+
+        Python filtra `DeprecationWarning` di default fuori da `__main__`:
+        con quella classe l'unico a vedere l'avviso sarebbe questo repo, cioe'
+        proprio chi non ne ha bisogno. Qui si simulano i filtri di default di
+        un consumatore.
+        """
+        with warnings.catch_warnings(record=True) as visti:
+            warnings.resetwarnings()
+            warnings.simplefilter("default")
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            stream.grains
+
+        assert [w for w in visti if issubclass(w.category, FutureWarning)]
 
     def test_voices_non_avvisa(self, stream, recwarn):
         """La fonte di verita' non e' toccata dalla deprecazione."""
         stream.voices
 
-        assert not [w for w in recwarn if w.category is DeprecationWarning]
+        assert not [w for w in recwarn if w.category is FutureWarning]

--- a/tests/core/test_stream_grains_view.py
+++ b/tests/core/test_stream_grains_view.py
@@ -114,6 +114,15 @@ class TestSemanticaDellaVista:
 
         assert [g.volume for g in s.grains] == [0.1, 0.2]
 
+    def test_su_grani_generati_e_il_flatten_di_voices(self, stream):
+        """Non solo su voci iniettate: anche sul percorso di generazione."""
+        stream.generate_grains()
+        attesi = sorted((g for voice in stream.voices for g in voice),
+                        key=lambda g: g.onset)
+
+        assert stream.grains
+        assert stream.grains == attesi
+
     def test_lettura_su_stream_non_generato_innesca_la_generazione(self, stream):
         s = stream
         assert s.generated is False

--- a/tests/core/test_stream_grains_view.py
+++ b/tests/core/test_stream_grains_view.py
@@ -23,6 +23,12 @@ import pytest
 
 from pge.core.grain import Grain
 
+# Questo file esercita `.grains` di proposito: e' il file che ne fissa il
+# contratto finche' esiste. Il DeprecationWarning e' atteso ovunque tranne
+# dove e' lui il soggetto (TestDeprecazione, che usa pytest.warns e vede
+# comunque il warning attraverso questo filtro).
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+
 
 @pytest.fixture
 def stream(build_stream):
@@ -152,3 +158,32 @@ class TestRepr:
 
         assert 'grains=lazy' in repr(s)
         assert s.generated is False
+
+
+# =============================================================================
+# 4. DEPRECAZIONE
+# =============================================================================
+
+class TestDeprecazione:
+    """La vista resta leggibile per un ciclo, poi sparisce (#201).
+
+    Non ha consumatori noti — ne' in PGE, ne' in PGE-ls o PGE-ui (che consuma
+    il JSON di GrainJsonWriter, non l'API Python), ne' negli script del repo
+    del paper CIM 2026 che pinna PGE come submodule — ma e' superficie
+    pubblica di una libreria a SemVer, quindi se ne va con un preavviso
+    invece che di colpo.
+    """
+
+    def test_leggerla_avvisa(self, stream):
+        with pytest.warns(DeprecationWarning, match="9.0.0"):
+            stream.grains
+
+    def test_l_avviso_nomina_il_rimpiazzo(self, stream):
+        with pytest.warns(DeprecationWarning, match=r"stream\.voices"):
+            stream.grains
+
+    def test_voices_non_avvisa(self, stream, recwarn):
+        """La fonte di verita' non e' toccata dalla deprecazione."""
+        stream.voices
+
+        assert not [w for w in recwarn if w.category is DeprecationWarning]

--- a/tests/core/test_stream_grains_view.py
+++ b/tests/core/test_stream_grains_view.py
@@ -1,0 +1,145 @@
+# tests/core/test_stream_grains_view.py
+"""Stream.grains e' una VISTA DERIVATA, non una seconda copia dei grani (#201).
+
+`generate_grains()` produceva due rappresentazioni degli stessi eventi tenute
+in due campi distinti — `_voices` (annidata per voce) e `_grains` (flat,
+ordinata per onset) — sincronizzate solo lungo il percorso di generazione.
+Fuori da quel percorso divergevano in silenzio, in entrambe le direzioni:
+
+- `stream.voices = [...]` lasciava `_grains` fermo al valore vecchio;
+- `stream.grains = [...]` lasciava `_voices` VUOTO e marcava `generated=True`.
+
+La seconda e' quella che fa danno: ogni backend legge `voices`, mai `grains`
+(score_writer, numpy_audio_renderer, grain_visuals, grain_json_writer), quindi
+uno stream iniettato via `.grains` renderizzava silenzio con uscita pulita e
+`__repr__` che continuava a dichiarare i grani presenti. Stessa classe di
+guasto di #225/#234: nessun errore, nessun avviso, un file muto.
+
+Qui si fissa il contratto che rende la divergenza impossibile per costruzione:
+una sola fonte di verita' (`_voices`) e `grains` calcolata a ogni lettura.
+"""
+
+import pytest
+
+from pge.core.grain import Grain
+
+
+@pytest.fixture
+def stream(build_stream):
+    """Stream vero, pronto a generare.
+
+    `build_stream` costruisce lo Stream attraverso `__init__`; i riferimenti
+    Csound (sample table, mappa finestre) li assegna normalmente il Generator,
+    quindi vanno forniti qui o `_create_grain` non arriva a costruire il Grain.
+    """
+    s = build_stream()
+    s.sample_table_num = 1
+    s.envelope_table_num = 2
+    s.window_table_map = {'hanning': 2}
+    return s
+
+
+def _grain(onset, volume=0.5):
+    return Grain(onset=onset, duration=0.01, pointer_pos=0.0, pitch_ratio=1.0,
+                 volume=volume, pan=0.5, sample_table=1, envelope_table=2)
+
+
+# =============================================================================
+# 1. NESSUNA DIVERGENZA POSSIBILE
+# =============================================================================
+
+class TestNessunaDivergenza:
+
+    def test_grains_riflette_le_voices_iniettate(self, stream):
+        """Direzione A: assegnare voices aggiorna anche la vista flat."""
+        s = stream
+        s.voices = [[_grain(0.0), _grain(0.1)]]
+
+        assert s.grains == [g for voice in s.voices for g in voice]
+
+    def test_iniezione_via_grains_rifiutata(self, stream):
+        """Direzione B: il setter che ammutoliva lo stream non esiste piu'.
+
+        Rifiutare con AttributeError e' il punto: prima l'assegnazione
+        riusciva e lasciava `.voices` vuoto, cioe' zero grani da renderizzare.
+        """
+        s = stream
+        grani = [g for voice in s.voices for g in voice]
+        assert grani, "lo stream di prova deve generare almeno un grano"
+
+        with pytest.raises(AttributeError, match="voices"):
+            s.grains = grani
+
+        # La fonte di verita' non e' stata toccata: niente stream muto.
+        assert [g for voice in s.voices for g in voice] == grani
+
+    def test_nessuno_stato_duplicato_ritenuto(self, stream):
+        """La vista e' ricalcolata, non conservata: due letture, due liste."""
+        s = stream
+
+        assert s.grains == s.grains          # stesso contenuto
+        assert s.grains is not s.grains      # oggetti distinti
+        assert '_grains' not in vars(s)      # nessun campo di appoggio
+
+    def test_mutare_la_vista_non_tocca_lo_stream(self, stream):
+        """Una vista derivata e' una fotografia: mutarla non desincronizza."""
+        s = stream
+        n = len(s.grains)
+
+        s.grains.append(_grain(999.0))
+
+        assert len(s.grains) == n
+
+
+# =============================================================================
+# 2. SEMANTICA DELLA VISTA (invariata rispetto a prima)
+# =============================================================================
+
+class TestSemanticaDellaVista:
+
+    def test_ordinata_per_onset(self, stream):
+        s = stream
+        s.voices = [[_grain(0.0), _grain(0.4)], [_grain(0.2), _grain(0.6)]]
+
+        assert [g.onset for g in s.grains] == [0.0, 0.2, 0.4, 0.6]
+
+    def test_a_parita_di_onset_resta_l_ordine_per_voce(self, stream):
+        """Il sort e' stabile: i pari-merito escono in ordine voice-major.
+
+        Non e' un dettaglio estetico — e' l'unica cosa che rende la vista
+        confrontabile con il flatten voice-major che usano i renderer.
+        """
+        s = stream
+        s.voices = [[_grain(0.0, volume=0.1)], [_grain(0.0, volume=0.2)]]
+
+        assert [g.volume for g in s.grains] == [0.1, 0.2]
+
+    def test_lettura_su_stream_non_generato_innesca_la_generazione(self, stream):
+        s = stream
+        assert s.generated is False
+
+        grani = s.grains
+
+        assert s.generated is True
+        assert grani == [g for voice in s.voices for g in voice]
+
+
+# =============================================================================
+# 3. __repr__ NON MENTE PIU'
+# =============================================================================
+
+class TestRepr:
+
+    def test_conta_dalle_voices(self, stream):
+        """Prima riportava il conteggio di `_grains`, rimasto a zero."""
+        s = stream
+        s.voices = [[_grain(0.0), _grain(0.1)], [_grain(0.2)]]
+
+        assert 'grains=3' in repr(s)
+
+    def test_non_innesca_la_generazione_lazy(self, stream):
+        """Vincolo #117: _create_streams stampa ogni stream appena creato."""
+        s = stream
+
+        assert 'grains=lazy' in repr(s)
+        assert s.generated is False

--- a/tests/core/test_stream_multivoice.py
+++ b/tests/core/test_stream_multivoice.py
@@ -12,7 +12,7 @@ Principi testati:
 - Voce 0 produce grani identici al comportamento mono-voice
 - N voci → ~N volte i grani (overall density = per_voice_density × N)
 - Ogni voce applica gli offset di VoiceConfig ai parametri del grano
-- self.grains è il flatten ordinato per onset di tutte le voci
+- flat_grains(self) è il flatten ordinato per onset di tutte le voci
 - self.voices ha un entry per ogni voce con grani
 
 Queste suite si appoggiano alla stessa infrastruttura di mock di test_stream.py.
@@ -181,22 +181,17 @@ class TestGenerateGrainsBackwardCompat:
         """1 voce, duration=1.0, inter_onset=0.1 → ~10 grani (floating point tolerance)."""
         s = _make_stream(duration=1.0, inter_onset=0.1)
         s.generate_grains()
-        assert len(s.grains) in (10, 11)
+        assert len(flat_grains(s)) in (10, 11)
 
     def test_single_voice_voices_list_has_one_entry(self):
         s = _make_stream(duration=1.0, inter_onset=0.1)
         s.generate_grains()
         assert len(s.voices) == 1
 
-    def test_single_voice_grains_equals_voices_0(self):
-        s = _make_stream(duration=1.0, inter_onset=0.1)
-        s.generate_grains()
-        assert s.grains == s.voices[0]
-
     def test_single_voice_onset_is_absolute(self):
         s = _make_stream(duration=0.5, onset=2.0, inter_onset=0.1)
         s.generate_grains()
-        assert s.grains[0].onset == pytest.approx(2.0)
+        assert flat_grains(s)[0].onset == pytest.approx(2.0)
 
     def test_generated_flag_set(self):
         s = _make_stream()
@@ -217,7 +212,7 @@ class TestGenerateGrainsMultiVoiceCount:
         s2 = _make_stream(duration=1.0, inter_onset=0.1, voice_manager=vm)
         s1.generate_grains()
         s2.generate_grains()
-        assert len(s2.grains) == len(s1.grains) * 2
+        assert len(flat_grains(s2)) == len(flat_grains(s1)) * 2
 
     def test_three_voices_triple_grain_count(self):
         vm = VoiceManager(max_voices=3)
@@ -225,7 +220,7 @@ class TestGenerateGrainsMultiVoiceCount:
         s3 = _make_stream(duration=1.0, inter_onset=0.1, voice_manager=vm)
         s1.generate_grains()
         s3.generate_grains()
-        assert len(s3.grains) == len(s1.grains) * 3
+        assert len(flat_grains(s3)) == len(flat_grains(s1)) * 3
 
     def test_two_voices_voices_list_has_two_entries(self):
         vm = VoiceManager(max_voices=2)
@@ -239,23 +234,6 @@ class TestGenerateGrainsMultiVoiceCount:
         s.generate_grains()
         counts = [len(v) for v in s.voices]
         assert counts[0] == counts[1] == counts[2]
-
-    def test_grains_is_flatten_of_all_voices(self):
-        vm = VoiceManager(max_voices=2)
-        s = _make_stream(duration=1.0, inter_onset=0.1, voice_manager=vm)
-        s.generate_grains()
-        expected = sorted(
-            [g for voice in s.voices for g in voice],
-            key=lambda g: g.onset
-        )
-        assert s.grains == expected
-
-    def test_grains_sorted_by_onset(self):
-        vm = VoiceManager(max_voices=2)
-        s = _make_stream(duration=1.0, inter_onset=0.1, voice_manager=vm)
-        s.generate_grains()
-        onsets = [g.onset for g in s.grains]
-        assert onsets == sorted(onsets)
 
 
 # =============================================================================
@@ -536,9 +514,9 @@ class TestGenerateGrainsReset:
         vm = VoiceManager(max_voices=2)
         s = _make_stream(duration=1.0, inter_onset=0.1, voice_manager=vm)
         s.generate_grains()
-        first_count = len(s.grains)
+        first_count = len(flat_grains(s))
         s.generate_grains()
-        assert len(s.grains) == first_count
+        assert len(flat_grains(s)) == first_count
 
     def test_voices_cleared_on_regeneration(self):
         vm = VoiceManager(max_voices=2)
@@ -734,6 +712,7 @@ class TestNumVoicesFractionalFade:
 # =============================================================================
 
 import itertools
+from conftest import flat_grains
 
 class TestScatter:
     """
@@ -768,14 +747,6 @@ class TestScatter:
         s = _make_stream(duration=1.0, inter_onset=0.1, voice_manager=vm)
         s.generate_grains()
         assert len(s.voices) == 3
-
-    def test_scatter_zero_grains_sorted_by_onset(self):
-        """scatter=0 → s.grains ordinato per onset."""
-        vm = VoiceManager(max_voices=2)
-        s = _make_stream(duration=1.0, inter_onset=0.1, voice_manager=vm)
-        s.generate_grains()
-        onsets = [g.onset for g in s.grains]
-        assert onsets == sorted(onsets)
 
     # ── SCATTER INERTE (IOT COSTANTE) ──────────────────────────────────────
 
@@ -852,19 +823,6 @@ class TestScatter:
         s.generate_grains()
         ticks = len(s.voices[0])
         assert s._scatter.get_value.call_count == ticks
-
-    def test_scatter_grains_sorted_by_onset_with_diverging_cursors(self):
-        """Anche con cursori divergenti, s.grains è ordinato per onset."""
-        vm = VoiceManager(max_voices=2)
-        iots = itertools.cycle([0.1, 0.2])
-        s = _make_stream(
-            duration=1.0, voice_manager=vm,
-            scatter_fn=lambda t: 1.0,
-            density_side_effect=lambda t, gd: next(iots),
-        )
-        s.generate_grains()
-        onsets = [g.onset for g in s.grains]
-        assert onsets == sorted(onsets)
 
 
 # =============================================================================
@@ -973,7 +931,7 @@ class TestGrainClipStrategyIntegration:
         assert len(s.voices[1]) == 0
 
     def test_default_grains_flat_excludes_out_of_bounds(self):
-        """stream.grains (flatten) non contiene grain fuori bounds."""
+        """flat_grains(stream) (flatten) non contiene grain fuori bounds."""
         from pge.strategies.voice_onset_strategy import LinearOnsetStrategy
         from pge.strategies.grain_clip_strategy import OverflowMarginClipStrategy
         vm = VoiceManager(max_voices=2, onset_strategy=LinearOnsetStrategy(step=10.0))
@@ -982,7 +940,7 @@ class TestGrainClipStrategyIntegration:
         s._clip_strategy = OverflowMarginClipStrategy(margin=0.0)
         s.generate_grains()
         stream_end = s.onset + s.duration
-        for g in s.grains:
+        for g in flat_grains(s):
             assert g.onset < stream_end
             assert g.onset + g.duration <= stream_end
 
@@ -1007,9 +965,9 @@ class TestGrainClipStrategyIntegration:
         s = _make_stream(duration=1.0, onset=0.0, inter_onset=0.25, grain_dur=0.25)
         s._clip_strategy = OverflowMarginClipStrategy(margin=0.0)
         s.generate_grains()
-        onsets = [g.onset for g in s.grains]
+        onsets = [g.onset for g in flat_grains(s)]
         assert any(o == pytest.approx(0.75) for o in onsets)
-        for g in s.grains:
+        for g in flat_grains(s):
             assert g.onset + g.duration <= 1.0 + 1e-9
 
     def test_grain_with_tail_overflow_excluded(self):
@@ -1019,7 +977,7 @@ class TestGrainClipStrategyIntegration:
         s = _make_stream(duration=1.0, onset=0.0, inter_onset=0.1, grain_dur=0.2)
         s._clip_strategy = OverflowMarginClipStrategy(margin=0.0)
         s.generate_grains()
-        for g in s.grains:
+        for g in flat_grains(s):
             assert g.onset + g.duration <= 1.0
 
     def test_margin_allows_tail_overflow(self):
@@ -1032,12 +990,12 @@ class TestGrainClipStrategyIntegration:
         s_loose._clip_strategy = OverflowMarginClipStrategy(margin=0.5)
         s_loose.generate_grains()
         # con margin=0.0 grain con coda > 1.0 esclusi, con margin=0.5 inclusi
-        assert len(s_loose.grains) > len(s_strict.grains)
+        assert len(flat_grains(s_loose)) > len(flat_grains(s_strict))
         # coda max con margin=0.0
-        for g in s_strict.grains:
+        for g in flat_grains(s_strict):
             assert g.onset + g.duration <= 1.0 + 1e-9
         # coda max con margin=0.5
-        for g in s_loose.grains:
+        for g in flat_grains(s_loose):
             assert g.onset + g.duration <= 1.5 + 1e-9
 
     def test_stream_with_nonzero_onset(self):
@@ -1046,7 +1004,7 @@ class TestGrainClipStrategyIntegration:
         s = _make_stream(duration=1.0, onset=5.0, inter_onset=0.1, grain_dur=0.05)
         s._clip_strategy = OverflowMarginClipStrategy(margin=0.0)
         s.generate_grains()
-        for g in s.grains:
+        for g in flat_grains(s):
             assert g.onset >= 5.0
             assert g.onset < 6.0 + 1e-9
             assert g.onset + g.duration <= 6.0 + 1e-9

--- a/tests/core/test_stream_multivoice.py
+++ b/tests/core/test_stream_multivoice.py
@@ -162,8 +162,9 @@ def _make_stream(
     from pge.strategies.grain_clip_strategy import PassthroughClipStrategy
     s._clip_strategy = PassthroughClipStrategy()
 
+    # `voices` e' l'unico ingresso: `grains` e' una vista derivata
+    # e non ha piu' un setter (issue #201).
     s.voices = []
-    s.grains = []
     s.generated = False
 
     return s

--- a/tests/core/test_stream_onset_default.py
+++ b/tests/core/test_stream_onset_default.py
@@ -18,6 +18,7 @@ import soundfile as sf
 
 from pge.core.stream import Stream
 from pge.core.stream_config import StreamContext, stream_onset_is_implicit
+from conftest import flat_grains
 
 
 SR = 48000
@@ -66,13 +67,13 @@ class TestOnsetDefaultsToOrigin:
 
     def test_grains_start_at_the_timeline_origin(self, tmp_path):
         """Il default e' visibile sui grani, non solo sull'attributo: la
-        generazione e' lazy, quindi il test legge `.grains` (issue #220)."""
+        generazione e' lazy, quindi il test materializza i grani (issue #220)."""
         _write_wav(tmp_path, seconds=2.0)
 
         stream = _build(tmp_path)
 
         assert stream.onset == pytest.approx(0.0)
-        onsets = [g.onset for g in stream.grains]
+        onsets = [g.onset for g in flat_grains(stream)]
         assert onsets, "senza onset lo stream deve comunque generare grani"
         assert min(onsets) == pytest.approx(0.0, abs=0.05)
         assert max(onsets) < 1.0, (
@@ -92,7 +93,7 @@ class TestOnsetDeclarationForms:
         stream = _build(tmp_path, onset=None)
 
         assert stream.onset == pytest.approx(0.0)
-        assert min(g.onset for g in stream.grains) == pytest.approx(0.0, abs=0.05)
+        assert min(g.onset for g in flat_grains(stream)) == pytest.approx(0.0, abs=0.05)
 
     def test_explicit_onset_still_wins(self, tmp_path):
         """Nessuna regressione sugli YAML esistenti: la posizione dichiarata
@@ -102,7 +103,7 @@ class TestOnsetDeclarationForms:
         stream = _build(tmp_path, onset=5.0)
 
         assert stream.onset == pytest.approx(5.0)
-        onsets = [g.onset for g in stream.grains]
+        onsets = [g.onset for g in flat_grains(stream)]
         assert min(onsets) >= 5.0
         assert max(onsets) < 6.0
 

--- a/tests/core/test_stream_read_direction.py
+++ b/tests/core/test_stream_read_direction.py
@@ -24,6 +24,7 @@ import soundfile as sf
 
 from pge.core.stream import Stream
 from pge.shared.exceptions import InvalidFieldValueError
+from conftest import flat_grains
 
 SR = 48000
 
@@ -60,7 +61,7 @@ def build(tmp_path):
 
 def _segni(stream):
     """I segni di pitch_ratio dei grani generati, in ordine di onset."""
-    return [g.pitch_ratio < 0 for g in stream.grains]
+    return [g.pitch_ratio < 0 for g in flat_grains(stream)]
 
 
 def _transizioni(stream):
@@ -72,7 +73,7 @@ def _transizioni(stream):
     anche quando il comportamento cambia del tutto.
     """
     out, precedente = [], None
-    for grain in stream.grains:
+    for grain in flat_grains(stream):
         segno = 1 if grain.pitch_ratio > 0 else -1
         if segno != precedente:
             out.append((round(grain.onset, 4), segno))
@@ -149,7 +150,7 @@ class TestScalare:
     def test_il_modulo_del_pitch_non_cambia(self, build):
         """La chiave governa il verso, non la trasposizione."""
         stream = build(grain={'read_direction': -1})
-        assert {abs(g.pitch_ratio) for g in stream.grains} == {1.0}
+        assert {abs(g.pitch_ratio) for g in flat_grains(stream)} == {1.0}
 
 
 # =============================================================================
@@ -162,8 +163,8 @@ class TestEnvelope:
     def test_il_verso_cambia_al_breakpoint(self, build):
         stream = build(grain={'read_direction': [[0, 1], [1.0, -1]]})
 
-        prima = [g.pitch_ratio for g in stream.grains if g.onset < 1.0]
-        dopo = [g.pitch_ratio for g in stream.grains if g.onset >= 1.0]
+        prima = [g.pitch_ratio for g in flat_grains(stream) if g.onset < 1.0]
+        dopo = [g.pitch_ratio for g in flat_grains(stream) if g.onset >= 1.0]
 
         assert prima and dopo
         assert all(r > 0 for r in prima)
@@ -173,7 +174,7 @@ class TestEnvelope:
         """`step` imposto: fra i due stati non c'e' rampa, quindi i grani
         portano solo i valori dichiarati."""
         stream = build(grain={'read_direction': [[0, 1], [1.0, -1]]})
-        assert {g.pitch_ratio for g in stream.grains} == {1.0, -1.0}
+        assert {g.pitch_ratio for g in flat_grains(stream)} == {1.0, -1.0}
 
     def test_step_esplicito_stessa_semantica(self, build):
         nudo = build(grain={'read_direction': [[0, 1], [1.0, -1]]})
@@ -185,7 +186,7 @@ class TestEnvelope:
         stream = build(grain={'read_direction': [[0, 1], [0.6, -1], [1.4, 1]]})
 
         def verso(t0, t1):
-            return {g.pitch_ratio for g in stream.grains
+            return {g.pitch_ratio for g in flat_grains(stream)
                     if t0 <= g.onset < t1}
 
         assert verso(0.0, 0.6) == {1.0}
@@ -204,8 +205,8 @@ class TestEnvelope:
         gruppo = build(grain={'read_direction': {
             'points': [[[0, 1], [1.0, -1]], 'step']}})
 
-        assert {g.pitch_ratio for g in compatto.grains} == {1.0, -1.0}
-        assert {g.pitch_ratio for g in gruppo.grains} == {1.0, -1.0}
+        assert {g.pitch_ratio for g in flat_grains(compatto)} == {1.0, -1.0}
+        assert {g.pitch_ratio for g in flat_grains(gruppo)} == {1.0, -1.0}
 
     def test_punto_del_pattern_senza_interp_renderizza(self, build):
         """`[x%, y, None]` dentro il pattern di un ciclo: il validatore lo
@@ -221,7 +222,7 @@ class TestEnvelope:
         senza = build(grain={'read_direction':
                              [[[0, 1], [100, 1]], 2.0, 2]})
 
-        assert {g.pitch_ratio for g in con.grains} == {1.0, -1.0}
+        assert {g.pitch_ratio for g in flat_grains(con)} == {1.0, -1.0}
         assert _transizioni(con) != _transizioni(senza)
 
     def test_time_unit_del_dict_resta_onorato(self, build):
@@ -230,8 +231,8 @@ class TestEnvelope:
         stream = build(grain={'read_direction': {
             'points': [[0, 1], [0.5, -1]], 'time_unit': 'normalized'}})
 
-        prima = [g.pitch_ratio for g in stream.grains if g.onset < 1.0]
-        dopo = [g.pitch_ratio for g in stream.grains if g.onset >= 1.0]
+        prima = [g.pitch_ratio for g in flat_grains(stream) if g.onset < 1.0]
+        dopo = [g.pitch_ratio for g in flat_grains(stream) if g.onset >= 1.0]
         assert prima and dopo
         assert all(r > 0 for r in prima)
         assert all(r < 0 for r in dopo)

--- a/tests/core/test_stream_voices_yaml.py
+++ b/tests/core/test_stream_voices_yaml.py
@@ -468,6 +468,7 @@ class TestStochasticStreamIdInjection:
 
 import hashlib
 import random as _random
+from conftest import flat_grains
 
 
 def _seeded_pos(seed, stream_id, vi, lo=-1.0, hi=1.0):
@@ -622,7 +623,7 @@ class TestVoicesYamlIntegration:
         s1.generate_grains()
         s2.generate_grains()
 
-        assert len(s2.grains) == len(s1.grains) * 2
+        assert len(flat_grains(s2)) == len(flat_grains(s1)) * 2
 
     def test_high_voice_count_renders(self):
         """Voci elevate (256): generate_grains rende senza errori, una lista per voce."""
@@ -632,7 +633,7 @@ class TestVoicesYamlIntegration:
         s.generate_grains()
 
         assert len(s.voices) == 256
-        assert len(s.grains) > 0
+        assert len(flat_grains(s)) > 0
 
     def test_chord_dom7_pitch_ratios_in_grains(self):
         """Voce 1 con dom7 ha pitch_ratio base × 2^(4/12)."""

--- a/tests/engine/test_default_variation_identity.py
+++ b/tests/engine/test_default_variation_identity.py
@@ -33,6 +33,7 @@ import yaml
 from unittest.mock import patch
 
 from pge.engine.generator import Generator
+from conftest import flat_grains
 
 
 # =============================================================================
@@ -99,7 +100,7 @@ def _materialize(tmp_path):
                 repr(g.onset), repr(g.duration), repr(g.pointer_pos),
                 repr(g.pitch_ratio), repr(g.volume), repr(g.pan),
             ]
-            for s in gen.streams for g in s.grains
+            for s in gen.streams for g in flat_grains(s)
         ]
     return rows
 

--- a/tests/engine/test_rng_group.py
+++ b/tests/engine/test_rng_group.py
@@ -29,6 +29,7 @@ import yaml
 from unittest.mock import patch
 
 from pge.engine.generator import Generator
+from conftest import flat_grains
 
 
 # =============================================================================
@@ -93,7 +94,7 @@ def _render_streams(tmp_path, streams, seed=42, filename='rng_group.yml'):
     with patch('pge.core.stream.get_sample_duration', return_value=10.0):
         gen.create_elements()
         for s in gen.streams:
-            _ = s.grains  # materializza (lazy)
+            _ = flat_grains(s)  # materializza (lazy)
     return gen
 
 
@@ -110,7 +111,7 @@ def _grain_signature(stream):
             round(g.pan, 9),
             inv_windows[g.envelope_table],
         )
-        for g in stream.grains
+        for g in flat_grains(stream)
     ]
 
 
@@ -174,13 +175,13 @@ class TestCousins:
     def _onsets(self, gen, stream_id):
         for s in gen.streams:
             if s.stream_id == stream_id:
-                return [round(g.onset, 9) for g in s.grains]
+                return [round(g.onset, 9) for g in flat_grains(s)]
         raise AssertionError(f"stream {stream_id} non trovato")
 
     def _field(self, gen, stream_id, attr):
         for s in gen.streams:
             if s.stream_id == stream_id:
-                return [round(getattr(g, attr), 9) for g in s.grains]
+                return [round(getattr(g, attr), 9) for g in flat_grains(s)]
         raise AssertionError(f"stream {stream_id} non trovato")
 
     def test_cousins_share_the_temporal_grid(self, tmp_path):

--- a/tests/engine/test_seed_component_isolation.py
+++ b/tests/engine/test_seed_component_isolation.py
@@ -39,6 +39,7 @@ from pge.controllers.window_selection_strategy import (
 )
 from pge.envelopes.envelope import Envelope
 from pge.parameters.parser import GranularParser
+from conftest import flat_grains
 
 
 # =============================================================================
@@ -84,7 +85,7 @@ def _render_streams(tmp_path, yaml_data, filename='iso.yml'):
     with patch('pge.core.stream.get_sample_duration', return_value=10.0):
         gen.create_elements()
         for s in gen.streams:
-            _ = s.grains  # materializza (lazy)
+            _ = flat_grains(s)  # materializza (lazy)
     return gen
 
 
@@ -101,7 +102,7 @@ def _grain_signature(stream):
             round(g.pan, 9),
             inv_windows[g.envelope_table],
         )
-        for g in stream.grains
+        for g in flat_grains(stream)
     ]
 
 
@@ -161,7 +162,7 @@ class TestSoloMuteInvariance:
 class TestLazyOrderInvariance:
 
     def test_materialization_order_is_irrelevant(self, tmp_path):
-        """I grani non dipendono dall'ordine di lettura di .grains: uno
+        """I grani non dipendono dall'ordine di materializzazione: uno
         stream cache-clean saltato non shifta i draw degli stream dirty."""
         data = _yaml_data([_stream_dict('s1'), _stream_dict('s2')])
 
@@ -171,8 +172,8 @@ class TestLazyOrderInvariance:
         gen_a.load_yaml()
         with patch('pge.core.stream.get_sample_duration', return_value=10.0):
             gen_a.create_elements()
-            _ = gen_a.streams[0].grains  # s1 prima
-            _ = gen_a.streams[1].grains
+            _ = gen_a.streams[0].voices  # s1 prima
+            _ = gen_a.streams[1].voices
 
         cfg_b = tmp_path / 'order_b.yml'
         cfg_b.write_text(yaml.safe_dump(data))
@@ -180,8 +181,8 @@ class TestLazyOrderInvariance:
         gen_b.load_yaml()
         with patch('pge.core.stream.get_sample_duration', return_value=10.0):
             gen_b.create_elements()
-            _ = gen_b.streams[1].grains  # s2 prima (come con s1 cache-clean)
-            _ = gen_b.streams[0].grains
+            _ = gen_b.streams[1].voices  # s2 prima (come con s1 cache-clean)
+            _ = gen_b.streams[0].voices
 
         assert _signature_of(gen_a, 's2') == _signature_of(gen_b, 's2')
         assert _signature_of(gen_a, 's1') == _signature_of(gen_b, 's1')

--- a/tests/engine/test_seed_reproducibility.py
+++ b/tests/engine/test_seed_reproducibility.py
@@ -32,6 +32,7 @@ import yaml
 from unittest.mock import patch
 
 from pge.engine.generator import Generator
+from conftest import flat_grains
 
 
 PROJECT_ROOT = os.path.abspath(
@@ -73,7 +74,7 @@ def _materialize_onsets(tmp_path, yaml_data):
     gen.load_yaml()
     with patch('pge.core.stream.get_sample_duration', return_value=10.0):
         gen.create_elements()
-        onsets = [round(g.onset, 9) for s in gen.streams for g in s.grains]
+        onsets = [round(g.onset, 9) for s in gen.streams for g in flat_grains(s)]
     return onsets
 
 

--- a/tests/parameters/test_parameter_range_anchor.py
+++ b/tests/parameters/test_parameter_range_anchor.py
@@ -27,6 +27,7 @@ from pge.parameters.parser import GranularParser
 from pge.parameters.parameter_definitions import ParameterBounds
 from pge.shared.distribution_strategy import ANCHOR_CENTER, ANCHOR_MIN
 from pge.shared.exceptions import InvalidFieldValueError
+from conftest import flat_grains
 
 
 BASE = 10.0
@@ -256,7 +257,7 @@ class TestYamlSurface:
         gen.load_yaml()
         with patch('pge.core.stream.get_sample_duration', return_value=10.0):
             gen.create_elements()
-            return [g.duration for s in gen.streams for g in s.grains]
+            return [g.duration for s in gen.streams for g in flat_grains(s)]
 
     def test_end_to_end_min_never_below_base(self, tmp_path):
         durations = self._render(tmp_path, 'min')

--- a/tests/rendering/test_audio_renderer.py
+++ b/tests/rendering/test_audio_renderer.py
@@ -124,7 +124,6 @@ class TestRenderSingleStreamContract:
         stream = MagicMock()
         stream.stream_id = 'test_stream'
         stream.voices = [[]]
-        stream.grains = []
         return stream
 
     def test_returns_string(self, renderer, mock_stream):

--- a/tests/rendering/test_csound_renderer.py
+++ b/tests/rendering/test_csound_renderer.py
@@ -66,7 +66,6 @@ def mock_stream():
     stream = MagicMock()
     stream.stream_id = 'test_stream'
     stream.voices = [[]]
-    stream.grains = []
     return stream
 
 

--- a/tests/rendering/test_numpy_audio_renderer.py
+++ b/tests/rendering/test_numpy_audio_renderer.py
@@ -119,7 +119,6 @@ def make_mock_stream(stream_id='s1', onset=0.0, duration=1.0,
         voices = [grains]
 
     stream.voices = voices
-    stream.grains = [g for voice in voices for g in voice]
     return stream
 
 

--- a/tests/test_lint_docs_git_absent.py
+++ b/tests/test_lint_docs_git_absent.py
@@ -1,0 +1,62 @@
+"""Il linter dei doc non deve dipendere dalla disponibilita' di git.
+
+La drift detection su `last_synced_commit` interroga git. Se git non c'e'
+(PATH ripulito) o la history non c'e' (sorgenti copiati senza .git), il check
+va spento: prima di questa guardia il linter moriva con FileNotFoundError
+oppure segnalava un falso "non risolve" su ogni doc.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LINTER = REPO_ROOT / "utils" / "lint_docs.py"
+
+
+def test_passa_senza_git_nel_path():
+    env = dict(os.environ, PATH="")
+    out = subprocess.run(
+        [sys.executable, str(LINTER)],
+        cwd=REPO_ROOT, env=env, capture_output=True, text=True,
+    )
+    assert out.returncode == 0, out.stdout + out.stderr
+    assert "non risolve" not in out.stdout
+
+
+def test_history_non_interrogabile_spegne_il_check(monkeypatch):
+    """git c'e' ma non ha history da interrogare (sorgenti senza .git)."""
+    sys.path.insert(0, str(REPO_ROOT / "utils"))
+    import lint_docs
+
+    lint_docs.history_available.cache_clear()
+    monkeypatch.setattr(
+        lint_docs.subprocess, "run",
+        lambda *a, **k: subprocess.CompletedProcess(a[0], 128, "", ""),
+    )
+    try:
+        assert lint_docs.history_available() is False
+    finally:
+        lint_docs.history_available.cache_clear()
+
+
+def test_sha_di_sole_cifre_non_e_uno_sha_stantio(monkeypatch):
+    """PyYAML consegna int uno SHA non quotato; l'ottale va nominato."""
+    sys.path.insert(0, str(REPO_ROOT / "utils"))
+    import lint_docs
+
+    lint_docs.history_available.cache_clear()
+    monkeypatch.setattr(lint_docs, "history_available", lambda: False)
+    fm = {
+        "slug": "x", "type": "reference", "status": "stable",
+        "tags": ["t"], "sources": ["utils/"],
+    }
+    lint = lint_docs.Linter()
+    lint.check_frontmatter(REPO_ROOT / "docs" / "x.md", {**fm, "last_synced_commit": 9764017})
+    assert lint.errors == []
+
+    lint = lint_docs.Linter()
+    lint.check_frontmatter(REPO_ROOT / "docs" / "x.md", {**fm, "last_synced_commit": 42798})
+    assert any("quotalo" in e for e in lint.errors)

--- a/utils/lint_docs.py
+++ b/utils/lint_docs.py
@@ -6,6 +6,7 @@ Rules (see docs/SCHEMAS.md — transitorio fino a Step 6, poi spostato in CLAUDE
 - slug uguale al basename del file (no .md)
 - type ∈ {reference, explanation, how-to}, status ∈ {stable, draft, deprecated}
 - sources path esistenti
+- last_synced_commit risolvibile a un oggetto git
 - Sezioni obbligatorie per tipo presenti, nell'ordine atteso
 - Wikilink [[slug]] risolvibili a uno slug noto
 - Nessun doc orfano (linkato da INDEX o da almeno un altro doc, esclusi i reference)
@@ -15,6 +16,7 @@ Exit code 0 se pulito, 1 altrimenti.
 from __future__ import annotations
 
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -107,6 +109,16 @@ class Linter:
                 p = REPO_ROOT / src
                 if not p.exists():
                     self.err(path, f"sources path does not exist: {src}")
+        sha = str(fm["last_synced_commit"]).strip()
+        # Senza questo, la drift detection e' decorativa: uno SHA che non
+        # risolve non e' un riferimento, e' una stringa.
+        if subprocess.run(
+            ["git", "cat-file", "-e", f"{sha}^{{commit}}"],
+            cwd=REPO_ROOT,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        ).returncode:
+            self.err(path, f"last_synced_commit non risolve a un commit: {sha}")
 
     def check_sections(self, path: Path, fm: dict, body: str) -> None:
         type_ = fm.get("type")

--- a/utils/lint_docs.py
+++ b/utils/lint_docs.py
@@ -67,6 +67,14 @@ def strip_code_blocks(text: str) -> str:
     return "\n".join(out)
 
 
+def is_shallow() -> bool:
+    out = subprocess.run(
+        ["git", "rev-parse", "--is-shallow-repository"],
+        cwd=REPO_ROOT, capture_output=True, text=True,
+    )
+    return out.stdout.strip() == "true"
+
+
 class Linter:
     def __init__(self) -> None:
         self.errors: list[str] = []
@@ -111,7 +119,12 @@ class Linter:
                     self.err(path, f"sources path does not exist: {src}")
         sha = str(fm["last_synced_commit"]).strip()
         # Senza questo, la drift detection e' decorativa: uno SHA che non
-        # risolve non e' un riferimento, e' una stringa.
+        # risolve non e' un riferimento, e' una stringa. Su un clone shallow
+        # non risolve niente per costruzione, quindi li' il check si spegne
+        # invece di segnalare venti falsi positivi (in CI il job docs fa
+        # fetch-depth: 0 apposta per tenerlo acceso).
+        if is_shallow():
+            return
         if subprocess.run(
             ["git", "cat-file", "-e", f"{sha}^{{commit}}"],
             cwd=REPO_ROOT,

--- a/utils/lint_docs.py
+++ b/utils/lint_docs.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import re
 import subprocess
 import sys
+from functools import cache
 from pathlib import Path
 
 import yaml
@@ -26,6 +27,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 DOCS = REPO_ROOT / "docs"
 TYPES = {"reference", "explanation", "how-to"}
 STATUSES = {"stable", "draft", "deprecated"}
+SHA_RE = re.compile(r"[0-9a-f]{7,40}")
 REQUIRED_FM_KEYS = {"slug", "type", "status", "tags", "sources", "last_synced_commit"}
 
 REQUIRED_SECTIONS = {
@@ -67,12 +69,24 @@ def strip_code_blocks(text: str) -> str:
     return "\n".join(out)
 
 
-def is_shallow() -> bool:
-    out = subprocess.run(
-        ["git", "rev-parse", "--is-shallow-repository"],
-        cwd=REPO_ROOT, capture_output=True, text=True,
-    )
-    return out.stdout.strip() == "true"
+@cache
+def history_available() -> bool:
+    """True se git puo' rispondere sulla history di questo albero.
+
+    False su un clone shallow (non risolve niente per costruzione), ma anche
+    dove git non c'e' o .git non c'e': sorgenti copiati, vendoring, archivio.
+    In tutti quei casi il check sugli SHA va spento, non fallito.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--is-shallow-repository"],
+            cwd=REPO_ROOT, capture_output=True, text=True,
+        )
+    except (OSError, FileNotFoundError):
+        return False
+    if out.returncode:
+        return False
+    return out.stdout.strip() != "true"
 
 
 class Linter:
@@ -117,15 +131,27 @@ class Linter:
                 p = REPO_ROOT / src
                 if not p.exists():
                     self.err(path, f"sources path does not exist: {src}")
+        # Uno SHA breve di sole cifre non e' quotato per convenzione (lo sono
+        # tutti nei doc), quindi PyYAML lo consegna int: str() lo rende, e
+        # 9764017 resta 9764017. Irrecuperabile e' solo lo zero iniziale, che
+        # YAML 1.1 legge ottale (0123456 -> 42798): li' l'informazione e'
+        # persa, e il messaggio deve nominare il quoting invece di far
+        # sembrare stantio un doc che non lo e'.
         sha = str(fm["last_synced_commit"]).strip()
-        # Senza questo, la drift detection e' decorativa: uno SHA che non
-        # risolve non e' un riferimento, e' una stringa. Su un clone shallow
-        # non risolve niente per costruzione, quindi li' il check si spegne
-        # invece di segnalare venti falsi positivi (in CI il job docs fa
-        # fetch-depth: 0 apposta per tenerlo acceso).
-        if is_shallow():
+        if not SHA_RE.fullmatch(sha):
+            self.err(
+                path,
+                f"last_synced_commit non e' uno SHA breve: {sha} "
+                "(se e' di sole cifre con lo zero iniziale, quotalo: "
+                "YAML lo legge come ottale)",
+            )
             return
-        if subprocess.run(
+        # Senza questo, la drift detection e' decorativa: uno SHA che non
+        # risolve non e' un riferimento, e' una stringa. Dove la history non
+        # e' interrogabile il check si spegne invece di segnalare venti falsi
+        # positivi (in CI il job docs fa fetch-depth: 0 apposta per tenerlo
+        # acceso).
+        if history_available() and subprocess.run(
             ["git", "cat-file", "-e", f"{sha}^{{commit}}"],
             cwd=REPO_ROOT,
             stdout=subprocess.DEVNULL,


### PR DESCRIPTION
Chiude #201, ma non come la issue proponeva. Rianalisi da zero: sotto c'è cosa non torna nella issue e cosa ho fatto invece.

> **Aggiornato dopo la review.** Cinque punti recepiti, in cinque commit: `743ceae` (drift detection), `f138d06` (`FutureWarning`), `6611351` (breaking nel CHANGELOG), `4dfa4da` (misure rifatte), `e2f5fc9` (CHANGELOG allineato). Dettaglio in fondo.

## Dove la issue ha ragione

`Stream.grains` non ha consumatori in produzione. Verificato su HEAD: i quattro backend iterano tutti `voices` (`score_writer`, `numpy_audio_renderer`, `grain_visuals`, `grain_json_writer`), e le uniche occorrenze di `.grains` in `src/` sono la property, la setter, `__repr__` e due commenti.

Ho chiuso anche il punto che la issue lasciava aperto («da verificare prima di procedere»): **nessuno script Python del repo del paper CIM 2026 legge `.grains`** — `render_example.py` e `annotate_panels.py` usano `Generator`. Idem `PGE-ls` (nessuna occorrenza) e `PGE-ui` (consuma il JSON di `GrainJsonWriter`, dove `grains` è una chiave dello schema, non l'API Python).

**E la issue contava giusto.** A `a6c5a8b`, il commit in cui è stata scritta, `git grep -c '\.grains' -- tests/` dà esattamente 82 occorrenze in 13 file. Il conteggio diverso che questa PR archiviava fra i «numeri stantii» era solo il repo che era avanzato nel frattempo: rilievo ritirato.

> **Aggiornamento.** Un consumatore interno è comparso *dopo* l'apertura di questa PR: `utils/bench_cost.py`, arrivato con `c569d0d`. Migrato nel merge di `main` — dettagli in fondo.

## Dove non ha ragione

**1. Mostra la divergenza innocua e non quella che fa danno.** La issue documenta `voices` → `grains` stantio. Ma nessuno legge `grains`, quindi non succede niente. La direzione opposta è il difetto vero:

```python
stream.grains = [...]   # setter pubblica
# → _voices resta VUOTO, generated = True
```

Ogni backend legge `voices`. Misurato end-to-end su uno stream da 1 s, 48 grani iniettati:

| | grani | picco | exit | repr |
|---|---|---|---|---|
| normale | 48 | 0.4624 | 0 | `grains=48` |
| iniezione via `.grains` | 48 | **0.0000** | 0 | `grains=48` |

Un file di silenzio puro, uscita pulita, nessun avviso, nessun log — e un `__repr__` che nel frattempo *conferma* che i grani ci sono. È la stessa classe di guasto di #225 e #234, e questa PR la chiama così: non refactoring di codice morto, ma un bug.

Una precisazione che la review ha ragione a chiedere: la setter era una **trappola latente**, non superficie documentata. La frase «iniezione esplicita dei grani (test/consumer)» che la issue cita è la docstring di `@voices.setter`, non di `grains.setter`, che docstring non ne aveva; e gli unici cinque chiamanti stavano in `tests/`. Il bug è riproducibile lo stesso — la tabella sopra è misurata — ma nessuno lo stava innescando.

**2. Il costo è sopravvalutato sull'asse sbagliato.** Misurato su uno stream da 959.920 grani: il flatten+sort eager è il **2.9%** del tempo di generazione, non un ordine di grandezza. L'argomento difendibile è la memoria — **8.1 MB ritenuti per milione di grani**, per tutta la vita dello Stream, per una lista che nessuno legge (191.6 → 183.5 MB su quello stream).

Il rovescio, che la review misura e questa PR non aveva misurato: la vista derivata **non è gratis in lettura**. Era O(1), ora è un flatten più un sort O(N log N) a ogni accesso — circa 88 ms a un milione di grani. È il prezzo di non poter più divergere, ed è il motivo per cui la property se ne va invece di restare comoda.

**3. La rimozione secca non è la mossa giusta**, e la issue non considera l'alternativa ovvia: renderla **derivata**. Così la divergenza sparisce *per costruzione* in entrambe le direzioni, il costo eager sparisce del tutto (chi non legge non paga nulla), e non si rompe niente. La rimozione, invece, è breaking su una libreria installabile a SemVer per una leggibilità che non è ovviamente migliore.

## Cosa fa questa PR

**`voices` resta l'unico backing field.** `grains` diventa una vista derivata, ricalcolata a ogni lettura: la divergenza non è più esprimibile. La **setter sparisce subito, senza preavviso** — un setter che riesce e produce un file muto non ha una versione "che avvisa": ora solleva `AttributeError` nominando il rimpiazzo. `__repr__` conta da `_voices` e smette di mentire.

Quella rimozione è un **breaking change** e sta sotto `### Modificato (breaking)`: **la prossima release è una major**. Delegare a `voices = [value]` per un ciclo era l'alternativa, e non è stata scelta perché sarebbe una supposizione — una voce sola dove il chiamante ne intendeva N — cioè un rendering diverso da quello atteso, di nuovo in silenzio.

**La property in lettura è deprecata**, rimozione in **9.0.0** (la prossima major dopo la v8.0.0 già rilasciata). Criterio diverso dalla setter perché il caso è diverso: la getter restituisce qualcosa di corretto, quindi può continuare a farlo per un ciclo. Il warning è un **`FutureWarning`**, non un `DeprecationWarning`: il secondo Python lo filtra di default fuori da `__main__`, quindi l'unico a vederlo sarebbe stato questo repo sotto pytest — cioè proprio chi non ne ha bisogno. Il testo nomina il rimpiazzo e spiega perché non ce n'è uno solo: `voices` è voice-major, la vista è per onset, e i renderer dipendono dal primo, perché l'ordine delle somme float è quel che rende un rendering riproducibile.

**La suite non passa più per `.grains`**: 77 chiamate a `conftest.flat_grains(stream)` in 12 file, che è la stessa riga scritta dove la si legge. Tolti sette test il cui soggetto era la vista (ora tutta in `tests/core/test_stream_grains_view.py`), fra cui due — `test_scatter_*_sorted_by_onset` — che erano **già vacui prima di questo lavoro**: il sort era incondizionato, quindi asserivano che `sorted()` restituisce una lista ordinata, non qualcosa sullo scatter. Tolte anche tre righe `stream.grains = ...` su `MagicMock` nei mock dei renderer.

Sul volume di quella migrazione la review ha ragione a metà, e la nota vale registrata: `pytest.ini` non ha `filterwarnings = error`, quindi la suite sarebbe passata comunque e buona parte del diff nasce dall'aver introdotto il warning, non dall'aver corretto il bug. Resta perché è lavoro dovuto alla rimozione in 9.0.0: revertire 77 siti per rifarli fra una major sarebbe churn peggiore.

## Verifica

- `make tests`: **5911 passed**, 10 skipped, 0 warning (dopo il secondo merge di `main`).
- **Rendering invariato**: stesso `sha256` sui campioni audio di un config **a seed fisso** (2 stream, multi-voce con scatter) fra `main` e questo branch — ri-verificato dopo entrambi i merge, da ultimo contro `cce3234`. La precisazione conta: 27 config su 32 non hanno `seed`, e senza seed due render dello stesso commit danno hash diversi. I due WAV differiscono per **un byte**, il timestamp che libsndfile stampa nel chunk `PEAK`.
- `make docs-index` + `make docs-lint`: OK (20 docs), col linter ora più severo di prima (vedi sotto).
- 14 test in `tests/core/test_stream_grains_view.py`: entrambe le direzioni della divergenza, l'ordine (stabile, pari-merito voice-major), il lazy, il repr, la deprecazione, e la visibilità del warning coi filtri di un consumatore.

## I merge di `main`, e perché non sono stati solo merge

`main` è avanzato (#233, #235, `make bench`) e il branch è andato in conflitto. Il conflitto vero era una collisione additiva su `CHANGELOG.md` — due voci in testa a `### Corretto`, tenute entrambe.

Ma `main` ha anche portato **`utils/bench_cost.py`**, che legge `Stream.grains` in due punti. Uno dei due è un problema, non un dettaglio di stile:

```python
n = sum(len(s.grains) for s in generator.streams)   # dentro t_build
```

sta nella regione cronometrata di `once_yaml` che dovrebbe isolare il costo di **costruire** i `Grain`. Con la vista ora derivata, quella riga paga anche un flatten più un sort O(N log N) per stream: su circa un milione di grani sono **~0,4 s attribuiti alla costruzione che costruzione non sono**. Cioè: la mia modifica avrebbe falsato il benchmark che misura la mia modifica. Contare da `voices` materializza allo stesso modo — che è il punto del docstring — senza appiattire niente.

Verificato che `bench_cost.py` gira, conta lo stesso numero di grani, e non tocca più l'API deprecata.

**Secondo merge** (`04e43dc`), dopo che #238 è entrato in `main`. Conflitto di forma diversa: `main` portava la voce di #222 in una sezione `### Modificato (breaking)` tutta sua, e il branch ne ha già una — quella aperta da `6611351` per la rimozione della setter. Tenerle entrambe avrebbe lasciato due sezioni omonime nello stesso blocco `[Non rilasciato]`, quindi la voce di #222 va in coda a quella esistente e `### Deprecato` resta dov'era.

Nello stesso commit, un'incoerenza rimasta dalla tornata di review: `f138d06` ha portato il preavviso della property da `DeprecationWarning` a `FutureWarning` nel codice, ma la voce `### Deprecato` del CHANGELOG diceva ancora `DeprecationWarning` — cioè il changelog descriveva un comportamento che il motore non ha più, proprio sul punto che la review aveva sollevato. Allineata.

## Cosa è cambiato dopo la review

**1. La drift detection non verificava che lo SHA esistesse** (`743ceae`). `utils/lint_docs.py` controllava la presenza di `last_synced_commit`, mai che risolvesse. Ora fa `git cat-file -e ^{commit}`. Col check, **due** doc falliscono: `multi-voice.md` a `8249cdb` (introdotto da questo branch) e `sonic-visualiser.md` a `a730371` (preesistente, da prima della rinomina dei package). Corretti a `8a8029c` e `4c3069c`.

**2. Il preavviso ora avvisa qualcuno** (`f138d06`). `DeprecationWarning` → `FutureWarning`, più un test che lo verifica simulando i filtri di default di un consumatore (`DeprecationWarning` silenziato, `simplefilter("default")`).

**3. Il breaking change è dichiarato tale** (`6611351`). La rimozione della setter esce da `### Corretto` ed entra in una sezione `### Modificato (breaking)`, che dice esplicitamente che la prossima release è una major e perché getter e setter hanno criteri opposti.

**4. Le misure di `costo-rendering.md` sono rifatte** (`4dfa4da`), non solo la sua firma. Rilanciato `make bench` sulla stessa macchina: `a` = 33,8 µs/grano, `b` = 1,42 ms/s, pareggio a 42 grani/s, errore mediano 0,9%. La differenza dai valori precedenti sta dentro l'oscillazione fra run che il doc già dichiarava, ma ora è misurata invece che presunta.

  Nello stesso commit: la riga 111 ora dice che la lazy sta su `voices`; le righe 113-115 non affermano più che `bench_cost.py` gira su un clone pulito, e anzi spiegano in che modo non ci gira. E la riga «esempio didattico multi-stream» della tabella delle fasi è sostituita da `configs/PGE_ff2_rassegna.yml`: quella dicitura non nominava un file, quindi non era riproducibile — e i due casi ora hanno il rapporto grani/durata rovesciato, il che rende visibile la quota di costruzione passare da un ottavo a un terzo.

**5. Il CHANGELOG dice le stesse cose del doc** (`e2f5fc9`): la voce di `make bench` ripeteva i numeri vecchi e la frase «gira su un clone pulito».

Non recepito, di proposito: **revertire la migrazione dei test**. La review stessa conclude che va tenuta, e concordo — vedi sopra.

Sull'igiene dei commit il rilievo è giusto e non è più rimediabile su quei commit senza riscrivere il branch: `b1232b0` mette implementazione e test insieme, e i marcatori conventional-commit sono invertiti rispetto a dove sta il breaking change. I cinque commit di quella tornata seguono il ciclo (il linter va rosso prima del fix degli SHA, i test del warning vanno rossi prima del cambio di classe).

## Impatto cross-repo

**Nessuno**, e verificato invece che dedotto. `Stream.grains` è API Python, non superficie YAML, CLI, errori o formati di output. `PGE-ls` non la nomina; `PGE-ui` consuma il JSON di `GrainJsonWriter`, che itera `voices` e il cui schema non cambia. Nessuna issue da aprire in quei repo.

Per la regola del submodule CIM: la modifica **non è osservabile** dagli esempi del paper — l'audio è identico e nessuno dei suoi script legge `.grains`. Niente bump del submodule. Resta il buco che la review ha trovato: la **wiki** del repo del paper descrive `Stream.grains` in tre pagine (`wiki/sources/pge/stream.md`, `wiki/sources/pge/renderer.md`, `wiki/concepts/intermediate-representation.md`), che questa PR rende stantie. Non è codice e non entra nel bump, ma va aggiornata: da tracciare là.

## Due cose fuori scope, da segnalare

**1. `pyproject.toml` è indietro di due release.** Dichiara `version = "7.2.0"` col commento «allineata al CHANGELOG», ma il CHANGELOG è a **v8.0.0** ("Timeline Origin", 2026-08-17). Non toccato qui — è una decisione di rilascio — ma è il motivo per cui la deprecazione punta a 9.0.0 e non a 8.0.0. Con la setter rimossa, quella prossima release deve comunque essere una major.

**2. `bench_cost.py` non gira su un clone pulito**, malgrado il suo docstring lo prometta, e la review ne ha trovato il **secondo** punto: oltre a `_load()` che costruisce il `Generator` senza `samples_dir`, anche `_render()` passa `ssdir=SSDIR`, che `_build_renderer` inoltra solo alle opzioni Csound — per il renderer NumPy conta `samples_dir`, quindi il `SampleRegistry` ricade su `./refs/` comunque. Difetto di `c569d0d`, non toccato qui; la review dice che apre la issue.