### PR TITLE
feat(log): quanti grani per stream, come lettura passiva a valle (#250)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,37 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Aggiunto
 
+- **Il log dice di nuovo quanti grani ha generato ogni stream** (issue #250).
+  Dopo `Rendering completato in ...` la CLI stampa una riga per stream:
+
+  ```
+    → stream2: 48213 grani (3 voci)
+    → stream3: grani non generati (cache)
+  ```
+
+  Il conteggio non e' mai stato una riga sua: usciva dal `__repr__` di
+  `Stream`, stampato a costruzione da `Generator._create_streams`. Con la
+  generazione lazy (#117) a quel punto i grani non esistono ancora, e il repr
+  dice `grains=lazy` — non un difetto, il prezzo corretto di #117. Il numero
+  torna quindi **a valle**, dove i grani ci sono davvero.
+
+  La lettura e' passiva e non rimette in circolo il lavoro che #117 aveva
+  tolto: `api.collect_grain_counts` legge `voices` solo sugli stream con
+  `generated` True (stesso schema di `export_grain_json`), quindi costa
+  O(voci) e non O(grani), e su chi e' stato saltato dalla cache non tocca
+  `.voices` — leggerla li' rigenererebbe in fase di stampa esattamente i
+  grani risparmiati. Per la stessa ragione non c'e' nessun contatore
+  mantenuto durante `generate_grains()`: sarebbe stato uno stato duplicato
+  rispetto a `voices`, che per design e' l'unica fonte di verita' (#201).
+
+  Il dato non nasce nella CLI ma in `RenderResult.grain_counts`
+  (`stream_id -> StreamGrainCount(grains, voices)`, `None` per gli stream non
+  materializzati): l'API resta senza print e il conteggio e' disponibile
+  anche ai consumer non-CLI. Ogni stream compare nella mappa, cosi' chi
+  stampa non deve tornare a interrogare `generator.streams` per sapere chi
+  manca; `None` significa "saltato dalla cache", non "zero grani", e la CLI
+  lo dice a parole invece di inventare un numero.
+
 - **`--bw`: un preset della partitura leggibile in stampa bianco e nero**
   (issue #248). La MAP e' pensata per lo schermo, e le figure del paper CIM
   2026 hanno un vincolo di leggibilita' in B&W. Il flag (o `BW=true` da Make,

--- a/docs/explanation/costo-rendering.md
+++ b/docs/explanation/costo-rendering.md
@@ -8,7 +8,7 @@ sources:
   - src/pge/core/stream.py
   - utils/bench_cost.py
   - utils/make_test_samples.py
-last_synced_commit: a4dc678
+last_synced_commit: be716c9
 ---
 
 # Costo del rendering — PythonGranularEngine
@@ -107,7 +107,12 @@ default.
 due regimi coincidono entro il rumore — serve a non pagare la generazione quando
 uno `Stream` viene istanziato ma non renderizzato. È il motivo per cui
 `Stream.__repr__` conta da `_voices` invece che dalla property: stampare gli
-stream appena creati, altrimenti, li genererebbe tutti.
+stream appena creati, altrimenti, li genererebbe tutti. Quel `grains=lazy` non
+è però una rinuncia al numero: il conteggio vero torna **a valle del render**,
+dove i grani ci sono già, in `RenderResult.grain_counts` — la mappa che
+`api.collect_grain_counts` riempie leggendo `voices` solo sugli stream con
+`generated` True (issue #250). È la stessa regola vista dall'altro capo: prima
+del render leggere costa una generazione, dopo costa O(voci).
 
 **Cosa non è misurato qui.** L'export della `map` (matplotlib) e gli altri export
 non entrano in questi numeri: sono consumatori della stessa lista di grani, con
@@ -151,6 +156,8 @@ Rilanciare `make bench` prima e dopo è il modo più diretto per accorgersene.
 - [[caching]] — come si evita di ripagare `a` su stream già renderizzati
 - [[cli]] — `--jobs`
 - [[multi-voice]] — ogni voce moltiplica i grani, quindi moltiplica `a`
+- [[use-as-library]] — `RenderResult.grain_counts`, il conteggio letto a valle
+  senza ripagare la generazione
 
 ## Riproduzione
 

--- a/docs/explanation/library-vs-cli.md
+++ b/docs/explanation/library-vs-cli.md
@@ -4,7 +4,7 @@ type: explanation
 status: stable
 tags: [api, cli, architecture, refactor]
 sources: [src/pge/api.py, src/pge/cli.py, src/main.py]
-last_synced_commit: 05e2508
+last_synced_commit: be716c9
 entry_for: [usare PGE come libreria, capire la divisione API/CLI]
 ---
 
@@ -23,8 +23,9 @@ replicavano l'orchestrazione a mano monkey-patchando i globali.
 Dal refactor library/CLI (plans/2026-07-08-001) il sistema ha due strati:
 
 - **`pge.api`** — API programmatica: `load_generator`, `build_renderer`,
-  `collect_cache_orphans`, `render`, `render_file`, `export_*`, con le
-  dataclass `CsoundOptions` (input) e `RenderResult` (output). Contratto:
+  `collect_cache_orphans`, `collect_grain_counts`, `render`, `render_file`,
+  `export_*`, con le dataclass `CsoundOptions` (input), `RenderResult`
+  (output) e `StreamGrainCount` (dentro `RenderResult`). Contratto:
   nessun `print`, nessun `sys.exit`, nessuna lettura di `sys.argv`; errori
   come eccezioni (`EngineError` e sottoclassi, `ValueError`); ogni default
   filesystem è un parametro esplicito (`samples_dir`,
@@ -65,6 +66,12 @@ Divisione delle policy (chi decide cosa):
 - Il GC della cache è una funzione separata (`collect_cache_orphans`)
   perché la CLI deve stamparne l'esito PRIMA del render (ordine stdout);
   `render_file` lo esegue da sé col default `run_cache_gc=True`.
+- Il conteggio dei grani (`collect_grain_counts`, issue #250) è la funzione
+  speculare: separata per lo stesso motivo di ordine, ma sull'altro lato del
+  render, e chiamata da `render` invece che dalla CLI perché il momento non è
+  una policy — leggere `voices` prima del render genererebbe i grani in fase
+  di stampa (generazione lazy, #117). `RenderResult` porta il risultato, alla
+  CLI resta la prosa.
 - `import pge` è economico: i simboli pesanti (ScoreVisualizer →
   matplotlib) sono lazy via `__getattr__` di modulo (PEP 562).
 

--- a/docs/how-to/use-as-library.md
+++ b/docs/how-to/use-as-library.md
@@ -4,7 +4,7 @@ type: how-to
 status: stable
 tags: [api, library, install, render]
 sources: [src/pge/api.py, pyproject.toml]
-last_synced_commit: 05e2508
+last_synced_commit: be716c9
 entry_for: [renderizzare da Python, integrare PGE in un altro progetto]
 ---
 
@@ -66,6 +66,23 @@ passare dalla CLI né monkey-patchare i globali.
 5. Csound: `renderer='csound'` con knob raggruppati in
    `api.CsoundOptions(orc_path=..., ssdir=..., sco_dir=...)`;
    `ssdir=None` eredita `samples_dir`.
+
+6. Quanti grani ha prodotto ogni stream: `result.grain_counts`, una voce per
+   stream nell'ordine di `generator.streams`.
+
+   ```python
+   for stream_id, count in result.grain_counts.items():
+       if count is None:
+           ...            # stream saltato dalla cache: non e' "zero grani"
+       else:
+           print(stream_id, count.grains, count.voices)
+   ```
+
+   È una lettura fatta a render finito su chi era già materializzato, e va
+   letta da lì: chiedere il conteggio a `stream.voices` prima del render
+   innescherebbe la generazione lazy (#117), cioè genererebbe i grani che la
+   cache stava per far risparmiare. Per lo stesso motivo `Stream.__repr__`
+   dice `grains=lazy`.
 
 ## File toccati
 

--- a/src/pge/api.py
+++ b/src/pge/api.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from pge.shared.constants import DEFAULT_OUTPUT_SR
 from pge.rendering.audio_format import DEFAULT_FORMAT, FORMATS
@@ -68,6 +68,18 @@ class SuperColliderOptions:
     osc_dir: Optional[str] = None           # None -> .osc temporanei (--keep-osc off)
 
 
+@dataclass(frozen=True)
+class StreamGrainCount:
+    """Quanti grani ha materializzato uno stream, e su quante voci (#250).
+
+    Non e' uno stato mantenuto da nessuno: e' il risultato di una lettura di
+    `voices` fatta a render finito. `voices` resta l'unica fonte di verita'
+    (#201) e questo Value Object solo la fotografa.
+    """
+    grains: int
+    voices: int
+
+
 @dataclass
 class RenderResult:
     """Esito di un render: tutto cio' che serve alla CLI per i suoi print."""
@@ -78,6 +90,9 @@ class RenderResult:
     jobs: Optional[int] = None         # jobs risolti (renderer.jobs); None per csound
     cache_manifest_path: Optional[str] = None
     gc_removed: List[str] = field(default_factory=list)  # stream orfani rimossi dal GC
+    # Una voce per stream, nell'ordine di generator.streams; None = stream non
+    # materializzato (saltato dalla cache), non "zero grani" (issue #250).
+    grain_counts: Dict[str, Optional[StreamGrainCount]] = field(default_factory=dict)
 
 
 def parameter_bounds(
@@ -338,6 +353,41 @@ def collect_cache_orphans(
     )
 
 
+def collect_grain_counts(
+    generator,
+) -> Dict[str, Optional[StreamGrainCount]]:
+    """Quanti grani ha generato ogni stream: lettura PASSIVA, a valle
+    (issue #250).
+
+    Va chiamata DOPO il rendering, ed e' quello che la rende gratis: legge
+    `voices` solo sugli stream che il render ha gia' materializzato
+    (`generated` True), quindi costa O(voci) e non O(grani). Sugli altri non
+    tocca `.voices`, che e' lazy (#117): leggerla li' rigenererebbe in fase di
+    stampa esattamente i grani che la cache aveva fatto risparmiare -- ed e'
+    il motivo per cui il conteggio non puo' tornare nel `__repr__` di Stream,
+    che `Generator._create_streams` stampa a costruzione.
+
+    Stesso schema di export_grain_json, stesso punto della pipeline. Ogni
+    stream compare nella mappa: `None` per chi non e' materializzato, cosi'
+    chi stampa non deve tornare a interrogare `generator.streams` per sapere
+    chi manca.
+    """
+    counts: Dict[str, Optional[StreamGrainCount]] = {}
+    for stream in generator.streams:
+        # getattr: uno stream duck-typed di un consumer esterno che non
+        # dichiara `generated` va assunto non materializzato -- la direzione
+        # sicura, quella che non innesca niente.
+        if not getattr(stream, 'generated', False):
+            counts[stream.stream_id] = None
+            continue
+        voices = stream.voices
+        counts[stream.stream_id] = StreamGrainCount(
+            grains=sum(len(v) for v in voices),
+            voices=len(voices),
+        )
+    return counts
+
+
 def render(
     generator,
     output_path: str,
@@ -413,6 +463,10 @@ def render(
         jobs=getattr(renderer_obj, 'jobs', None),
         cache_manifest_path=cache_manifest_path,
         gc_removed=gc_removed,
+        # Dopo engine.render: a quel punto i grani degli stream dirty sono
+        # materializzati nel processo padre (anche con jobs > 1: i task del
+        # pool si costruiscono qui), quindi la lettura non genera nulla.
+        grain_counts=collect_grain_counts(generator),
     )
 
 

--- a/src/pge/cli.py
+++ b/src/pge/cli.py
@@ -575,6 +575,20 @@ def main():
         jobs_note = f" (jobs={renderer.jobs})" if renderer_type == 'numpy' else ""
         print(f"\n Rendering completato in {result.elapsed_seconds:.2f}s{jobs_note}")
 
+        # Quanti grani per stream (issue #250). Il numero non puo' tornare nel
+        # `__repr__` di Stream, stampato a costruzione: li' i grani non
+        # esistono ancora (generazione lazy, #117) e leggerli li' genererebbe
+        # tutto in fase di stampa. Qui il render li ha gia' materializzati e
+        # api.render li ha contati; alla CLI resta solo la prosa.
+        for stream_id, count in result.grain_counts.items():
+            if count is None:
+                print(f"  → {stream_id}: grani non generati (cache)")
+            else:
+                grani = "grano" if count.grains == 1 else "grani"
+                voci = "voce" if count.voices == 1 else "voci"
+                print(f"  → {stream_id}: {count.grains} {grani} "
+                      f"({count.voices} {voci})")
+
         print(f"\n Generazione completata! {len(generated)} file generati:")
         for path in generated:
             print(f"    {path}")

--- a/src/pge/core/stream.py
+++ b/src/pge/core/stream.py
@@ -1035,6 +1035,8 @@ class Stream:
         # ogni stream; leggere la property .grains rigenererebbe tutto.
         # Il conteggio viene da _voices: leggerlo dal vecchio campo _grains
         # faceva mentire il repr su ogni stream con le voci iniettate (#201).
+        # Il 'lazy' qui non e' una mancanza: il numero vero lo dice il log a
+        # valle del render, da RenderResult.grain_counts (#250).
         grain_count = (sum(len(v) for v in self._voices)
                        if self.generated else 'lazy')
         return (f"Stream(id={self.stream_id}, onset={self.onset}, "

--- a/tests/main_mocks.py
+++ b/tests/main_mocks.py
@@ -166,3 +166,45 @@ def run_main(mocks, argv_list):
     }):
         with patch.object(sys, 'argv', argv_list):
             mocks['main'].main()
+
+
+class LazyStreamDouble:
+    """Stream finto con la laziness vera (#117): `.voices` esplode se lo
+    stream non e' materializzato.
+
+    Estratto da test_api.py/test_main.py, dove ne esistevano due copie
+    identiche, per la ragione per cui esiste questo modulo: la fixture dei
+    confini sta in un posto solo. Serve ai test di `collect_grain_counts`
+    (#250) e a chiunque debba distinguere uno stream materializzato da uno
+    saltato dalla cache -- un accesso di troppo e' un test rosso, non una
+    lentezza silenziosa in produzione.
+
+    `materialize()` e' il pezzo che permette di misurare il MOMENTO della
+    lettura e non solo il suo esito: uno stream che nasce non materializzato
+    e viene materializzato dal render finto distingue un conteggio fatto
+    dopo `engine.render` da uno fatto prima.
+    """
+
+    def __init__(self, stream_id, voices=None):
+        self.stream_id = stream_id
+        self.generated = voices is not None
+        self._voices = voices
+
+    def materialize(self, voices):
+        """Come fa il renderer: legge i grani e da quel momento `generated`
+        e' True."""
+        self._voices = voices
+        self.generated = True
+
+    @property
+    def voices(self):
+        if not self.generated:
+            raise AssertionError(
+                f"accesso a .voices su {self.stream_id}: innescherebbe "
+                "la generazione lazy (#117)")
+        return self._voices
+
+
+def fake_grains(n):
+    """n grani finti: `collect_grain_counts` ne guarda solo il numero."""
+    return [MagicMock(name=f'grain{i}') for i in range(n)]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -614,6 +614,116 @@ class TestRender:
 
 
 # =============================================================================
+# collect_grain_counts / RenderResult.grain_counts
+# =============================================================================
+
+class TestCollectGrainCounts:
+    """collect_grain_counts: lettura PASSIVA a valle del render (issue #250).
+
+    Il conteggio esce da `voices` -- unica fonte di verita' (#201) -- e solo
+    sugli stream gia' materializzati: leggere `.voices` su uno stream con
+    `generated` falso innescherebbe la generazione lazy (#117), cioe'
+    rigenererebbe in fase di stampa proprio i grani che la cache ha appena
+    fatto risparmiare.
+    """
+
+    class _Stream:
+        """Stream finto con la laziness vera: `.voices` esplode se lo stream
+        non e' materializzato, cosi' un accesso di troppo e' un test rosso e
+        non una lentezza silenziosa."""
+
+        def __init__(self, stream_id, voices=None):
+            self.stream_id = stream_id
+            self.generated = voices is not None
+            self._voices = voices
+
+        @property
+        def voices(self):
+            if not self.generated:
+                raise AssertionError(
+                    f"accesso a .voices su {self.stream_id}: innescherebbe "
+                    "la generazione lazy (#117)")
+            return self._voices
+
+    def _grains(self, n):
+        return [MagicMock(name=f'grain{i}') for i in range(n)]
+
+    def test_stream_materializzato_conta_grani_e_voci(self, api_mocks):
+        gen = api_mocks['generator_instance']
+        gen.streams = [self._Stream(
+            's1', [self._grains(10), self._grains(7), self._grains(3)])]
+
+        counts = api_mocks['api'].collect_grain_counts(gen)
+
+        assert counts['s1'].grains == 20
+        assert counts['s1'].voices == 3
+
+    def test_stream_non_materializzato_vale_none(self, api_mocks):
+        """Cache-clean: nessun numero inventato, e nessuna lettura di
+        .voices (la _Stream finta solleverebbe)."""
+        gen = api_mocks['generator_instance']
+        gen.streams = [self._Stream('s_clean')]
+
+        counts = api_mocks['api'].collect_grain_counts(gen)
+
+        assert counts == {'s_clean': None}
+
+    def test_ogni_stream_ha_una_voce_nella_mappa(self, api_mocks):
+        """Anche i cache-clean compaiono: la CLI stampa da questa mappa e non
+        deve tornare a iterare generator.streams per sapere chi manca."""
+        gen = api_mocks['generator_instance']
+        gen.streams = [
+            self._Stream('s1', [self._grains(2)]),
+            self._Stream('s2'),
+            self._Stream('s3', [self._grains(1), self._grains(1)]),
+        ]
+
+        counts = api_mocks['api'].collect_grain_counts(gen)
+
+        assert list(counts) == ['s1', 's2', 's3']   # ordine di generator.streams
+        assert counts['s1'].grains == 2
+        assert counts['s2'] is None
+        assert counts['s3'].voices == 2
+
+    def test_stream_senza_attributo_generated_vale_none(self, api_mocks):
+        """Stream duck-typed di un consumer esterno: si assume non
+        materializzato (direzione sicura, nessun accesso a .voices)."""
+        class Foreign:
+            stream_id = 'esterno'
+
+            @property
+            def voices(self):
+                raise AssertionError('non deve essere letto')
+
+        gen = api_mocks['generator_instance']
+        gen.streams = [Foreign()]
+
+        assert api_mocks['api'].collect_grain_counts(gen) == {'esterno': None}
+
+    def test_render_popola_grain_counts(self, api_mocks):
+        gen = api_mocks['generator_instance']
+        gen.ftable_manager.get_all_tables.return_value = {}
+        gen.streams = [
+            self._Stream('s1', [self._grains(4), self._grains(4)]),
+            self._Stream('s2'),
+        ]
+
+        result = api_mocks['api'].render(gen, 'out.aif', renderer='numpy')
+
+        assert result.grain_counts['s1'].grains == 8
+        assert result.grain_counts['s1'].voices == 2
+        assert result.grain_counts['s2'] is None
+
+    def test_render_result_default_e_mappa_vuota(self, api_mocks):
+        """Chi costruisce un RenderResult a mano (CLI test, consumer) non
+        deve passare il campo."""
+        result = api_mocks['api'].RenderResult(
+            audio_paths=[], elapsed_seconds=0.0,
+            renderer_type='numpy', per_stream=False)
+        assert result.grain_counts == {}
+
+
+# =============================================================================
 # load_generator / render_file
 # =============================================================================
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -19,7 +19,9 @@ import types
 import pytest
 from unittest.mock import MagicMock, patch
 
-from tests.main_mocks import build_mock_modules
+from tests.main_mocks import (
+    build_mock_modules, LazyStreamDouble, fake_grains,
+)
 
 
 @pytest.fixture
@@ -627,26 +629,10 @@ class TestCollectGrainCounts:
     fatto risparmiare.
     """
 
-    class _Stream:
-        """Stream finto con la laziness vera: `.voices` esplode se lo stream
-        non e' materializzato, cosi' un accesso di troppo e' un test rosso e
-        non una lentezza silenziosa."""
-
-        def __init__(self, stream_id, voices=None):
-            self.stream_id = stream_id
-            self.generated = voices is not None
-            self._voices = voices
-
-        @property
-        def voices(self):
-            if not self.generated:
-                raise AssertionError(
-                    f"accesso a .voices su {self.stream_id}: innescherebbe "
-                    "la generazione lazy (#117)")
-            return self._voices
+    _Stream = LazyStreamDouble
 
     def _grains(self, n):
-        return [MagicMock(name=f'grain{i}') for i in range(n)]
+        return fake_grains(n)
 
     def test_stream_materializzato_conta_grani_e_voci(self, api_mocks):
         gen = api_mocks['generator_instance']
@@ -713,6 +699,36 @@ class TestCollectGrainCounts:
         assert result.grain_counts['s1'].grains == 8
         assert result.grain_counts['s1'].voices == 2
         assert result.grain_counts['s2'] is None
+
+    def test_render_conta_dopo_engine_render_non_prima(self, api_mocks):
+        """Il MOMENTO della lettura e' il vincolo di #250, non un dettaglio.
+
+        Qui gli stream nascono non materializzati ed e' `engine.render` a
+        materializzarne uno: se `collect_grain_counts` risalisse sopra la
+        chiamata al render, la mappa direbbe `None` per tutti -- e in
+        produzione quel `None` sarebbe il caso buono, perche' sugli stream
+        veri leggere `.voices` prima del render li genererebbe in fase di
+        stampa, che e' esattamente il lavoro che #117 aveva tolto. Gli altri
+        test della classe usano stream gia' materializzati alla costruzione,
+        quindi non distinguono il prima dal dopo.
+        """
+        gen = api_mocks['generator_instance']
+        gen.ftable_manager.get_all_tables.return_value = {}
+        dirty = self._Stream('s_dirty')
+        clean = self._Stream('s_clean')   # saltato dalla cache: nessuno lo tocca
+        gen.streams = [dirty, clean]
+
+        def _render_materializza(*args, **kwargs):
+            dirty.materialize([self._grains(3), self._grains(2)])
+            return ['/out/test.aif']
+
+        api_mocks['engine_instance'].render.side_effect = _render_materializza
+
+        result = api_mocks['api'].render(gen, 'out.aif', renderer='numpy')
+
+        assert result.grain_counts['s_dirty'].grains == 5
+        assert result.grain_counts['s_dirty'].voices == 2
+        assert result.grain_counts['s_clean'] is None
 
     def test_render_result_default_e_mappa_vuota(self, api_mocks):
         """Chi costruisce un RenderResult a mano (CLI test, consumer) non

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -28,7 +28,9 @@ from unittest.mock import MagicMock, patch, call
 # library/CLI). Ogni test ottiene mock freschi per isolamento completo.
 # =============================================================================
 
-from tests.main_mocks import mocks, run_main  # noqa: F401  (fixture pytest)
+from tests.main_mocks import (  # noqa: F401  (`mocks` e' una fixture pytest)
+    mocks, run_main, LazyStreamDouble, fake_grains,
+)
 
 
 # =============================================================================
@@ -1356,29 +1358,11 @@ class TestGrainCountLog:
     `RenderResult.grain_counts`.
     """
 
-    class _Stream:
-        """Stream finto con la laziness vera: `.voices` esplode se lo stream
-        non e' materializzato, cosi' una lettura di troppo e' un test rosso e
-        non una lentezza silenziosa in produzione."""
-
-        def __init__(self, stream_id, voices=None):
-            self.stream_id = stream_id
-            self.generated = voices is not None
-            self._voices = voices
-
-        @property
-        def voices(self):
-            if not self.generated:
-                raise AssertionError(
-                    f"accesso a .voices su {self.stream_id}: innescherebbe "
-                    "la generazione lazy (#117)")
-            return self._voices
-
     def _stream(self, stream_id, voices=None):
-        return self._Stream(stream_id, voices)
+        return LazyStreamDouble(stream_id, voices)
 
     def _grains(self, n):
-        return [MagicMock(name=f'g{i}') for i in range(n)]
+        return fake_grains(n)
 
     def _run(self, mocks, streams, argv=None):
         mocks['generator_instance'].streams = streams

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1343,6 +1343,90 @@ class TestGrainJsonOnlyGeneratedStreams:
 
 
 # =============================================================================
+# TEST LOG: quanti grani ha generato ogni stream (issue #250)
+# =============================================================================
+
+class TestGrainCountLog:
+    """
+    Il conteggio dei grani era una parola dentro il `__repr__` di Stream,
+    stampato a costruzione; con la generazione lazy (#117) il repr dice
+    `grains=lazy` perche' i grani a quel punto non esistono, ed e' giusto
+    cosi'. La riga torna a valle del render, dove i grani sono gia'
+    materializzati: la CLI non la calcola, la legge da
+    `RenderResult.grain_counts`.
+    """
+
+    class _Stream:
+        """Stream finto con la laziness vera: `.voices` esplode se lo stream
+        non e' materializzato, cosi' una lettura di troppo e' un test rosso e
+        non una lentezza silenziosa in produzione."""
+
+        def __init__(self, stream_id, voices=None):
+            self.stream_id = stream_id
+            self.generated = voices is not None
+            self._voices = voices
+
+        @property
+        def voices(self):
+            if not self.generated:
+                raise AssertionError(
+                    f"accesso a .voices su {self.stream_id}: innescherebbe "
+                    "la generazione lazy (#117)")
+            return self._voices
+
+    def _stream(self, stream_id, voices=None):
+        return self._Stream(stream_id, voices)
+
+    def _grains(self, n):
+        return [MagicMock(name=f'g{i}') for i in range(n)]
+
+    def _run(self, mocks, streams, argv=None):
+        mocks['generator_instance'].streams = streams
+        run_main(mocks, argv or ['main.py', 'in.yml', '/out/test.aif'])
+
+    def test_riga_con_grani_e_voci(self, mocks, capsys):
+        self._run(mocks, [self._stream(
+            'stream2', [self._grains(3), self._grains(2)])])
+        assert '  → stream2: 5 grani (2 voci)' in capsys.readouterr().out
+
+    def test_singolare(self, mocks, capsys):
+        """Prosa italiana: un grano solo non e' '1 grani'."""
+        self._run(mocks, [self._stream('s1', [self._grains(1)])])
+        assert '  → s1: 1 grano (1 voce)' in capsys.readouterr().out
+
+    def test_stream_cache_clean_senza_numero(self, mocks, capsys):
+        """Saltato dalla cache: nessun numero inventato, e soprattutto
+        nessuna lettura di .voices che lo rigenererebbe (#117)."""
+        self._run(mocks, [self._stream('s_clean')])
+        out = capsys.readouterr().out
+        assert '  → s_clean: grani non generati (cache)' in out
+
+    def test_ogni_stream_ha_la_sua_riga(self, mocks, capsys):
+        self._run(mocks, [
+            self._stream('s1', [self._grains(4)]),
+            self._stream('s2'),
+            self._stream('s3', [self._grains(1), self._grains(1)]),
+        ])
+        out = capsys.readouterr().out
+        assert '  → s1: 4 grani (1 voce)' in out
+        assert '  → s2: grani non generati (cache)' in out
+        assert '  → s3: 2 grani (2 voci)' in out
+
+    def test_dopo_rendering_completato_e_prima_dei_file(self, mocks, capsys):
+        """Le righe appartengono al render, non alla lista dei file."""
+        self._run(mocks, [self._stream('s1', [self._grains(2)])])
+        out = capsys.readouterr().out
+        assert (out.index('Rendering completato')
+                < out.index('  → s1: 2 grani')
+                < out.index('Generazione completata'))
+
+    def test_nessuna_riga_senza_stream(self, mocks, capsys):
+        self._run(mocks, [])
+        out = capsys.readouterr().out
+        assert 'grani' not in out
+
+
+# =============================================================================
 # TEST FLAG --magnify / --magnify-at (lente di ingrandimento della partitura)
 # =============================================================================
 


### PR DESCRIPTION
Chiude #250.

## Cosa si vede

Dopo `Rendering completato in ...`, una riga per stream:

```
 Rendering completato in 0.37s (jobs=3)
  → stream1: 138 grani (1 voce)
  → stream2: 110 grani (1 voce)
```

e alla seconda passata, con tutto clean in cache:

```
 Rendering completato in 0.00s (jobs=3)
  → stream1: grani non generati (cache)
  → stream2: grani non generati (cache)
```

(output reale di `PGE_test.yml`, `--renderer numpy --per-stream --cache`,
prima e seconda passata: lo `0.00s` della seconda è la prova che la riga non
ha rigenerato niente.)

## Design

La issue lasciava aperte due collocazioni; scelta la seconda — il dato nasce
in `RenderResult`, la CLI stampa e basta.

- **`api.StreamGrainCount`** — Value Object frozen `(grains, voices)`. Non è
  stato mantenuto da nessuno: è la fotografia di una lettura di `voices` fatta
  a render finito.
- **`RenderResult.grain_counts: Dict[str, Optional[StreamGrainCount]]`** — una
  voce per stream, nell'ordine di `generator.streams`. `None` = stream non
  materializzato (saltato dalla cache), **non** "zero grani".
- **`api.collect_grain_counts(generator)`** — accanto a `collect_cache_orphans`,
  chiamata da `render()` dopo `engine.render`.
- **`cli.py`** — solo la prosa, con l'accordo singolare/plurale (`1 grano
  (1 voce)`).

## Il vincolo della issue: costo zero

La lettura è passiva e non rimette in circolo il lavoro che #117 aveva tolto:

- `voices` si legge **solo** sugli stream con `generated` True (stesso schema
  di `api.export_grain_json`), quindi costa O(voci) e non O(grani);
- sugli stream saltati dalla cache `.voices` non viene toccata: leggerla lì
  rigenererebbe in fase di stampa esattamente i grani che la cache aveva fatto
  risparmiare;
- nessun contatore mantenuto durante `generate_grains()` — sarebbe stato uno
  stato duplicato rispetto a `voices`, unica fonte di verità (#201).

Il momento della lettura è corretto anche con `jobs > 1`: i grani degli stream
dirty si materializzano nel processo padre (i task del pool si costruiscono
lì), quindi il conteggio vede quello che il render ha davvero prodotto.

Ogni stream compare nella mappa, cache-clean inclusi: altrimenti chi stampa
dovrebbe tornare a interrogare `generator.streams` per sapere chi manca, e la
mappa non sarebbe autosufficiente.

Uno stream duck-typed che non dichiara `generated` è assunto non
materializzato — la direzione sicura, quella che non innesca niente.

## Test

TDD, rosso → verde: 12 test nuovi, tutti falliti prima dell'implementazione.

- `tests/test_api.py::TestCollectGrainCounts` — multi-voce, cache-clean → `None`,
  ogni stream nella mappa e nell'ordine giusto, stream senza `generated`,
  popolamento da `render()`, default `{}` per chi costruisce un `RenderResult`
  a mano.
- `tests/test_main.py::TestGrainCountLog` — le righe stampate, il singolare,
  la posizione (dopo `Rendering completato`, prima della lista dei file),
  nessuna riga senza stream.

In entrambe le suite lo stream finto ha la **laziness vera**: `.voices` solleva
`AssertionError` se lo stream non è materializzato. Un accesso di troppo è un
test rosso, non una lentezza silenziosa in produzione.

**Aggiunto in review** (13° test): quei finti nascono già materializzati,
quindi pinnavano l'**esito** della lettura ma non il suo **momento** — e il
momento è il vincolo della issue. Misurato: spostando `collect_grain_counts`
sopra `engine.render` la suite restava interamente verde.
`test_render_conta_dopo_engine_render_non_prima` chiude il buco — gli stream
nascono non materializzati ed è il render finto a materializzarne uno
(`side_effect` su `engine.render`), così una lettura anticipata dà `None` per
tutti ed è rossa. Il doppio finto, che viveva in due copie identiche, è passato
in `tests/main_mocks.py` come `LazyStreamDouble` (+ `fake_grains`), con il
`materialize()` che serve a misurare il momento.

`make tests`: 6197 passed, 10 skipped.

## Impatto cross-repo

Nessuno — ma non per la ragione scritta nella issue. `PGE-ls` non invoca
affatto la CLI; **`PGE-ui` invece il log lo parsa davvero**:
`render_pipeline.parse_render_line` trasforma lo stdout di `src/main.py` in
eventi NDJSON. La conclusione regge lo stesso, per verifica e non per premessa:
le righe nuove non matchano nessuno dei due regex del bridge — `_RE_CACHE_LINE`
vuole il prefisso `[CACHE]`, `_RE_STEM_PATH` una riga che finisce in
`.aif|.aiff|.wav|.flac` — quindi finiscono nel log dell'editor come testo e
basta, senza inventare `stream-start`/`stream-done`. Nessuna issue collegata,
ma la prossima modifica alla superficie stdout va confrontata con quel parser.

Non cambiano YAML, schema, errori, formati né flag: cambia solo il testo su
stdout, e `RenderResult` guadagna un campo con default.

Nessun impatto sugli esempi del paper CIM 2026: `render_example.py` non
dipende dal log né da `RenderResult`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZExrnRVk8cty2UpAh17Tv