### PR TITLE
fix(bench): il sample sintetico arriva a chi lo deve leggere (#243)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,68 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ---
 
+## [Non rilasciato]
+
+### Corretto
+
+- **`make bench` non girava su un clone pulito** (issue #243).
+  `utils/bench_cost.py` genera un seno sintetico quando manca `refs/voice.wav`
+  — i `.wav` non sono versionati — ma non lo diceva a nessuno dei due
+  consumatori: `_load()` costruiva il `Generator` senza `samples_dir` e
+  `_render()` passava la directory come `ssdir`, che vale solo per Csound.
+  Entrambi i percorsi ricadevano sul globale `./refs/` e lo script moriva in
+  `SampleNotFoundError` nel primo sweep, prima di misurare qualsiasi cosa. Ora
+  la directory arriva come `samples_dir` a entrambi (l'API ne deriva anche
+  l'`ssdir` per Csound), e le due directory in gioco restano separate: gli
+  sweep leggono il seno sintetico, il *caso di riferimento*
+  (`make bench YAML=...`) legge da `refs/`, perche' uno YAML reale cita il
+  proprio sample e nella tmpdir del seno non lo troverebbe — stato non
+  ipotetico, `make test-samples` scrive `refs/pino.wav` e non `voice.wav`.
+
+- **Il caso di riferimento non si porta piu' via gli sweep.**
+  `configs/PGE_cim.yml`, il caso documentato, cita proprio `voice.wav`: su un
+  clone pulito moriva *dopo* i tre sweep e prima del `json.dump`, cioe' un
+  minuto e mezzo di misure buttate. Ora il suo sample si risolve prima degli
+  sweep, e se il caso di riferimento fallisce lo stesso il JSON degli sweep
+  viene scritto comunque. La directory dei suoi sample e' passabile come
+  secondo argomento (`python utils/bench_cost.py <yaml> <dir>`) e attraversa
+  `run_yaml`/`once_yaml`: `None` significa `refs/` per il caso di riferimento
+  e "la directory degli sweep" per `_load`/`_render`, e la sentinella si
+  risolve nel corpo di ciascuno invece di essere inoltrata tal quale.
+
+### Modificato
+
+- **`bench_cost.py` parla con l'API pubblica** — `api.load_generator` e
+  `api.build_renderer` invece di `cli._build_renderer`. E' la classe di bug
+  della #243 chiusa dal chiamante: `_build_renderer(tipo, gen, **kwargs)`
+  pesca i kwargs con `.get()`, quindi `ssdir=` su un build numpy era un no-op
+  che nessuno poteva vedere, mentre sulla firma keyword-only dell'API lo
+  stesso errore e' un `TypeError`. Sparisce con esso `sfdir=OUT`, ugualmente
+  inerte, e l'ultimo consumatore di un simbolo privato di `pge.cli` fuori da
+  `main.py`.
+
+- **Importare `bench_cost` non tocca piu' il filesystem.** La tmpdir e il seno
+  sintetico erano effetti collaterali dell'import: ogni `make tests` lasciava
+  una `/tmp/pge_bench_*` orfana e, dove `voice.wav` manca, ci scriveva dentro
+  ~288 KB di wav. Ora `out_dir()` e `sweep_sample()` sono pigri, e l'import di
+  `make_test_samples` — con la riga in `sys.path` che lo rende possibile —
+  sta nel ramo che lo usa.
+
+- **Una sola grafia del seno sintetico.** `utils/make_sine.py` ne teneva una
+  copia propria (ampiezza, dissolvenza ai bordi, campioni in float) e la #243
+  ne aveva prodotta una terza dentro `bench_cost.py`. Ora passano tutte da
+  `make_test_samples.genera`, che ha guadagnato `amp`, `fade_sec` e `subtype`;
+  i default restano quelli dei sample di prova, quindi i file scritti in
+  `refs/` sono identici byte a byte.
+
+- **Il JSON del benchmark registra il sample** che ha prodotto i numeri. Da
+  quando il ramo di fallback misura davvero, gli sweep girano sia su
+  `voice.wav` sia su un seno di 3 s, e la lunghezza del buffer entra nel
+  comportamento di cache, quindi nel coefficiente `a`: due run non
+  confrontabili erano indistinguibili a posteriori.
+
+---
+
 ## [v9.0.2] — 2026-08-30
 
 ### Fixed
@@ -350,23 +412,6 @@ dopo il tag v9.0.0.
   skippa non verifica niente.
 
 ### Corretto
-
-- **`make bench` non girava su un clone pulito** (issue #243).
-  `utils/bench_cost.py` genera un seno sintetico quando manca `refs/voice.wav`
-  — i `.wav` non sono versionati — ma non lo diceva a nessuno dei due
-  consumatori: `_load()` costruiva il `Generator` senza `samples_dir` e
-  `_render()` passava la directory come `ssdir`, che `_build_renderer` inoltra
-  solo dentro `CsoundOptions`. Entrambi i percorsi ricadevano sul globale
-  `./refs/` e lo script moriva in `SampleNotFoundError` nel primo sweep, prima
-  di misurare qualsiasi cosa. Ora passa `samples_dir` a entrambi (l'API ne
-  deriva anche l'`ssdir` per Csound) e riusa `utils/make_test_samples.py` per
-  scrivere il seno, invece di tenerne una terza grafia propria. Le due
-  directory in gioco restano separate: gli sweep leggono il seno sintetico, il
-  *caso di riferimento* (`make bench YAML=...`) legge da `refs/`, perche' uno
-  YAML reale cita il proprio sample e nella tmpdir del seno non lo troverebbe
-  — stato non ipotetico, `make test-samples` scrive `refs/pino.wav` e non
-  `voice.wav`. Il globale si chiama ora `SAMPLES_DIR`: era `SSDIR`, il nome
-  che aveva suggerito il kwarg sbagliato.
 
 - **`Stream.grains` poteva ammutolire uno stream senza dire niente** (issue
   #201). `generate_grains()` teneva gli stessi eventi in due campi — `_voices`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -344,7 +344,13 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   `./refs/` e lo script moriva in `SampleNotFoundError` nel primo sweep, prima
   di misurare qualsiasi cosa. Ora passa `samples_dir` a entrambi (l'API ne
   deriva anche l'`ssdir` per Csound) e riusa `utils/make_test_samples.py` per
-  scrivere il seno, invece di tenerne una terza grafia propria.
+  scrivere il seno, invece di tenerne una terza grafia propria. Le due
+  directory in gioco restano separate: gli sweep leggono il seno sintetico, il
+  *caso di riferimento* (`make bench YAML=...`) legge da `refs/`, perche' uno
+  YAML reale cita il proprio sample e nella tmpdir del seno non lo troverebbe
+  — stato non ipotetico, `make test-samples` scrive `refs/pino.wav` e non
+  `voice.wav`. Il globale si chiama ora `SAMPLES_DIR`: era `SSDIR`, il nome
+  che aveva suggerito il kwarg sbagliato.
 
 - **`Stream.grains` poteva ammutolire uno stream senza dire niente** (issue
   #201). `generate_grains()` teneva gli stessi eventi in due campi — `_voices`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -335,6 +335,17 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Corretto
 
+- **`make bench` non girava su un clone pulito** (issue #243).
+  `utils/bench_cost.py` genera un seno sintetico quando manca `refs/voice.wav`
+  — i `.wav` non sono versionati — ma non lo diceva a nessuno dei due
+  consumatori: `_load()` costruiva il `Generator` senza `samples_dir` e
+  `_render()` passava la directory come `ssdir`, che `_build_renderer` inoltra
+  solo dentro `CsoundOptions`. Entrambi i percorsi ricadevano sul globale
+  `./refs/` e lo script moriva in `SampleNotFoundError` nel primo sweep, prima
+  di misurare qualsiasi cosa. Ora passa `samples_dir` a entrambi (l'API ne
+  deriva anche l'`ssdir` per Csound) e riusa `utils/make_test_samples.py` per
+  scrivere il seno, invece di tenerne una terza grafia propria.
+
 - **`Stream.grains` poteva ammutolire uno stream senza dire niente** (issue
   #201). `generate_grains()` teneva gli stessi eventi in due campi — `_voices`,
   annidato per voce, e `_grains`, flat e ordinato per onset — allineati solo

--- a/docs/explanation/costo-rendering.md
+++ b/docs/explanation/costo-rendering.md
@@ -8,7 +8,7 @@ sources:
   - src/pge/core/stream.py
   - utils/bench_cost.py
   - utils/make_test_samples.py
-last_synced_commit: e540483
+last_synced_commit: a4dc678
 ---
 
 # Costo del rendering — PythonGranularEngine

--- a/docs/explanation/costo-rendering.md
+++ b/docs/explanation/costo-rendering.md
@@ -128,10 +128,17 @@ circa 0,3 s a invocazione, che su un rendering breve non è trascurabile.
   `refs/voice.wav` genera un seno sintetico in una directory temporanea
   riusando `utils/make_test_samples.py`, e passa quella directory come
   `samples_dir` sia al `Generator` sia al renderer — non come `ssdir`, che
-  vale solo per Csound (issue #243). Il seno vale per i tre sweep, che di
-  materiale audio non guardano niente; il *caso di riferimento*
-  (`make bench YAML=...`) legge invece da `refs/`, perche' uno YAML reale cita
-  il proprio sample.
+  vale solo per Csound (issue #243). Il seno vale per i tre sweep, ai quali
+  serve materiale audio qualsiasi e non un materiale particolare: il buffer
+  viene letto per ogni grano — quella lettura *è* l'overlap-add, cioè il
+  termine `a` — ma quale file sia non cambia la forma del modello. Il *caso di
+  riferimento* (`make bench YAML=...`) legge invece da `refs/` (o dalla
+  directory passata come secondo argomento), perché uno YAML reale cita il
+  proprio sample; se quel sample manca lo script lo dice **prima** degli
+  sweep, invece di buttare un minuto e mezzo di misure. Il JSON registra quale
+  sample ha prodotto i numeri: la lunghezza del buffer entra nel comportamento
+  di cache, quindi nel coefficiente `a`, e due run su materiale diverso non
+  sono confrontabili.
 
 Un cambiamento che tocchi la costruzione del `Grain` o l'overlap-add si vede
 sul coefficiente `a`; uno che tocchi la scrittura del file si vede su `b`.
@@ -151,6 +158,11 @@ Rilanciare `make bench` prima e dopo è il modo più diretto per accorgersene.
 make bench                            # i tre sweep + il fit
 make bench YAML=configs/PGE_cim.yml   # + un caso di riferimento reale
 ```
+
+Il caso di riferimento vuole il proprio sample in `refs/`: `PGE_cim.yml` cita
+`voice.wav`, che non è versionato. Se manca, lo script lo dice subito — prima
+degli sweep — e si può passare una directory di sample diversa come secondo
+argomento (`python utils/bench_cost.py configs/PGE_cim.yml /altri/refs`).
 
 Lo script stampa i tre sweep, la ripartizione delle fasi sul caso di riferimento
 e i coefficienti del fit, e scrive un JSON con tutti i punti in una directory

--- a/docs/explanation/costo-rendering.md
+++ b/docs/explanation/costo-rendering.md
@@ -7,6 +7,7 @@ sources:
   - src/pge/rendering/numpy_audio_renderer.py
   - src/pge/core/stream.py
   - utils/bench_cost.py
+  - utils/make_test_samples.py
 last_synced_commit: f138d06
 ---
 
@@ -127,7 +128,10 @@ circa 0,3 s a invocazione, che su un rendering breve non è trascurabile.
   `refs/voice.wav` genera un seno sintetico in una directory temporanea
   riusando `utils/make_test_samples.py`, e passa quella directory come
   `samples_dir` sia al `Generator` sia al renderer — non come `ssdir`, che
-  vale solo per Csound (issue #243).
+  vale solo per Csound (issue #243). Il seno vale per i tre sweep, che di
+  materiale audio non guardano niente; il *caso di riferimento*
+  (`make bench YAML=...`) legge invece da `refs/`, perche' uno YAML reale cita
+  il proprio sample.
 
 Un cambiamento che tocchi la costruzione del `Grain` o l'overlap-add si vede
 sul coefficiente `a`; uno che tocchi la scrittura del file si vede su `b`.

--- a/docs/explanation/costo-rendering.md
+++ b/docs/explanation/costo-rendering.md
@@ -123,12 +123,11 @@ circa 0,3 s a invocazione, che su un rendering breve non è trascurabile.
   `voices`, deprecata dalla issue #201: non partecipa al costo se non la si
   legge, e il benchmark non la legge.)
 - `utils/bench_cost.py` — produce tutte le misure di questa pagina. Non ha
-  dipendenze oltre a quelle del motore e genera un sample sintetico se `refs/`
-  è vuota, ma **su un clone pulito non gira lo stesso**: `_load()` costruisce
-  il `Generator` senza `samples_dir` e `_render()` passa il sample sintetico
-  come `ssdir`, che vale solo per Csound — entrambi i percorsi ricadono sul
-  globale `./refs/` e lo script muore in `SampleNotFoundError` prima di
-  misurare. Difetto noto, tracciato a parte.
+  dipendenze oltre a quelle del motore e gira su un clone pulito: se manca
+  `refs/voice.wav` genera un seno sintetico in una directory temporanea
+  riusando `utils/make_test_samples.py`, e passa quella directory come
+  `samples_dir` sia al `Generator` sia al renderer — non come `ssdir`, che
+  vale solo per Csound (issue #243).
 
 Un cambiamento che tocchi la costruzione del `Grain` o l'overlap-add si vede
 sul coefficiente `a`; uno che tocchi la scrittura del file si vede su `b`.

--- a/docs/explanation/costo-rendering.md
+++ b/docs/explanation/costo-rendering.md
@@ -8,7 +8,7 @@ sources:
   - src/pge/core/stream.py
   - utils/bench_cost.py
   - utils/make_test_samples.py
-last_synced_commit: f138d06
+last_synced_commit: e540483
 ---
 
 # Costo del rendering — PythonGranularEngine

--- a/tests/test_bench_cost_samples_dir.py
+++ b/tests/test_bench_cost_samples_dir.py
@@ -1,0 +1,130 @@
+"""Il sample sintetico deve arrivare a chi lo legge (issue #243).
+
+`utils/bench_cost.py` sceglie una directory di sample e la passa a due
+consumatori: il `Generator` (che risolve il sample in generazione) e il
+renderer (che lo legge in overlap-add). La classe di bug che la #243 ha
+prodotto e' invisibile a review e CI: `_build_renderer(tipo, gen, **kwargs)`
+pesca i kwargs con `.get()`, quindi un nome sbagliato — `ssdir=`, che vale solo
+per Csound — non e' un TypeError ma un no-op silenzioso, e la directory
+ricadeva sul default storico `./refs/`.
+
+Qui si asserisce il comportamento osservabile: il sample viene risolto nella
+directory che si e' passata. Piu' la separazione fra le due directory in gioco,
+che un unico globale aveva confuso: quella degli sweep (la tmpdir del seno
+sintetico) e quella del caso di riferimento (uno YAML reale, che cita il
+proprio sample e lo cerca in `refs/`).
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+@pytest.fixture(scope="module")
+def bench():
+    sys.path.insert(1, os.path.join(REPO_ROOT, "utils"))
+    import bench_cost
+
+    return bench_cost
+
+
+def _scrivi_sample_e_yaml(bench, tmp_path):
+    """Un seno in una directory che non e' ne' `refs/` ne' quella degli sweep."""
+    import make_test_samples
+
+    samples_dir = tmp_path / "samples"
+    samples_dir.mkdir()
+    make_test_samples.genera(
+        str(samples_dir / "solo_qui.wav"), freq=220.0, dur=1.0, sr=bench.SR
+    )
+    yml = tmp_path / "bench.yml"
+    yml.write_text(
+        bench.YAML_TEMPLATE.format(dur=0.5, den=20, sample="solo_qui.wav")
+    )
+    return str(samples_dir), str(yml)
+
+
+def test_il_render_risolve_il_sample_nella_samples_dir(bench, tmp_path):
+    """Il test portante: con `ssdir=` al posto di `samples_dir=` qui si muore.
+
+    Il sample esiste solo nella directory passata, quindi il fallback su
+    `./refs/` non puo' mascherare nulla. `_load` copre la generazione,
+    `_render` il rendering: sono i due difetti indipendenti della #243, e
+    correggerne uno solo sposta l'errore invece di toglierlo.
+    """
+    samples_dir, yml = _scrivi_sample_e_yaml(bench, tmp_path)
+
+    generator = bench._load(yml, samples_dir=samples_dir)
+    assert bench._render(generator, samples_dir=samples_dir) > 0
+
+
+def test_il_caso_di_riferimento_non_eredita_la_dir_degli_sweep(bench, monkeypatch):
+    """`once_yaml` legge da `refs/`, non dalla tmpdir del seno sintetico.
+
+    Quando `refs/voice.wav` manca, `SAMPLES_DIR` e' una tmpdir che contiene
+    *solo* `bench_sample.wav`: uno YAML reale che cita il proprio sample non ci
+    si trova. Lo stato non e' ipotetico — `make test-samples` scrive
+    `refs/pino.wav` e non `voice.wav`, ed e' prerequisito di `make e2e-tests`.
+    """
+    visti = []
+
+    class _FakeStream:
+        onset, duration, voices = 0.0, 1.0, [[]]
+
+    class _FakeGenerator:
+        streams = [_FakeStream()]
+
+    monkeypatch.setattr(
+        bench, "_load",
+        lambda path, samples_dir=None: visti.append(("load", samples_dir))
+        or _FakeGenerator(),
+    )
+    monkeypatch.setattr(
+        bench, "_render",
+        lambda gen, samples_dir=None: visti.append(("render", samples_dir)) or 0.0,
+    )
+
+    bench.once_yaml("/non/letto.yml")
+
+    assert visti == [("load", bench.REFS), ("render", bench.REFS)]
+    assert bench.REFS == os.path.join(REPO_ROOT, "refs")
+
+
+def test_il_renderer_riceve_samples_dir_e_non_ssdir(bench, monkeypatch):
+    """Il nome del kwarg, per esteso: `.get()` non protesta su quello sbagliato."""
+    catturati = {}
+
+    class _FakeEngine:
+        def __init__(self, renderer):
+            pass
+
+        def render(self, **kwargs):
+            return None
+
+    monkeypatch.setattr(
+        bench, "_build_renderer",
+        lambda tipo, gen, **kwargs: catturati.update(tipo=tipo, **kwargs),
+    )
+    monkeypatch.setattr(bench, "RenderingEngine", _FakeEngine)
+
+    class _FakeGenerator:
+        streams = []
+
+    bench._render(_FakeGenerator(), samples_dir="/dev/null/x")
+
+    assert catturati["samples_dir"] == "/dev/null/x"
+    assert "ssdir" not in catturati
+
+
+def test_default_degli_sweep_e_la_dir_del_sample_sintetico(bench):
+    """Senza argomento si usa la directory scelta da `ensure_sample()`."""
+    assert bench.SAMPLES_DIR in (bench.REFS, bench.OUT)
+    if bench.SAMPLES_DIR == bench.OUT:
+        assert bench.SAMPLE == "bench_sample.wav"
+        assert os.path.exists(os.path.join(bench.OUT, bench.SAMPLE))
+    else:
+        assert bench.SAMPLE == "voice.wav"

--- a/tests/test_bench_cost_samples_dir.py
+++ b/tests/test_bench_cost_samples_dir.py
@@ -3,21 +3,25 @@
 `utils/bench_cost.py` sceglie una directory di sample e la passa a due
 consumatori: il `Generator` (che risolve il sample in generazione) e il
 renderer (che lo legge in overlap-add). La classe di bug che la #243 ha
-prodotto e' invisibile a review e CI: `_build_renderer(tipo, gen, **kwargs)`
+prodotto e' invisibile a review e CI: `cli._build_renderer(tipo, gen, **kwargs)`
 pesca i kwargs con `.get()`, quindi un nome sbagliato — `ssdir=`, che vale solo
 per Csound — non e' un TypeError ma un no-op silenzioso, e la directory
 ricadeva sul default storico `./refs/`.
 
 Qui si asserisce il comportamento osservabile: il sample viene risolto nella
-directory che si e' passata. Piu' la separazione fra le due directory in gioco,
-che un unico globale aveva confuso: quella degli sweep (la tmpdir del seno
-sintetico) e quella del caso di riferimento (uno YAML reale, che cita il
-proprio sample e lo cerca in `refs/`).
+directory giusta, sia negli sweep (che non passano nessun argomento: e' il
+percorso della issue) sia quando la directory e' esplicita. Piu' la separazione
+fra le due directory in gioco, che un unico globale aveva confuso: quella degli
+sweep (la tmpdir del seno sintetico) e quella del caso di riferimento (uno YAML
+reale, che cita il proprio sample e lo cerca in `refs/`).
 """
 from __future__ import annotations
 
+import glob
 import os
+import subprocess
 import sys
+import tempfile
 
 import pytest
 
@@ -30,6 +34,26 @@ def bench():
     import bench_cost
 
     return bench_cost
+
+
+@pytest.fixture
+def clone_pulito(bench, monkeypatch, tmp_path):
+    """Lo stato della issue: `refs/` senza `voice.wav`, sweep sul seno.
+
+    `refs/` viene sostituita da una directory vuota invece di leggere quella
+    vera: cosi' il test dice la stessa cosa in CI (dove `voice.wav` non c'e'
+    mai) e sulla macchina di chi quel file ce l'ha. Senza, l'asserzione
+    diventerebbe una disgiunzione sui due stati dell'ambiente, cioe' qualcosa
+    che non puo' fallire in modo informativo.
+    """
+    vuota = tmp_path / "refs_vuota"
+    vuota.mkdir()
+    lavoro = tmp_path / "out"
+    lavoro.mkdir()
+    monkeypatch.setattr(bench, "REFS", str(vuota))
+    monkeypatch.setattr(bench, "_OUT", str(lavoro))
+    monkeypatch.setattr(bench, "_SWEEP", None)
+    return bench
 
 
 def _scrivi_sample_e_yaml(bench, tmp_path):
@@ -48,7 +72,42 @@ def _scrivi_sample_e_yaml(bench, tmp_path):
     return str(samples_dir), str(yml)
 
 
-def test_il_render_risolve_il_sample_nella_samples_dir(bench, tmp_path):
+def test_gli_sweep_risolvono_il_sample_su_un_clone_pulito(clone_pulito):
+    """Il sintomo della #243: `once()` non passa `samples_dir`, e deve girare.
+
+    E' il ramo che gli sweep usano davvero. Rimettere `REFS` come default di
+    `_load`/`_render` — la mutazione piu' naturale — fa morire questo test in
+    `SampleNotFoundError`, che e' letteralmente la issue: su un clone pulito lo
+    script non arrivava a misurare niente.
+    """
+    bench = clone_pulito
+    nome, samples_dir = bench.sweep_sample()
+    assert (nome, samples_dir) == ("bench_sample.wav", bench.out_dir())
+
+    yml = os.path.join(bench.out_dir(), "sweep.yml")
+    with open(yml, "w") as handle:
+        handle.write(bench.YAML_TEMPLATE.format(dur=0.5, den=20, sample=nome))
+
+    generator = bench._load(yml)
+    assert bench._render(generator) > 0
+
+
+def test_con_voice_wav_in_refs_gli_sweep_usano_quello(bench, monkeypatch, tmp_path):
+    """L'altro ramo: con `refs/voice.wav` presente non si genera niente."""
+    import make_test_samples
+
+    refs = tmp_path / "refs"
+    refs.mkdir()
+    make_test_samples.genera(str(refs / "voice.wav"), freq=220.0, dur=1.0, sr=bench.SR)
+    monkeypatch.setattr(bench, "REFS", str(refs))
+    monkeypatch.setattr(bench, "_OUT", None)
+    monkeypatch.setattr(bench, "_SWEEP", None)
+
+    assert bench.sweep_sample() == ("voice.wav", str(refs))
+    assert bench._OUT is None  # nessuna directory di lavoro creata per nulla
+
+
+def test_il_render_risolve_il_sample_nella_samples_dir(bench, monkeypatch, tmp_path):
     """Il test portante: con `ssdir=` al posto di `samples_dir=` qui si muore.
 
     Il sample esiste solo nella directory passata, quindi il fallback su
@@ -56,6 +115,7 @@ def test_il_render_risolve_il_sample_nella_samples_dir(bench, tmp_path):
     `_render` il rendering: sono i due difetti indipendenti della #243, e
     correggerne uno solo sposta l'errore invece di toglierlo.
     """
+    monkeypatch.setattr(bench, "_OUT", str(tmp_path))
     samples_dir, yml = _scrivi_sample_e_yaml(bench, tmp_path)
 
     generator = bench._load(yml, samples_dir=samples_dir)
@@ -65,10 +125,15 @@ def test_il_render_risolve_il_sample_nella_samples_dir(bench, tmp_path):
 def test_il_caso_di_riferimento_non_eredita_la_dir_degli_sweep(bench, monkeypatch):
     """`once_yaml` legge da `refs/`, non dalla tmpdir del seno sintetico.
 
-    Quando `refs/voice.wav` manca, `SAMPLES_DIR` e' una tmpdir che contiene
-    *solo* `bench_sample.wav`: uno YAML reale che cita il proprio sample non ci
-    si trova. Lo stato non e' ipotetico — `make test-samples` scrive
-    `refs/pino.wav` e non `voice.wav`, ed e' prerequisito di `make e2e-tests`.
+    Quando `refs/voice.wav` manca, la directory degli sweep e' una tmpdir che
+    contiene *solo* `bench_sample.wav`: uno YAML reale che cita il proprio
+    sample non ci si trova. Lo stato non e' ipotetico — `make test-samples`
+    scrive `refs/pino.wav` e non `voice.wav`, ed e' prerequisito di
+    `make e2e-tests`.
+
+    `samples_dir=None` esplicito vale come l'assenza dell'argomento: in
+    `_load`/`_render` quella sentinella significa "la directory degli sweep",
+    e inoltrarla tal quale rimetterebbe il caso di riferimento proprio li'.
     """
     visti = []
 
@@ -89,13 +154,29 @@ def test_il_caso_di_riferimento_non_eredita_la_dir_degli_sweep(bench, monkeypatc
     )
 
     bench.once_yaml("/non/letto.yml")
+    bench.once_yaml("/non/letto.yml", samples_dir=None)
 
-    assert visti == [("load", bench.REFS), ("render", bench.REFS)]
+    assert visti == [("load", bench.REFS), ("render", bench.REFS)] * 2
     assert bench.REFS == os.path.join(REPO_ROOT, "refs")
 
 
+def test_run_yaml_inoltra_la_samples_dir(bench, monkeypatch):
+    """La manopola arriva fino in fondo, non si ferma a `once_yaml`."""
+    visti = []
+    monkeypatch.setattr(
+        bench, "once_yaml",
+        lambda path, samples_dir=None: visti.append(samples_dir)
+        or (1.0, 10, 2.0, 0.1, 0.2, 0.7),
+    )
+
+    riga = bench.run_yaml("/non/letto.yml", samples_dir="/altrove")
+
+    assert visti == ["/altrove"] * bench.REPS
+    assert riga["samples_dir"] == "/altrove"
+
+
 def test_il_renderer_riceve_samples_dir_e_non_ssdir(bench, monkeypatch):
-    """Il nome del kwarg, per esteso: `.get()` non protesta su quello sbagliato."""
+    """Il nome del kwarg, per esteso: `.get()` non protestava su quello sbagliato."""
     catturati = {}
 
     class _FakeEngine:
@@ -106,10 +187,11 @@ def test_il_renderer_riceve_samples_dir_e_non_ssdir(bench, monkeypatch):
             return None
 
     monkeypatch.setattr(
-        bench, "_build_renderer",
+        bench.api, "build_renderer",
         lambda tipo, gen, **kwargs: catturati.update(tipo=tipo, **kwargs),
     )
     monkeypatch.setattr(bench, "RenderingEngine", _FakeEngine)
+    monkeypatch.setattr(bench, "_OUT", "/non/scritto")
 
     class _FakeGenerator:
         streams = []
@@ -118,13 +200,76 @@ def test_il_renderer_riceve_samples_dir_e_non_ssdir(bench, monkeypatch):
 
     assert catturati["samples_dir"] == "/dev/null/x"
     assert "ssdir" not in catturati
+    assert "sfdir" not in catturati
 
 
-def test_default_degli_sweep_e_la_dir_del_sample_sintetico(bench):
-    """Senza argomento si usa la directory scelta da `ensure_sample()`."""
-    assert bench.SAMPLES_DIR in (bench.REFS, bench.OUT)
-    if bench.SAMPLES_DIR == bench.OUT:
-        assert bench.SAMPLE == "bench_sample.wav"
-        assert os.path.exists(os.path.join(bench.OUT, bench.SAMPLE))
-    else:
-        assert bench.SAMPLE == "voice.wav"
+def test_lapi_rifiuta_il_kwarg_sbagliato(bench):
+    """Il fix strutturale: sull'API pubblica `ssdir=` e' un TypeError.
+
+    `cli._build_renderer` lo avrebbe ingoiato con `.get()` senza dire niente —
+    e' cosi' che la #243 e' potuta nascere. Passando da `api.build_renderer` la
+    stessa svista non e' piu' scrivibile in silenzio.
+    """
+    with pytest.raises(TypeError):
+        bench.api.build_renderer("numpy", object(), ssdir="/x")
+
+
+def test_il_sample_del_caso_di_riferimento_e_verificato_prima_degli_sweep(
+    bench, monkeypatch, tmp_path
+):
+    """Fail-fast: `configs/PGE_cim.yml` cita `voice.wav`, cioe' il file mancante.
+
+    Su un clone pulito il caso documentato (`make bench YAML=...`) muore sul
+    proprio sample. Se muore dopo i tre sweep si porta via un minuto e mezzo di
+    misure, perche' il `json.dump` viene dopo. Qui si verifica sia che
+    `check_ref_sample` sollevi, sia che `main()` lo faccia prima di far partire
+    gli sweep.
+    """
+    monkeypatch.setattr(bench, "_SWEEP", None)
+    yml = tmp_path / "ref.yml"
+    yml.write_text(bench.YAML_TEMPLATE.format(dur=0.5, den=20, sample="manca.wav"))
+
+    with pytest.raises(SystemExit) as errore:
+        bench.check_ref_sample(str(yml), samples_dir=str(tmp_path))
+    assert "manca.wav" in str(errore.value)
+
+    # Senza argomento la verifica guarda in `refs/`, non nella directory degli
+    # sweep: e' la stessa sentinella invertita che la #243 ha prodotto in
+    # `once_yaml`, e qui era stata riprodotta pari pari.
+    with pytest.raises(SystemExit) as errore:
+        bench.check_ref_sample(str(yml))
+    assert bench.REFS in str(errore.value)
+    assert bench._SWEEP is None  # il seno degli sweep non e' stato nemmeno scritto
+
+    def _sweep_vietato(*args, **kwargs):
+        raise AssertionError("gli sweep sono partiti prima della verifica")
+
+    monkeypatch.setattr(bench, "run", _sweep_vietato)
+    monkeypatch.setattr(sys, "argv", ["bench_cost.py", str(yml), str(tmp_path)])
+    with pytest.raises(SystemExit):
+        bench.main()
+
+
+def test_importare_il_modulo_non_tocca_il_filesystem():
+    """Un import non deve creare la tmpdir ne' scriverci dentro il seno.
+
+    `import bench_cost` da un test faceva `mkdtemp` + `ensure_sample()`: ogni
+    `make tests` lasciava una `/tmp/pge_bench_*` orfana e, dove `voice.wav`
+    manca (la CI), ci scriveva dentro un wav da ~288 KB. Lo stato ora e' pigro,
+    e questo test lo verifica dove si vede: in un processo nuovo.
+    """
+    codice = (
+        "import sys; sys.path.insert(1, %r); import bench_cost as b;"
+        "print(b._OUT, b._SWEEP)" % os.path.join(REPO_ROOT, "utils")
+    )
+    modello = os.path.join(tempfile.gettempdir(), "pge_bench_*")
+    prima = set(glob.glob(modello))
+
+    esito = subprocess.run(
+        [sys.executable, "-c", codice],
+        capture_output=True, text=True, cwd=REPO_ROOT,
+    )
+
+    assert esito.returncode == 0, esito.stderr
+    assert esito.stdout.strip() == "None None"
+    assert set(glob.glob(modello)) == prima

--- a/tests/test_make_test_samples_genera.py
+++ b/tests/test_make_test_samples_genera.py
@@ -1,0 +1,53 @@
+"""Una sola grafia del seno sintetico (issue #243).
+
+`utils/make_test_samples.genera` e' l'unico posto in cui il repo scrive una
+sinusoide: `utils/make_sine.py` ne teneva una copia propria (ampiezza,
+dissolvenza ai bordi, campioni in float) e `utils/bench_cost.py` ne aveva
+aggiunta una terza. Le due varianti sopravvivono come parametri, e i default
+restano quelli dei sample di prova — `refs/pino.wav` entra nel fingerprint
+della cache degli stream senza `duration` (#205), quindi cambiarne i campioni
+non e' gratis.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+import soundfile as sf
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(1, os.path.join(REPO_ROOT, "utils"))
+
+from make_test_samples import SAMPLES, genera  # noqa: E402
+
+
+def test_i_default_sono_quelli_dei_sample_di_prova(tmp_path):
+    """PCM_16, ampiezza 0.5, nessuna dissolvenza: `refs/pino.wav` non si muove."""
+    path = str(tmp_path / "pino.wav")
+    genera(path, **SAMPLES["pino.wav"])
+
+    info = sf.info(path)
+    audio, sr = sf.read(path)
+    atteso = 0.5 * np.sin(
+        2 * np.pi * 440.0 * np.arange(int(3.0 * 48000)) / 48000
+    )
+
+    assert (info.subtype, sr, len(audio)) == ("PCM_16", 48000, 144000)
+    # PCM_16: il confronto e' a meno del passo di quantizzazione.
+    assert np.max(np.abs(audio - atteso)) < 1e-4
+
+
+def test_i_parametri_di_make_sine_sopravvivono(tmp_path):
+    """Ampiezza, dissolvenza e float: le tre differenze di `make_sine.py`."""
+    path = str(tmp_path / "sine.wav")
+    genera(path, freq=440.0, dur=0.5, sr=48000,
+           amp=0.6, fade_sec=0.005, subtype="FLOAT")
+
+    audio, sr = sf.read(path)
+
+    assert sf.info(path).subtype == "FLOAT"
+    assert abs(np.max(np.abs(audio)) - 0.6) < 1e-3
+    # I bordi salgono e scendono: e' la dissolvenza che evita il click.
+    assert audio[0] == 0.0 and abs(audio[-1]) < 1e-3
+    assert np.max(np.abs(audio[: int(0.005 * sr)])) < 0.6

--- a/utils/bench_cost.py
+++ b/utils/bench_cost.py
@@ -50,12 +50,14 @@ import matplotlib  # noqa: E402
 matplotlib.use("Agg")
 
 import numpy as np  # noqa: E402
-import soundfile as sf  # noqa: E402
 
 from pge.engine.generator import Generator  # noqa: E402
 from pge.rendering.render_mode import MixRenderMode  # noqa: E402
 from pge.rendering.rendering_engine import RenderingEngine  # noqa: E402
 from pge.cli import _build_renderer  # noqa: E402
+
+sys.path.insert(0, os.path.join(REPO, "utils"))
+import make_test_samples  # noqa: E402
 
 REPS = 3
 OUT = tempfile.mkdtemp(prefix="pge_bench_")
@@ -88,8 +90,7 @@ def ensure_sample():
         return "voice.wav", refs
     path = os.path.join(OUT, "bench_sample.wav")
     if not os.path.exists(path):
-        t = np.arange(int(3 * SR)) / SR
-        sf.write(path, 0.5 * np.sin(2 * np.pi * 220 * t), SR)
+        make_test_samples.genera(path, freq=220.0, dur=3.0, sr=SR)
         print(f"refs/voice.wav assente: uso un seno sintetico ({path})")
     return "bench_sample.wav", OUT
 
@@ -100,7 +101,8 @@ SAMPLE, SSDIR = ensure_sample()
 def _render(generator):
     """Renderizza e ritorna il tempo del solo overlap-add + scrittura."""
     renderer = _build_renderer(
-        "numpy", generator, output_sr=SR, ssdir=SSDIR, sfdir=OUT, use_cache=False, jobs=1
+        "numpy", generator, output_sr=SR, samples_dir=SSDIR, sfdir=OUT,
+        use_cache=False, jobs=1
     )
     t0 = time.perf_counter()
     RenderingEngine(renderer).render(
@@ -112,7 +114,7 @@ def _render(generator):
 
 
 def _load(path):
-    generator = Generator(path)
+    generator = Generator(path, samples_dir=SSDIR)
     generator.load_yaml()
     generator.create_elements()
     return generator

--- a/utils/bench_cost.py
+++ b/utils/bench_cost.py
@@ -25,14 +25,16 @@ qui interessa la scala, non il wall clock di una macchina. I coefficienti
 dipendono dalla macchina; la forma del modello no.
 
 Uso:
-    python utils/bench_cost.py                      # solo i tre sweep
-    python utils/bench_cost.py configs/PGE_cim.yml  # + caso di riferimento
+    python utils/bench_cost.py                       # solo i tre sweep
+    python utils/bench_cost.py configs/PGE_cim.yml   # + caso di riferimento
+    python utils/bench_cost.py configs/x.yml /altri/refs   # sample altrove
     make bench YAML=configs/PGE_cim.yml
 
 Il sample degli sweep e' `refs/voice.wav`; se manca (i .wav non sono
 versionati) lo script ne genera uno sintetico in un file temporaneo, cosi' gira
 su un clone pulito. Il caso di riferimento non lo eredita: uno YAML reale cita
-il proprio sample, e lo cerca in `refs/` (issue #243).
+il proprio sample, e lo cerca in `refs/` (o nella directory passata come
+secondo argomento). Issue #243.
 """
 from __future__ import annotations
 
@@ -42,6 +44,7 @@ import statistics
 import sys
 import tempfile
 import time
+import traceback
 
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(REPO, "src"))
@@ -52,16 +55,12 @@ matplotlib.use("Agg")
 
 import numpy as np  # noqa: E402
 
-from pge.engine.generator import Generator  # noqa: E402
+from pge import api  # noqa: E402
 from pge.rendering.render_mode import MixRenderMode  # noqa: E402
 from pge.rendering.rendering_engine import RenderingEngine  # noqa: E402
-from pge.cli import _build_renderer  # noqa: E402
-
-sys.path.insert(1, os.path.join(REPO, "utils"))
-import make_test_samples  # noqa: E402
+from pge.shared.exceptions import EngineError  # noqa: E402
 
 REPS = 3
-OUT = tempfile.mkdtemp(prefix="pge_bench_")
 REFS = os.path.join(REPO, "refs")
 SR = 48000
 
@@ -79,6 +78,26 @@ streams:
 seed: 2026
 """
 
+# Stato pigro. Importare questo modulo non deve creare una tmpdir ne'
+# scriverci dentro un wav: i test lo importano
+# (tests/test_bench_cost_samples_dir.py), e un import che lascia una
+# /tmp/pge_bench_* orfana a ogni `make tests` e' un effetto collaterale che
+# nessuno ha chiesto.
+_OUT = None
+_SWEEP = None
+
+
+def out_dir():
+    """Directory di lavoro: YAML e audio di servizio, piu' il JSON finale.
+
+    Non viene rimossa a fine run di proposito: il JSON dei punti di misura sta
+    li' dentro ed e' il prodotto dello script.
+    """
+    global _OUT
+    if _OUT is None:
+        _OUT = tempfile.mkdtemp(prefix="pge_bench_")
+    return _OUT
+
 
 def ensure_sample():
     """Nome del sample per gli sweep, dentro la samples_dir che passiamo.
@@ -86,40 +105,76 @@ def ensure_sample():
     Ritorna (basename, samples_dir) — `samples_dir`, non `ssdir`: quello vale
     solo per Csound, ed e' il nome sbagliato che ha causato la issue #243. Con
     `refs/voice.wav` presente si usa quello; se manca, un seno di 3 s in un
-    file temporaneo — agli sweep serve materiale qualsiasi, non un materiale
-    particolare.
+    file temporaneo — agli sweep serve materiale audio qualsiasi, non un
+    materiale particolare.
     """
     if os.path.exists(os.path.join(REFS, "voice.wav")):
         return "voice.wav", REFS
-    path = os.path.join(OUT, "bench_sample.wav")
-    if not os.path.exists(path):
-        make_test_samples.genera(path, freq=220.0, dur=3.0, sr=SR)
-        print(f"refs/voice.wav assente: uso un seno sintetico ({path})")
-    return "bench_sample.wav", OUT
+    # L'import (e la riga in sys.path che lo rende possibile) sta nel ramo che
+    # lo usa: e' l'idioma di `make_test_samples.genera`, che importa numpy e
+    # soundfile nel corpo. Altrimenti ogni importatore di questo modulo si
+    # porta a casa REPO/utils in sys.path anche senza il seno sintetico.
+    sys.path.insert(1, os.path.join(REPO, "utils"))
+    import make_test_samples
+
+    path = os.path.join(out_dir(), "bench_sample.wav")
+    make_test_samples.genera(path, freq=220.0, dur=3.0, sr=SR)
+    print(f"refs/voice.wav assente: uso un seno sintetico ({path})")
+    return "bench_sample.wav", out_dir()
 
 
-# Il sample degli sweep: `refs/` o la tmpdir del fallback. NON e' la directory
-# del caso di riferimento, che legge il proprio sample da `refs/` (once_yaml).
-SAMPLE, SAMPLES_DIR = ensure_sample()
+def sweep_sample():
+    """Il sample degli sweep, deciso una volta sola: `refs/` o la tmpdir.
+
+    NON e' il sample del caso di riferimento, che legge il proprio da `refs/`
+    (v. `once_yaml`).
+    """
+    global _SWEEP
+    if _SWEEP is None:
+        _SWEEP = ensure_sample()
+    return _SWEEP
+
+
+def _ref_dir(samples_dir):
+    """La directory dei sample del caso di riferimento: `None` -> `REFS`.
+
+    NON e' la sentinella di `_load`/`_render`, dove `None` significa "la
+    directory degli sweep". Inoltrarla tal quale rimette il caso di riferimento
+    sul seno sintetico, che e' il difetto della #243: sta qui, in un posto
+    solo, perche' due posti divergono — e infatti erano gia' divergiti.
+    """
+    return REFS if samples_dir is None else samples_dir
+
+
+def _sweep_dir(samples_dir):
+    """La directory dei sample degli sweep: `None` -> quella di `ensure_sample`.
+
+    L'altra meta' di `_ref_dir`: `None` significa cose diverse a seconda di chi
+    lo scrive, e le due sentinelle hanno un nome ciascuna proprio perche'
+    confonderle e' il difetto della #243.
+    """
+    return sweep_sample()[1] if samples_dir is None else samples_dir
 
 
 def _render(generator, samples_dir=None):
     """Renderizza e ritorna il tempo del solo overlap-add + scrittura.
 
     `samples_dir` (None -> quella degli sweep) e' la directory in cui la
-    registry cerca il sample. Va passata come `samples_dir` e non come `ssdir`:
-    `_build_renderer` inoltra `ssdir` solo dentro `CsoundOptions`, e pesca i
-    kwargs con `.get()` — un nome sbagliato qui e' un no-op silenzioso (#243).
+    registry cerca il sample. Si passa a `api.build_renderer`, che e' l'API
+    pubblica e ha una firma keyword-only: `ssdir=` — che vale solo per Csound —
+    li' e' un TypeError, mentre `cli._build_renderer` pesca i kwargs con
+    `.get()` e lo ingoiava in silenzio. E' la classe di bug della #243, chiusa
+    dal chiamante.
     """
-    renderer = _build_renderer(
+    renderer = api.build_renderer(
         "numpy", generator, output_sr=SR,
-        samples_dir=SAMPLES_DIR if samples_dir is None else samples_dir,
-        sfdir=OUT, use_cache=False, jobs=1
+        samples_dir=_sweep_dir(samples_dir),
+        jobs=1,
     )
     t0 = time.perf_counter()
     RenderingEngine(renderer).render(
         streams=generator.streams,
-        output_path=os.path.join(OUT, "bench.aif"),
+        output_path=os.path.join(out_dir(), "bench.aif"),
         mode=MixRenderMode(),
     )
     return time.perf_counter() - t0
@@ -127,18 +182,14 @@ def _render(generator, samples_dir=None):
 
 def _load(path, samples_dir=None):
     """Parsa lo YAML e costruisce gli oggetti. `samples_dir`: v. `_render`."""
-    generator = Generator(
-        path, samples_dir=SAMPLES_DIR if samples_dir is None else samples_dir
-    )
-    generator.load_yaml()
-    generator.create_elements()
-    return generator
+    return api.load_generator(path, samples_dir=_sweep_dir(samples_dir))
 
 
 def once(dur, den):
-    path = os.path.join(OUT, "bench.yml")
+    sample, _ = sweep_sample()
+    path = os.path.join(out_dir(), "bench.yml")
     with open(path, "w") as handle:
-        handle.write(YAML_TEMPLATE.format(dur=dur, den=den, sample=SAMPLE))
+        handle.write(YAML_TEMPLATE.format(dur=dur, den=den, sample=sample))
     generator = _load(path)
     t = _render(generator)
     return t, sum(len(v) for s in generator.streams for v in s.voices)
@@ -152,13 +203,20 @@ def run(dur, den):
     return dict(dur=dur, den=den, n=n, t=min(times), t_med=statistics.median(times))
 
 
-def once_yaml(path, samples_dir=REFS):
+def once_yaml(path, samples_dir=None):
     """Come once(), su uno YAML reale, separando le tre fasi.
 
-    Legge da `refs/`, non dalla directory degli sweep: quando `refs/voice.wav`
-    manca, quella e' una tmpdir che contiene *solo* il seno sintetico, e lo
-    YAML reale cita il proprio sample (issue #243). Il caso si presenta con
-    `refs/` popolata: `make test-samples` scrive `pino.wav` e non `voice.wav`.
+    `samples_dir` (None -> `REFS`, cioe' il `refs/` del repo) e' la directory
+    del caso di riferimento, e non e' quella degli sweep: quando
+    `refs/voice.wav` manca, quella e' una tmpdir che contiene *solo* il seno
+    sintetico, e lo YAML reale cita il proprio sample (issue #243). Il caso si
+    presenta con `refs/` popolata: `make test-samples` scrive `pino.wav` e non
+    `voice.wav`.
+
+    `None` significa qui `REFS` e non "la directory degli sweep" come in
+    `_load`/`_render`: la sentinella e' risolta nel corpo proprio perche'
+    inoltrarla tal quale rimetterebbe il caso di riferimento sul sample degli
+    sweep.
 
     I grani sono lazy: `Stream.voices` li materializza al primo accesso, e senza
     forzarlo quel costo finisce dentro il tempo di render. Toccarli qui non
@@ -171,6 +229,8 @@ def once_yaml(path, samples_dir=REFS):
     `t_build` — su un milione di grani circa 0,4 s attribuiti alla costruzione
     che costruzione non sono.
     """
+    samples_dir = _ref_dir(samples_dir)
+
     t0 = time.perf_counter()
     generator = _load(path, samples_dir=samples_dir)
     t_setup = time.perf_counter() - t0
@@ -184,18 +244,45 @@ def once_yaml(path, samples_dir=REFS):
     return t_setup + t_build + t_mix, n, dur, t_setup, t_build, t_mix
 
 
-def run_yaml(path):
+def run_yaml(path, samples_dir=None):
     times, parts, n, dur = [], None, 0, 0.0
     for _ in range(REPS):
-        t, n, dur, t_setup, t_build, t_mix = once_yaml(path)
+        t, n, dur, t_setup, t_build, t_mix = once_yaml(path, samples_dir=samples_dir)
         times.append(t)
         if parts is None or t == min(times):
             parts = (t_setup, t_build, t_mix)
     return dict(
         yaml=os.path.relpath(path, REPO), dur=dur, den=None, n=n,
+        samples_dir=_ref_dir(samples_dir),
         t=min(times), t_med=statistics.median(times),
         t_setup=parts[0], t_build=parts[1], t_mix=parts[2],
     )
+
+
+def check_ref_sample(path, samples_dir=None):
+    """Risolve il sample del caso di riferimento *prima* degli sweep.
+
+    Gli sweep durano oltre un minuto e `main()` scrive il JSON dopo il caso di
+    riferimento: senza questa verifica un sample mancante si porta via tutte le
+    misure. Il caso non e' di laboratorio — `configs/PGE_cim.yml`, il caso
+    documentato, cita `voice.wav`, cioe' proprio il file la cui assenza fa
+    scattare il seno sintetico degli sweep.
+
+    Costa un `_load` in piu' sul caso di riferimento (parse+setup, decimi di
+    secondo): il prezzo di sapere in due secondi cio' che altrimenti si scopre
+    dopo novanta.
+    """
+    samples_dir = _ref_dir(samples_dir)
+    try:
+        _load(path, samples_dir=samples_dir)
+    except (EngineError, OSError) as err:
+        raise SystemExit(
+            f"caso di riferimento non utilizzabile: {err}\n"
+            f"  yaml: {path}\n"
+            f"  sample cercati in: {samples_dir}\n"
+            "  i .wav non sono versionati: `make test-samples`, oppure passa la "
+            "directory dei sample come secondo argomento"
+        ) from err
 
 
 def fit(rows):
@@ -221,6 +308,10 @@ def fit(rows):
 
 def main():
     rows = {}
+    ref_yaml = os.path.abspath(sys.argv[1]) if len(sys.argv) > 1 else None
+    ref_dir = sys.argv[2] if len(sys.argv) > 2 else None
+    if ref_yaml is not None:
+        check_ref_sample(ref_yaml, samples_dir=ref_dir)
 
     print("\n== A: durata fissa 10 s, densita' crescente ==")
     print(f"{'density':>8} {'grani':>7} {'t_min(s)':>9} {'us/grano':>9}")
@@ -246,17 +337,34 @@ def main():
         rows["C"].append(r)
         print(f"{dur:>7}s {r['n']:>7} {r['t']:>9.3f} {1e6 * r['t'] / r['n']:>9.1f}")
 
-    if len(sys.argv) > 1:
-        ref = run_yaml(os.path.abspath(sys.argv[1]))
-        rows["ref"] = [ref]
-        print(f"\n== caso di riferimento ({ref['yaml']}): {ref['n']} grani su "
-              f"{ref['dur']:.1f} s -> {ref['t']:.2f} s ==")
-        print(f"   parse+setup {ref['t_setup']:.3f}s | costruzione dei grani "
-              f"{ref['t_build']:.3f}s ({1e6 * ref['t_build'] / ref['n']:.1f} us/grano) | "
-              f"overlap-add+scrittura {ref['t_mix']:.3f}s")
+    if ref_yaml is not None:
+        # Il caso di riferimento gira dopo gli sweep e prima del json.dump:
+        # qualunque cosa gli succeda, i tre sweep sono gia' costati un minuto e
+        # mezzo e non si buttano. Il sample mancante — il modo tipico di
+        # fallire — l'ha gia' intercettato check_ref_sample() prima di tutto.
+        try:
+            ref = run_yaml(ref_yaml, samples_dir=ref_dir)
+        except Exception:
+            print("\n!! caso di riferimento fallito, scrivo comunque gli sweep:")
+            traceback.print_exc()
+        else:
+            rows["ref"] = [ref]
+            print(f"\n== caso di riferimento ({ref['yaml']}): {ref['n']} grani su "
+                  f"{ref['dur']:.1f} s -> {ref['t']:.2f} s ==")
+            print(f"   parse+setup {ref['t_setup']:.3f}s | costruzione dei grani "
+                  f"{ref['t_build']:.3f}s ({1e6 * ref['t_build'] / ref['n']:.1f} us/grano) | "
+                  f"overlap-add+scrittura {ref['t_mix']:.3f}s")
 
     rows["fit"] = fit(rows)
-    out = os.path.join(OUT, "bench_cost.json")
+    # Quale sample ha prodotto i numeri: da quando il ramo di fallback misura
+    # davvero (#243) gli sweep girano sia su `voice.wav` sia su un seno di 3 s,
+    # e la dimensione del buffer entra nel comportamento di cache, quindi nel
+    # coefficiente `a`. Senza questa riga due run non confrontabili sono
+    # indistinguibili a posteriori.
+    sample, samples_dir = sweep_sample()
+    rows["sample"] = {"name": sample, "dir": samples_dir}
+    print(f"sample degli sweep: {sample} ({samples_dir})")
+    out = os.path.join(out_dir(), "bench_cost.json")
     with open(out, "w") as handle:
         json.dump(rows, handle, indent=1)
     print("json:", out)

--- a/utils/bench_cost.py
+++ b/utils/bench_cost.py
@@ -31,7 +31,8 @@ Uso:
 
 Il sample degli sweep e' `refs/voice.wav`; se manca (i .wav non sono
 versionati) lo script ne genera uno sintetico in un file temporaneo, cosi' gira
-su un clone pulito.
+su un clone pulito. Il caso di riferimento non lo eredita: uno YAML reale cita
+il proprio sample, e lo cerca in `refs/` (issue #243).
 """
 from __future__ import annotations
 
@@ -56,11 +57,12 @@ from pge.rendering.render_mode import MixRenderMode  # noqa: E402
 from pge.rendering.rendering_engine import RenderingEngine  # noqa: E402
 from pge.cli import _build_renderer  # noqa: E402
 
-sys.path.insert(0, os.path.join(REPO, "utils"))
+sys.path.insert(1, os.path.join(REPO, "utils"))
 import make_test_samples  # noqa: E402
 
 REPS = 3
 OUT = tempfile.mkdtemp(prefix="pge_bench_")
+REFS = os.path.join(REPO, "refs")
 SR = 48000
 
 YAML_TEMPLATE = """composition:
@@ -79,15 +81,16 @@ seed: 2026
 
 
 def ensure_sample():
-    """Nome del sample per gli sweep, dentro la ssdir che passiamo al renderer.
+    """Nome del sample per gli sweep, dentro la samples_dir che passiamo.
 
-    Ritorna (basename, ssdir). Con `refs/voice.wav` presente si usa quello; se
-    manca, un seno di 3 s in un file temporaneo — agli sweep serve materiale
-    qualsiasi, non un materiale particolare.
+    Ritorna (basename, samples_dir) — `samples_dir`, non `ssdir`: quello vale
+    solo per Csound, ed e' il nome sbagliato che ha causato la issue #243. Con
+    `refs/voice.wav` presente si usa quello; se manca, un seno di 3 s in un
+    file temporaneo — agli sweep serve materiale qualsiasi, non un materiale
+    particolare.
     """
-    refs = os.path.join(REPO, "refs")
-    if os.path.exists(os.path.join(refs, "voice.wav")):
-        return "voice.wav", refs
+    if os.path.exists(os.path.join(REFS, "voice.wav")):
+        return "voice.wav", REFS
     path = os.path.join(OUT, "bench_sample.wav")
     if not os.path.exists(path):
         make_test_samples.genera(path, freq=220.0, dur=3.0, sr=SR)
@@ -95,14 +98,23 @@ def ensure_sample():
     return "bench_sample.wav", OUT
 
 
-SAMPLE, SSDIR = ensure_sample()
+# Il sample degli sweep: `refs/` o la tmpdir del fallback. NON e' la directory
+# del caso di riferimento, che legge il proprio sample da `refs/` (once_yaml).
+SAMPLE, SAMPLES_DIR = ensure_sample()
 
 
-def _render(generator):
-    """Renderizza e ritorna il tempo del solo overlap-add + scrittura."""
+def _render(generator, samples_dir=None):
+    """Renderizza e ritorna il tempo del solo overlap-add + scrittura.
+
+    `samples_dir` (None -> quella degli sweep) e' la directory in cui la
+    registry cerca il sample. Va passata come `samples_dir` e non come `ssdir`:
+    `_build_renderer` inoltra `ssdir` solo dentro `CsoundOptions`, e pesca i
+    kwargs con `.get()` — un nome sbagliato qui e' un no-op silenzioso (#243).
+    """
     renderer = _build_renderer(
-        "numpy", generator, output_sr=SR, samples_dir=SSDIR, sfdir=OUT,
-        use_cache=False, jobs=1
+        "numpy", generator, output_sr=SR,
+        samples_dir=SAMPLES_DIR if samples_dir is None else samples_dir,
+        sfdir=OUT, use_cache=False, jobs=1
     )
     t0 = time.perf_counter()
     RenderingEngine(renderer).render(
@@ -113,8 +125,11 @@ def _render(generator):
     return time.perf_counter() - t0
 
 
-def _load(path):
-    generator = Generator(path, samples_dir=SSDIR)
+def _load(path, samples_dir=None):
+    """Parsa lo YAML e costruisce gli oggetti. `samples_dir`: v. `_render`."""
+    generator = Generator(
+        path, samples_dir=SAMPLES_DIR if samples_dir is None else samples_dir
+    )
     generator.load_yaml()
     generator.create_elements()
     return generator
@@ -137,8 +152,13 @@ def run(dur, den):
     return dict(dur=dur, den=den, n=n, t=min(times), t_med=statistics.median(times))
 
 
-def once_yaml(path):
+def once_yaml(path, samples_dir=REFS):
     """Come once(), su uno YAML reale, separando le tre fasi.
+
+    Legge da `refs/`, non dalla directory degli sweep: quando `refs/voice.wav`
+    manca, quella e' una tmpdir che contiene *solo* il seno sintetico, e lo
+    YAML reale cita il proprio sample (issue #243). Il caso si presenta con
+    `refs/` popolata: `make test-samples` scrive `pino.wav` e non `voice.wav`.
 
     I grani sono lazy: `Stream.voices` li materializza al primo accesso, e senza
     forzarlo quel costo finisce dentro il tempo di render. Toccarli qui non
@@ -152,14 +172,14 @@ def once_yaml(path):
     che costruzione non sono.
     """
     t0 = time.perf_counter()
-    generator = _load(path)
+    generator = _load(path, samples_dir=samples_dir)
     t_setup = time.perf_counter() - t0
 
     t0 = time.perf_counter()
     n = sum(len(v) for s in generator.streams for v in s.voices)
     t_build = time.perf_counter() - t0
 
-    t_mix = _render(generator)
+    t_mix = _render(generator, samples_dir=samples_dir)
     dur = max(s.onset + s.duration for s in generator.streams)
     return t_setup + t_build + t_mix, n, dur, t_setup, t_build, t_mix
 

--- a/utils/make_sine.py
+++ b/utils/make_sine.py
@@ -8,13 +8,20 @@ Default: 440 Hz, 16 s, refs/sine440.wav (48 kHz mono).
 La sinusoide e' stazionaria: la posizione di lettura (pointer) non ne cambia
 l'altezza, solo la fase. Le altezze percepite nascono dai ratio di pitch delle
 voci. Una piccola dissolvenza ai bordi evita il click iniziale/finale.
+
+La sinusoide la scrive `make_test_samples.genera`: qui restano solo i
+parametri che distinguono questo materiale da quello dei test (ampiezza,
+dissolvenza, campioni in float). Tenerne una copia propria significava avere
+due definizioni della stessa cosa che possono divergere.
 """
 from __future__ import annotations
 
+import os
 import sys
 
-import numpy as np
-import soundfile as sf
+sys.path.insert(1, os.path.dirname(os.path.abspath(__file__)))
+
+from make_test_samples import genera  # noqa: E402
 
 
 def main() -> None:
@@ -23,18 +30,8 @@ def main() -> None:
     out_path = sys.argv[3] if len(sys.argv) > 3 else "refs/sine440.wav"
 
     sr = 48000
-    amplitude = 0.6
-    t = np.arange(int(round(duration * sr)), dtype=np.float64) / sr
-    signal = amplitude * np.sin(2.0 * np.pi * freq * t)
-
-    # Dissolvenza di 5 ms ai bordi: evita il transiente di apertura/chiusura.
-    fade = int(0.005 * sr)
-    if fade > 0 and signal.size > 2 * fade:
-        ramp = np.linspace(0.0, 1.0, fade)
-        signal[:fade] *= ramp
-        signal[-fade:] *= ramp[::-1]
-
-    sf.write(out_path, signal.astype(np.float32), sr, subtype="FLOAT")
+    genera(out_path, freq=freq, dur=duration, sr=sr,
+           amp=0.6, fade_sec=0.005, subtype="FLOAT")
     print(f"Scritto {out_path}: {freq} Hz, {duration} s, {sr} Hz mono")
 
 

--- a/utils/make_test_samples.py
+++ b/utils/make_test_samples.py
@@ -31,13 +31,30 @@ SAMPLES = {
 }
 
 
-def genera(path, *, freq, dur, sr):
+def genera(path, *, freq, dur, sr, amp=0.5, fade_sec=0.0, subtype='PCM_16'):
+    """Scrive una sinusoide di `dur` secondi a `freq` Hz in `path`.
+
+    I tre parametri opzionali esistono per `utils/make_sine.py`, che scriveva
+    la stessa sinusoide con un'ampiezza diversa, una dissolvenza ai bordi e in
+    float: era una seconda grafia dello stesso oggetto, e la issue #243 ne
+    aveva prodotta una terza dentro `utils/bench_cost.py`. I default sono
+    quelli dei sample di prova, cosi' i file in `refs/` non si muovono.
+
+    numpy e soundfile si importano qui e non a livello di modulo: chi importa
+    questo file per riusare `genera` non deve pagarli, e la CI li ha solo
+    dentro il venv.
+    """
     import numpy as np
     import soundfile as sf
 
-    t = np.arange(int(dur * sr)) / sr
-    audio = 0.5 * np.sin(2 * np.pi * freq * t)
-    sf.write(path, audio.astype('float32'), sr, subtype='PCM_16')
+    t = np.arange(int(round(dur * sr))) / sr
+    audio = amp * np.sin(2 * np.pi * freq * t)
+    fade = int(fade_sec * sr)
+    if fade > 0 and audio.size > 2 * fade:
+        rampa = np.linspace(0.0, 1.0, fade)
+        audio[:fade] *= rampa
+        audio[-fade:] *= rampa[::-1]
+    sf.write(path, audio.astype('float32'), sr, subtype=subtype)
 
 
 def main(argv=None):


### PR DESCRIPTION
Chiude #243.

## Cosa era rotto

`utils/bench_cost.py` promette nel docstring di girare su un clone pulito: se manca `refs/voice.wav` (i `.wav` non sono versionati) si scrive un seno in un file temporaneo. Il seno lo scriveva davvero, ma non lo diceva a nessuno dei due consumatori — due difetti indipendenti:

1. `_load()` costruiva `Generator(path)` senza `samples_dir`: `Stream` risolveva il sample sul globale `./refs/` e moriva in `SampleNotFoundError` dentro `once()`, cioe' nel primo sweep, prima di misurare qualsiasi cosa.
2. `_render()` passava la directory come `ssdir`, che `cli._build_renderer` inoltra **solo** dentro `CsoundOptions` e solo per `renderer_type == 'csound'`. Per il path NumPy conta `samples_dir`: la registry ricadeva di nuovo su `./refs/`. Sistemato solo il primo difetto, l'errore si sarebbe spostato dalla generazione al rendering.

Sistemati quei due, ne sono emersi altri due, entrambi nel ramo che la correzione rendeva raggiungibile per la prima volta:

3. `once_yaml()` chiama `_load()` e `_render()`, che leggevano lo stesso globale. Nel ramo di fallback quella directory contiene **solo** `bench_sample.wav`, quindi il *caso di riferimento* — uno YAML reale passato come argomento — non risolveva piu' il proprio sample.
4. E anche separando le due directory, il caso di riferimento **documentato** continuava a morire: `configs/PGE_cim.yml` cita `voice.wav`, cioe' proprio il file la cui assenza fa scattare il fallback. Moriva dopo i tre sweep e prima del `json.dump`: un minuto e mezzo di misure buttate, la stessa dinamica del bug originale, solo spostata.

| stato | caso di riferimento | sweep |
| --- | --- | --- |
| `main` | OK con `voice.wav` presente | `SampleNotFoundError: 'bench_sample.wav' in ./refs/` |
| dopo i difetti 1-2 | `SampleNotFoundError` nella tmpdir | OK |
| dopo il difetto 3 | OK con lo YAML giusto, `SampleNotFoundError` dopo 90 s con `PGE_cim.yml` | OK |
| questa PR | OK, o errore in 0,3 s | OK |

## Cosa cambia

**Le due directory hanno due sentinelle, e ognuna ha un nome.** `_sweep_dir()` e `_ref_dir()`: `None` significa "la directory degli sweep" nella prima e "`refs/`" nella seconda, e ciascuna risolve nel proprio corpo invece di inoltrare il valore. Inoltrarlo era il difetto 3, e riscriverlo era facile: la prima stesura del fail-fast di questa PR l'ha rifatto identico, ed e' il motivo per cui le sentinelle ora sono due funzioni con un nome. La manopola attraversa `once_yaml` -> `run_yaml` -> `main()`, che la prende come secondo argomento (`python utils/bench_cost.py <yaml> <dir>`): prima della PR il controllo era il cwd, ed era stato tolto senza sostituto.

**Il caso di riferimento si verifica prima degli sweep.** `check_ref_sample()` risolve il suo sample in 0,3 s invece di 90; e `main()` avvolge comunque `run_yaml` in un try/except, cosi' qualunque altra cosa gli succeda il JSON degli sweep — che e' gia' costato un minuto e mezzo — si scrive lo stesso.

**`bench_cost` parla con l'API pubblica**: `api.load_generator` e `api.build_renderer` al posto di `cli._build_renderer`. E' la classe di bug della #243 chiusa dal chiamante — `_build_renderer(tipo, gen, **kwargs)` pesca con `.get()`, quindi un nome sbagliato non e' un `TypeError` ma un no-op che nessuno puo' vedere, mentre l'API ha una firma keyword-only e su `ssdir=` solleva. Con esso sparisce `sfdir=OUT`, ugualmente inerte per il path NumPy, e l'ultimo consumatore di un simbolo privato di `pge.cli` fuori da `main.py`, che `use-as-library.md` scoraggia. `_load` era `api.load_generator` riscritto, parametro nuovo compreso.

**Importare il modulo non tocca piu' il filesystem.** `mkdtemp` + `ensure_sample()` erano effetti collaterali dell'import: ogni `make tests` lasciava una `/tmp/pge_bench_*` orfana e, dove `voice.wav` manca (la CI), ci scriveva dentro ~288 KB di wav. `out_dir()` e `sweep_sample()` sono pigri; l'import di `make_test_samples` — con la riga in `sys.path` che lo permette — sta nel ramo che lo usa; la guardia `if not os.path.exists(path)`, che su una `mkdtemp` appena creata non poteva scattare, e' via.

**Una sola grafia del seno sintetico.** `utils/make_sine.py` ne teneva una copia propria (ampiezza, dissolvenza ai bordi, campioni in float) e la #243 ne aveva prodotta una terza. Ora passano tutte da `make_test_samples.genera`, che ha guadagnato `amp`, `fade_sec` e `subtype`: i default restano quelli dei sample di prova e i file scritti sono identici byte a byte (sha256 verificato su entrambi i casi), perche' la durata di `refs/pino.wav` entra nel fingerprint della cache degli stream senza `duration` (#205).

**Il JSON registra il sample** che ha prodotto i numeri. Ora che entrambi i rami misurano, gli sweep girano sia su `voice.wav` sia su un seno di 3 s, e la lunghezza del buffer entra nel comportamento di cache e quindi nel coefficiente `a`: due run non confrontabili erano indistinguibili a posteriori.

La rampa d'ampiezza decrescente di `tests/e2e/test_supercollider_e2e.py` **resta separata di proposito**: serve a rendere osservabile la posizione di lettura del grano, cosa che un tono stazionario non permette (il test a `pointer.start=2.0` misura un rapporto ~3x sul picco, che con un seno costante sarebbe 1.0).

## Test

`tests/test_bench_cost_samples_dir.py` (nove test) e `tests/test_make_test_samples_genera.py` (due).

Il sintomo originale della #243 — gli sweep su un clone pulito, cioe' `_load`/`_render` **senza** argomento — non era coperto: rimettere `REFS` come loro default lasciava tutto verde e riportava lo script a morire al primo sweep. Ora lo copre `test_gli_sweep_risolvono_il_sample_su_un_clone_pulito`, che sostituisce `refs/` con una directory vuota invece di leggere quella vera, cosi' dice la stessa cosa in CI e sulla macchina di chi ha `voice.wav` — l'asserzione che rimpiazza era una disgiunzione sui due stati dell'ambiente, cioe' qualcosa che non poteva fallire in modo informativo.

Il test portante non usa mock: scrive un seno in una directory che non e' ne' `refs/` ne' quella degli sweep e ci fa passare `_load()` + `_render()`. Il sample esiste **solo** li'.

Verificati per mutazione, ognuna fa cadere il test giusto e solo quello: default `REFS` negli sweep, `once_yaml` che inoltra `None`, `run_yaml` che non inoltra, `ssdir=` al posto di `samples_dir=`, stato eager all'import, fail-fast tolto da `main()`, `check_ref_sample` che eredita la directory degli sweep.

## Documentazione

`docs/explanation/costo-rendering.md`: «i tre sweep, che di materiale audio non guardano niente» diceva il contrario di quello che la pagina misura — il buffer viene letto per ogni grano, e quella lettura *e'* l'overlap-add, cioe' il termine `a`. Cio' che e' indifferente agli sweep e' quale file sia. La sezione Riproduzione dice ora che il caso di riferimento vuole il proprio sample in `refs/` e che la directory si puo' passare come secondo argomento. `sources:` elenca `utils/make_test_samples.py`; `last_synced_commit` risincronizzato in un commit separato, cosi' non si autoinvalida.

`CHANGELOG.md`: la voce sta in una **nuova** `[Non rilasciato]`. Il branch parte da `f16ee0c`, quando quella sezione aveva ancora quel nome; su `main` e' diventata `## [v9.0.0]` ed e' taggata, e il merge (pulito, nessun conflitto) avrebbe fatto atterrare la voce dentro una versione gia' rilasciata.

## Follow-up

#252 — `cli._build_renderer` ingoia in silenzio ogni kwarg sconosciuto. Questa PR chiude il caso concreto dal chiamante, non il difetto: resta per `main.py` e per chiunque altro.

## Verifica

- `python utils/bench_cost.py configs/PGE_envelope_syntax_test.yml` con `refs/pino.wav` presente e `voice.wav` assente — lo stato in cui lascia `make test-samples`, prerequisito di `make e2e-tests`: tre sweep, 23 punti, caso di riferimento misurato (986 grani su 84 s), fit stampato, riga del sample, JSON scritto;
- `python utils/bench_cost.py configs/PGE_cim.yml` su un clone pulito: errore in **0,33 s** che nomina `refs/`, senza creare la tmpdir ne' scrivere il seno;
- lo stesso script importato da un albero senza `refs/`: il seno finisce nella tmpdir e `once(1.0, 20)` misura invece di sollevare;
- `make tests`: 6106 passed, 10 skipped, e zero `/tmp/pge_bench_*` lasciate indietro;
- `make docs-lint`: OK (21 docs); `build_docs_index.py` non muove `INDEX.md`.

## Impatto cross-repo

Nessuno. Il cambiamento e' confinato a due script in `utils/`, ai test e a un doc: non tocca sintassi YAML, bounds, gerarchia errori, CLI o formati di output. `api.build_renderer` e `api.load_generator` sono soltanto *consumate*, non cambiate. Niente issue su PGE-ls / PGE-ui, e niente che gli esempi del paper CIM esercitino: nessun bump del submodule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B6XFukEwa9KiinWgssRqUb