### PR TITLE
fix(cli): _build_renderer non ingoia piu' i kwarg che non conosce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,44 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Corretto
 
+- **`cli._build_renderer` ingoiava in silenzio ogni kwarg sconosciuto**
+  (issue #252). La funzione raccoglieva tutto in `**kwargs` e poi pescava
+  una chiave per volta con `.get()`: non c'era nessun punto in cui un nome
+  fuori elenco venisse notato. Non un `TypeError`, non un warning — un
+  no-op, con il default al posto del valore che il chiamante credeva di
+  aver passato.
+
+  Non e' teorico: e' cosi' che e' nata la #243. `utils/bench_cost.py`
+  passava `ssdir=<tmpdir>` (e `sfdir=<tmpdir>`) a un build `numpy`, dove
+  entrambi vengono letti solo dentro il ramo Csound. Il `SampleRegistry`
+  ricadeva sul default storico `./refs/` e lo script moriva in
+  `SampleNotFoundError` senza che niente nominasse la causa. Nessuno dei
+  due era visibile alla review, e nessuno dei due poteva rompere un test —
+  perche' non succedeva niente. La PR #247 aveva chiuso il caso concreto
+  dal lato del chiamante (`bench_cost.py` passa da `api.build_renderer`,
+  keyword-only), lasciando il difetto per `main.py` e per ogni chiamante
+  futuro.
+
+  L'elenco dei kwargs accettati e' finito e noto, quindi ora sta nella
+  firma: keyword-only, con i default storici invariati. Il controllo lo fa
+  Python. Due dettagli che la firma non dice da sola:
+
+  - `ssdir`/`sfdir` (come `orc_path`, `incdir`, `message_level`, `sco_dir`)
+    restano accettati su qualsiasi backend e ignorati fuori da Csound: la
+    CLI li passa sempre, quindi rifiutarli romperebbe ogni render NumPy.
+    Il docstring lo dice ad alta voce — non e' un refuso da correggere in
+    silenzio, e' un fraintendimento: la directory dei sample valida per
+    tutti i backend e' `samples_dir`, e su Csound e' anche il fallback di
+    `ssdir`;
+  - `use_cache` senza `yaml_basename` era `kwargs['yaml_basename']`, cioe'
+    un `KeyError` nudo. Ora e' un `ValueError` che nomina la chiave mancante
+    e il path del manifest che serviva a comporre.
+
+  Nessun cambiamento alla superficie pubblica: flag, YAML, errori utente e
+  formati restano quelli. `_build_renderer` e' un adapter interno, e
+  `api.build_renderer` — l'API che PGE-ui e i consumer programmatici usano —
+  aveva gia' la firma esplicita.
+
 - **`--log-dir` spostava solo meta' dei log** (issue #251). Il flag era
   parsato correttamente e finiva al renderer, ma i due logger configurati
   prima del render — clip ed errori engine — avevano `'./logs'` scritto a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,9 +85,10 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   firma: keyword-only, con i default storici invariati. Il controllo lo fa
   Python. Due dettagli che la firma non dice da sola:
 
-  - `ssdir`/`sfdir` (come `orc_path`, `incdir`, `message_level`, `sco_dir`)
-    restano accettati su qualsiasi backend e ignorati fuori da Csound: la
-    CLI li passa sempre, quindi rifiutarli romperebbe ogni render NumPy.
+  - `ssdir`/`sfdir` (come `orc_path`, `incdir`, `log_dir`, `message_level`,
+    `sco_dir`) restano accettati su qualsiasi backend e ignorati fuori da
+    Csound: la CLI li passa sempre, quindi rifiutarli romperebbe ogni
+    render NumPy.
     Il docstring lo dice ad alta voce — non e' un refuso da correggere in
     silenzio, e' un fraintendimento: la directory dei sample valida per
     tutti i backend e' `samples_dir`, e su Csound e' anche il fallback di

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -93,11 +93,13 @@ default al posto del valore che credeva di aver passato — è così che è nata
 senza che niente nominasse la causa). L'elenco dei kwargs accettati è finito e
 noto, quindi lo verifica Python.
 
-`ssdir`, `sfdir`, `orc_path`, `incdir`, `message_level` e `sco_dir` restano
-accettati su qualsiasi backend e ignorati fuori da Csound — la CLI li passa
-sempre, quindi rifiutarli romperebbe ogni render NumPy. La directory dei sample
-valida per tutti i backend è `samples_dir`; su Csound è anche il fallback di
-`ssdir`.
+`ssdir`, `sfdir`, `orc_path`, `incdir`, `log_dir`, `message_level` e `sco_dir`
+restano accettati su qualsiasi backend e ignorati fuori da Csound — la CLI li
+passa sempre, quindi rifiutarli romperebbe ogni render NumPy
+(`tests/test_cli_build_renderer_signature.py` lo esercita su entrambi i backend
+non-Csound, e rilegge il sito di chiamata per il *perché*: è lì che quei nomi
+sono passati incondizionatamente). La directory dei sample valida per tutti i
+backend è `samples_dir`; su Csound è anche il fallback di `ssdir`.
 
 Caching incrementale è componente separato, vedi [[caching]].
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -5,8 +5,9 @@ status: stable
 tags: [architecture, rendering, ocp]
 sources:
   - src/pge/rendering/
+  - src/pge/cli.py
   - src/main.py
-last_synced_commit: 1aba65c
+last_synced_commit: 7387d73
 ---
 
 # Architettura Renderer
@@ -73,11 +74,30 @@ class MixRenderMode(RenderMode):
 **main.py** è agnostico — un solo punto di factory:
 
 ```python
-renderer = _build_renderer(renderer_type, generator, **kwargs)
+renderer = _build_renderer(renderer_type, generator,
+                           output_sr=..., jobs=..., samples_dir=...,
+                           use_cache=..., cache_dir=..., yaml_basename=...,
+                           orc_path=..., ssdir=..., sfdir=...,   # Csound
+                           sc_synthdef_source=..., osc_dir=...)  # SuperCollider
 engine = RenderingEngine(renderer)
 mode = StemsRenderMode() if per_stream else MixRenderMode()
 generated = engine.render(streams=generator.streams, output_path=output_file, mode=mode)
 ```
