### PR TITLE
feat(visualizer): --bw, un preset della partitura leggibile in stampa bianco e nero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,62 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ---
 
+## [Unreleased]
+
+### Aggiunto
+
+- **`--bw`: un preset della partitura leggibile in stampa bianco e nero**
+  (issue #248). La MAP e' pensata per lo schermo, e le figure del paper CIM
+  2026 hanno un vincolo di leggibilita' in B&W. Il flag (o `BW=true` da Make,
+  o `config={'bw': True}` da libreria) sposta i default del visualizer; a
+  flag spento non cambia un pixel.
+
+  In grigio collassavano due cose, e in modo peggiore di quanto sembri:
+
+  - **il segno del detune.** I due bracci di `pitch_div` non hanno solo la
+    stessa chiarezza: convertita in luminanza la mappa non e' nemmeno
+    monotona. A +/-150 cent su un range di +/-300 i due grani stanno a 0.510
+    e 0.595, a +/-50 cent a 0.481 e 0.509 — cioe' un grano calante e uno
+    crescente diventano lo stesso grigio. `pitch_div_bw` spende sulla
+    luminanza tutta l'escursione, in modo strettamente monotono, compressa a
+    circa 0.15-0.85: col braccio alto sul bianco i grani acuti sparirebbero
+    sulla carta, col basso sul nero si confonderebbero con assi e griglia;
+  - **l'identita' delle curve.** `ENVELOPE_STYLES`, mappa **parallela** a
+    `ENVELOPE_COLORS` nello stesso modulo matplotlib-free, sostituisce la
+    tinta con `(linestyle, linewidth)`: il pattern dice il parametro, lo
+    spessore dice la variante (`_prob` piu' sottile della base, `_range` piu'
+    spesso), come faceva il chiaro/scuro della stessa tinta. La coppia e'
+    unica per chiave.
+
+  **L'alpha dei grani viene fissata, e costa qualcosa.** Sul fondo bianco il
+  composito e' `a*g + (1-a)`: l'alpha e la luminanza del grigio sono lo
+  **stesso canale**, e con l'alpha libera un grano grave suonato piano
+  schiarisce fino a leggersi come acuto — il canale che il preset esiste per
+  salvare mangiato da quello che prova a conservare. Fissandola a 0.9 il
+  grigio torna funzione del solo pitch (un grano grave e pianissimo resta piu'
+  scuro di uno acuto e forte), ma **il volume smette di dirsi nel riempimento
+  del grano**. Il prezzo e' esplicito e si riapre passando
+  `grain_alpha_range`. Non 1.0: a opacita' piena un cluster denso diventa una
+  lastra e la densita' smette di leggersi.
+
+  Il preset e' un insieme di **default**, non un modo a parte: ogni chiave
+  passata insieme a `bw` vince, e i dizionari-dato si fondono sul preset
+  invece che sui default cromatici — ritoccare un colore non riporta a colori
+  tutti gli altri. Con gli stili in gioco la legenda per-corsia diventa un
+  **campione** della curva (stesso pattern, stesso spessore, su tutta la
+  larghezza utile della colonna) invece del simbolo corto storico, che di un
+  tratteggio non mostrerebbe nemmeno un ciclo: matplotlib scala il pattern per
+  lo spessore, quindi ingrossare la chiave per farla vedere l'avrebbe
+  riportata a leggersi piena.
+
+  Monocromo anche a schermo: waveform, maschera del loop, lente e label degli
+  stream passano a grigi. Verificato a pixel su `PGE_test.yml` — saturazione
+  massima 0 su tutta la pagina.
+
+  Nuova doc: [`docs/how-to/print-score-bw.md`](docs/how-to/print-score-bw.md).
+
+---
+
 ## [v9.0.0] — "Third Backend" — 2026-08-30
 
 ### Aggiunto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   (issue #248). La MAP e' pensata per lo schermo, e le figure del paper CIM
   2026 hanno un vincolo di leggibilita' in B&W. Il flag (o `BW=true` da Make,
   o `config={'bw': True}` da libreria) sposta i default del visualizer; a
-  flag spento non cambia un pixel.
+  flag spento non cambia un pixel — con una sola eccezione, dichiarata sotto
+  fra le correzioni, che riguarda chi fissava gia' `grain_alpha_range`.
 
   In grigio collassavano due cose, e in modo peggiore di quanto sembri:
 
@@ -61,6 +62,35 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   Nuova doc: [`docs/how-to/print-score-bw.md`](docs/how-to/print-score-bw.md).
 
 ### Corretto
+
+- **La colorbar del pitch dipingeva un grigio che nessun grano ha.** E' la
+  chiave di lettura della mappa, ma disegnava il colore *nudo* della colormap
+  mentre i grani sono compositi sul fondo della pagina all'alpha del volume:
+  chi accostava un grano alla barra lo leggeva sistematicamente piu' acuto di
+  quanto fosse. Col preset B&W il bias era misurabile — 0.149 sulla barra
+  contro 0.234 sulla pagina all'estremo grave, 0.503 contro 0.553 al centro.
+
+  Finche' l'alpha varia col volume non c'e' un valore solo da mostrare, e la
+  barra resta opaca come e' sempre stata. Quando l'alpha e' **fissata** la
+  corrispondenza e' esprimibile esattamente, e la barra la segue: adesso
+  dipinge 0.235 / 0.859 contro i 0.234 / 0.866 dei grani (il resto e'
+  antialiasing). L'alpha si passa alla colorbar invece di cuocerla nella
+  mappa, cosi' barra e grani compongono sullo stesso fondo qualunque esso sia.
+
+  La condizione e' l'alpha fissata, **non** il preset: una config a colori che
+  passa un `grain_alpha_range` degenere (`(0.6, 0.6)`) ha lo stesso problema e
+  riceve la stessa correzione. E' l'unico punto in cui `--bw` si vede a flag
+  spento.
+
+- **Una coppia malformata in `envelope_styles` non si nominava.** E' l'unico
+  dizionario-dato della config il cui valore viene spacchettato in due, e una
+  stringa ne e' una coppia plausibile: `tuple('--')` vale `('-', '-')`, cioe'
+  uno spessore che non e' un numero. L'errore arrivava da dentro matplotlib
+  (`could not convert string to float: '-'`) senza nominare ne' la chiave ne'
+  il parametro. Ora `_envelope_style` verifica la forma e lo dice. Resta
+  l'unica eccezione alla regola dello schema, che verifica i nomi delle chiavi
+  e non i tipi dei valori — perche' qui il tipo sbagliato *non* si vede al
+  primo giro.
 
 - **`make bench` non girava su un clone pulito** (issue #243).
   `utils/bench_cost.py` genera un seno sintetico quando manca `refs/voice.wav`

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,10 @@ PAGE_DURATION ?= 15
 # duration = la durata (storico), read-span = la porzione di sample che il
 # grano percorre davvero (durata x |pitch_ratio|). Vuoto = duration.
 GRAIN_HEIGHT ?=
+# Preset della partitura leggibile in stampa bianco e nero (issue #248):
+# pitch acromatico, envelope neri distinti dal tratteggio (richiede
+# AUTOVISUAL=true)
+BW ?= false
 FILE ?= PGE_test
 TEST ?= false
 PRECLEAN ?=true
@@ -151,6 +155,7 @@ help:
 	@echo "  AUTOVISUAL=true/false- Genera visualizzazioni PDF"
 	@echo "  PAGE_DURATION=secondi - Durata pagina nel plot partitura (default: 15, richiede AUTOVISUAL=true)"
 	@echo "  GRAIN_HEIGHT=duration|read-span - Altezza del grano nella partitura: durata (default) o porzione di sample letta davvero (richiede AUTOVISUAL=true)"
+	@echo "  BW=true/false        - Partitura leggibile in stampa bianco e nero (richiede AUTOVISUAL=true)"
 	@echo "  TEST=true/false      - Build tutti i file o solo FILE"
 	@echo "  CLEAN_RPP=true/false - make clean rimuove anche .rpp (default: false, preserva lavoro REAPER)"
 	@echo "  REAPER=true/false        - Esporta progetto Reaper .rpp"

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -34,6 +34,7 @@
 | [add-voice-strategy](how-to/add-voice-strategy.md) | stable | voices, strategy, extension |
 | [add-window-function](how-to/add-window-function.md) | stable | window, grain, extension |
 | [make-parameter-envelope-aware](how-to/make-parameter-envelope-aware.md) | stable | parameters, envelopes, extension |
+| [print-score-bw](how-to/print-score-bw.md) | stable | visualizer, score, print, bw, cli, paper |
 | [reaper](how-to/reaper.md) | stable | reaper, daw, workflow, output |
 | [sonic-visualiser](how-to/sonic-visualiser.md) | stable | sonic-visualiser, export, envelope, output, workflow |
 | [use-as-library](how-to/use-as-library.md) | stable | api, library, install, render |
@@ -58,6 +59,7 @@
 | make-parameter-envelope-aware | make-parameter-envelope-aware |
 | reaper-workflow | reaper |
 | renderizzare da Python | use-as-library |
+| stampare-la-partitura-in-bianco-e-nero | print-score-bw |
 | usare PGE come libreria | library-vs-cli |
 | yaml-syntax | yaml |
 

--- a/docs/how-to/print-score-bw.md
+++ b/docs/how-to/print-score-bw.md
@@ -85,7 +85,8 @@ config={'bw': True, 'envelope_colors': {'volume': '#c1121f'}}
 | `grain_alpha_range` | `(0.9, 0.9)` | fissata: vedi sotto |
 | `envelope_colors` | tutte `#000000` | la tinta non distingue piu' niente |
 | `envelope_styles` | `ENVELOPE_STYLES` | il tratteggio prende il posto della tinta: un pattern per parametro, lo spessore per la variante |
-| `waveform_color`, `loop_mask_color`, `magnify_color` | grigi | un preset monocromo lo e' anche a schermo |
+| `magnify_projection.marker_edge` | `#ffffff`, 1.4 pt | l'anello del marker della lente e' l'unico pezzo della lente che atterra *sulla curva*: col nero degli envelope si spegnerebbe, e il marker diventerebbe un breakpoint qualunque |
+| `waveform_color`, `loop_mask_color`, `magnify_color`, `stream_label_color` | grigi | un preset monocromo lo e' anche a schermo |
 
 ### L'alpha, e cosa costa
 
@@ -103,6 +104,19 @@ riempimento del grano**. E' il prezzo, ed e' esplicito; si riapre passando
 Non 1.0 perche' a opacita' piena un cluster denso diventa una lastra unica e la
 densita' smette di leggersi.
 
+Fissarla ha un effetto collaterale utile: la **colorbar del pitch** puo' dire
+il vero. E' la chiave di lettura dei grani, ma dipingeva il colore nudo della
+mappa mentre i grani sono compositi sul fondo bianco — chi accostava un grano
+alla barra lo leggeva sistematicamente piu' acuto di quanto fosse. Con l'alpha
+guidata dal volume non c'e' un valore solo da mostrare e la barra resta opaca,
+cioe' storica; con l'alpha fissata la corrispondenza e' esatta e la barra la
+segue.
+
+La condizione e' **l'alpha fissata, non `bw`**: una config a colori che passa
+un `grain_alpha_range` degenere (`(0.6, 0.6)`) ottiene la stessa correzione,
+perche' ha lo stesso problema. E' l'unico punto in cui questo lavoro si vede a
+preset spento — per il resto la pagina a colori e' identica pixel per pixel.
+
 ### Il tratteggio degli envelope
 
 `ENVELOPE_STYLES` (in `rendering/envelope_extractor.py`, il modulo
@@ -113,6 +127,13 @@ unica per chiave. Due livelli di lettura, come nei colori:
 - il **pattern** dice il parametro, come faceva la tinta;
 - lo **spessore** dice la variante, come faceva il chiaro/scuro: `_prob` piu'
   sottile della base, `_range` piu' spesso.
+
+Il valore e' spacchettato in due, e una stringa ne e' una coppia plausibile
+(`tuple('--')` vale `('-', '-')`), quindi `_envelope_style` ne verifica la
+forma e nomina la chiave: senza, l'errore arriverebbe da dentro matplotlib
+(`could not convert string to float: '-'`) e non direbbe quale parametro
+guardare. E' l'eccezione dichiarata alla regola dello schema, che verifica i
+nomi delle chiavi e non i tipi dei valori.
 
 I cinque parametri che si incontrano piu' spesso nella stessa corsia — volume,
 pitch, grain_duration, pan, density — prendono i cinque pattern piu' distanti
@@ -133,9 +154,11 @@ Per aggiungere un parametro al preset, o cambiarne la resa:
   qui**: senza, in B&W torna una linea come tutte le altre;
 - `src/pge/rendering/visualizer_config.py` — `VisualizerConfig._bw_defaults`,
   cioe' quali default il preset sposta, e `BW_GRAIN_ALPHA`;
-- `src/pge/rendering/score_visualizer.py` — `PITCH_DIVERGING_BW` e
+- `src/pge/rendering/score_visualizer.py` — `PITCH_DIVERGING_BW`,
   `_envelope_style`, che risolve lo stile di una curva (le curve per-voce
-  `__vN` prendono quello della base);
+  `__vN` prendono quello della base) e ne verifica la forma, e
+  `_add_pitch_colorbar`, che compone la barra sull'alpha dei grani quando ce
+  n'e' una sola;
 - `src/pge/cli.py`, `make/build.mk`, `Makefile` — il flag e la variabile make.
 
 ## Test da aggiornare

--- a/docs/how-to/print-score-bw.md
+++ b/docs/how-to/print-score-bw.md
@@ -1,0 +1,168 @@
+---
+slug: print-score-bw
+type: how-to
+status: stable
+tags: [visualizer, score, print, bw, cli, paper]
+sources:
+  - src/pge/rendering/score_visualizer.py
+  - src/pge/rendering/visualizer_config.py
+  - src/pge/rendering/envelope_extractor.py
+  - src/pge/cli.py
+  - make/build.mk
+last_synced_commit: c2e1ad3
+entry_for: [stampare-la-partitura-in-bianco-e-nero]
+---
+
+# Stampare la partitura in bianco e nero
+
+**Documenti collegati:** [[INDEX]] · [[cli]] · [[score-visualizer-layout]]
+
+La MAP e' pensata per lo schermo. Su carta in bianco e nero — dentro un paper,
+per esempio — perde informazione, e il flag `--bw` seleziona un preset che non
+la perde. Origine: issue #248.
+
+## Quando usarlo
+
+Quando la partitura finisce su carta, o dentro un documento che verra' stampato
+o fotocopiato in bianco e nero. Due cose collassano nella conversione in
+grigio, e sono le due che il preset ricostruisce:
+
+- **il segno del detune.** La colormap divergente di default (`pitch_div`) ha
+  il braccio freddo e quello caldo alla *stessa* chiarezza. In grigio non e'
+  solo che i due bracci si somigliano: la luminanza non e' nemmeno monotona.
+  A +/-150 cent su un range di +/-300 i due grani stanno a 0.510 e 0.595 di
+  luminanza, a +/-50 cent a 0.481 e 0.509. Un grano calante e uno crescente
+  diventano lo stesso grigio, e il segno del detune sparisce;
+- **l'identita' delle curve.** Gli envelope si distinguono solo per tinta:
+  volume, pan e grain_duration in grigio diventano tre linee identiche.
+
+Non serve se la figura resta a schermo o va in stampa a colori: a flag spento
+niente cambia.
+
+## Prerequisiti
+
+Nessuno oltre a `--visualize`: il preset agisce sulla partitura, non sul
+rendering audio. Non tocca il file YAML ne' i default a colori.
+
+## Passi
+
+Da CLI, insieme a `--visualize`:
+
+```bash
+python src/main.py configs/brano.yml --visualize --bw
+```
+
+Da `make`, con `AUTOVISUAL=true`:
+
+```bash
+make AUTOVISUAL=true BW=true FILE=brano
+```
+
+Da libreria, come chiave di config del visualizer:
+
+```python
+from pge import api
+
+gen = api.load_generator('configs/brano.yml', samples_dir='./refs/')
+api.export_score_pdf(gen, 'brano.pdf', config={'bw': True})
+```
+
+Il preset e' un insieme di **default**, non un lucchetto: qualunque chiave
+passata insieme a `bw` vince, e i dizionari-dato si fondono sul preset invece
+che sui default cromatici. Ritoccare un colore non riporta a colori tutti gli
+altri:
+
+```python
+config={'bw': True, 'envelope_colors': {'volume': '#c1121f'}}
+# volume rosso, tutte le altre curve nere
+```
+
+### Cosa cambia, e perche'
+
+| Chiave | Preset | Ragione |
+|---|---|---|
+| `grain_colormap` | `pitch_div_bw` | divergente acromatica: la luminanza, unico asse percettivo del grigio, spesa tutta sul detune. Compressa a circa 0.15-0.85 — col braccio alto sul bianco i grani acuti sparirebbero, col basso sul nero si confonderebbero con assi e griglia |
+| `grain_alpha_range` | `(0.9, 0.9)` | fissata: vedi sotto |
+| `envelope_colors` | tutte `#000000` | la tinta non distingue piu' niente |
+| `envelope_styles` | `ENVELOPE_STYLES` | il tratteggio prende il posto della tinta: un pattern per parametro, lo spessore per la variante |
+| `waveform_color`, `loop_mask_color`, `magnify_color` | grigi | un preset monocromo lo e' anche a schermo |
+
+### L'alpha, e cosa costa
+
+Sul fondo bianco il composito e' `a*g + (1-a)`: **l'alpha e la luminanza del
+grigio sono lo stesso canale**. Con l'alpha libera, un grano grave suonato
+piano schiarisce fino a leggersi come acuto — il canale che il preset esiste
+per salvare verrebbe mangiato da quello che prova a conservare.
+
+Il preset fissa l'alpha a 0.9. Il grigio del grano torna funzione del solo
+pitch, e l'ordinamento e' garantito: un grano grave e pianissimo resta piu'
+scuro di uno acuto e forte. In cambio **il volume smette di dirsi nel
+riempimento del grano**. E' il prezzo, ed e' esplicito; si riapre passando
+`grain_alpha_range`, sapendo che si riapre anche l'ambiguita'.
+
+Non 1.0 perche' a opacita' piena un cluster denso diventa una lastra unica e la
+densita' smette di leggersi.
+
+### Il tratteggio degli envelope
+
+`ENVELOPE_STYLES` (in `rendering/envelope_extractor.py`, il modulo
+matplotlib-free) e' la mappa **parallela** a `ENVELOPE_COLORS`: stesse chiavi,
+l'altro canale. Il valore e' la coppia `(linestyle, linewidth)`, e la coppia e'
+unica per chiave. Due livelli di lettura, come nei colori:
+
+- il **pattern** dice il parametro, come faceva la tinta;
+- lo **spessore** dice la variante, come faceva il chiaro/scuro: `_prob` piu'
+  sottile della base, `_range` piu' spesso.
+
+I cinque parametri che si incontrano piu' spesso nella stessa corsia — volume,
+pitch, grain_duration, pan, density — prendono i cinque pattern piu' distanti
+fra loro; gli altri riusano un pattern con uno spessore diverso. Con una
+ventina di parametri e forse dieci tratteggi davvero distinguibili in stampa,
+il limite e' dichiarato invece che nascosto: la **legenda per-corsia** resta la
+chiave, e col preset acceso il suo tratto e' un campione fedele della curva
+(stesso pattern, stesso spessore, su tutta la larghezza utile della colonna)
+invece del simbolo corto storico, che di un tratteggio non mostrerebbe nemmeno
+un ciclo.
+
+## File toccati
+
+Per aggiungere un parametro al preset, o cambiarne la resa:
+
+- `src/pge/rendering/envelope_extractor.py` — `ENVELOPE_STYLES`, i pattern e
+  `BW_ENVELOPE_COLOR`. **Una chiave nuova in `ENVELOPE_COLORS` ne vuole una
+  qui**: senza, in B&W torna una linea come tutte le altre;
+- `src/pge/rendering/visualizer_config.py` — `VisualizerConfig._bw_defaults`,
+  cioe' quali default il preset sposta, e `BW_GRAIN_ALPHA`;
+- `src/pge/rendering/score_visualizer.py` — `PITCH_DIVERGING_BW` e
+  `_envelope_style`, che risolve lo stile di una curva (le curve per-voce
+  `__vN` prendono quello della base);
+- `src/pge/cli.py`, `make/build.mk`, `Makefile` — il flag e la variabile make.
+
+## Test da aggiornare
+
+- `tests/rendering/test_bw_preset.py` — la suite del preset: parita' fra le due
+  tabelle, unicita' delle coppie, acromaticita' e monotonia della colormap,
+  merge degli override, alpha fissa, stile che arriva a curva e legenda;
+- `tests/test_main.py` (`TestBwFlag`) e `tests/test_cli_contract.py` — il flag
+  e la usage golden;
+- `tests/test_api.py` — la config di default di `export_score_pdf`, che
+  rispecchia quella della CLI.
+
+## Verifica
+
+La verifica vera e' pixel, non `assert`: la pagina non deve avere colore.
+
+```python
+import numpy as np
+from PIL import Image
+
+im = np.asarray(Image.open('page_000.png').convert('RGB')).astype(float)
+saturazione = im.max(axis=2) - im.min(axis=2)
+print(saturazione.max())   # 0.0 col preset acceso
+```
+
+Poi, sulla figura stampata (o convertita in scala di grigi), controllare le tre
+cose che l'issue nomina: il **segno del detune** sui grani ai due estremi del
+range di pitch, l'**identita' delle curve** degli envelope contro la legenda, e
+che nessun grano sia sparito nel bianco della pagina o annegato nel nero degli
+assi.

--- a/docs/how-to/print-score-bw.md
+++ b/docs/how-to/print-score-bw.md
@@ -9,7 +9,7 @@ sources:
   - src/pge/rendering/envelope_extractor.py
   - src/pge/cli.py
   - make/build.mk
-last_synced_commit: c2e1ad3
+last_synced_commit: b97ce5e
 entry_for: [stampare-la-partitura-in-bianco-e-nero]
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -9,7 +9,7 @@ sources:
   - src/pge/rendering/grain_visuals.py
   - src/pge/rendering/supercollider_renderer.py
   - make/build.mk
-last_synced_commit: 9764017
+last_synced_commit: c2e1ad3
 entry_for: [cli-flags, build-flags]
 ---
 
@@ -57,6 +57,7 @@ Senza argomenti: stampa usage ed esce con codice 1.
 | `--show-static` | `-s` | off | `SHOWSTATIC` | include i parametri statici nella partitura |
 | `--show-voice-offsets` | — | off | `SHOWVOICEOFFSETS` | disegna gli offset per-voce nella partitura: una curva per voce per `voice_pitch_offset` e `voice_pointer_offset`, piu' la curva singola di `voice_pointer_range` (vedi [[yaml]] blocco `voices`) |
 | `--magnify` | — | off | `MAGNIFY` | lente di ingrandimento automatica nella partitura: proietta un cerchio zoomato sul cluster di grani piu' denso di ogni pagina (vedi `--magnify-at` per il targeting esplicito) |
+| `--bw` | — | off | `BW` | preset della partitura leggibile in stampa bianco e nero: mappa del pitch acromatica (`pitch_div_bw`), envelope neri distinti dal tratteggio invece che dalla tinta, alpha dei grani fissata. Vedi [[print-score-bw]] |
 | `--per-stream` | `-p` | off | `STEMS` | un file audio per stream (stems) invece del mix singolo |
 | `--cache` | — | off | `CACHE` | build incrementale per stream (richiede `--per-stream`, vedi [[caching]]) |
 | `--reaper` | — | off | `REAPER` | esporta progetto Reaper `.rpp` (vedi [[reaper]]) |
@@ -185,6 +186,19 @@ Vincoli tra flag e comportamento nelle combinazioni non valide:
   `markersize`/`labels` per lo stile). Niente da proiettare, niente
   disegnato: stream senza curve dinamiche, o istante fuori dall'estensione
   dello stream.
+- **`--bw`** ha effetto solo insieme a `--visualize`. E' un interruttore,
+  quindi non ha valore da validare: scritto senza `--visualize` non fa nulla e
+  non e' un errore. Non e' un modo a parte ma un insieme di **default**
+  diversi, tutti sovrascrivibili chiave per chiave dalla config del visualizer
+  (`ScoreVisualizer(config=...)`, `api.export_score_pdf(config=...)`); i
+  dizionari-dato (`envelope_colors`, `envelope_styles`) si fondono sul preset,
+  non sui default cromatici. Si combina con gli altri flag della partitura:
+  e' una tavolozza, non un modo di lettura. Un effetto va dichiarato perche'
+  non e' gratuito: l'alpha dei grani viene **fissata**, quindi in `--bw` il
+  volume non si legge piu' nel riempimento del grano — sul fondo bianco alpha
+  e luminanza del grigio sono lo stesso canale, e lasciarla libera
+  cancellerebbe il segno del detune che il preset esiste per salvare. Dettagli
+  e come riaprirla: [[print-score-bw]].
 - **`--grain-height`** ha effetto solo insieme a `--visualize`; la
   validazione del valore avviene comunque (valore ignoto → exit 1 anche
   senza `--visualize`), come per `--plot-envelopes`. Il valore è un modo di
@@ -253,6 +267,12 @@ python src/main.py configs/brano.yml --visualize --grain-height read-span
 
 # Equivalente via Make
 make all FILE=brano AUTOVISUAL=true GRAIN_HEIGHT=read-span
+
+# Partitura leggibile in stampa bianco e nero (figure di un paper)
+python src/main.py configs/brano.yml --visualize --bw
+
+# Equivalente via Make
+make all FILE=brano AUTOVISUAL=true BW=true
 
 # Partitura con lente automatica sul cluster piu' denso di ogni pagina
 python src/main.py configs/brano.yml --visualize --magnify

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -9,7 +9,7 @@ sources:
   - src/pge/rendering/grain_visuals.py
   - src/pge/rendering/supercollider_renderer.py
   - make/build.mk
-last_synced_commit: c2e1ad3
+last_synced_commit: c1bbb04
 entry_for: [cli-flags, build-flags]
 ---
 

--- a/make/build.mk
+++ b/make/build.mk
@@ -62,6 +62,12 @@ ifneq ($(strip $(GRAIN_HEIGHT)),)
 PYFLAGS += --grain-height $(GRAIN_HEIGHT)
 endif
 
+# 2c-ter. Se BW e' true, aggiungi --bw (issue #248): preset della partitura
+# leggibile in stampa bianco e nero (pitch acromatico, envelope a tratteggio).
+ifeq ($(BW), true)
+PYFLAGS += --bw
+endif
+
 # 2d. Se MAGNIFY e' true, aggiungi --magnify (lente automatica sul cluster denso)
 ifeq ($(MAGNIFY), true)
 PYFLAGS += --magnify

--- a/src/pge/api.py
+++ b/src/pge/api.py
@@ -485,6 +485,7 @@ def export_score_pdf(
         'magnify_auto': False,
         'magnify_targets': [],
         'grain_height': 'duration',
+        'bw': False,
     }
     if config:
         merged.update(config)

--- a/src/pge/cli.py
+++ b/src/pge/cli.py
@@ -212,6 +212,7 @@ def main():
             "[--magnify] [--magnify-at SPEC] "
             "[--page-duration SECONDI] "
             "[--grain-height duration|read-span] "
+            "[--bw] "
             "[--per-stream] "
             "[--renderer csound|numpy|supercollider] "
             "[--jobs N|auto] "
@@ -292,6 +293,14 @@ def main():
                       f"Valori: {', '.join(_GRAIN_HEIGHT_CLI_MODES)}")
                 sys.exit(1)
             grain_height = _GRAIN_HEIGHT_CLI_MODES[raw]
+
+    # --bw: preset della partitura leggibile in stampa bianco e nero
+    # (issue #248). Mappa del pitch acromatica (la divergente a colori ha i due
+    # bracci alla stessa chiarezza, quindi in grigio il segno del detune
+    # sparisce) ed envelope neri distinti dal tratteggio invece che dalla
+    # tinta. Effetto solo con --visualize, come --show-static. E' un
+    # interruttore: non ha valore da validare.
+    bw = '--bw' in sys.argv
 
     # --magnify: lente automatica sul cluster piu' denso (una per pagina).
     # Effetto solo con --visualize, come --show-static. Token esatto: '--magnify'