+
+`_build_renderer` è un adapter CLI → API, e la sua firma è **esplicita e
+keyword-only** (issue #252). Con `**kwargs` + `.get()` un nome fuori elenco non
+era né un errore né un warning: era un no-op, e chi lo aveva scritto otteneva il
+default al posto del valore che credeva di aver passato — è così che è nata la
+#243 (`ssdir=` su un build `numpy`, letto solo nel ramo Csound: il
+`SampleRegistry` ricadeva su `./refs/` e il run moriva in `SampleNotFoundError`
+senza che niente nominasse la causa). L'elenco dei kwargs accettati è finito e
+noto, quindi lo verifica Python.
+
+`ssdir`, `sfdir`, `orc_path`, `incdir`, `message_level` e `sco_dir` restano
+accettati su qualsiasi backend e ignorati fuori da Csound — la CLI li passa
+sempre, quindi rifiutarli romperebbe ogni render NumPy. La directory dei sample
+valida per tutti i backend è `samples_dir`; su Csound è anche il fallback di
+`ssdir`.
 
 Caching incrementale è componente separato, vedi [[caching]].
 
@@ -171,6 +191,10 @@ Sequenza e invarianti:
 - L'elenco dei tipi validi vive in `RendererFactory.available_types()`, ed è
   quello che i messaggi d'errore e la CLI interrogano: un backend nuovo non
   richiede di aggiornare nessuna lista scritta a mano
+- I flag CLI di un backend nuovo vanno **dichiarati nella firma** di
+  `cli._build_renderer`, non solo letti: un nome non dichiarato è un `TypeError`
+  al primo render, non un silenzio (`tests/test_cli_build_renderer_signature.py`
+  confronta la firma col sito di chiamata dentro `main()`)
 
 ### Copertura test
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -7,7 +7,7 @@ sources:
   - src/pge/rendering/
   - src/pge/cli.py
   - src/main.py
-last_synced_commit: 7387d73
+last_synced_commit: 8e21c03
 ---
 
 # Architettura Renderer

--- a/docs/how-to/add-renderer.md
+++ b/docs/how-to/add-renderer.md
@@ -9,7 +9,7 @@ sources:
   - src/pge/rendering/supercollider_renderer.py
   - src/pge/api.py
   - src/pge/cli.py
-last_synced_commit: 7387d73
+last_synced_commit: 8e21c03
 entry_for: [add-renderer]
 ---
 

--- a/docs/how-to/add-renderer.md
+++ b/docs/how-to/add-renderer.md
@@ -8,7 +8,8 @@ sources:
   - src/pge/rendering/audio_renderer.py
   - src/pge/rendering/supercollider_renderer.py
   - src/pge/api.py
-last_synced_commit: 8c896d8
+  - src/pge/cli.py
+last_synced_commit: 7387d73
 entry_for: [add-renderer]
 ---
 
@@ -34,7 +35,7 @@ L'ultimo backend aggiunto è SuperCollider (issue #228): è l'esempio lavorato d
 3. Implementa `render_single_stream(stream, output_path)` (onset **relativi**, STEMS) e `render_merged_streams(streams, output_path)` (onset **assoluti**, MIX). `render_streams()` è concreto nell'ABC: fai override solo se hai un modo migliore del loop
 4. Registra in `src/pge/rendering/renderer_factory.py`: aggiungi il nome a `_VALID_TYPES` e il ramo di costruzione in `create()`. `available_types()` è l'unico elenco dei tipi validi — messaggi d'errore e CLI lo chiedono lì
 5. Aggiungi il ramo in `api.build_renderer()`, e una dataclass di opzioni accanto a `CsoundOptions` / `SuperColliderOptions` se il backend ha configurazione propria