@@ -609,6 +618,7 @@ def main():
                 'magnify_auto': magnify_auto,
                 'magnify_targets': magnify_targets,
                 'grain_height': grain_height,
+                'bw': bw,
             }, samples_dir=samples_dir)
 
         print(f"Log: {get_clip_log_path()}")

--- a/src/pge/rendering/envelope_extractor.py
+++ b/src/pge/rendering/envelope_extractor.py
@@ -76,6 +76,101 @@ ENVELOPE_COLORS = {
 PLOT_ENVELOPE_KEYS = frozenset(ENVELOPE_COLORS)
 
 
+# =============================================================================
+# STILI DI LINEA — l'altro canale delle stesse chiavi (issue #248)
+# =============================================================================
+# Stampata in bianco e nero la tabella qui sopra collassa: volume, pan e
+# grain_duration si distinguono solo per tinta, e in grigio diventano tre
+# linee identiche. ENVELOPE_STYLES e' la mappa PARALLELA a ENVELOPE_COLORS —
+# stesse chiavi, l'altro canale — che il preset `bw` accende al posto della
+# tinta.
+#
+# Vive qui e non in score_visualizer per la stessa ragione dei colori: e' una
+# tabella di dati, non di oggetti matplotlib. I pattern sono nella forma
+# (offset, (on, off, ...)) che matplotlib accetta come linestyle, ma restano
+# tuple di numeri: nessun import da questo modulo.
+#
+# Il valore e' la coppia (linestyle, linewidth), e la coppia e' l'IDENTITA'
+# della curva sulla carta: nessuna chiave la ripete (test_bw_preset). Due
+# livelli di lettura, come nei colori:
+#   - il PATTERN dice il parametro (la tinta);
+#   - lo SPESSORE dice la variante (il chiaro/scuro): _prob piu' sottile della
+#     base, _range piu' spesso.
+# I cinque parametri che si incontrano piu' spesso nella stessa corsia —
+# volume, pitch, grain_duration, pan, density — prendono i cinque pattern piu'
+# distanti fra loro; gli altri riusano un pattern con uno spessore diverso.
+# Con una ventina di parametri e forse otto o nove tratteggi davvero
+# distinguibili in stampa, l'alternativa sarebbe fingere che venti pattern
+# diversi si leggano: la legenda per-corsia (issue #91) resta la chiave.
+
+_SOLID = '-'
+_DASH = (0, (5, 2.5))
+_DOT = (0, (1, 1.8))
+_DASHDOT = (0, (5, 1.6, 1, 1.6))
+_SHORTDASH = (0, (2.5, 1.4))
+_DASHDOTDOT = (0, (5, 1.4, 1, 1.4, 1, 1.4))
+_LONGDASH = (0, (10, 2))
+_SPARSEDOT = (0, (1, 4))
+_DASHDASH = (0, (5, 1.4, 2, 1.4))
+_TRIPLEDOT = (0, (1, 1.4, 1, 1.4, 1, 4))
+
+# Stile di chi non ha una entry: il disegno storico. E' anche cio' che rende
+# il preset spento un no-op — con `envelope_styles` vuoto ogni curva risolve
+# qui, cioe' a com'e' sempre stata disegnata.
+ENVELOPE_STYLE_DEFAULT = (_SOLID, 1.1)
+
+# Colore unico degli envelope col preset B&W acceso: la tinta non porta piu'
+# informazione, quindi non c'e' ragione di spenderla.
+BW_ENVELOPE_COLOR = '#000000'
+
+ENVELOPE_STYLES = {
+    # === OUTPUT ===
+    'volume': (_SOLID, 1.1),
+    'volume_prob': (_SOLID, 0.6),
+    'volume_range': (_SOLID, 1.7),
+    'pan': (_DASHDOT, 1.1),
+    'pan_prob': (_DASHDOT, 0.6),
+    'pan_range': (_DASHDOT, 1.7),
+
+    # === GRAIN ===
+    'grain_duration': (_DOT, 1.2),
+    'grain_duration_prob': (_DOT, 0.7),
+    'grain_duration_range': (_DOT, 1.8),
+    'reverse': (_DASHDOTDOT, 1.1),
+    'reverse_prob': (_DASHDOTDOT, 0.6),
+    # L'altra chiave del verso: pattern proprio, non lo spessore di 'reverse'.
+    # Le due sono un gruppo esclusivo, ma quando compaiono insieme e' perche'
+    # l'autore ha sbagliato — ed e' proprio allora che devono distinguersi.
+    'read_direction': (_TRIPLEDOT, 1.1),
+    'read_direction_prob': (_TRIPLEDOT, 0.6),
+
+    # === POINTER ===
+    'pointer_start': (_SHORTDASH, 1.1),
+    'pointer_speed': (_SHORTDASH, 1.7),
+    'pointer_deviation': (_DASHDASH, 1.1),
+    'pointer_deviation_prob': (_DASHDASH, 0.6),
+    'loop_dur': (_SPARSEDOT, 1.3),
+
+    # === PITCH ===
+    'pitch': (_DASH, 1.3),
+
+    # === DENSITY ===
+    'density': (_LONGDASH, 1.1),
+    'fill_factor': (_LONGDASH, 1.7),
+    # Derivata dalla densita': stesso pattern, tratto piu' leggero.
+    'effective_density': (_LONGDASH, 0.7),
+    'distribution': (_DASHDASH, 1.7),
+
+    # === VOICES ===
+    'num_voices': (_DASH, 1.8),
+    'scatter': (_DASHDOTDOT, 1.7),
+    # Gli offset per-voce riusano il pattern del parametro che spostano.
+    'voice_pitch_offset': (_DASH, 0.7),
+    'voice_pointer_offset': (_SHORTDASH, 0.7),
+    'voice_pointer_range': (_TRIPLEDOT, 1.7),
+}
+
+
 def base_param_name(key):
     """Nome base di una chiave envelope: strippa il suffisso per-voce '__vN'
     (issue #90). 'voice_pitch_offset__v2' -> 'voice_pitch_offset'; chiavi senza

--- a/src/pge/rendering/score_visualizer.py
+++ b/src/pge/rendering/score_visualizer.py
@@ -34,21 +34,48 @@ PITCH_DIVERGING = LinearSegmentedColormap.from_list(
     'pitch_div', ['#3b1f8b', '#3a8fd6', '#777777', '#f08c00', '#f2d024']
 )
 
-# Registrazione con guardia: idempotente anche su re-import del modulo.
-try:
-    plt.get_cmap('pitch_div')
-except (ValueError, KeyError):
+# La stessa mappa per la carta in bianco e nero (issue #248), scelta dal preset
+# `bw`. I due bracci di PITCH_DIVERGING hanno la STESSA chiarezza: convertita
+# in grigio, un grano a +300 cent e uno a -300 cent diventano lo stesso grigio
+# e il segno del detune sparisce. Il grigio ha un solo asse percettivo, la
+# luminanza: qui e' speso tutto sul detune, monotono dal grave all'acuto.
+#
+# Compressa a circa 0.15-0.85 invece che a tutto il dominio: col braccio alto
+# sul bianco i grani acuti sparirebbero sulla pagina, col basso sul nero si
+# confonderebbero con assi e griglia. Il centro resta il grigio medio, come il
+# #777777 della mappa a colori: nessun detune = nessuno scarto dal mezzo.
+#
+# La rampa e' lineare nel valore sRGB, non in L*: l'obiettivo e' stare dentro
+# i due estremi utili in stampa, non l'uniformita' percettiva.
+PITCH_DIVERGING_BW = LinearSegmentedColormap.from_list(
+    'pitch_div_bw', ['#262626', '#535353', '#808080', '#acacac', '#d9d9d9']
+)
+
+
+def _register_colormap(cmap):
+    """Registra una colormap col suo nome, una volta sola.
+
+    Con guardia: idempotente anche su re-import del modulo.
+    """
     try:
-        import matplotlib as mpl
-        mpl.colormaps.register(PITCH_DIVERGING)
-    except (AttributeError, ImportError):
-        plt.register_cmap(cmap=PITCH_DIVERGING)
+        plt.get_cmap(cmap.name)
+    except (ValueError, KeyError):
+        try:
+            import matplotlib as mpl
+            mpl.colormaps.register(cmap)
+        except (AttributeError, ImportError):
+            plt.register_cmap(cmap=cmap)
+
+
+_register_colormap(PITCH_DIVERGING)
+_register_colormap(PITCH_DIVERGING_BW)
 
 # Colori di default e universo dei nomi plottabili. Definiti nel modulo
 # matplotlib-free rendering.envelope_extractor (issue #150) e ri-esportati qui
 # per retro-compatibilita': main.py importa PLOT_ENVELOPE_KEYS da qui, i test
 # importano ENVELOPE_COLORS da qui.
-from pge.rendering.envelope_extractor import ENVELOPE_COLORS, PLOT_ENVELOPE_KEYS  # noqa: F401,E402
+from pge.rendering.envelope_extractor import (  # noqa: F401,E402
+    ENVELOPE_COLORS, ENVELOPE_STYLE_DEFAULT, PLOT_ENVELOPE_KEYS)
 from pge.rendering import envelope_display  # noqa: E402
 from pge.rendering import grain_visuals  # noqa: E402
 from pge.rendering import magnifier_projection  # noqa: E402
@@ -295,6 +322,21 @@ class ScoreVisualizer:
         return self.cmap(grain_visuals.pitch_position(
             pitch_ratio, cents_range, pitch_range=self.config['pitch_range']))
     
+    def _envelope_style(self, param_name):
+        """(linestyle, linewidth) di una curva envelope.
+
+        L'altro canale del colore, e con la stessa regola di chi lo risolve:
+        le curve per-voce '__vN' prendono lo stile della base (issue #90), o
+        una voce sarebbe l'unica linea piena della corsia.
+
+        Con `envelope_styles` vuota — cioe' senza preset B&W — ogni chiave
+        risolve a ENVELOPE_STYLE_DEFAULT, che e' il disegno storico: la
+        partitura a colori non cambia di un punto.
+        """
+        styles = self.config.get('envelope_styles') or {}
+        return tuple(styles.get(self._base_param_name(param_name),
+                                ENVELOPE_STYLE_DEFAULT))
+
     def _volume_to_alpha(self, volume_db):
         """Mappa volume (dB) → alpha/opacità."""
         return grain_visuals.volume_alpha(
@@ -969,7 +1011,10 @@ class ScoreVisualizer:
             fontsize=self._fs(self.config['label_fontsize'] - 1),
             verticalalignment='top',
             horizontalalignment='left',
-            color='darkblue',
+            # L'unico accento cromatico che non passa dalla config: col preset
+            # B&W diventa grigio scuro, altrimenti sarebbe la sola parola
+            # colorata di una pagina monocroma (issue #248).
+            color='#1a1a1a' if self.config.get('bw') else 'darkblue',
             alpha=0.8,
             bbox=dict(boxstyle='round,pad=0.2', facecolor='white', 
                     alpha=0.7, edgecolor='none')
@@ -1218,12 +1263,15 @@ class ScoreVisualizer:
         for param_name, envelope in envelopes.items():
             # Colore (curve per-voce '__vN' usano il colore del base, #90)
             color = colors.get(self._base_param_name(param_name), '#333333')
+            # Tratto: senza preset B&W e' ('-', 1.1), cioe' il disegno storico.
+            linestyle, linewidth = self._envelope_style(param_name)
 
             # Envelope per-segmento eterogeneo (issue #68): rendering per-segmento
             if self._is_per_segment_heterogeneous(envelope):
                 self._draw_envelope_per_segment(
                     ax, envelope, param_name, color,
                     stream_start, y_base, y_height, t_start, t_end,
+                    style=(linestyle, linewidth),
                 )
                 self._annotate_breakpoints(ax, envelope, param_name, color,
                                            stream_start, y_base, y_height,
@@ -1287,7 +1335,8 @@ class ScoreVisualizer:
                 
                 # Disegna con drawstyle='steps-post' per gradini
                 if len(times) > 0:
-                    ax.plot(times, values, color=color, linewidth=1.1, 
+                    ax.plot(times, values, color=color, linewidth=linewidth,
+                        linestyle=linestyle,
                         alpha=0.8, label=param_name, drawstyle='steps-post')
             
             else:
@@ -1311,8 +1360,8 @@ class ScoreVisualizer:
                 y_values = y_base + values * y_height
                 
                 # Disegna curva
-                ax.plot(times, y_values, color=color, linewidth=1.1, 
-                    alpha=0.8, label=param_name)
+                ax.plot(times, y_values, color=color, linewidth=linewidth,
+                    linestyle=linestyle, alpha=0.8, label=param_name)
             
             # === ANNOTAZIONE BREAKPOINT ===
             self._annotate_breakpoints(ax, envelope, param_name, color,
@@ -1332,6 +1381,7 @@ class ScoreVisualizer:
     def _draw_envelope_per_segment(
         self, ax, envelope, param_name, color,
         stream_start, y_base, y_height, t_start, t_end,
+        style=None,
     ):
         """
         Disegna envelope eterogeneo segmento per segmento (issue #68).
@@ -1340,7 +1390,12 @@ class ScoreVisualizer:
         - step: drawstyle='steps-post' (gradini netti)
         - linear: linea retta tra estremi
         - cubic: campionamento denso del segmento
+
+        style: la coppia (linestyle, linewidth) della curva (issue #248).
+        None = la risolve da se', cosi' chi chiama questo metodo direttamente
+        non deve conoscerla.
         """
+        linestyle, linewidth = style or self._envelope_style(param_name)
         for seg in envelope.segments:
             seg_t0 = stream_start + seg.start_time
             seg_t1 = stream_start + seg.end_time
@@ -1358,10 +1413,12 @@ class ScoreVisualizer:
                 v_right = seg.breakpoints[-1][1]
                 y_left = y_base + self._normalize_envelope_value(param_name, v_left) * y_height
                 y_right = y_base + self._normalize_envelope_value(param_name, v_right) * y_height
-                ax.plot([a, b], [y_left, y_left], color=color, linewidth=1.1, alpha=0.8)
+                ax.plot([a, b], [y_left, y_left], color=color,
+                        linewidth=linewidth, linestyle=linestyle, alpha=0.8)
                 # Salto verticale a fine segmento (se b == seg_t1)
                 if b >= seg_t1:
-                    ax.plot([b, b], [y_left, y_right], color=color, linewidth=1.1, alpha=0.8)
+                    ax.plot([b, b], [y_left, y_right], color=color,
+                            linewidth=linewidth, linestyle=linestyle, alpha=0.8)
 
             elif strategy_name == 'linear':
                 # Usa seg.evaluate() per evitare bug precisione float al boundary
@@ -1371,7 +1428,8 @@ class ScoreVisualizer:
                 v_b = seg.evaluate(b - stream_start)
                 y_a = y_base + self._normalize_envelope_value(param_name, v_a) * y_height
                 y_b = y_base + self._normalize_envelope_value(param_name, v_b) * y_height
-                ax.plot([a, b], [y_a, y_b], color=color, linewidth=1.1, alpha=0.8)
+                ax.plot([a, b], [y_a, y_b], color=color,
+                        linewidth=linewidth, linestyle=linestyle, alpha=0.8)
 
             else:  # cubic
                 import numpy as np
@@ -1381,7 +1439,8 @@ class ScoreVisualizer:
                 for t in ts:
                     v = seg.evaluate(t - stream_start)
                     ys.append(y_base + self._normalize_envelope_value(param_name, v) * y_height)
-                ax.plot(ts, ys, color=color, linewidth=1.1, alpha=0.8)
+                ax.plot(ts, ys, color=color,
+                        linewidth=linewidth, linestyle=linestyle, alpha=0.8)
 
     def _annotate_breakpoints(self, ax, envelope, param_name, color,
                                stream_start, y_base, y_height,
@@ -1503,9 +1562,31 @@ class ScoreVisualizer:
         ax.axis('off')
         colors = self.config['envelope_colors']
 
+        # Con gli stili in gioco il tratto della chiave e' un CAMPIONE della
+        # curva, non un simbolo: stesso pattern e stesso spessore, su tutta la
+        # larghezza utile della colonna (il testo comincia a 0.4). Le due cose
+        # sono necessarie entrambe. Il tratto storico e' il 5% della colonna,
+        # cioe' qualche punto: meno di un ciclo di tratteggio, che ci si
+        # leggerebbe pieno. E matplotlib scala il pattern per lo spessore,
+        # quindi un tratto ingrossato per farsi vedere allungherebbe anche il
+        # ciclo, riportando la chiave a leggersi piena. Lo spessore, poi, e'
+        # meta' dell'informazione: e' li' che una probabilita' si distingue
+        # dalla sua base.
+        #
+        # La misura e' la stessa per tutte le voci, comprese quelle a tratto
+        # pieno: una colonna con due lunghezze di chiave fa leggere lo stub
+        # corto come un altro tratteggio.
+        styled = bool(self.config.get('envelope_styles'))
+
         for param_name, y, stream_id in legend_entries:
             color = colors.get(self._base_param_name(param_name), '#333333')
-            ax.plot([0.1, 0.15], [y, y], color=color, linewidth=2)
+            linestyle, linewidth = self._envelope_style(param_name)
+            if styled:
+                x0, x1, key_width = 0.02, 0.38, linewidth
+            else:
+                x0, x1, key_width = 0.1, 0.15, 2
+            ax.plot([x0, x1], [y, y], color=color,
+                    linestyle=linestyle, linewidth=key_width)
             # clip_on=True: anche un nome inatteso non sfora mai nel plot,
             # viene tagliato al bordo della colonna legenda (issue #96).
             ax.text(0.4, y, self._legend_display_name(param_name),

--- a/src/pge/rendering/score_visualizer.py
+++ b/src/pge/rendering/score_visualizer.py
@@ -305,9 +305,17 @@ class ScoreVisualizer:
         # grigio che i grani hanno davvero: composito su fondo bianco, non il
         # colore nudo della mappa. Con l'alpha guidata dal volume non c'e' un
         # valore solo da mostrare e la barra resta opaca, come e' sempre stata;
-        # quando l'alpha e' FISSATA (preset B&W) la corrispondenza e'
-        # esprimibile esattamente, e allora tacerla sarebbe un bias
-        # sistematico: ogni grano si leggerebbe piu' acuto di quanto e'.
+        # quando l'alpha e' FISSATA la corrispondenza e' esprimibile
+        # esattamente, e allora tacerla sarebbe un bias sistematico: ogni
+        # grano si leggerebbe piu' acuto di quanto e'.
+        #
+        # La condizione e' l'alpha fissata, NON il preset: `bw` non compare
+        # qui. Il preset e' solo il modo piu' comune di arrivarci, e una
+        # config che fissa `grain_alpha_range` per conto suo — a colori,
+        # senza `bw` — ha esattamente lo stesso bisogno. E' anche l'unico
+        # punto in cui questa PR si vede a preset spento, e si vede solo li'
+        # (issue #248).
+        #
         # L'alpha si passa alla colorbar e non si cuoce dentro la mappa: cosi'
         # barra e grani compongono sullo stesso fondo, qualunque esso sia,
         # invece di dare per scontato il bianco.
@@ -350,10 +358,29 @@ class ScoreVisualizer:
         Con `envelope_styles` vuota — cioe' senza preset B&W — ogni chiave
         risolve a ENVELOPE_STYLE_DEFAULT, che e' il disegno storico: la
         partitura a colori non cambia di un punto.
+
+        La FORMA del valore si verifica qui, ed e' l'unico posto dove ha
+        senso. Lo schema (rendering.visualizer_config) verifica i nomi delle
+        chiavi e non i tipi, per scelta dichiarata: un tipo sbagliato "si vede
+        al primo giro". Questo valore no — `tuple('--')` e' `('-', '-')`,
+        cioe' una coppia perfettamente plausibile con uno spessore che non e'
+        un numero, e l'errore che ne segue arriva da dentro matplotlib
+        (`could not convert string to float: '-'`) senza nominare ne' la
+        chiave di config ne' il parametro. Tre righe nel lettore invece di un
+        validatore.
         """
+        key = self._base_param_name(param_name)
         styles = self.config.get('envelope_styles') or {}
-        return tuple(styles.get(self._base_param_name(param_name),
-                                ENVELOPE_STYLE_DEFAULT))
+        style = styles.get(key, ENVELOPE_STYLE_DEFAULT)
+        try:
+            linestyle, linewidth = style
+            linewidth = float(linewidth)
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"envelope_styles[{key!r}] deve essere la coppia "
+                f"(linestyle, linewidth) con lo spessore numerico; "
+                f"ricevuto {style!r}") from None
+        return (linestyle, linewidth)
 
     def _projection_marker_edge(self):
         """(colore, spessore) dell'anello del marker di proiezione.

--- a/src/pge/rendering/score_visualizer.py
+++ b/src/pge/rendering/score_visualizer.py
@@ -42,8 +42,15 @@ PITCH_DIVERGING = LinearSegmentedColormap.from_list(
 #
 # Compressa a circa 0.15-0.85 invece che a tutto il dominio: col braccio alto
 # sul bianco i grani acuti sparirebbero sulla pagina, col basso sul nero si
-# confonderebbero con assi e griglia. Il centro resta il grigio medio, come il
+# confonderebbero con assi e griglia. Il centro e' il grigio medio, come il
 # #777777 della mappa a colori: nessun detune = nessuno scarto dal mezzo.
+#
+# Quelli sono i valori della MAPPA. Sulla pagina il grano e' composito su
+# fondo bianco all'alpha del preset (`a*g + (1-a)`, alpha 0.9), quindi la
+# banda diventa 0.23-0.87 e lo zero cade a 0.55: piu' chiara di mezzo tono,
+# non centrata. E' la barra a doversi adeguare al grano, non viceversa —
+# _add_pitch_colorbar le passa la stessa alpha, cosi' la chiave di lettura
+# mostra il grigio che il lettore ha davanti invece del colore nudo.
 #
 # La rampa e' lineare nel valore sRGB, non in L*: l'obiettivo e' stare dentro
 # i due estremi utili in stampa, non l'uniformita' percettiva.
@@ -293,9 +300,20 @@ class ScoreVisualizer:
             label = 'pitch (ratio)'
 
         cax = fig.add_subplot(cax_spec)
-        cbar = fig.colorbar(
-            ScalarMappable(norm=norm, cmap=self.cmap), cax=cax
-        )
+        mappable = ScalarMappable(norm=norm, cmap=self.cmap)
+        # La barra e' la CHIAVE di lettura dei grani, quindi deve mostrare il
+        # grigio che i grani hanno davvero: composito su fondo bianco, non il
+        # colore nudo della mappa. Con l'alpha guidata dal volume non c'e' un
+        # valore solo da mostrare e la barra resta opaca, come e' sempre stata;
+        # quando l'alpha e' FISSATA (preset B&W) la corrispondenza e'
+        # esprimibile esattamente, e allora tacerla sarebbe un bias
+        # sistematico: ogni grano si leggerebbe piu' acuto di quanto e'.
+        # L'alpha si passa alla colorbar e non si cuoce dentro la mappa: cosi'
+        # barra e grani compongono sullo stesso fondo, qualunque esso sia,
+        # invece di dare per scontato il bianco.
+        alpha_lo, alpha_hi = self.config['grain_alpha_range']
+        alpha = float(alpha_lo) if alpha_lo == alpha_hi else None
+        cbar = fig.colorbar(mappable, cax=cax, alpha=alpha)
         # Scarta i tick troppo vicini agli estremi del range: con colorbar
         # impilate (una per stream, hspace=0) il tick di fondo della colorbar
         # sopra e quello di testa della colorbar sotto cadono sullo stesso bordo
@@ -336,6 +354,19 @@ class ScoreVisualizer:
         styles = self.config.get('envelope_styles') or {}
         return tuple(styles.get(self._base_param_name(param_name),
                                 ENVELOPE_STYLE_DEFAULT))
+
+    def _projection_marker_edge(self):
+        """(colore, spessore) dell'anello del marker di proiezione.
+
+        Il colore ricade sull'accento della lente quando la config non ne
+        dichiara uno proprio: e' il comportamento storico. La chiave esiste
+        perche' l'anello e' l'unico pezzo della lente che atterra SULLA CURVA
+        invece che sui grani, e col preset B&W curva e accento sono due neri —
+        li' l'anello si spegne e il marker diventa un breakpoint qualunque.
+        """
+        cfg = self.config['magnify_projection']
+        return (cfg['marker_edge'] or self.config['magnify_color'],
+                cfg['markeredgewidth'])
 
     def _volume_to_alpha(self, volume_db):
         """Mappa volume (dB) → alpha/opacità."""
@@ -805,10 +836,12 @@ class ScoreVisualizer:
             return
 
         # Stesso accento della lente (anello sorgente e connettori): la
-        # proiezione e' un pezzo della lente, non un elemento a se'. Il
-        # tratteggio la tiene distinguibile dalle curve anche in stampa B&W,
-        # dove il rosso e' un grigio come gli altri.
+        # proiezione e' un pezzo della lente, non un elemento a se'. La
+        # verticale e' tratteggiata perche' resti distinguibile dalle curve
+        # anche in stampa; col preset B&W anche le curve sono tratteggiate, e
+        # li' a separarla e' l'orientamento — nessun envelope corre verticale.
         accent = self.config['magnify_color']
+        marker_edge, marker_edge_width = self._projection_marker_edge()
         tc = float(resolved.t)
         line = ax_env.axvline(x=tc, color=accent, linestyle=cfg['linestyle'],
                               linewidth=cfg['linewidth'], alpha=cfg['alpha'],
@@ -824,12 +857,16 @@ class ScoreVisualizer:
         for order, point in enumerate(sorted(points, key=lambda p: p.y)):
             color = colors.get(self._base_param_name(point.param), '#333333')
             # Faccia del colore della curva (dice a quale valore appartiene),
-            # bordo dell'accento della lente (dice da dove viene il marker):
-            # in scala di grigi resta un pallino cerchiato sulla verticale.
+            # anello della lente (dice da dove viene il marker): quel che
+            # separa questo marker dai pallini dei breakpoint e' l'anello,
+            # quindi deve staccare dalla faccia. Vedi _projection_marker_edge:
+            # col preset B&W la faccia e' nera come ogni curva e l'anello
+            # diventa chiaro, invece di essere il nero quasi uguale
+            # dell'accento.
             marker, = ax_env.plot(
                 [tc], [point.y], 'o', color=color,
-                markersize=cfg['markersize'], markeredgecolor=accent,
-                markeredgewidth=0.8, zorder=4)
+                markersize=cfg['markersize'], markeredgecolor=marker_edge,
+                markeredgewidth=marker_edge_width, zorder=4)
             marker.set_gid('poc-projection-marker')
 
             if not cfg['labels']:
@@ -1011,10 +1048,7 @@ class ScoreVisualizer:
             fontsize=self._fs(self.config['label_fontsize'] - 1),
             verticalalignment='top',
             horizontalalignment='left',
-            # L'unico accento cromatico che non passa dalla config: col preset
-            # B&W diventa grigio scuro, altrimenti sarebbe la sola parola
-            # colorata di una pagina monocroma (issue #248).
-            color='#1a1a1a' if self.config.get('bw') else 'darkblue',
+            color=self.config['stream_label_color'],
             alpha=0.8,
             bbox=dict(boxstyle='round,pad=0.2', facecolor='white', 
                     alpha=0.7, edgecolor='none')

--- a/src/pge/rendering/visualizer_config.py
+++ b/src/pge/rendering/visualizer_config.py
@@ -32,7 +32,8 @@ from dataclasses import (
 from typing import Optional
 
 from pge.shared.constants import DEFAULT_OUTPUT_SR
-from pge.rendering.envelope_extractor import ENVELOPE_COLORS
+from pge.rendering.envelope_extractor import (
+    BW_ENVELOPE_COLOR, ENVELOPE_COLORS, ENVELOPE_STYLES)
 
 
 # =============================================================================
@@ -132,6 +133,10 @@ ENVELOPE_RANGES = {
 }
 
 
+# Alpha unica dei grani col preset B&W (vedi VisualizerConfig._bw_defaults).
+BW_GRAIN_ALPHA = 0.9
+
+
 # =============================================================================
 # LO SCHEMA
 # =============================================================================
@@ -143,6 +148,13 @@ class VisualizerConfig:
     I campi sono raggruppati per natura: cosa mostrare, dove metterlo, che
     aspetto dargli. Nel dizionario stavano tutti mescolati.
     """
+
+    # --- PRESET --------------------------------------------------------------
+    # Partitura leggibile in stampa bianco e nero (issue #248). Non e' un modo
+    # a parte: sposta i DEFAULT di alcuni campi (vedi _bw_defaults), che
+    # restano tutti sovrascrivibili uno per uno. Spento, la pagina e' identica
+    # a prima.
+    bw: bool = False
 
     # --- COSA MOSTRARE -------------------------------------------------------
     # Directory dei sample per waveform e durate; None -> fallback su PATHSAMPLES.
@@ -237,6 +249,13 @@ class VisualizerConfig:
         default_factory=lambda: deepcopy(ENVELOPE_RANGES))
     envelope_colors: dict = field(
         default_factory=lambda: dict(ENVELOPE_COLORS))
+    # Stile di linea per chiave: {nome: (linestyle, linewidth)}. Vuoto = ogni
+    # curva col disegno storico (ENVELOPE_STYLE_DEFAULT), distinta solo dalla
+    # tinta. Lo riempie il preset `bw`, dove la tinta non porta piu'
+    # informazione e il tratteggio prende il suo posto (issue #248); resta
+    # riempibile a mano, che e' il modo di dare a una curva un tratto proprio
+    # anche a colori.
+    envelope_styles: dict = field(default_factory=dict)
     # Frazione della banda di OGNI stream riservata alla sua riga envelope
     # (issue #113: un subplot envelope per stream, sotto i suoi grani).
     envelope_panel_ratio: float = 0.3
@@ -255,6 +274,45 @@ class VisualizerConfig:
     magnify_projection: MagnifyProjection = MagnifyProjection()
 
     # =========================================================================
+
+    @classmethod
+    def _bw_defaults(cls):
+        """I default che `bw: True` sostituisce, prima degli scarti utente.
+
+        Sono DEFAULT, non valori imposti: chi passa `grain_colormap` insieme a
+        `bw` ottiene la propria mappa, e chi ritocca un colore non si vede
+        tornare a colori tutti gli altri (il merge dei dizionari-dato parte da
+        qui, non dalla tabella cromatica).
+
+        Il preset lo applica `from_overrides`, che e' la porta da cui passa la
+        config del visualizer. Costruire `VisualizerConfig(bw=True)` a mano
+        NON lo applica: il dataclass non sa quali campi il chiamante ha
+        dichiarato, quindi non saprebbe quali sostituire senza cancellare le
+        scelte esplicite.
+        """
+        return {
+            # Un solo asse percettivo, speso sul detune (score_visualizer
+            # .PITCH_DIVERGING_BW).
+            'grain_colormap': 'pitch_div_bw',
+            # Sul fondo bianco il composito e' `a*g + (1-a)`: l'alpha e la
+            # luminanza del grigio sono LO STESSO canale, e con l'alpha libera
+            # un grano grave suonato piano schiarisce fino a leggersi acuto.
+            # Fissandola, il grigio del grano resta funzione del solo pitch.
+            # Il volume smette di dirsi nel riempimento: e' il prezzo, e si
+            # riapre passando `grain_alpha_range`. Non 1.0 perche' a opacita'
+            # piena un cluster denso diventa una lastra unica.
+            'grain_alpha_range': (BW_GRAIN_ALPHA, BW_GRAIN_ALPHA),
+            # La tinta non distingue piu' niente: la sostituisce il tratteggio.
+            'envelope_colors': {key: BW_ENVELOPE_COLOR for key in ENVELOPE_COLORS},
+            'envelope_styles': dict(ENVELOPE_STYLES),
+            # Gli accenti cromatici restanti. Convertiti in grigio sarebbero
+            # leggibili comunque, ma un preset monocromo lo e' anche a schermo:
+            # tre macchie di colore in una pagina per il resto grigia si
+            # leggono come una svista.
+            'waveform_color': '#666666',
+            'loop_mask_color': '#4d4d4d',
+            'magnify_color': '#1a1a1a',
+        }
 
     @classmethod
     def _default_of(cls, spec):
@@ -303,9 +361,14 @@ class VisualizerConfig:
                 "chiavi di configurazione sconosciute per ScoreVisualizer: "
                 + ", ".join(unknown))
 
-        values = {}
+        # Col preset acceso i default di alcuni campi cambiano PRIMA del
+        # merge: gli scarti dell'utente si applicano sopra il preset, non
+        # sopra i default a colori.
+        base = cls._bw_defaults() if (overrides or {}).get('bw') else {}
+
+        values = dict(base)
         for name, value in (overrides or {}).items():
-            default = cls._default_of(by_name[name])
+            default = base.get(name, cls._default_of(by_name[name]))
             # Mapping e non dict, come per l'argomento intero: il primo livello
             # accetta qualunque mapping, e se qui si guardasse il tipo concreto
             # la stessa configurazione sarebbe fusa o sostituita a seconda di

--- a/src/pge/rendering/visualizer_config.py
+++ b/src/pge/rendering/visualizer_config.py
@@ -81,13 +81,22 @@ class MagnifyProjection:
     sono le due cose che cambiano davvero da una partitura all'altra.
     """
     enabled: bool = True
-    # Tratteggio e non tinta unita: la partitura deve restare leggibile anche
-    # stampata in scala di grigi, dove il rosso della lente e' un grigio come
-    # gli altri.
+    # Tratteggio e non tinta unita: la verticale deve restare distinguibile
+    # dalle curve anche stampata in scala di grigi. Col preset B&W le curve
+    # sono tratteggiate a loro volta, e li' a separarle e' l'orientamento —
+    # una verticale in mezzo a curve che descrivono il tempo.
     linestyle: str = '--'
     linewidth: float = 0.6
     alpha: float = 0.8
     markersize: float = 5.0
+    # Anello del marker. None = l'accento della lente, che e' il default
+    # storico. Esiste come chiave propria perche' l'anello vive su un altro
+    # fondo rispetto al resto della lente: gli altri artisti della lente
+    # stanno sui grani, questo sta SULLA CURVA, e col preset B&W curva e
+    # accento sono due neri. Li' l'anello si spegne, e il marker diventa
+    # indistinguibile da un breakpoint qualunque.
+    marker_edge: Optional[str] = None
+    markeredgewidth: float = 0.8
     labels: bool = True                  # etichette col valore reale
 
 
@@ -235,6 +244,12 @@ class VisualizerConfig:
 
     # --- STILE ---------------------------------------------------------------
     stream_gap_ratio: float = 0.05        # gap fra stream (5% dell'altezza)
+    # Colore della label dello stream nel subplot dei grani. E' una chiave e
+    # non un letterale nel disegno perche' `bw` deve restare un selettore di
+    # default: se il codice di disegno lo rilegge, una config costruita a mano
+    # con `bw=True` non e' inerte ma incoerente — pagina a colori con un solo
+    # elemento grigio.
+    stream_label_color: str = 'darkblue'
     label_fontsize: float = 8
     title_fontsize: float = 12
     breakpoint_fontsize: float = 6
@@ -311,7 +326,15 @@ class VisualizerConfig:
             # leggono come una svista.
             'waveform_color': '#666666',
             'loop_mask_color': '#4d4d4d',
+            # L'accento della lente resta scuro perche' e' scelto contro i
+            # GRANI, ed e' piu' scuro del piu' scuro di essi. A cambiare e'
+            # solo l'anello del marker di proiezione, che e' l'unico pezzo
+            # della lente che atterra sulle curve.
             'magnify_color': '#1a1a1a',
+            'magnify_projection': replace(
+                MagnifyProjection(), marker_edge='#ffffff',
+                markeredgewidth=1.4),
+            'stream_label_color': '#1a1a1a',
         }
 
     @classmethod

--- a/tests/rendering/test_bw_preset.py
+++ b/tests/rendering/test_bw_preset.py
@@ -24,8 +24,9 @@ FISSA — vedi TestFixedAlpha per il perche' e per cosa costa.
 import matplotlib
 matplotlib.use('Agg')  # backend non-interattivo obbligatorio nei test
 import matplotlib.pyplot as plt
+import numpy as np
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from pge.rendering.envelope_extractor import (
     ENVELOPE_COLORS, ENVELOPE_STYLES, ENVELOPE_STYLE_DEFAULT, BW_ENVELOPE_COLOR)
@@ -425,3 +426,218 @@ class TestStyleReachesTheLegend:
         dashed = self._legend_line(bw_config(), 'density').get_xdata()
         solid = self._legend_line(bw_config(), 'volume').get_xdata()
         assert list(solid) == list(dashed)
+
+
+# =============================================================================
+# LA CHIAVE DI LETTURA: LA COLORBAR (review #249, punto 1)
+# =============================================================================
+
+def luminance(color):
+    """Luminanza relativa di un colore, come la vede una stampa in grigio."""
+    r, g, b, _ = matplotlib.colors.to_rgba(color)
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b
+
+
+def composited(grey, alpha):
+    """Il grigio che finisce sulla carta: fondo bianco, `a*g + (1-a)`."""
+    return alpha * grey + (1.0 - alpha)
+
+
+class TestColorbarMatchesTheGrains:
+    """La colorbar del pitch e' la chiave di lettura della mappa acromatica:
+    se il suo grigio non e' quello dei grani, chi accosta un grano alla barra
+    sbaglia sistematicamente il verso.
+
+    Coi grani a opacita' variabile la barra non poteva che essere indicativa —
+    non c'e' un'alpha sola da mostrare. Col preset l'alpha e' fissata, quindi
+    la corrispondenza e' esprimibile ed e' un dovere.
+    """
+
+    def _colorbar_greys(self, config):
+        """I grigi effettivamente dipinti nella colonna della colorbar."""
+        viz = ScoreVisualizer(MagicMock(streams=[MagicMock()]), config=config)
+        fig = plt.figure(figsize=(2, 4), facecolor='white')
+        gs = fig.add_gridspec(1, 1)
+        viz._add_pitch_colorbar(fig, gs[0, 0], (-300.0, 300.0), True)
+        fig.canvas.draw()
+        cax = fig.axes[-1]
+        box = cax.get_window_extent()
+        buf = np.asarray(fig.canvas.buffer_rgba(), dtype=float) / 255.0
+        h = buf.shape[0]
+        # Colonna centrale della barra, dal basso (grave) all'alto (acuto).
+        col = int((box.x0 + box.x1) / 2)
+        y0, y1 = int(box.y0) + 3, int(box.y1) - 3
+        strip = buf[h - y1:h - y0, col, :3]
+        return strip[::-1]   # dal grave all'acuto
+
+    def test_the_bar_carries_the_grain_alpha(self):
+        """Il grigio in cima e in fondo alla barra e' quello di un grano allo
+        stesso pitch, non quello della mappa a opacita' piena."""
+        config = bw_config()
+        alpha = config['grain_alpha_range'][0]
+        cmap = plt.get_cmap(config['grain_colormap'])
+        strip = self._colorbar_greys(config)
+        for x, sample in ((0.0, strip[0]), (1.0, strip[-1])):
+            atteso = composited(cmap(x)[0], alpha)
+            assert sample[0] == pytest.approx(atteso, abs=0.02)
+
+    def test_the_bar_is_still_achromatic(self):
+        strip = self._colorbar_greys(bw_config())
+        assert np.allclose(strip[:, 0], strip[:, 1], atol=0.01)
+        assert np.allclose(strip[:, 1], strip[:, 2], atol=0.01)
+
+    def test_a_variable_alpha_leaves_the_bar_opaque(self):
+        """Senza preset l'alpha varia col volume: non c'e' un valore solo da
+        mostrare, e la barra resta quella storica a opacita' piena."""
+        config = plain_config()
+        cmap = plt.get_cmap(config['grain_colormap'])
+        strip = self._colorbar_greys(config)
+        assert strip[0][0] == pytest.approx(cmap(0.0)[0], abs=0.02)
+
+
+class TestTheDocstringNumbersAreThePageNumbers:
+    """I due estremi e il centro, come finiscono sulla carta."""
+
+    def test_the_page_greys_stay_off_black_and_white(self):
+        cmap = plt.get_cmap('pitch_div_bw')
+        alpha = bw_config()['grain_alpha_range'][0]
+        assert 0.20 <= composited(cmap(0.0)[0], alpha) <= 0.28
+        assert 0.82 <= composited(cmap(1.0)[0], alpha) <= 0.90
+
+    def test_the_sign_of_the_detune_survives_on_the_page(self):
+        """Il numero che conta davvero: il salto fra due detune simmetrici,
+        sulla pagina e non sulla mappa."""
+        cmap = plt.get_cmap('pitch_div_bw')
+        alpha = bw_config()['grain_alpha_range'][0]
+        for span in (0.5, 0.25):   # +/-300 e +/-150 cent su un range di 300
+            lo = composited(cmap(0.5 - span)[0], alpha)
+            hi = composited(cmap(0.5 + span)[0], alpha)
+            assert (hi - lo) > 0.25
+
+
+# =============================================================================
+# LA LENTE (review #249, punto 2)
+# =============================================================================
+
+FAKE_SR = 44100
+FAKE_AUDIO = np.sin(
+    2 * np.pi * 440 * np.linspace(0, 4.0, int(44100 * 4.0))
+).astype(np.float32)
+
+
+def lens_scene():
+    """Uno stream con due curve e una lente puntata a meta' corsa."""
+    from pge.envelopes.envelope import Envelope
+    s = MagicMock()
+    s.stream_id = 's1'
+    s.onset = 0.0
+    s.duration = 20.0
+    s.sample = 'piano.wav'
+    s.voices = [[_lens_grain(i * 2.5) for i in range(8)]]
+    for name in ('volume', 'pan', 'pointer_start', 'num_voices',
+                 'scatter', 'pointer_speed'):
+        delattr(s, name)
+    s.density = Envelope([[0, 10.0], [20, 30.0]])
+    return [s]
+
+
+def _lens_grain(onset):
+    g = MagicMock()
+    g.onset = onset
+    g.duration = 0.05
+    g.pointer_pos = 0.5
+    g.pitch_ratio = 1.0
+    g.volume = -6.0
+    return g
+
+
+def render_with_lens(config):
+    cfg = {'page_duration': 30.0, 'magnify_targets': [{'t': 6.0, 'y': 1.0}]}
+    cfg.update(config)
+    viz = ScoreVisualizer(MagicMock(streams=lens_scene()), config=cfg)
+    with patch('soundfile.read', return_value=(FAKE_AUDIO, FAKE_SR)):
+        viz.analyze()
+        fig = viz.render_page(0)
+    fig.canvas.draw()
+    return fig
+
+
+def projection_markers(fig):
+    return [a for ax in fig.axes for a in ax.lines
+            if a.get_gid() == 'poc-projection-marker']
+
+
+class TestLensMarkerStaysCircled:
+    """Il marker della proiezione e' un pallino CERCHIATO: la faccia dice a
+    quale curva appartiene, l'anello che viene dalla lente.
+
+    Col preset la faccia e' nera come ogni envelope e l'accento della lente e'
+    quasi nero: l'anello sparirebbe, e il marker diventerebbe indistinguibile
+    da un breakpoint qualunque — cioe' il preset toglierebbe una lettura
+    mentre dichiara di darne.
+    """
+
+    def test_the_ring_contrasts_with_the_face(self):
+        markers = projection_markers(render_with_lens({'bw': True}))
+        assert markers
+        for m in markers:
+            gap = abs(luminance(m.get_markerfacecolor())
+                      - luminance(m.get_markeredgecolor()))
+            assert gap > 0.5, gap
+
+    def test_the_ring_is_wide_enough_to_read(self):
+        markers = projection_markers(render_with_lens({'bw': True}))
+        for m in markers:
+            assert m.get_markeredgewidth() >= 1.2
+
+    def test_without_the_preset_the_marker_is_unchanged(self):
+        """A flag spento l'anello resta l'accento della lente, spesso 0.8."""
+        markers = projection_markers(render_with_lens({}))
+        assert markers
+        accento = plain_config()['magnify_color']
+        for m in markers:
+            assert matplotlib.colors.to_hex(m.get_markeredgecolor()) == accento
+            assert m.get_markeredgewidth() == pytest.approx(0.8)
+
+    def test_the_edge_defaults_to_the_lens_accent(self):
+        viz = ScoreVisualizer.__new__(ScoreVisualizer)
+        viz.config = plain_config()
+        edge, width = viz._projection_marker_edge()
+        assert edge == plain_config()['magnify_color']
+        assert width == pytest.approx(0.8)
+
+    def test_the_preset_overrides_only_the_marker_edge(self):
+        """L'accento della lente NON cambia: e' scelto bene contro i grani
+        (piu' scuro del grano piu' scuro). Quello che cambia e' l'anello, che
+        e' dove incontra il nero delle curve."""
+        config = bw_config()
+        assert config['magnify_color'] == '#1a1a1a'
+        edge, _ = _viz_with(config)._projection_marker_edge()
+        assert luminance(edge) > 0.9
+
+
+def _viz_with(config):
+    viz = ScoreVisualizer.__new__(ScoreVisualizer)
+    viz.config = config
+    return viz
+
+
+# =============================================================================
+# IL PRESET NON DEVE POTER DIVENTARE INERTE (review #249, punti 3 e 4)
+# =============================================================================
+
+class TestThePresetCannotBeShadowed:
+
+    def test_bw_is_not_read_by_the_drawing_code(self):
+        """`bw` seleziona default e basta. Finche' il disegno lo rilegge,
+        costruire `VisualizerConfig(bw=True)` a mano non e' inerte ma
+        INCOERENTE: partitura a colori con un elemento grigio scuro."""
+        import inspect
+        from pge.rendering import score_visualizer
+        sorgente = inspect.getsource(score_visualizer)
+        assert "config.get('bw')" not in sorgente
+        assert "config['bw']" not in sorgente
+
+    def test_the_stream_label_colour_is_a_config_key(self):
+        assert plain_config()['stream_label_color'] == 'darkblue'
+        assert luminance(bw_config()['stream_label_color']) < 0.2

--- a/tests/rendering/test_bw_preset.py
+++ b/tests/rendering/test_bw_preset.py
@@ -1,0 +1,427 @@
+# tests/rendering/test_bw_preset.py
+"""
+Preset B&W della partitura (issue #248).
+
+La MAP e' pensata per lo schermo. Stampata in bianco e nero perde
+informazione in due punti, e sono i due che questa suite presidia:
+
+1. la colormap del pitch (`pitch_div`) ha i due bracci alla STESSA chiarezza,
+   quindi in grigio +300 e -300 cent diventano lo stesso grigio: il segno del
+   detune sparisce;
+2. le curve degli envelope si distinguono solo per tinta, quindi in grigio
+   volume/pan/grain_duration diventano tre linee identiche.
+
+Il preset risponde con due canali che il grigio ha davvero: la luminanza per
+il pitch (mappa divergente acromatica, compressa lontano da bianco e nero) e
+il tratteggio per gli envelope (nero per tutte le curve, un pattern per
+chiave).
+
+Un terzo problema non ha una risposta gratis: l'alpha guidata dal volume si
+somma alla luminanza del grigio, ed e' lo stesso canale. Il preset la
+FISSA — vedi TestFixedAlpha per il perche' e per cosa costa.
+"""
+
+import matplotlib
+matplotlib.use('Agg')  # backend non-interattivo obbligatorio nei test
+import matplotlib.pyplot as plt
+import pytest
+from unittest.mock import MagicMock
+
+from pge.rendering.envelope_extractor import (
+    ENVELOPE_COLORS, ENVELOPE_STYLES, ENVELOPE_STYLE_DEFAULT, BW_ENVELOPE_COLOR)
+from pge.rendering.visualizer_config import VisualizerConfig
+from pge.rendering.score_visualizer import ScoreVisualizer
+
+
+@pytest.fixture(autouse=True)
+def close_figures():
+    yield
+    plt.close('all')
+
+
+def bw_config(**overrides):
+    """La config del visualizer col preset acceso."""
+    return VisualizerConfig.from_overrides({'bw': True, **overrides}).as_dict()
+
+
+def plain_config(**overrides):
+    return VisualizerConfig.from_overrides(overrides or None).as_dict()
+
+
+# =============================================================================
+# LA TAVOLA DEGLI STILI
+# =============================================================================
+
+class TestEnvelopeStylesTable:
+    """`ENVELOPE_STYLES` e' la mappa parallela a `ENVELOPE_COLORS`: stessa
+    chiave, l'altro canale."""
+
+    def test_covers_exactly_the_same_keys_as_the_colors(self):
+        """Parallela vuol dire totale: una chiave con un colore e senza stile
+        in B&W tornerebbe una linea come tutte le altre, ed e' esattamente il
+        collasso che il preset esiste per chiudere."""
+        assert set(ENVELOPE_STYLES) == set(ENVELOPE_COLORS)
+
+    def test_every_entry_is_a_linestyle_and_a_positive_width(self):
+        for key, value in ENVELOPE_STYLES.items():
+            linestyle, linewidth = value
+            assert isinstance(linestyle, (str, tuple)), key
+            assert isinstance(linewidth, (int, float)) and linewidth > 0, key
+
+    def test_the_table_holds_no_matplotlib_object(self):
+        """envelope_extractor e' il modulo matplotlib-free (issue #150): i
+        pattern sono dati puri, altrimenti l'export SV si trascinerebbe dietro
+        la pila di plotting per leggere una tabella."""
+        for key, (linestyle, _) in ENVELOPE_STYLES.items():
+            if isinstance(linestyle, tuple):
+                offset, onoff = linestyle
+                assert isinstance(offset, (int, float)), key
+                assert isinstance(onoff, tuple) and len(onoff) % 2 == 0, key
+                assert all(isinstance(x, (int, float)) for x in onoff), key
+
+    def test_no_two_keys_share_the_same_pair(self):
+        """La coppia (pattern, spessore) e' l'identita' della curva sulla
+        carta: due chiavi con la stessa coppia sarebbero indistinguibili
+        anche col preset acceso."""
+        pairs = [tuple(v) for v in ENVELOPE_STYLES.values()]
+        duplicates = {p for p in pairs if pairs.count(p) > 1}
+        assert not duplicates, f"coppie ripetute: {sorted(map(str, duplicates))}"
+
+    @pytest.mark.parametrize('base,variant', [
+        ('volume', 'volume_prob'),
+        ('volume', 'volume_range'),
+        ('pan', 'pan_prob'),
+        ('pan', 'pan_range'),
+        ('grain_duration', 'grain_duration_prob'),
+        ('grain_duration', 'grain_duration_range'),
+        ('reverse', 'reverse_prob'),
+        ('pointer_deviation', 'pointer_deviation_prob'),
+    ])
+    def test_variants_keep_the_pattern_of_their_base(self, base, variant):
+        """Il chiaro/scuro della stessa tinta diventa sottile/spesso dello
+        stesso tratteggio: la parentela fra una curva e la sua probabilita' o
+        la sua deviazione resta leggibile."""
+        assert ENVELOPE_STYLES[variant][0] == ENVELOPE_STYLES[base][0]
+        assert ENVELOPE_STYLES[variant][1] != ENVELOPE_STYLES[base][1]
+
+    def test_prob_variants_are_thinner_than_their_base(self):
+        for key, (_, width) in ENVELOPE_STYLES.items():
+            if key.endswith('_prob'):
+                base = key[:-len('_prob')]
+                assert width < ENVELOPE_STYLES[base][1], key
+
+    def test_default_style_is_the_historical_one(self):
+        """Chi non ha una entry disegna come si e' sempre disegnato: linea
+        piena, spessore 1.1."""
+        assert ENVELOPE_STYLE_DEFAULT == ('-', 1.1)
+
+
+# =============================================================================
+# LA COLORMAP ACROMATICA
+# =============================================================================
+
+class TestBwColormap:
+    """`pitch_div_bw`: la divergente del pitch spesa tutta sulla luminanza."""
+
+    def cmap(self):
+        return plt.get_cmap('pitch_div_bw')
+
+    def test_is_registered_under_its_name(self):
+        """La config la nomina come stringa, come 'pitch_div': senza
+        registrazione il preset fallirebbe dentro `plt.get_cmap`."""
+        assert self.cmap() is not None
+
+    @pytest.mark.parametrize('x', [0.0, 0.15, 0.25, 0.5, 0.75, 0.9, 1.0])
+    def test_is_achromatic(self, x):
+        r, g, b, _ = self.cmap()(x)
+        assert r == pytest.approx(g, abs=1e-6)
+        assert g == pytest.approx(b, abs=1e-6)
+
+    def test_luminance_is_strictly_increasing(self):
+        """E' l'invariante che salva il segno del detune: piu' acuto = piu'
+        chiaro, senza inversioni lungo il percorso."""
+        values = [self.cmap()(x / 64.0)[0] for x in range(65)]
+        for lo, hi in zip(values, values[1:]):
+            assert hi > lo
+
+    def test_the_arms_stop_short_of_black_and_white(self):
+        """Compressa a circa 0.15-0.85: col braccio alto sul bianco i grani
+        acuti sparirebbero sulla carta, col basso sul nero si confonderebbero
+        con assi e griglia."""
+        assert 0.10 <= self.cmap()(0.0)[0] <= 0.20
+        assert 0.80 <= self.cmap()(1.0)[0] <= 0.90
+
+    def test_the_centre_is_mid_grey(self):
+        """Zero cent = nessun detune: sta in mezzo, come il #777777 della
+        mappa a colori."""
+        assert self.cmap()(0.5)[0] == pytest.approx(0.5, abs=0.04)
+
+    def test_the_colour_map_is_untouched(self):
+        """Il preset aggiunge, non sostituisce: 'pitch_div' resta cromatica."""
+        r, g, b, _ = plt.get_cmap('pitch_div')(0.0)
+        assert not (r == g == b)
+
+
+# =============================================================================
+# IL PRESET NELLA CONFIG
+# =============================================================================
+
+class TestBwPreset:
+    """`bw: True` sposta i default; l'utente resta l'ultima parola."""
+
+    def test_off_by_default(self):
+        assert plain_config()['bw'] is False
+
+    def test_off_changes_nothing(self):
+        """A flag spento la partitura e' identica a prima: e' la condizione
+        per cui questa issue non tocca nessuna figura gia' generata."""
+        before = plain_config()
+        after = plain_config(bw=False)
+        after.pop('bw')
+        before.pop('bw')
+        assert after == before
+
+    def test_grains_switch_to_the_achromatic_map(self):
+        assert bw_config()['grain_colormap'] == 'pitch_div_bw'
+
+    def test_every_envelope_turns_black(self):
+        colors = bw_config()['envelope_colors']
+        assert set(colors) == set(ENVELOPE_COLORS)
+        assert set(colors.values()) == {BW_ENVELOPE_COLOR}
+
+    def test_envelope_styles_come_in(self):
+        assert bw_config()['envelope_styles'] == ENVELOPE_STYLES
+
+    def test_styles_are_empty_without_the_preset(self):
+        """Senza preset nessuno stile: le curve restano piene, distinte dalla
+        tinta come sempre."""
+        assert plain_config()['envelope_styles'] == {}
+
+    def test_the_chromatic_accents_turn_grey(self):
+        """Un preset monocromo lo e' anche a schermo: waveform, maschera del
+        loop e lente non restano le uniche macchie di colore."""
+        config = bw_config()
+        for key in ('waveform_color', 'loop_mask_color', 'magnify_color'):
+            r, g, b, _ = matplotlib.colors.to_rgba(config[key])
+            assert r == g == b, key
+
+    def test_an_explicit_override_beats_the_preset(self):
+        """Il preset e' un default, non un lucchetto."""
+        config = bw_config(grain_colormap='turbo')
+        assert config['grain_colormap'] == 'turbo'
+
+    def test_a_partial_override_merges_onto_the_preset(self):
+        """Ritoccare un colore non riporta a colori tutti gli altri: il merge
+        parte dal preset, non dai default cromatici."""
+        config = bw_config(envelope_colors={'volume': '#ff0000'})
+        assert config['envelope_colors']['volume'] == '#ff0000'
+        assert config['envelope_colors']['pan'] == BW_ENVELOPE_COLOR
+
+    def test_a_partial_style_override_merges_onto_the_preset(self):
+        config = bw_config(envelope_styles={'volume': ('-', 3.0)})
+        assert config['envelope_styles']['volume'] == ('-', 3.0)
+        assert config['envelope_styles']['pan'] == ENVELOPE_STYLES['pan']
+
+    def test_the_preset_does_not_leak_into_the_module_table(self):
+        """La tavola di modulo non si tocca: due visualizer, uno B&W e uno no,
+        convivono."""
+        bw_config()['envelope_colors']['volume'] = '#123456'
+        assert ENVELOPE_COLORS['volume'] != '#123456'
+        assert plain_config()['envelope_colors']['volume'] == ENVELOPE_COLORS['volume']
+
+    def test_unknown_keys_still_refused_with_the_preset_on(self):
+        with pytest.raises(ValueError):
+            VisualizerConfig.from_overrides({'bw': True, 'banana': 1})
+
+    def test_direct_construction_does_not_apply_the_preset(self):
+        """La porta e' `from_overrides`, ed e' quella che il visualizer usa.
+        Il costruttore non sa quali campi il chiamante ha dichiarato, quindi
+        non saprebbe quali sostituire senza cancellare le scelte esplicite: il
+        preset li' non si applica, e questo test lo dice invece di lasciarlo
+        scoprire."""
+        config = VisualizerConfig(bw=True).as_dict()
+        assert config['grain_colormap'] == 'pitch_div'
+        assert config['envelope_styles'] == {}
+
+
+# =============================================================================
+# L'ALPHA
+# =============================================================================
+
+class TestFixedAlpha:
+    """Sul bianco l'alpha e la luminanza del grigio sono lo STESSO canale.
+
+    Composito su fondo bianco: `a*g + (1-a)`. Con alpha libera un grano scuro
+    (detune negativo) suonato piano schiarisce fino a leggersi come acuto: il
+    canale che il preset esiste per salvare verrebbe mangiato da quello che
+    prova a conservare. Il preset fissa l'alpha, quindi il composito resta una
+    funzione monotona del solo pitch.
+
+    Il volume smette di dirsi nel riempimento del grano: e' il prezzo, ed e'
+    reversibile passando `grain_alpha_range` nella config.
+    """
+
+    def test_alpha_range_is_degenerate(self):
+        lo, hi = bw_config()['grain_alpha_range']
+        assert lo == hi
+
+    def test_alpha_leaves_room_for_overlap(self):
+        """Non 1.0: a opacita' piena un cluster denso diventa una lastra e la
+        densita' smette di leggersi."""
+        lo, hi = bw_config()['grain_alpha_range']
+        assert 0.8 <= lo < 1.0
+
+    def test_the_default_alpha_range_is_untouched(self):
+        assert plain_config()['grain_alpha_range'] == (0.3, 1.0)
+
+    def test_composited_luminance_orders_by_pitch_not_by_volume(self):
+        """Il test che vale: un grano grave e piano resta piu' scuro di uno
+        acuto e forte, che e' cio' che oggi non e' vero."""
+        viz = ScoreVisualizer(MagicMock(streams=[MagicMock()]), config={'bw': True})
+        cents_range = (-300.0, 300.0)
+
+        def composited(cents, volume_db):
+            grey = viz._pitch_to_color(2.0 ** (cents / 1200.0), cents_range)[0]
+            alpha = viz._volume_to_alpha(volume_db)
+            return alpha * grey + (1.0 - alpha)
+
+        quiet_low = composited(-300.0, -60.0)   # grave, pianissimo
+        loud_high = composited(+300.0, 0.0)     # acuto, forte
+        loud_low = composited(-300.0, 0.0)
+        quiet_high = composited(+300.0, -60.0)
+        assert quiet_low < loud_high
+        assert quiet_low == pytest.approx(loud_low)
+        assert quiet_high == pytest.approx(loud_high)
+
+
+# =============================================================================
+# LO STILE ARRIVA AL DISEGNO
+# =============================================================================
+
+def make_env_viz(config):
+    """Un visualizer ridotto alla sola corsia envelope, come in
+    test_score_visualizer_per_segment."""
+    viz = ScoreVisualizer.__new__(ScoreVisualizer)
+    viz.config = config
+    viz.config['envelope_ranges'] = {'density': (0, 100)}
+    viz._get_stream_envelopes = lambda s: {'density': s.density}
+    viz._normalize_envelope_value = lambda name, v: v / 100.0
+    viz._annotate_breakpoints = lambda *a, **k: None
+    return viz
+
+
+def make_env_stream(env):
+    stream = MagicMock()
+    stream.onset = 0.0
+    stream.duration = 1.0
+    stream.density = env
+    return stream
+
+
+class TestStyleReachesTheCurve:
+
+    def _draw(self, config):
+        from pge.envelopes.envelope import Envelope
+        viz = make_env_viz(config)
+        fig, ax = plt.subplots()
+        viz._draw_envelopes(ax, make_env_stream(Envelope([[0, 0], [1, 100]])),
+                            0.0, 1.0, 0.0, 1.0)
+        return ax.lines
+
+    def test_without_the_preset_the_curve_is_solid(self):
+        """Il default e' il disegno storico, byte per byte: linea piena a
+        1.1."""
+        lines = self._draw(plain_config())
+        assert len(lines) == 1
+        assert lines[0].get_linestyle() == '-'
+        assert lines[0].get_linewidth() == pytest.approx(1.1)
+
+    def test_with_the_preset_the_curve_takes_its_pattern(self):
+        lines = self._draw(bw_config())
+        expected_ls, expected_lw = ENVELOPE_STYLES['density']
+        assert lines[0].get_linewidth() == pytest.approx(expected_lw)
+        assert lines[0].get_linestyle() != '-'
+
+    def test_the_curve_is_black(self):
+        lines = self._draw(bw_config())
+        assert matplotlib.colors.to_hex(lines[0].get_color()) == BW_ENVELOPE_COLOR
+
+    def test_step_curves_take_the_pattern_too(self):
+        from pge.envelopes.envelope import Envelope
+        viz = make_env_viz(bw_config())
+        fig, ax = plt.subplots()
+        env = Envelope({'type': 'step', 'points': [[0, 0], [0.5, 100], [1, 0]]})
+        viz._draw_envelopes(ax, make_env_stream(env), 0.0, 1.0, 0.0, 1.0)
+        assert ax.lines[0].get_linestyle() != '-'
+
+    def test_per_segment_curves_take_the_pattern_too(self):
+        """Il rendering per-segmento (issue #68) disegna una linea per
+        segmento: se lo stile non passasse di li', un envelope eterogeneo
+        resterebbe pieno mentre gli altri sono tratteggiati."""
+        from pge.envelopes.envelope import Envelope
+        viz = make_env_viz(bw_config())
+        fig, ax = plt.subplots()
+        env = Envelope([[0, 0, 'step'], [0.5, 100, 'linear'], [1, 0]])
+        viz._draw_envelopes(ax, make_env_stream(env), 0.0, 1.0, 0.0, 1.0)
+        assert len(ax.lines) >= 2
+        for line in ax.lines:
+            assert line.get_linestyle() != '-'
+
+    def test_per_voice_curves_inherit_the_style_of_their_base(self):
+        """Le curve per-voce '__vN' prendono il colore della base (issue #90):
+        lo stile segue la stessa regola, o una voce sarebbe l'unica linea
+        piena della corsia."""
+        viz = make_env_viz(bw_config())
+        assert viz._envelope_style('density__v2') == ENVELOPE_STYLES['density']
+
+    def test_an_unknown_key_falls_back_to_the_historical_style(self):
+        viz = make_env_viz(bw_config())
+        assert viz._envelope_style('banana') == ENVELOPE_STYLE_DEFAULT
+
+
+class TestStyleReachesTheLegend:
+    """La legenda e' la chiave di lettura: se il suo tratto non mostra il
+    pattern, il pattern sulla curva non e' attribuibile a niente."""
+
+    def _legend_line(self, config, param='density'):
+        viz = ScoreVisualizer.__new__(ScoreVisualizer)
+        viz.config = config
+        fig, ax = plt.subplots()
+        viz._draw_envelope_legend(ax, [(param, 0.5, 's1')])
+        return ax.lines[0]
+
+    def test_without_the_preset_the_key_is_unchanged(self):
+        line = self._legend_line(plain_config())
+        assert line.get_linestyle() == '-'
+        assert line.get_linewidth() == pytest.approx(2)
+        assert list(line.get_xdata()) == [0.1, 0.15]
+
+    def test_the_key_shows_the_curve_pattern(self):
+        line = self._legend_line(bw_config())
+        assert line.get_linestyle() != '-'
+
+    def test_the_key_carries_the_curve_width(self):
+        """Lo spessore e' meta' dell'informazione: e' li' che una probabilita'
+        si distingue dalla sua base. Una chiave ingrossata per farsi vedere la
+        perderebbe — e allungherebbe anche il ciclo del tratteggio, che
+        matplotlib scala per lo spessore, riportando la chiave a leggersi
+        piena."""
+        for param in ('density', 'volume_prob', 'volume_range'):
+            line = self._legend_line(bw_config(), param)
+            assert line.get_linewidth() == pytest.approx(
+                ENVELOPE_STYLES[param][1])
+
+    def test_a_styled_key_gets_a_longer_stroke(self):
+        """Il tratto storico e' il 5% della colonna: qualche punto, meno di un
+        ciclo di tratteggio, quindi si leggerebbe pieno."""
+        line = self._legend_line(bw_config())
+        x0, x1 = line.get_xdata()
+        assert (x1 - x0) > 0.05 * 3
+        assert x1 < 0.4  # non entra sotto il testo della legenda
+
+    def test_the_stroke_is_the_same_length_for_a_solid_entry(self):
+        """Due lunghezze di chiave nella stessa colonna fanno leggere lo stub
+        corto come un altro tratteggio: la misura e' una sola."""
+        dashed = self._legend_line(bw_config(), 'density').get_xdata()
+        solid = self._legend_line(bw_config(), 'volume').get_xdata()
+        assert list(solid) == list(dashed)

--- a/tests/rendering/test_bw_preset.py
+++ b/tests/rendering/test_bw_preset.py
@@ -380,6 +380,45 @@ class TestStyleReachesTheCurve:
         assert viz._envelope_style('banana') == ENVELOPE_STYLE_DEFAULT
 
 
+class TestAMalformedStyleNamesItself:
+    """`envelope_styles` e' l'unico dizionario-dato il cui VALORE viene
+    spacchettato in due, e una stringa ne e' una coppia plausibile:
+    `tuple('--')` vale `('-', '-')`. Senza guardia l'errore arriva da dentro
+    matplotlib — `could not convert string to float: '-'` — e non nomina ne'
+    la chiave di config ne' il parametro.
+
+    Lo schema verifica i nomi e non i tipi per scelta dichiarata (vedi il
+    docstring di rendering.visualizer_config): questo e' il caso che quella
+    scelta lascia scoperto, e si chiude nel lettore.
+    """
+
+    @pytest.mark.parametrize('bad', [
+        '--',              # coppia plausibile: ('-', '-')
+        5,                 # non spacchettabile
+        ('-', 'spesso'),   # spessore non numerico
+        ('-', 1.1, 0),     # tre valori
+    ])
+    def test_the_error_names_the_key_and_the_value(self, bad):
+        viz = make_env_viz(plain_config(envelope_styles={'density': bad}))
+        with pytest.raises(ValueError) as exc:
+            viz._envelope_style('density')
+        messaggio = str(exc.value)
+        assert 'envelope_styles' in messaggio
+        assert 'density' in messaggio
+        assert repr(bad) in messaggio
+
+    def test_a_well_formed_pair_passes(self):
+        """Anche scritta come lista: e' la forma in cui arriva da YAML o JSON."""
+        viz = make_env_viz(plain_config(envelope_styles={'density': [':', 2]}))
+        assert viz._envelope_style('density') == (':', 2.0)
+
+    def test_the_table_of_the_preset_passes_whole(self):
+        """Il preset stesso non deve poter cadere in questa guardia."""
+        viz = make_env_viz(bw_config())
+        for key in ENVELOPE_STYLES:
+            assert viz._envelope_style(key) == ENVELOPE_STYLES[key]
+
+
 class TestStyleReachesTheLegend:
     """La legenda e' la chiave di lettura: se il suo tratto non mostra il
     pattern, il pattern sulla curva non e' attribuibile a niente."""
@@ -493,6 +532,23 @@ class TestColorbarMatchesTheGrains:
         cmap = plt.get_cmap(config['grain_colormap'])
         strip = self._colorbar_greys(config)
         assert strip[0][0] == pytest.approx(cmap(0.0)[0], abs=0.02)
+
+    def test_a_fixed_alpha_reaches_the_bar_even_without_the_preset(self):
+        """La condizione e' l'alpha FISSATA, non `bw`.
+
+        Una config a colori che fissa `grain_alpha_range` da se' ha esattamente
+        lo stesso bisogno del preset, e la barra la segue. E' anche l'unico
+        punto in cui l'issue #248 si vede a preset spento: legarlo a un test
+        invece che a un commento e' il modo di non far passare per no-op una
+        cosa che no-op non e'.
+        """
+        config = plain_config(grain_alpha_range=(0.6, 0.6))
+        cmap = plt.get_cmap(config['grain_colormap'])
+        strip = self._colorbar_greys(config)
+        assert strip[0][0] == pytest.approx(composited(cmap(0.0)[0], 0.6),
+                                            abs=0.02)
+        # E non e' il colore nudo della mappa, che e' cio' che dipingeva prima.
+        assert abs(strip[0][0] - cmap(0.0)[0]) > 0.05
 
 
 class TestTheDocstringNumbersAreThePageNumbers:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -846,6 +846,7 @@ class TestExportScorePdf:
         'magnify_auto': False,
         'magnify_targets': [],
         'grain_height': 'duration',
+        'bw': False,
     }
 
     def test_default_config_matches_cli(self, api_mocks):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -849,6 +849,18 @@ class TestExportScorePdf:
         'bw': False,
     }
 
+    def test_defaults_never_shadow_the_bw_preset(self, api_mocks):
+        """I default dell'API stanno SOPRA il preset `bw`, che e' un default a
+        sua volta: `from_overrides` non puo' distinguere un default dell'API
+        da una scelta dell'utente. Il giorno in cui questo dict acquistasse una
+        chiave che il preset sposta, `--bw` diventerebbe inerte in silenzio.
+        Le due chiavi devono restare disgiunte (issue #248)."""
+        from pge.rendering.visualizer_config import VisualizerConfig
+
+        collisione = (set(self.CLI_DEFAULT_CONFIG)
+                      & set(VisualizerConfig._bw_defaults()))
+        assert not collisione, sorted(collisione)
+
     def test_default_config_matches_cli(self, api_mocks):
         gen = api_mocks['generator_instance']
         out = api_mocks['api'].export_score_pdf(gen, 'score.pdf')

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -13,7 +13,7 @@ Usa la stessa fixture a sys.modules di test_main.py (tests/main_mocks.py).
 
 Il golden si muove solo quando la CLI acquista superficie di proposito --
 non durante un refactor, che e' il vincolo che questo file difende. Ultimo
-movimento: issue #228, il terzo backend audio e i suoi flag.
+movimento: issue #248, il flag --bw del preset B&W della partitura.
 """
 
 import sys
@@ -30,6 +30,7 @@ USAGE = (
     "[--magnify] [--magnify-at SPEC] "
     "[--page-duration SECONDI] "
     "[--grain-height duration|read-span] "
+    "[--bw] "
     "[--per-stream] "
     "[--renderer csound|numpy|supercollider] "
     "[--jobs N|auto] "

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -385,6 +385,46 @@ class TestGrainHeightFlag:
 
 
 # =============================================================================
+# TEST FLAG --bw
+# =============================================================================
+
+class TestBwFlag:
+    """
+    --bw sceglie il preset della partitura leggibile in stampa bianco e nero
+    (issue #248): mappa del pitch acromatica, envelope neri distinti dal
+    tratteggio. Arriva alla config di ScoreVisualizer come `bw`; e' un
+    interruttore, quindi non ha valore da validare.
+    """
+
+    def _get_viz_config(self, mocks, argv):
+        with patch.object(sys, 'argv', argv):
+            mocks['main'].main()
+        _, kwargs = mocks['ScoreVisualizer'].call_args
+        return kwargs['config']
+
+    def test_default_is_off(self, mocks):
+        """Senza flag la partitura resta a colori: nessuna figura gia'
+        generata cambia aspetto da sola."""
+        config = self._get_viz_config(
+            mocks, ['main.py', 'test.yml', 'out.aif', '--visualize'])
+        assert config.get('bw') is False
+
+    def test_flag_reaches_the_config(self, mocks):
+        config = self._get_viz_config(
+            mocks, ['main.py', 'test.yml', 'out.aif', '--visualize', '--bw'])
+        assert config.get('bw') is True
+
+    def test_combines_with_the_other_score_flags(self, mocks):
+        """Il preset non esclude il resto: e' una tavolozza, non un modo."""
+        config = self._get_viz_config(
+            mocks, ['main.py', 'test.yml', 'out.aif', '--visualize', '--bw',
+                    '--grain-height', 'read-span', '--show-static'])
+        assert config.get('bw') is True
+        assert config.get('grain_height') == 'read_span'
+        assert config.get('show_static_params') is True
+
+
+# =============================================================================
 # TEST FLAG --page-duration
 # =============================================================================
 


### PR DESCRIPTION
Chiude #248.

`--bw` (o `BW=true` da Make, o `config={'bw': True}` da libreria) seleziona un
preset della partitura leggibile su carta in bianco e nero. A flag spento non
cambia un pixel — con **una** eccezione, dichiarata sotto: la colorbar, per chi
fissava gia' `grain_alpha_range`. E' la condizione che rende questa PR sicura
su ogni figura gia' generata.

> **Aggiornata dopo due giri di review.** Il primo ([risposta punto per
> punto](https://github.com/DMGiulioRomano/PythonGranularEngine/pull/249#issuecomment-5513714514))
> ha corretto la chiave di lettura e l'anello della lente; il secondo — vedi
> *Il secondo giro* in fondo — ha qualificato la promessa del no-op e chiuso un
> errore che non si nominava. Le tabelle e i numeri qui sotto sono quelli
> attuali; il corpo su cui il primo giro si e' espresso e' il commit `215f789`.

## Il problema, misurato

L'issue dice che i due bracci di `pitch_div` hanno la stessa chiarezza. In
realta' e' peggio: convertita in luminanza, **quella mappa non e' nemmeno
monotona** — sale a 0.510 a un quarto del range, poi *scende* a 0.468 al
centro. Coppie simmetriche di detune, su un range di ±300 cent:

| detune | `pitch_div` (grigio) | `pitch_div_bw` |
|---|---|---|
| ±300 cent | 0.175 / 0.795 (Δ 0.620) | 0.149 / 0.851 (Δ 0.702) |
| ±150 cent | 0.510 / 0.595 (Δ **0.085**) | 0.326 / 0.677 (Δ 0.350) |
| ±50 cent | 0.481 / 0.509 (Δ **0.028**) | 0.442 / 0.560 (Δ 0.118) |

A ±150 cent, in stampa, quei due grani sono lo stesso grigio.

Quelli sono i valori della **mappa**. Sulla **pagina** il grano e' composito su
fondo bianco all'alpha del preset, quindi la banda diventa 0.23–0.87 e lo zero
cade a 0.55; i delta restano 0.632 a ±300 cent e 0.315 a ±150. La conclusione
non cambia, i numeri si spostano — ed e' la barra a doversi adeguare al grano
(vedi sotto), non viceversa.

## Cosa fa il preset

| Chiave | Preset | Ragione |
|---|---|---|
| `grain_colormap` | `pitch_div_bw` | divergente acromatica, strettamente monotona, compressa a ~0.15-0.85: col braccio alto sul bianco i grani acuti sparirebbero, col basso sul nero si confonderebbero con assi e griglia |
| `grain_alpha_range` | `(0.9, 0.9)` | fissata — vedi sotto |
| `envelope_colors` | tutte `#000000` | la tinta non distingue piu' niente |
| `envelope_styles` | `ENVELOPE_STYLES` | il tratteggio prende il posto della tinta |
| `magnify_projection.marker_edge` | `#ffffff`, 1.4 pt | l'anello del marker della lente e' l'unico pezzo della lente che atterra *sulla curva*: col nero degli envelope si spegnerebbe |
| `waveform_color`, `loop_mask_color`, `magnify_color`, `stream_label_color` | grigi | un preset monocromo lo e' anche a schermo |

La **colorbar del pitch** riceve la stessa alpha dei grani quando l'alpha e'
degenere: e' la chiave di lettura, e deve mostrare il grigio che il lettore ha
davanti invece del colore nudo della mappa. Con l'alpha guidata dal volume non
c'e' un valore solo da mostrare e la barra resta opaca, cioe' storica.

**`ENVELOPE_STYLES`** e' la mappa *parallela* a `ENVELOPE_COLORS`, nello stesso
modulo matplotlib-free (i pattern sono tuple di numeri, nessun import). Due
livelli di lettura, come nei colori: il **pattern** dice il parametro, lo
**spessore** dice la variante — `_prob` piu' sottile della base, `_range` piu'
spesso, esattamente il ruolo che aveva il chiaro/scuro della stessa tinta. La
coppia `(linestyle, linewidth)` e' unica per chiave, ed e' un test.

Il limite e' dichiarato invece che nascosto: con ~20 parametri e forse dieci
tratteggi davvero distinguibili in stampa, i cinque che si incontrano piu'
spesso nella stessa corsia (volume, pitch, grain_duration, pan, density)
prendono i cinque pattern piu' distanti, gli altri riusano un pattern con uno
spessore diverso. La legenda per-corsia resta la chiave.

## Le due decisioni che costano qualcosa

**1. L'alpha viene fissata.** Sul fondo bianco il composito e' `a*g + (1-a)`:
l'alpha e la luminanza del grigio sono lo **stesso canale**. Con l'alpha libera
un grano grave suonato piano schiarisce fino a leggersi come acuto — il canale
che il preset esiste per salvare mangiato da quello che prova a conservare.
Fissandola a 0.9 il grigio torna funzione del solo pitch e l'ordinamento e'
garantito (test: un grano grave e pianissimo resta piu' scuro di uno acuto e
forte), ma **il volume smette di dirsi nel riempimento del grano**. Il prezzo
e' esplicito, documentato, e si riapre passando `grain_alpha_range`. Non 1.0
perche' a opacita' piena un cluster denso diventa una lastra e la densita'
smette di leggersi.

L'issue lasciava la scelta ("da valutare se restringerlo o fissarlo"): fissarla
e' l'unica delle due che da' una proprieta' verificabile invece di una
sovrapposizione piu' piccola. Ed e' anche quella che rende esprimibile la
correzione della colorbar, che prima non lo era.

**2. La legenda cambia geometria, ma solo col preset acceso.** Il tratto
storico e' il 5% della colonna, cioe' qualche punto: meno di un ciclo di
tratteggio, che ci si legge pieno. E matplotlib scala il pattern per lo
spessore, quindi ingrossare la chiave per farla vedere avrebbe allungato anche
il ciclo, riportandola a leggersi piena — verificato rendendo la colonna alla
sua larghezza reale. Con gli stili in gioco la chiave diventa un **campione**
della curva: stesso pattern, stesso spessore, su tutta la larghezza utile.
Misura unica per tutte le voci, comprese quelle a tratto pieno — due lunghezze
nella stessa colonna fanno leggere lo stub corto come un altro tratteggio.

## L'unica eccezione al no-op

La correzione della colorbar e' governata dall'**alpha fissata, non da `bw`**.
Una config a colori che passa un `grain_alpha_range` degenere — `(0.6, 0.6)` —
ha lo stesso problema e riceve la stessa correzione: la sua pagina non e' piu'
identica a quella di prima (misurati ~22k pixel, tutti nella barra). E' l'unico
punto in cui questo lavoro si vede a preset spento.

Il comportamento resta quello giusto: legarlo a `bw` rimetterebbe il bias
sistematico addosso a chi fissa l'alpha da se', che e' esattamente chi ha lo
stesso bisogno. A cambiare, nel secondo giro, sono il commento nel codice, la
doc e un test che pinna la regola.

## Verifica

- **La pagina non ha colore**: saturazione massima 0.0, zero pixel colorati su
  tutta la figura (la versione a colori ne ha il 4.8%). Ricontrollato su una
  seconda partitura con loop, voci e offset per-voce: 0.0 anche li'.
- **La barra dice il vero**: dipinge 0.235 / 0.549 / 0.859 contro i 0.234 /
  0.553 / 0.866 dei grani (il resto e' antialiasing).
- **"A flag spento non cambia un pixel"**: A/B a pixel fra `origin/main` e la
  testa del branch, stessa partitura a seed fisso, due pagine con lente,
  parametri statici, colorbar ed envelope — **zero** pixel diversi in modalita'
  colore. Con `grain_alpha_range` degenere, la differenza attesa e' la barra e
  solo la barra.
- Legenda, corsia envelope e i due marker (proiezione vs breakpoint) ispezionati
  a dimensione reale.

`make tests`: **6184 passed**, 10 skipped (i 10 skip preesistenti). `docs-lint`
e `docs-index-check` verdi.

## Il secondo giro

Due rilievi, entrambi su cose che il preset dichiarava e non manteneva.

1. **La promessa del no-op era incondizionata e non lo e'.** Vedi la sezione
   sopra: comportamento invariato, ma adesso lo dicono il commento, il
   CHANGELOG, la how-to e un test
   (`test_a_fixed_alpha_reaches_the_bar_even_without_the_preset`) invece di
   nessuno.
2. **Una coppia malformata in `envelope_styles` non si nominava.** E' l'unico
   dizionario-dato della config il cui valore viene spacchettato in due, e una
   stringa ne e' una coppia plausibile: `tuple('--')` vale `('-', '-')`, cioe'
   uno spessore che non e' un numero. L'errore arrivava da dentro matplotlib
   (`could not convert string to float: '-'`) senza nominare ne' la chiave ne'
   il parametro. La guardia sta in `_envelope_style` e non nello schema: quello
   verifica i nomi delle chiavi e non i tipi *per scelta dichiarata*, perche'
   "un tipo sbagliato si vede al primo giro" — questo e' il caso in cui non si
   vede.

Piu' due voci di igiene: la tabella della how-to non elencava
`stream_label_color` ne' l'anello del marker, e il `last_synced_commit` dei due
doc puntava al changelog di v9.0.0 invece che al commit che ha cambiato le loro
sources (per la how-to era gia' alla deriva, scritta prima dei fix del primo
giro).

## Impatto cross-repo

- **PGE-ls**: nessuno. Il preset non tocca sintassi YAML, bounds dei parametri,
  ne' messaggi d'errore.
- **PGE-ui**: c'e' un nuovo flag CLI che la UI puo' esporre nel popover di
  render, accanto a `--plot-envelopes` e `--magnify-at`. Issue aperta li':
  DMGiulioRomano/PGE-ui#152.

## File

- `rendering/envelope_extractor.py` — `ENVELOPE_STYLES`, i pattern,
  `ENVELOPE_STYLE_DEFAULT`, `BW_ENVELOPE_COLOR`
- `rendering/score_visualizer.py` — `PITCH_DIVERGING_BW`, `_envelope_style` (con
  la guardia sulla forma della coppia), lo stile applicato a curve
  (linear/step/per-segmento) e legenda, `_projection_marker_edge`, la colorbar
  compositata
- `rendering/visualizer_config.py` — `bw`, `envelope_styles`,
  `stream_label_color`, `marker_edge`/`markeredgewidth`, `_bw_defaults`
- `cli.py`, `api.py`, `Makefile`, `make/build.mk` — il flag e la variabile
- `docs/how-to/print-score-bw.md` (nuova), `docs/reference/cli.md`, `CHANGELOG.md`
- `tests/rendering/test_bw_preset.py` (nuova, 74 test), `tests/test_main.py`,
  `tests/test_cli_contract.py`, `tests/test_api.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kt1dRucqYBmWVQbsNmR9n