-6. Mappa i flag CLI in `cli._build_renderer` e aggiorna la usage string (il golden `tests/test_cli_contract.py` la difende: va aggiornato di proposito)
+6. Mappa i flag CLI in `cli._build_renderer`: i nomi vanno **dichiarati nella firma** (keyword-only, issue #252), non solo letti nel corpo — uno non dichiarato è un `TypeError` al primo render invece di un no-op silenzioso, e `tests/test_cli_build_renderer_signature.py` confronta la firma col sito di chiamata dentro `main()`. Aggiorna anche la usage string (il golden `tests/test_cli_contract.py` la difende: va aggiornato di proposito)
 7. `make/build.mk` non va toccato se il backend non ha bisogno di flag propri: il ramo generico è `ifneq ($(RENDERER), csound)`
 8. Aggiungi test unit + integrazione + e2e per il nuovo renderer
 
@@ -45,7 +46,7 @@ L'ultimo backend aggiunto è SuperCollider (issue #228): è l'esempio lavorato d
 | `src/pge/rendering/<nome>_renderer.py` | nuovo file |
 | `src/pge/rendering/renderer_factory.py` | `_VALID_TYPES` + ramo in `create()` |
 | `src/pge/api.py` | ramo in `build_renderer` + dataclass opzioni |
-| `src/pge/cli.py` | parsing flag + usage string |
+| `src/pge/cli.py` | parsing flag + firma di `_build_renderer` + usage string |
 | `docs/reference/cli.md` · `docs/reference/errors.md` | flag e nuovi errori |
 | `tests/rendering/test_<nome>_renderer.py` | nuovi test |
 | `tests/test_cli_contract.py` | golden della usage string |

--- a/src/pge/cli.py
+++ b/src/pge/cli.py
@@ -79,9 +79,10 @@ def _build_renderer(
     kwargs accettati e' finito e noto, quindi il controllo lo fa Python.
 
     **`ssdir` e `sfdir` sono opzioni Csound**, come `orc_path`, `incdir`,
-    `message_level` e `sco_dir`: su un build `numpy` o `supercollider`
-    vengono accettate e ignorate. Non e' un refuso da correggere in silenzio
-    -- il nome esiste -- ma un fraintendimento: la directory dei sample per
+    `log_dir`, `message_level` e `sco_dir`: su un build `numpy` o
+    `supercollider` vengono accettate e ignorate. Non e' un refuso da
+    correggere in silenzio -- il nome esiste -- ma un fraintendimento:
+    la directory dei sample per
     tutti i backend e' `samples_dir`, e su Csound e' anche il fallback di
     `ssdir` (la precedenza la risolve l'API).
 
@@ -575,7 +576,9 @@ def main():
                 osc_dir = sys.argv[idx + 1]
 
     # --format aiff|wav|flac (default: aiff)
-    from pge.rendering.audio_format import FORMATS, DEFAULT_FORMAT
+    # DEFAULT_FORMAT e' gia' a livello di modulo: e' il default della
+    # firma di _build_renderer, valutato all'import.
+    from pge.rendering.audio_format import FORMATS
     audio_format = DEFAULT_FORMAT
     if '--format' in sys.argv:
         idx = sys.argv.index('--format')

--- a/src/pge/cli.py
+++ b/src/pge/cli.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import traceback
+from typing import Optional, Union
 
 from pge.shared.logger import (
     configure_clip_logger, get_clip_log_path,
@@ -12,6 +13,10 @@ from pge.shared.logger import (
 )
 from pge.shared.exceptions import EngineError
 from pge.shared.constants import DEFAULT_OUTPUT_SR
+# Import non lazy: e' il default di _build_renderer, valutato all'import.
+# Modulo senza dipendenze (una dataclass e un dict), e api.py lo importa
+# gia' a livello di modulo -- non aggiunge niente al costo di `import pge.cli`.
+from pge.rendering.audio_format import DEFAULT_FORMAT
 from pge.engine.generator import Generator
 from pge.rendering.score_visualizer import ScoreVisualizer, PLOT_ENVELOPE_KEYS
 
@@ -28,7 +33,34 @@ def _handle_engine_error(err: EngineError) -> None:
     logger.error("%s\n%s", err, traceback.format_exc())
 
 
-def _build_renderer(renderer_type: str, generator, **kwargs):
+def _build_renderer(
+    renderer_type: str,
+    generator,
+    *,
+    # Comuni a tutti i backend
+    output_sr: int = DEFAULT_OUTPUT_SR,
+    jobs: Union[int, str] = 'auto',
+    audio_format=DEFAULT_FORMAT,
+    samples_dir: Optional[str] = None,
+    # Cache incrementale (policy CLI: un manifest per progetto)
+    use_cache: bool = False,
+    cache_dir: str = 'cache',
+    yaml_basename: Optional[str] = None,
+    # Csound
+    orc_path: str = 'csound/main.orc',
+    incdir: str = 'src',
+    ssdir: Optional[str] = None,
+    sfdir: str = 'output',
+    log_dir: str = 'logs',
+    message_level: int = 134,
+    sco_dir: Optional[str] = None,
+    # SuperCollider
+    sc_synthdef_source: Optional[str] = None,
+    sc_synthdef_dir: Optional[str] = None,
+    sc_block_size: Optional[int] = None,
+    sc_max_nodes: Optional[int] = None,
+    osc_dir: Optional[str] = None,
+):
     """
     Crea il renderer appropriato in base al tipo, delegando ad api.build_renderer.
 
@@ -37,28 +69,58 @@ def _build_renderer(renderer_type: str, generator, **kwargs):
     firma keyword-only dell'API e conserva qui il print `[CACHE] Manifest:`
     (i print sono policy CLI, l'API non stampa).
 
+    La firma e' esplicita e keyword-only (issue #252). Con `**kwargs` +
+    `.get()` un nome fuori elenco non era ne' un errore ne' un warning: era
+    un no-op, e chi lo aveva scritto otteneva il default al posto del valore
+    che credeva di aver passato. E' cosi' che e' nata la #243
+    (`ssdir=<tmpdir>` su un build `numpy`, letto solo nel ramo Csound: il
+    `SampleRegistry` ricadeva su `./refs/` e lo script moriva in
+    `SampleNotFoundError` senza che niente nominasse la causa). L'elenco dei
+    kwargs accettati e' finito e noto, quindi il controllo lo fa Python.
+
+    **`ssdir` e `sfdir` sono opzioni Csound**, come `orc_path`, `incdir`,
+    `message_level` e `sco_dir`: su un build `numpy` o `supercollider`
+    vengono accettate e ignorate. Non e' un refuso da correggere in silenzio
+    -- il nome esiste -- ma un fraintendimento: la directory dei sample per
+    tutti i backend e' `samples_dir`, e su Csound e' anche il fallback di
+    `ssdir` (la precedenza la risolve l'API).
+
     Args:
         renderer_type: 'csound', 'numpy' o 'supercollider'
         generator: istanza di Generator con streams gia' creati
-        **kwargs: argomenti specifici per ogni renderer
+        output_sr: sample rate di render
+        jobs: worker del renderer NumPy ('auto' = policy CLI); ignorato altrove
+        audio_format: AudioFormat di output
+        samples_dir: directory dei sample; None -> default storico ('refs')
+        use_cache: attiva la cache incrementale per stream
+        cache_dir: directory del manifest ({cache_dir}/{yaml_basename}.json)
+        yaml_basename: basename del progetto; obbligatorio con use_cache
+        orc_path, incdir, ssdir, sfdir, log_dir, message_level, sco_dir:
+            opzioni Csound
+        sc_synthdef_source, sc_synthdef_dir, sc_block_size, sc_max_nodes,
+            osc_dir: opzioni SuperCollider
 
     Returns:
         Istanza di AudioRenderer configurata
 
     Raises:
+        TypeError: se viene passato un kwarg che non e' in questo elenco
+        ValueError: se use_cache e' attivo senza yaml_basename
         InvalidRendererError: se renderer_type non e' supportato
     """
-    from pge.rendering.audio_format import DEFAULT_FORMAT
-
     # Il print del manifest avveniva dentro i rami numpy/csound: per un tipo
     # ignoto l'errore arrivava senza print. Parita' preservata col guard, che
     # ora chiede l'elenco all'API invece di tenerne una copia -- e' cosi' che
     # un backend nuovo eredita l'annuncio del manifest.
     cache_manifest_path = None
-    if renderer_type in api.renderer_types() and kwargs.get('use_cache'):
+    if renderer_type in api.renderer_types() and use_cache:
         import os as _os
-        yaml_basename = kwargs['yaml_basename']
-        cache_dir = kwargs.get('cache_dir', 'cache')
+        if yaml_basename is None:
+            # Prima era `kwargs['yaml_basename']`, cioe' un KeyError nudo che
+            # non diceva a chi chiamava che cosa mancava.
+            raise ValueError(
+                "use_cache richiede yaml_basename: il manifest e' "
+                f"{cache_dir}/<yaml_basename>.json")
         # Un manifest per progetto, come sempre: la separazione fra backend
         # sta nel fingerprint (StreamCacheManager.compute_fingerprint), che
         # e' il livello a cui vive il problema -- il manifest resta uno, il
@@ -70,15 +132,15 @@ def _build_renderer(renderer_type: str, generator, **kwargs):
     csound_options = None
     if renderer_type == 'csound':
         csound_options = api.CsoundOptions(
-            orc_path=kwargs.get('orc_path', 'csound/main.orc'),
-            incdir=kwargs.get('incdir', 'src'),
+            orc_path=orc_path,
+            incdir=incdir,
             # None (nessun --ssdir): la precedenza la risolve l'API,
             # che ricade su samples_dir e poi sul default storico 'refs'.
-            ssdir=kwargs.get('ssdir'),
-            sfdir=kwargs.get('sfdir', 'output'),
-            log_dir=kwargs.get('log_dir', 'logs'),
-            message_level=kwargs.get('message_level', 134),
-            sco_dir=kwargs.get('sco_dir'),
+            ssdir=ssdir,
+            sfdir=sfdir,
+            log_dir=log_dir,
+            message_level=message_level,
+            sco_dir=sco_dir,
         )
 
     sc_options = None
@@ -86,20 +148,20 @@ def _build_renderer(renderer_type: str, generator, **kwargs):
         # Nessun default ricopiato: cio' che la CLI non ha visto resta None,
         # e a decidere e' il renderer (unica sede dei valori).
         sc_options = api.SuperColliderOptions(
-            synthdef_source=kwargs.get('sc_synthdef_source'),
-            synthdef_dir=kwargs.get('sc_synthdef_dir'),
-            block_size=kwargs.get('sc_block_size'),
-            max_nodes=kwargs.get('sc_max_nodes'),
-            osc_dir=kwargs.get('osc_dir'),
+            synthdef_source=sc_synthdef_source,
+            synthdef_dir=sc_synthdef_dir,
+            block_size=sc_block_size,
+            max_nodes=sc_max_nodes,
+            osc_dir=osc_dir,
         )
 
     return api.build_renderer(
         renderer_type,
         generator,
-        output_sr=kwargs.get('output_sr', DEFAULT_OUTPUT_SR),
-        jobs=kwargs.get('jobs', 'auto'),
-        audio_format=kwargs.get('audio_format', DEFAULT_FORMAT),
-        samples_dir=kwargs.get('samples_dir'),
+        output_sr=output_sr,
+        jobs=jobs,
+        audio_format=audio_format,
+        samples_dir=samples_dir,
         cache_manifest_path=cache_manifest_path,
         csound=csound_options,
         supercollider=sc_options,

--- a/tests/test_bench_cost_samples_dir.py
+++ b/tests/test_bench_cost_samples_dir.py
@@ -3,10 +3,12 @@
 `utils/bench_cost.py` sceglie una directory di sample e la passa a due
 consumatori: il `Generator` (che risolve il sample in generazione) e il
 renderer (che lo legge in overlap-add). La classe di bug che la #243 ha
-prodotto e' invisibile a review e CI: `cli._build_renderer(tipo, gen, **kwargs)`
-pesca i kwargs con `.get()`, quindi un nome sbagliato — `ssdir=`, che vale solo
-per Csound — non e' un TypeError ma un no-op silenzioso, e la directory
-ricadeva sul default storico `./refs/`.
+prodotto era invisibile a review e CI: `cli._build_renderer(tipo, gen, **kwargs)`
+pescava i kwargs con `.get()`, quindi un nome sbagliato — `ssdir=`, che vale
+solo per Csound — non era un TypeError ma un no-op silenzioso, e la directory
+ricadeva sul default storico `./refs/`. La #252 ha chiuso anche quella porta
+(firma esplicita); qui resta il comportamento osservabile, che non dipende da
+quale delle due la difende.
 
 Qui si asserisce il comportamento osservabile: il sample viene risolto nella
 directory giusta, sia negli sweep (che non passano nessun argomento: e' il
@@ -208,7 +210,8 @@ def test_lapi_rifiuta_il_kwarg_sbagliato(bench):
 
     `cli._build_renderer` lo avrebbe ingoiato con `.get()` senza dire niente —
     e' cosi' che la #243 e' potuta nascere. Passando da `api.build_renderer` la
-    stessa svista non e' piu' scrivibile in silenzio.
+    stessa svista non e' piu' scrivibile in silenzio; dalla #252 non lo e' piu'
+    nemmeno dall'altra parte, ma il chiamante giusto resta questo.
     """
     with pytest.raises(TypeError):
         bench.api.build_renderer("numpy", object(), ssdir="/x")

--- a/tests/test_cli_build_renderer_signature.py
+++ b/tests/test_cli_build_renderer_signature.py
@@ -31,12 +31,27 @@ from pge.cli import _build_renderer
 CLI_PATH = inspect.getsourcefile(_build_renderer)
 
 
-def _chiamate_a_build_renderer():
-    """I nodi `ast.Call` di `_build_renderer` dentro `cli.py`."""
+def _albero_di_cli():
+    """L'AST di `cli.py`.
+
+    Un albero solo per test, e passato per argomento: i nodi `ast` si
+    confrontano per identita', quindi due parse dello stesso file non hanno
+    un nodo in comune e ogni confronto fra le due non e' falso — e' vuoto.
+    """
     with open(CLI_PATH, encoding='utf-8') as fh:
-        tree = ast.parse(fh.read(), filename=CLI_PATH)
+        return ast.parse(fh.read(), filename=CLI_PATH)
+
+
+def _main_di_cli(albero):
+    """Il nodo `main()` di `cli.py`."""
+    return next(n for n in albero.body
+                if isinstance(n, ast.FunctionDef) and n.name == 'main')
+
+
+def _chiamate_a_build_renderer(albero):
+    """I nodi `ast.Call` di `_build_renderer` dentro `cli.py`."""
     chiamate = [
-        node for node in ast.walk(tree)
+        node for node in ast.walk(albero)
         if isinstance(node, ast.Call)
         and isinstance(node.func, ast.Name)
         and node.func.id == '_build_renderer'
@@ -101,7 +116,7 @@ class TestFirmaEsplicita:
         `_build_renderer` era invisibile: nessun errore, nessun test rosso.
         Qui i due elenchi vengono confrontati direttamente.
         """
-        chiamate = _chiamate_a_build_renderer()
+        chiamate = _chiamate_a_build_renderer(_albero_di_cli())
 
         firma = set(inspect.signature(_build_renderer).parameters)
         for chiamata in chiamate:
@@ -199,11 +214,27 @@ class TestOpzioniCsoundFuoriDaCsound:
 
     def test_percio_la_cli_le_passa_a_ogni_render(self):
         """Il perche' della regola, letto dal sorgente: il sito di chiamata
-        e' uno solo e non e' condizionato al backend."""
-        chiamate = _chiamate_a_build_renderer()
+        e' uno solo, non e' dentro un ramo per backend, e li passa tutti.
+
+        Le tre cose insieme, perche' separate non dicono niente: un unico
+        sito che passasse i sette nomi da dentro `if renderer_type ==
+        'csound'` renderebbe la firma comune inutile senza far fallire
+        nessuna delle altre due asserzioni.
+        """
+        albero = _albero_di_cli()
+        chiamate = _chiamate_a_build_renderer(albero)
         assert len(chiamate) == 1, (
             "piu' di un sito di chiamata: la regola qui sotto vale per quello "
             "unico e incondizionato")
+
+        rami = [n for n in ast.walk(_main_di_cli(albero))
+                if isinstance(n, ast.If)]
+        dentro = [n for n in rami if chiamate[0] in set(ast.walk(n))]
+        assert not dentro, (
+            "il sito di chiamata e' dentro un ramo condizionale: se i nomi "
+            "Csound non partono piu' a ogni render, la firma comune non e' "
+            "piu' il posto dove devono stare")
+
         passati = {kw.arg for kw in chiamate[0].keywords}
         assert set(self.CSOUND_ONLY) <= passati, (
             "la CLI non passa piu' "

--- a/tests/test_cli_build_renderer_signature.py
+++ b/tests/test_cli_build_renderer_signature.py
@@ -25,8 +25,24 @@ from pge import api
 from pge.cli import _build_renderer
 
 
-REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-CLI_PATH = os.path.join(REPO_ROOT, 'src', 'pge', 'cli.py')
+# Il sorgente del modulo *importato*, non un path ricostruito a mano: la
+# guardia confronta la firma con il sito di chiamata, e i due devono venire
+# per costruzione dallo stesso file.
+CLI_PATH = inspect.getsourcefile(_build_renderer)
+
+
+def _chiamate_a_build_renderer():
+    """I nodi `ast.Call` di `_build_renderer` dentro `cli.py`."""
+    with open(CLI_PATH, encoding='utf-8') as fh:
+        tree = ast.parse(fh.read(), filename=CLI_PATH)
+    chiamate = [
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == '_build_renderer'
+    ]
+    assert chiamate, "nessuna chiamata a _build_renderer in cli.py"
+    return chiamate
 
 
 @pytest.fixture
@@ -85,20 +101,19 @@ class TestFirmaEsplicita:
         `_build_renderer` era invisibile: nessun errore, nessun test rosso.
         Qui i due elenchi vengono confrontati direttamente.
         """
-        with open(CLI_PATH, encoding='utf-8') as fh:
-            tree = ast.parse(fh.read(), filename=CLI_PATH)
-
-        chiamate = [
-            node for node in ast.walk(tree)
-            if isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Name)
-            and node.func.id == '_build_renderer'
-        ]
-        assert chiamate, "nessuna chiamata a _build_renderer in cli.py"
+        chiamate = _chiamate_a_build_renderer()
 
         firma = set(inspect.signature(_build_renderer).parameters)
         for chiamata in chiamate:
-            passati = {kw.arg for kw in chiamata.keywords if kw.arg}
+            # `**opts` si presenta come una keyword con `arg is None`: i nomi
+            # non sono piu' nel sorgente, quindi la guardia non ha piu' niente
+            # da confrontare e tacerebbe — lo stesso silenzio che i **kwargs
+            # nella firma producevano dall'altro lato. A runtime resterebbe il
+            # TypeError, ma solo il giorno in cui quel ramo viene eseguito.
+            assert all(kw.arg for kw in chiamata.keywords), (
+                "il sito di chiamata usa **unpacking: i nomi passati non sono "
+                "piu' leggibili dal sorgente e questa guardia diventa inerte")
+            passati = {kw.arg for kw in chiamata.keywords}
             assert passati <= firma, (
                 "main() passa a _build_renderer nomi che la firma non "
                 f"dichiara: {sorted(passati - firma)}")
@@ -153,6 +168,47 @@ class TestDefaultInvariati:
         atteso = os.path.join('cache', 'brano.json')
         assert costruito.call_args.kwargs['cache_manifest_path'] == atteso
         assert f"[CACHE] Manifest: {atteso}" in capsys.readouterr().out
+
+
+class TestOpzioniCsoundFuoriDaCsound:
+    """I nomi Csound restano accettati su ogni backend, e ignorati.
+
+    E' la decisione piu' caricata del fix, e finora viveva solo nel
+    docstring: la CLI passa `ssdir`, `sfdir`, `orc_path`, `incdir`,
+    `log_dir`, `message_level` e `sco_dir` a *ogni* render, quindi
+    restringere la firma al solo ramo Csound — "correggere il refuso" —
+    romperebbe ogni render NumPy con un TypeError. La firma esplicita rende
+    quella pulizia scrivibile in una riga; finche' resta prosa, niente la
+    ferma.
+    """
+
+    CSOUND_ONLY = dict(orc_path='/o.orc', incdir='/inc', ssdir='/s',
+                       sfdir='/f', log_dir='/log', message_level=7,
+                       sco_dir='/sco')
+
+    @pytest.mark.parametrize('tipo', ['numpy', 'supercollider'])
+    def test_sono_accettate(self, tipo, gen, costruito):
+        _build_renderer(tipo, gen, **self.CSOUND_ONLY)
+
+    @pytest.mark.parametrize('tipo', ['numpy', 'supercollider'])
+    def test_ma_non_arrivano_allapi(self, tipo, gen, costruito):
+        """Accettate non vuol dire inoltrate: fuori da Csound `csound` resta
+        None, e con esso ogni valore che ci sarebbe finito dentro."""
+        _build_renderer(tipo, gen, **self.CSOUND_ONLY)
+        assert costruito.call_args.kwargs['csound'] is None
+
+    def test_percio_la_cli_le_passa_a_ogni_render(self):
+        """Il perche' della regola, letto dal sorgente: il sito di chiamata
+        e' uno solo e non e' condizionato al backend."""
+        chiamate = _chiamate_a_build_renderer()
+        assert len(chiamate) == 1, (
+            "piu' di un sito di chiamata: la regola qui sotto vale per quello "
+            "unico e incondizionato")
+        passati = {kw.arg for kw in chiamate[0].keywords}
+        assert set(self.CSOUND_ONLY) <= passati, (
+            "la CLI non passa piu' "
+            f"{sorted(set(self.CSOUND_ONLY) - passati)}: se nessun backend "
+            "le riceve, il posto giusto non e' piu' la firma comune")
 
 
 class TestCacheSenzaBasename:

--- a/tests/test_cli_build_renderer_signature.py
+++ b/tests/test_cli_build_renderer_signature.py
@@ -1,0 +1,164 @@
+"""L'adapter CLI -> API deve rifiutare i nomi che non conosce (issue #252).
+
+`_build_renderer(tipo, generator, **kwargs)` raccoglieva tutto in `**kwargs` e
+poi pescava una chiave per volta con `.get()`: un nome fuori elenco non era un
+`TypeError`, non era un warning, era un no-op perfetto. E' cosi' che e' nata la
+#243 — `utils/bench_cost.py` passava `ssdir=<tmpdir>` a un build `numpy`, dove
+`ssdir` viene letto solo nel ramo Csound, e il `SampleRegistry` ricadeva sul
+default storico `./refs/` senza che niente nominasse la causa.
+
+Questi test fissano il contratto della firma esplicita: l'elenco dei kwargs e'
+finito e noto, quindi lo verifica Python. Piu' due guardie che il resto della
+correzione non si sfaldi: i default storici non si sono mossi, e il sito di
+chiamata dentro `main()` non puo' divergere dalla firma senza che qualcosa lo
+dica (con `**kwargs` divergeva in silenzio, che e' esattamente il difetto).
+"""
+
+import ast
+import inspect
+import os
+
+import pytest
+from unittest.mock import Mock, patch
+
+from pge import api
+from pge.cli import _build_renderer
+
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CLI_PATH = os.path.join(REPO_ROOT, 'src', 'pge', 'cli.py')
+
+
+@pytest.fixture
+def gen():
+    """Generator finto: `_build_renderer` non lo tocca, lo inoltra e basta."""
+    return Mock(name='generator')
+
+
+@pytest.fixture
+def costruito():
+    """Cattura la chiamata ad `api.build_renderer` senza costruire nulla."""
+    with patch.object(api, 'build_renderer') as build:
+        yield build
+
+
+class TestKwargSconosciuto:
+    """Il test chiesto dalla issue: oggi passa, e non dovrebbe.
+
+    Tutti e tre montano `costruito`: senza, un `Mock` al posto del generator
+    fa sollevare `TypeError` al renderer vero, e il test passerebbe per la
+    ragione sbagliata anche con `**kwargs` intatto. Con l'API sostituita
+    l'unico `TypeError` possibile e' quello della firma.
+    """
+
+    def test_nome_inventato_e_typeerror(self, gen, costruito):
+        with pytest.raises(TypeError):
+            _build_renderer('numpy', gen, kwarg_inesistente=1)
+
+    def test_il_refuso_di_samples_dir_e_typeerror(self, gen, costruito):
+        """La forma concreta della svista: un nome plausibile e sbagliato."""
+        with pytest.raises(TypeError):
+            _build_renderer('numpy', gen, sample_dir='/tmp/x')
+
+    def test_gli_argomenti_sono_keyword_only(self, gen, costruito):
+        """Nessun terzo posizionale: la lettura del sito di chiamata non
+        deve dipendere dall'ordine."""
+        with pytest.raises(TypeError):
+            _build_renderer('numpy', gen, 48000)
+
+
+class TestFirmaEsplicita:
+    """La firma e' l'elenco, non un commento nel docstring."""
+
+    def test_niente_var_keyword(self):
+        params = inspect.signature(_build_renderer).parameters.values()
+        var_kw = [p.name for p in params
+                  if p.kind is inspect.Parameter.VAR_KEYWORD]
+        assert var_kw == [], (
+            f"_build_renderer ha ancora **{var_kw[0]}: i nomi fuori elenco "
+            "tornano a essere no-op silenziosi")
+
+    def test_il_sito_di_chiamata_non_diverge_dalla_firma(self):
+        """Guardia strutturale sul sorgente, non sull'esecuzione di main().
+
+        Con `**kwargs` un flag nuovo passato da `main()` e mai letto dentro
+        `_build_renderer` era invisibile: nessun errore, nessun test rosso.
+        Qui i due elenchi vengono confrontati direttamente.
+        """
+        with open(CLI_PATH, encoding='utf-8') as fh:
+            tree = ast.parse(fh.read(), filename=CLI_PATH)
+
+        chiamate = [
+            node for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == '_build_renderer'
+        ]
+        assert chiamate, "nessuna chiamata a _build_renderer in cli.py"
+
+        firma = set(inspect.signature(_build_renderer).parameters)
+        for chiamata in chiamate:
+            passati = {kw.arg for kw in chiamata.keywords if kw.arg}
+            assert passati <= firma, (
+                "main() passa a _build_renderer nomi che la firma non "
+                f"dichiara: {sorted(passati - firma)}")
+
+
+class TestDefaultInvariati:
+    """La firma esplicita non deve spostare nessun default storico."""
+
+    def test_chiamata_nuda(self, gen, costruito):
+        from pge.shared.constants import DEFAULT_OUTPUT_SR
+        from pge.rendering.audio_format import DEFAULT_FORMAT
+
+        _build_renderer('numpy', gen)
+
+        _, kwargs = costruito.call_args
+        assert kwargs['output_sr'] == DEFAULT_OUTPUT_SR
+        assert kwargs['jobs'] == 'auto'
+        assert kwargs['audio_format'] is DEFAULT_FORMAT
+        assert kwargs['samples_dir'] is None
+        assert kwargs['cache_manifest_path'] is None
+        assert kwargs['csound'] is None
+        assert kwargs['supercollider'] is None
+
+    def test_opzioni_csound(self, gen, costruito):
+        _build_renderer('csound', gen, ssdir='/s', sfdir='/f', sco_dir='/sco')
+
+        opts = costruito.call_args.kwargs['csound']
+        assert (opts.ssdir, opts.sfdir, opts.sco_dir) == ('/s', '/f', '/sco')
+        # I default storici del ramo restano dove stavano
+        assert opts.orc_path == 'csound/main.orc'
+        assert opts.incdir == 'src'
+        assert opts.log_dir == 'logs'
+        assert opts.message_level == 134
+
+    def test_opzioni_supercollider(self, gen, costruito):
+        _build_renderer('supercollider', gen,
+                        sc_synthdef_source='/a.scd', sc_block_size=64,
+                        osc_dir='/osc')
+
+        opts = costruito.call_args.kwargs['supercollider']
+        assert opts.synthdef_source == '/a.scd'
+        assert opts.block_size == 64
+        assert opts.osc_dir == '/osc'
+        # Nessun default ricopiato dalla CLI: decide il renderer
+        assert opts.synthdef_dir is None
+        assert opts.max_nodes is None
+
+    def test_manifest_della_cache(self, gen, costruito, capsys):
+        _build_renderer('numpy', gen, use_cache=True, yaml_basename='brano',
+                        cache_dir='cache')
+
+        atteso = os.path.join('cache', 'brano.json')
+        assert costruito.call_args.kwargs['cache_manifest_path'] == atteso
+        assert f"[CACHE] Manifest: {atteso}" in capsys.readouterr().out
+
+
+class TestCacheSenzaBasename:
+    """`use_cache` senza `yaml_basename` era un KeyError nudo."""
+
+    def test_dice_cosa_manca(self, gen, costruito):
+        with pytest.raises(ValueError) as errore:
+            _build_renderer('numpy', gen, use_cache=True)
+        assert 'yaml_basename' in str(errore.value)

--- a/utils/bench_cost.py
+++ b/utils/bench_cost.py
@@ -162,9 +162,10 @@ def _render(generator, samples_dir=None):
     `samples_dir` (None -> quella degli sweep) e' la directory in cui la
     registry cerca il sample. Si passa a `api.build_renderer`, che e' l'API
     pubblica e ha una firma keyword-only: `ssdir=` — che vale solo per Csound —
-    li' e' un TypeError, mentre `cli._build_renderer` pesca i kwargs con
-    `.get()` e lo ingoiava in silenzio. E' la classe di bug della #243, chiusa
-    dal chiamante.
+    li' e' un TypeError. Su `cli._build_renderer`, che pescava i kwargs con
+    `.get()`, era invece un no-op silenzioso: e' la classe di bug della #243,
+    chiusa prima da questo lato (#247) e poi alla radice, con la firma
+    esplicita di `_build_renderer` (#252).
     """
     renderer = api.build_renderer(
         "numpy", generator, output_sr=SR,


### PR DESCRIPTION
Closes #252.

## Il difetto

`_build_renderer(tipo, generator, **kwargs)` raccoglieva tutto in `**kwargs` e poi pescava una chiave per volta con `.get()`. Non c'era nessun punto in cui un nome fuori elenco venisse notato: non un `TypeError`, non un warning — un no-op perfetto, con il default al posto del valore che il chiamante credeva di aver passato.

Non e' teorico: e' cosi' che e' nata la #243. `utils/bench_cost.py` passava `ssdir=<tmpdir>` (e `sfdir=<tmpdir>`) a un build `numpy`, dove entrambi vengono letti solo dentro il ramo Csound. Il `SampleRegistry` ricadeva sul default storico `./refs/`, lo script moriva in `SampleNotFoundError` e niente nominava la causa. Nessuno dei due era visibile alla review, e nessuno dei due poteva rompere un test — perche' non succedeva niente.

La PR #247 aveva chiuso il caso concreto dal lato del chiamante; il difetto restava per `main.py` e per ogni chiamante futuro.

## La correzione

Opzione 1 della issue: **firma esplicita keyword-only**. L'elenco dei kwargs accettati e' finito e noto, quindi ora sta nella firma e il controllo lo fa Python. Tutti i default storici invariati (`jobs='auto'`, `audio_format=DEFAULT_FORMAT`, `cache_dir='cache'`, i sette del ramo Csound, i `None` del ramo SuperCollider).

Due dettagli che la firma non dice da sola:

- **`ssdir`/`sfdir` restano accettati su ogni backend**, e ignorati fuori da Csound (come `orc_path`, `incdir`, `log_dir`, `message_level`, `sco_dir`): la CLI li passa sempre, quindi rifiutarli romperebbe ogni render NumPy. Il docstring lo dice ad alta voce, come chiedeva la issue — non e' un refuso da correggere in silenzio, e' un fraintendimento: la directory dei sample valida per tutti i backend e' `samples_dir`, e su Csound e' anche il fallback di `ssdir`.
- **`use_cache` senza `yaml_basename`** era `kwargs['yaml_basename']`, cioe' un `KeyError` nudo. Ora e' un `ValueError` che nomina la chiave mancante e il path del manifest che serviva a comporre. E' l'unico cambiamento di comportamento osservabile del diff, su un percorso che dalla CLI non e' raggiungibile (`main()` passa sempre il basename). Resta un `ValueError` nudo di proposito: la gerarchia `EngineError` e' per gli errori del compositore, con `user_message()` per il terminale, e `yaml_basename` non e' un campo YAML ma un kwarg che la CLI deriva da se'. E' un errore del chiamante, della stessa classe del `TypeError` qui sopra.

`DEFAULT_FORMAT` passa a import di modulo: e' un default della firma, valutato all'import, e il lazy import dentro la funzione non basta piu'. Non costa niente — `api.py` lo importa gia' a livello di modulo, e il modulo e' una dataclass piu' un dict. Per la stessa ragione `main()` non lo re-importa piu' in locale: importa il solo `FORMATS`.

## Test

`tests/test_cli_build_renderer_signature.py` (15 casi). Quello chiesto dalla issue — `_build_renderer('numpy', gen, kwarg_inesistente=1)` deve sollevare — piu' le guardie perche' la correzione non si sfaldi:

- la firma non torna ad avere `**kwargs` (`inspect.signature`);
- il sito di chiamata dentro `main()` non puo' divergere dalla firma in silenzio: guardia AST sul sorgente di `cli.py`, che confronta i nomi passati con quelli dichiarati. Con `**kwargs` un flag nuovo mai letto era invisibile — nessun errore, nessun test rosso. La guardia legge il sorgente del modulo **importato** (`inspect.getsourcefile`), non un path ricostruito a mano: firma e sito di chiamata devono venire per costruzione dallo stesso file. E rifiuta un `**unpack` al sito di chiamata, che le toglierebbe i nomi da confrontare e la renderebbe inerte — lo stesso silenzio, dall'altro lato;
- **i nomi Csound restano accettati fuori da Csound**: numpy e supercollider costruiti passando tutti e sette, con la verifica che accettati non voglia dire inoltrati (`csound` resta `None`). E' la decisione piu' caricata del fix, e il sorgente dice anche il perche': il sito di chiamata e' uno solo e non e' condizionato al backend. Se un giorno la CLI smette di passarli, il posto giusto non e' piu' la firma comune;
- nessun default storico si e' mosso (chiamata nuda, ramo Csound, ramo SuperCollider, path del manifest e print `[CACHE] Manifest:`).

I tre casi di `TestKwargSconosciuto` montano `api.build_renderer` sostituita di proposito: senza, un `Mock` al posto del generator fa sollevare `TypeError` al renderer vero e il test passerebbe per la ragione sbagliata anche con `**kwargs` intatto.

Ogni guardia e' stata verificata per sabotaggio: `**unpack` al sito di chiamata e rimozione di `ssdir`/`sfdir` dalla firma comune fanno fallire quelle giuste.

`make tests`: 6211 passed, 10 skipped. `make docs-lint`: OK (22 docs).

## Impatto cross-repo

**Nessuno.** La superficie pubblica non cambia: flag CLI (il golden `test_cli_contract.py` e' verde invariato), sintassi YAML, gerarchia errori, formati di output. `_build_renderer` e' un adapter interno, e `api.build_renderer` — l'API che PGE-ui e i consumer programmatici usano — aveva gia' la firma esplicita. Nessuna issue aperta su PGE-ls o PGE-ui.

Per la stessa ragione non serve bumpare il submodule nel paper CIM 2026: gli esempi non esercitano niente di cio' che cambia (rendering, score visualizer e la superficie usata da `render_example.py` sono intatti).

## Documentazione

- `docs/explanation/architecture.md`: lo snippet mostrava `_build_renderer(..., **kwargs)`, cioe' la forma rimossa; ora c'e' la firma vera piu' il perche', e una riga in *Implicazioni codice*.
- `docs/how-to/add-renderer.md`: il passo 6 diceva "mappa i flag CLI in `cli._build_renderer`" senza dire dove — nel corpo bastava, ed e' per questo che un flag nuovo poteva restare inerte.
- `src/pge/cli.py` entra fra le `sources` di entrambi: lo documentavano gia', ma fuori dalla drift detection il prossimo cambio di firma non li avrebbe segnalati.
- `log_dir` entra negli elenchi delle opzioni Csound (docstring, `architecture.md`, CHANGELOG): i parametri Csound-only sono sette, gli elenchi ne nominavano sei.
- `utils/bench_cost.py` e `tests/test_bench_cost_samples_dir.py` descrivevano al presente il difetto che questa PR chiude — una delle tre e' il docstring del test che contrappone l'API alla CLI proprio su quella differenza. Passano al passato, con il riferimento a quale porta ha chiuso cosa (#247 dal chiamante, #252 alla radice).
- Voce di CHANGELOG sotto *Corretto*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tx5jrwNRyDdHCTnBLtJnX4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tx5jrwNRyDdHCTnBLtJnX4)_