### PR TITLE
fix(csound): csound assente non e' piu' «file YAML non trovato» (#241)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,11 +147,12 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
   ```
   [ERRORE] Csound: binario 'csound' non trovato
-    Hint:         Installa csound (`make install-system-deps`; su Fedora/RHEL
-                  non e' nei repo e va compilato dai sorgenti, vedi README),
-                  oppure usa `--renderer numpy`, che non richiede binari
-                  esterni.
+    Hint:         Installa csound (`make install-system-deps`; su Fedora/RHEL non e' nei repo e va compilato dai sorgenti, vedi README), oppure usa `--renderer numpy`, che non richiede binari esterni.
   ```
+
+  Il blocco è l'output reale: `user_message()` non manda a capo l'hint, e
+  mostrarlo qui rincolonnato descriveva una riga che il programma non stampa
+  (`docs/reference/errors.md` lo riporta com'è).
 
   Il rimedio nomina la compilazione dai sorgenti perche' `make
   install-system-deps` csound su Fedora/RHEL non lo installa — non c'e' nei

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,10 +180,23 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   fallire — exit code diverso da zero, e da questa release anche il binario
   assente — saltava le due righe e lasciava il file in `/tmp`, con un nome
   casuale che l'utente non ha modo di ritrovare. Su una macchina senza csound
-  non era un caso raro ma la norma: uno per tentativo. Ora la chiamata sta in
-  un `try/finally` in entrambi i chiamanti (STEMS e MIX passano dallo stesso
-  `_run_csound`); `--keep-sco` continua a valere, perche' la condizione e'
-  rimasta la stessa.
+  non era un caso raro ma la norma: uno per tentativo.
+
+  Il `try/finally` copre l'intero passo, **scrittura dello score inclusa**, e
+  non la sola chiamata a csound: il file temporaneo lo crea `mkstemp` prima
+  che ScoreWriter ci scriva, e i grani sono lazy (issue #117) — si
+  materializzano proprio li', con tutti i modi di essere invalidi che il
+  parse non ha visto. Uno score che muore scrivendo lasciava un `.sco` in
+  `/tmp` esattamente come il binario assente. STEMS e MIX passano ora dallo
+  stesso `_render`, cosi' la regola di cancellazione ha una scrittura sola:
+  e' la forma che `SuperColliderRenderer._render` ha da sempre, ed era il
+  ramo csound a non averla.
+
+  `--keep-sco` continua a valere, perche' la condizione e' rimasta la stessa
+  — ma ora e' anche testata sul ramo dei fallimenti, che prima la
+  cancellazione non la eseguiva affatto: e' il render fallito quello che si
+  vuole ispezionare, e un `finally` che perdesse quella condizione
+  cancellerebbe proprio il file che il flag promette di tenere.
 
 - **`--log-dir` spostava solo meta' dei log** (issue #251). Il flag era
   parsato correttamente e finiva al renderer, ma i due logger configurati

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,7 +197,21 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   — ma ora e' anche testata sul ramo dei fallimenti, che prima la
   cancellazione non la eseguiva affatto: e' il render fallito quello che si
   vuole ispezionare, e un `finally` che perdesse quella condizione
-  cancellerebbe proprio il file che il flag promette di tenere.
+  cancellerebbe proprio il file che il flag promette di tenere. Testata anche
+  sul ramo che finisce bene, che e' il piu' battuto e non ne aveva nessuna: un
+  render che smettesse di ripulire lascerebbe un `.sco` per stem e la suite
+  resterebbe verde.
+
+  Chiudere quella perdita porta pero' via anche il `.sco` dell'exit code
+  diverso da zero, che prima sopravviveva per via dello stesso difetto — ed e'
+  il caso in cui quello score serve. Il messaggio di `CsoundRenderError` offre
+  una riga `Comando:` da rieseguire, e quel comando nomina lo score appena
+  cancellato: senza dirlo, la prima azione che il messaggio suggerisce e' un
+  no-op, cioe' lo stesso metro con cui questa release ha riscritto l'hint di
+  csound assente. `_SubprocessRenderError` ha ora un `hint` opzionale — stessa
+  riga di `_BinaryNotFoundError` — e il ramo csound lo valorizza nominando
+  `--keep-sco` quando lo score era temporaneo. Con il flag gia' attivo l'hint
+  non compare: il rimedio non esiste piu'.
 
 - **`--log-dir` spostava solo meta' dei log** (issue #251). Il flag era
   parsato correttamente e finiva al renderer, ma i due logger configurati

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,13 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   `--keep-sco` quando lo score era temporaneo. Con il flag gia' attivo l'hint
   non compare: il rimedio non esiste piu'.
 
+  Quel flag non riporta pero' lo score al path che il `Comando:` mostra: con
+  `--sco-dir` lo scrive in una directory stabile, e senza, `mkstemp` pesca
+  ogni volta un nome nuovo. L'hint dice quindi che la riga mostrata non e'
+  piu' rieseguibile e rimanda a quella del messaggio successivo — invitare a
+  rieseguire *quella* avrebbe spostato di un livello lo stesso
+  rimedio-che-non-fa-nulla, invece di toglierlo.
+
 - **`--log-dir` spostava solo meta' dei log** (issue #251). Il flag era
   parsato correttamente e finiva al renderer, ma i due logger configurati
   prima del render — clip ed errori engine — avevano `'./logs'` scritto a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,9 +147,17 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
   ```
   [ERRORE] Csound: binario 'csound' non trovato
-    Hint:         Installa csound (`make install-system-deps`), oppure usa
-                  `--renderer numpy`, che non richiede binari esterni.
+    Hint:         Installa csound (`make install-system-deps`; su Fedora/RHEL
+                  non e' nei repo e va compilato dai sorgenti, vedi README),
+                  oppure usa `--renderer numpy`, che non richiede binari
+                  esterni.
   ```
+
+  Il rimedio nomina la compilazione dai sorgenti perche' `make
+  install-system-deps` csound su Fedora/RHEL non lo installa — non c'e' nei
+  repo ne' in RPM Fusion, e il target lo dice invece di provarci. Un
+  messaggio azionabile la cui prima azione e' un no-op proprio sulla
+  piattaforma da cui viene la issue vale quanto quello che ha sostituito.
 
   Non eredita da `FileNotFoundError`, per la stessa ragione per cui non lo fa
   `SuperColliderNotFoundError` (#228): il tipo di un errore serve a chi lo
@@ -163,10 +171,19 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   annuncia. Un `FileNotFoundError` che nessuno ha ancora tradotto finisce nel
   ramo generico — messaggio e traceback — invece che in un messaggio falso.
 
-  Nota per chi usa la libreria: la docstring di `render_single_stream`
-  prometteva `FileNotFoundError` per csound assente. La promessa **era** il
-  difetto e cambia con il codice; chi la catturava per nome deve passare a
-  `CsoundNotFoundError` (o a `EngineError`, che le copre tutte).
+  La conseguenza per chi usa la libreria e' un cambio di superficie, ed e'
+  scritta fra le modifiche qui sotto invece che sepolta qui.
+
+- **Il `.sco` temporaneo sopravviveva a ogni render csound fallito**
+  (review della PR #256). Senza `--keep-sco` lo score e' un file temporaneo,
+  e la sua cancellazione stava *dopo* la chiamata a csound: qualunque modo di
+  fallire — exit code diverso da zero, e da questa release anche il binario
+  assente — saltava le due righe e lasciava il file in `/tmp`, con un nome
+  casuale che l'utente non ha modo di ritrovare. Su una macchina senza csound
+  non era un caso raro ma la norma: uno per tentativo. Ora la chiamata sta in
+  un `try/finally` in entrambi i chiamanti (STEMS e MIX passano dallo stesso
+  `_run_csound`); `--keep-sco` continua a valere, perche' la condizione e'
+  rimasta la stessa.
 
 - **`--log-dir` spostava solo meta' dei log** (issue #251). Il flag era
   parsato correttamente e finiva al renderer, ma i due logger configurati
@@ -286,6 +303,15 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   `voice.wav` sia su un seno di 3 s, e la lunghezza del buffer entra nel
   comportamento di cache, quindi nel coefficiente `a`: due run non
   confrontabili erano indistinguibili a posteriori.
+
+- **BREAKING — `render_single_stream` e `render_merged_streams` del renderer
+  csound non sollevano piu' `FileNotFoundError`** quando csound non e' nel
+  PATH (issue #241, vedi la correzione qui sopra). Il tipo era promesso dalla
+  docstring, ma la promessa *era* il difetto: quel tipo la CLI lo intercetta
+  per annunciare un file YAML mancante. Ora e' `CsoundNotFoundError`. Chi lo
+  catturava per nome deve passare a quello, o a `EngineError`, che copre
+  tutti gli errori del motore. Un `except FileNotFoundError` attorno a un
+  render csound smette di catturare in silenzio: l'eccezione risale.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,41 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Corretto
 
+- **Csound non installato veniva annunciato come «file YAML non trovato»**
+  (issue #241). `CsoundRenderer._run_csound` lasciava salire il
+  `FileNotFoundError` che `subprocess.run` alza quando il binario non e' nel
+  PATH, e in `cli.main()` quel tipo aveva il **primo** handler della catena,
+  tenuto per il file di configurazione. Su una macchina senza csound
+  (Fedora/RHEL, dove il README gia' suggerisce `RENDERER=numpy`) il render
+  moriva dicendo che il file YAML non esisteva — mentre era stato letto e
+  parsato pochi istanti prima, e il difetto stava a valle.
+
+  Il guasto ha ora un tipo suo, `CsoundNotFoundError`, con il rimedio dentro
+  il messaggio:
+
+  ```
+  [ERRORE] Csound: binario 'csound' non trovato
+    Hint:         Installa csound (`make install-system-deps`), oppure usa
+                  `--renderer numpy`, che non richiede binari esterni.
+  ```
+
+  Non eredita da `FileNotFoundError`, per la stessa ragione per cui non lo fa
+  `SuperColliderNotFoundError` (#228): il tipo di un errore serve a chi lo
+  cattura, non a descriverne la causa. Le due classi erano identiche a meno
+  del nome del tool, quindi ora condividono la base `_BinaryNotFoundError`,
+  come i due errori di exit code condividono `_SubprocessRenderError`.
+
+  Il tipo giusto non basta se chi cattura e' troppo largo: l'handler
+  `FileNotFoundError` della CLI si e' stretto attorno a `Generator()` +
+  `load_yaml()`, l'unico punto che puo' sollevarlo per il motivo che
+  annuncia. Un `FileNotFoundError` che nessuno ha ancora tradotto finisce nel
+  ramo generico — messaggio e traceback — invece che in un messaggio falso.
+
+  Nota per chi usa la libreria: la docstring di `render_single_stream`
+  prometteva `FileNotFoundError` per csound assente. La promessa **era** il
+  difetto e cambia con il codice; chi la catturava per nome deve passare a
+  `CsoundNotFoundError` (o a `EngineError`, che le copre tutte).
+
 - **`--log-dir` spostava solo meta' dei log** (issue #251). Il flag era
   parsato correttamente e finiva al renderer, ma i due logger configurati
   prima del render — clip ed errori engine — avevano `'./logs'` scritto a

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -7,7 +7,7 @@ sources:
   - src/pge/rendering/
   - src/pge/cli.py
   - src/main.py
-last_synced_commit: 6084479
+last_synced_commit: 845f47f
 ---
 
 # Architettura Renderer
@@ -190,8 +190,10 @@ Sequenza e invarianti:
 - Caching: vedi [[caching]]
 - Errori specifici renderer: `CsoundRenderError`, `SuperColliderRenderError`,
   `CsoundNotFoundError`, `SuperColliderNotFoundError`, `InvalidRendererError`
-  (vedi [[errors]]): i due "non trovato" dicono che manca il binario del
-  backend, e nessuno dei due eredita da `FileNotFoundError`
+  (vedi [[errors]]): i due "non trovato" dicono che manca ciò che serve a far
+  partire il backend — il binario, e per SuperCollider anche il sorgente della
+  SynthDef da cui il binario si compila — e nessuno dei due eredita da
+  `FileNotFoundError`
 - L'elenco dei tipi validi vive in `RendererFactory.available_types()`, ed è
   quello che i messaggi d'errore e la CLI interrogano: un backend nuovo non
   richiede di aggiornare nessuna lista scritta a mano

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -7,7 +7,7 @@ sources:
   - src/pge/rendering/
   - src/pge/cli.py
   - src/main.py
-last_synced_commit: 8e21c03
+last_synced_commit: 6084479
 ---
 
 # Architettura Renderer

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -7,7 +7,7 @@ sources:
   - src/pge/rendering/
   - src/pge/cli.py
   - src/main.py
-last_synced_commit: 1d80252
+last_synced_commit: 0110399
 ---
 
 # Architettura Renderer

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -7,7 +7,7 @@ sources:
   - src/pge/rendering/
   - src/pge/cli.py
   - src/main.py
-last_synced_commit: 845f47f
+last_synced_commit: 1d80252
 ---
 
 # Architettura Renderer
@@ -191,8 +191,9 @@ Sequenza e invarianti:
 - Errori specifici renderer: `CsoundRenderError`, `SuperColliderRenderError`,
   `CsoundNotFoundError`, `SuperColliderNotFoundError`, `InvalidRendererError`
   (vedi [[errors]]): i due "non trovato" dicono che manca ciò che serve a far
-  partire il backend — il binario, e per SuperCollider anche il sorgente della
-  SynthDef da cui il binario si compila — e nessuno dei due eredita da
+  partire il backend — il binario, e per SuperCollider anche il sorgente `.scd`
+  che `sclang` compila nel `.scsyndef` caricato dallo score (non è il binario a
+  compilarsi da lì: quello si installa) — e nessuno dei due eredita da
   `FileNotFoundError`
 - L'elenco dei tipi validi vive in `RendererFactory.available_types()`, ed è
   quello che i messaggi d'errore e la CLI interrogano: un backend nuovo non

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -6,7 +6,7 @@ tags: [architecture, rendering, ocp]
 sources:
   - src/pge/rendering/
   - src/main.py
-last_synced_commit: 1aba65c
+last_synced_commit: 5b24556
 ---
 
 # Architettura Renderer
@@ -167,7 +167,9 @@ Sequenza e invarianti:
 - Aggiungere una mode (es. per-voice): nuova `RenderMode` subclass + uso in main; ABC invariata
 - Caching: vedi [[caching]]
 - Errori specifici renderer: `CsoundRenderError`, `SuperColliderRenderError`,
-  `SuperColliderNotFoundError`, `InvalidRendererError` (vedi [[errors]])
+  `CsoundNotFoundError`, `SuperColliderNotFoundError`, `InvalidRendererError`
+  (vedi [[errors]]): i due "non trovato" dicono che manca il binario del
+  backend, e nessuno dei due eredita da `FileNotFoundError`
 - L'elenco dei tipi validi vive in `RendererFactory.available_types()`, ed è
   quello che i messaggi d'errore e la CLI interrogano: un backend nuovo non
   richiede di aggiornare nessuna lista scritta a mano

--- a/docs/how-to/add-renderer.md
+++ b/docs/how-to/add-renderer.md
@@ -9,7 +9,7 @@ sources:
   - src/pge/rendering/supercollider_renderer.py
   - src/pge/api.py
   - src/pge/cli.py
-last_synced_commit: 8e21c03
+last_synced_commit: 845f47f
 entry_for: [add-renderer]
 ---
 
@@ -33,6 +33,22 @@ L'ultimo backend aggiunto è SuperCollider (issue #228): è l'esempio lavorato d
 1. Crea il modulo in `src/pge/rendering/<nome>_renderer.py` ed eredita `AudioRenderer`
 2. Dichiara `renderer_type = '<nome>'` (finisce in `RenderResult.renderer_type`)
 3. Implementa `render_single_stream(stream, output_path)` (onset **relativi**, STEMS) e `render_merged_streams(streams, output_path)` (onset **assoluti**, MIX). `render_streams()` è concreto nell'ABC: fai override solo se hai un modo migliore del loop
+
+   Se il backend delega a un binario esterno, due regole che questo progetto
+   ha già dovuto imparare due volte (#228, #241):
+
+   - **binario assente = sottoclasse d'errore dedicata, mai `FileNotFoundError`**.
+     La CLI intercetta quel tipo per annunciare «file YAML non trovato»: un
+     binario che manca e passa di lì viene riportato all'utente come una
+     configurazione inesistente. C'è una base comune per questi errori, vedi
+     [[errors]]
+   - **lo score temporaneo si cancella in un `finally` che copre anche la sua
+     scrittura**, non solo la chiamata al binario: il file temporaneo esiste
+     dal momento in cui se ne prende il path, e i grani sono lazy (#117) —
+     si materializzano proprio mentre lo score si scrive. Un `try` stretto
+     sul solo subprocess lascia uno score orfano a ogni render che muore
+     prima
+
 4. Registra in `src/pge/rendering/renderer_factory.py`: aggiungi il nome a `_VALID_TYPES` e il ramo di costruzione in `create()`. `available_types()` è l'unico elenco dei tipi validi — messaggi d'errore e CLI lo chiedono lì
 5. Aggiungi il ramo in `api.build_renderer()`, e una dataclass di opzioni accanto a `CsoundOptions` / `SuperColliderOptions` se il backend ha configurazione propria
 6. Mappa i flag CLI in `cli._build_renderer`: i nomi vanno **dichiarati nella firma** (keyword-only, issue #252), non solo letti nel corpo — uno non dichiarato è un `TypeError` al primo render invece di un no-op silenzioso, e `tests/test_cli_build_renderer_signature.py` confronta la firma col sito di chiamata dentro `main()`. Aggiorna anche la usage string (il golden `tests/test_cli_contract.py` la difende: va aggiornato di proposito)

--- a/docs/how-to/add-renderer.md
+++ b/docs/how-to/add-renderer.md
@@ -9,7 +9,7 @@ sources:
   - src/pge/rendering/supercollider_renderer.py
   - src/pge/api.py
   - src/pge/cli.py
-last_synced_commit: 845f47f
+last_synced_commit: 1d80252
 entry_for: [add-renderer]
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -8,9 +8,10 @@ sources:
   - src/pge/cli.py
   - src/pge/shared/logger.py
   - src/pge/rendering/grain_visuals.py
+  - src/pge/rendering/csound_renderer.py
   - src/pge/rendering/supercollider_renderer.py
   - make/build.mk
-last_synced_commit: 5b24556
+last_synced_commit: 6084479
 entry_for: [cli-flags, build-flags]
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -10,7 +10,7 @@ sources:
   - src/pge/rendering/grain_visuals.py
   - src/pge/rendering/supercollider_renderer.py
   - make/build.mk
-last_synced_commit: 68654ba
+last_synced_commit: 5b24556
 entry_for: [cli-flags, build-flags]
 ---
 
@@ -114,7 +114,12 @@ Vincoli tra flag e comportamento nelle combinazioni non valide:
   fingerprint: modificare `pge_grain.scd` o `main.orc` non invalida nulla. La
   garbage collection degli stream orfani scatta solo con entrambe attive.
 - **`--keep-sco` / `--sco-dir`** hanno effetto solo con `--renderer csound`
-  (gli altri renderer non producono `.sco`).
+  (gli altri renderer non producono `.sco`). Il backend richiede `csound` nel
+  PATH: binario assente → `CsoundNotFoundError`, che nomina il rimedio
+  (installare csound, oppure `--renderer numpy`; vedi [[errors]]). Fino alla
+  issue #241 lo stesso caso usciva come «file YAML non trovato», perché la
+  CLI intercettava il `FileNotFoundError` del subprocess con l'handler tenuto
+  per il file di configurazione.
 - **`--log-dir` non è un flag csound**, benché sia stato a lungo scritto in
   mezzo a loro: vale con qualunque renderer, perché i due log che scrive la
   fase di caricamento (errori engine e clip) esistono prima che si scelga un

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -11,7 +11,7 @@ sources:
   - src/pge/rendering/csound_renderer.py
   - src/pge/rendering/supercollider_renderer.py
   - make/build.mk
-last_synced_commit: 6084479
+last_synced_commit: 845f47f
 entry_for: [cli-flags, build-flags]
 ---
 
@@ -120,7 +120,11 @@ Vincoli tra flag e comportamento nelle combinazioni non valide:
   (installare csound, oppure `--renderer numpy`; vedi [[errors]]). Fino alla
   issue #241 lo stesso caso usciva come «file YAML non trovato», perché la
   CLI intercettava il `FileNotFoundError` del subprocess con l'handler tenuto
-  per il file di configurazione.
+  per il file di configurazione. Senza `--keep-sco` lo score è un file
+  temporaneo e **viene cancellato anche quando il render fallisce** — csound
+  assente, exit code diverso da zero, o un errore mentre lo score si scrive:
+  il `.sco` di un render fallito si ispeziona con `--keep-sco`, che è la
+  modalità in cui quel file non è temporaneo.
 - **`--log-dir` non è un flag csound**, benché sia stato a lungo scritto in
   mezzo a loro: vale con qualunque renderer, perché i due log che scrive la
   fase di caricamento (errori engine e clip) esistono prima che si scelga un

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -11,7 +11,7 @@ sources:
   - src/pge/rendering/csound_renderer.py
   - src/pge/rendering/supercollider_renderer.py
   - make/build.mk
-last_synced_commit: 1d80252
+last_synced_commit: 0110399
 entry_for: [cli-flags, build-flags]
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -11,7 +11,7 @@ sources:
   - src/pge/rendering/csound_renderer.py
   - src/pge/rendering/supercollider_renderer.py
   - make/build.mk
-last_synced_commit: 845f47f
+last_synced_commit: 1d80252
 entry_for: [cli-flags, build-flags]
 ---
 
@@ -124,7 +124,9 @@ Vincoli tra flag e comportamento nelle combinazioni non valide:
   temporaneo e **viene cancellato anche quando il render fallisce** — csound
   assente, exit code diverso da zero, o un errore mentre lo score si scrive:
   il `.sco` di un render fallito si ispeziona con `--keep-sco`, che è la
-  modalità in cui quel file non è temporaneo.
+  modalità in cui quel file non è temporaneo. È anche quello che dice il
+  messaggio d'errore, che altrimenti offrirebbe un `Comando:` da rieseguire
+  nominando uno score che non c'è più (vedi [[errors]]).
 - **`--log-dir` non è un flag csound**, benché sia stato a lungo scritto in
   mezzo a loro: vale con qualunque renderer, perché i due log che scrive la
   fase di caricamento (errori engine e clip) esistono prima che si scelga un

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -5,7 +5,8 @@ status: stable
 tags: [errors, exceptions, user-facing]
 sources:
   - src/pge/shared/exceptions.py
-last_synced_commit: 5b24556
+  - src/pge/cli.py
+last_synced_commit: 6084479
 entry_for: [error-handling]
 ---
 
@@ -307,7 +308,7 @@ Il campo `stage` distingue i due binari, perché hanno rimedi diversi:
 ### Csound non installato
 ```
 [ERRORE] Csound: binario 'csound' non trovato
-  Hint:         Installa csound (`make install-system-deps`), oppure usa `--renderer numpy`, che non richiede binari esterni.
+  Hint:         Installa csound (`make install-system-deps`; su Fedora/RHEL non e' nei repo e va compilato dai sorgenti, vedi README), oppure usa `--renderer numpy`, che non richiede binari esterni.
   Dettagli:     /tmp/engine.log
 ```
 

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -6,7 +6,7 @@ tags: [errors, exceptions, user-facing]
 sources:
   - src/pge/shared/exceptions.py
   - src/pge/cli.py
-last_synced_commit: 6084479
+last_synced_commit: 1d80252
 entry_for: [error-handling]
 ---
 
@@ -114,6 +114,14 @@ EngineError                                  (Exception)
   configurazione mancante. Quelli che nessuno ha ancora tradotto finiscono
   ora nel ramo generico — messaggio e traceback — invece che in un messaggio
   falso.
+- **La riga `Comando:` di `_SubprocessRenderError` invita a rieseguire, quindi
+  deve restare rieseguibile.** Lo score che vi compare è temporaneo e il
+  renderer lo cancella in un `finally` — anche quando il binario esce con un
+  codice d'errore, che è il caso in cui quello score serve. Perciò la base ha
+  un `hint` opzionale e il ramo csound lo valorizza con `--keep-sco` quando lo
+  score era temporaneo: senza, la prima azione che il messaggio suggerisce è
+  un no-op. Stessa forma dell'hint di `_BinaryNotFoundError`, e stessa regola —
+  un rimedio si scrive solo quando c'è.
 - `EngineRuntimeError` separa runtime engine da config; sotto-classi future
   (es. errori I/O di rendering) si appendono qui.
 - Ogni sotto-classe override `user_message()` con formato strutturato.
@@ -281,12 +289,17 @@ streams:
 ### Csound subprocess fallito
 ```
 [ERRORE] Csound rendering fallito (exit code 2)
-  Comando:      csound -o out.aif score.csd
+  Comando:      csound -o out.aif /tmp/tmpx3k9.sco
   Output:       error: undefined opcode
+  Hint:         Lo score .sco era temporaneo ed e' stato rimosso: rilancia con `--keep-sco` per conservarlo e rieseguire il comando qui sopra.
   Stream:       drone_low
   Config:       configs/PGE_test.yml
   Dettagli:     /tmp/engine.log
 ```
+
+La riga `Hint:` compare solo senza `--keep-sco`: con il flag lo score è già
+sul disco e suggerirlo manderebbe l'utente a cercare un'opzione che ha già
+passato.
 
 ### SuperCollider subprocess fallito
 Il campo `stage` distingue i due binari, perché hanno rimedi diversi:

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -6,7 +6,8 @@ tags: [errors, exceptions, user-facing]
 sources:
   - src/pge/shared/exceptions.py
   - src/pge/cli.py
-last_synced_commit: 1d80252
+  - src/pge/rendering/csound_renderer.py
+last_synced_commit: 0110399
 entry_for: [error-handling]
 ---
 

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -5,7 +5,7 @@ status: stable
 tags: [errors, exceptions, user-facing]
 sources:
   - src/pge/shared/exceptions.py
-last_synced_commit: ae61d22
+last_synced_commit: 5b24556
 entry_for: [error-handling]
 ---
 
@@ -76,7 +76,9 @@ EngineError                                  (Exception)
     ├── _SubprocessRenderError               base dei render delegati a un binario
     │   ├── CsoundRenderError                (anche RuntimeError, backward-compat)
     │   └── SuperColliderRenderError         #228 — scsynth/sclang exit != 0
-    └── SuperColliderNotFoundError           #228 — binario o sorgente assente
+    └── _BinaryNotFoundError                 base dei binari esterni assenti
+        ├── CsoundNotFoundError              #241 — csound non nel PATH
+        └── SuperColliderNotFoundError       #228 — binario o sorgente assente
 ```
 
 **Regole di design:**
@@ -91,12 +93,26 @@ EngineError                                  (Exception)
   la prima riga per csound, l'ultima per sclang/scsynth, che aprono sempre
   con il proprio preambolo — e considera **anche lo stdout**, che è dove
   entrambi i binari SuperCollider scrivono i loro errori.
-- **`SuperColliderNotFoundError` NON eredita da `FileNotFoundError`**, anche
-  se descrive un file che non c'è. La CLI intercetta `FileNotFoundError`
-  *prima* di `EngineError`, per annunciare «file YAML non trovato»: un
+- **`_BinaryNotFoundError` NON eredita da `FileNotFoundError`**, anche se
+  descrive un file che non c'è — e nemmeno le sue due sottoclassi. La CLI
+  intercetta `FileNotFoundError` per annunciare «file YAML non trovato»: un
   binario mancante che passasse di lì verrebbe riportato all'utente come una
   configurazione inesistente. Il tipo di un errore serve a chi lo cattura,
-  non a descriverne la causa.
+  non a descriverne la causa. `SuperColliderNotFoundError` (#228) nasce già
+  così; `CsoundNotFoundError` (#241) è la stessa regola applicata al ramo
+  csound, che quel difetto lo aveva davvero: `_run_csound` lasciava salire il
+  `FileNotFoundError` del subprocess, e su una macchina senza csound l'utente
+  si sentiva dire che il suo YAML non esisteva — letto e parsato pochi
+  istanti prima. Le due classi differiscono per il solo nome del tool, quindi
+  il messaggio vive nella base comune, come per `_SubprocessRenderError`.
+- **L'handler `FileNotFoundError` della CLI è stretto attorno a
+  `Generator()` + `load_yaml()`** (#241), non in fondo al `try` di
+  `cli.main()`. Il tipo giusto per chi lo solleva non basta se chi lo cattura
+  è troppo largo: l'ordine dei due handler (`FileNotFoundError` prima di
+  `EngineError`) rendeva l'errore di *qualunque* fase un file di
+  configurazione mancante. Quelli che nessuno ha ancora tradotto finiscono
+  ora nel ramo generico — messaggio e traceback — invece che in un messaggio
+  falso.
 - `EngineRuntimeError` separa runtime engine da config; sotto-classi future
   (es. errori I/O di rendering) si appendono qui.
 - Ogni sotto-classe override `user_message()` con formato strutturato.
@@ -287,6 +303,16 @@ Il campo `stage` distingue i due binari, perché hanno rimedi diversi:
   Hint:         Installa SuperCollider (Debian/Ubuntu: apt install supercollider; macOS: brew install --cask supercollider) oppure usa --renderer numpy.
   Dettagli:     /tmp/engine.log
 ```
+
+### Csound non installato
+```
+[ERRORE] Csound: binario 'csound' non trovato
+  Hint:         Installa csound (`make install-system-deps`), oppure usa `--renderer numpy`, che non richiede binari esterni.
+  Dettagli:     /tmp/engine.log
+```
+
+Fino alla issue #241 lo stesso guasto usciva come `Errore: file
+'configs/x.yml' non trovato`, con exit 1 e nessuna menzione di csound.
 
 ---
 

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -120,7 +120,10 @@ EngineError                                  (Exception)
   codice d'errore, che è il caso in cui quello score serve. Perciò la base ha
   un `hint` opzionale e il ramo csound lo valorizza con `--keep-sco` quando lo
   score era temporaneo: senza, la prima azione che il messaggio suggerisce è
-  un no-op. Stessa forma dell'hint di `_BinaryNotFoundError`, e stessa regola —
+  un no-op. Il flag però non ricrea *quel* file, quindi l'hint dice che la
+  riga mostrata non si riesegue e rimanda a quella del messaggio successivo —
+  altrimenti il rimedio-che-non-fa-nulla si sposta di un livello invece di
+  sparire. Stessa forma dell'hint di `_BinaryNotFoundError`, e stessa regola —
   un rimedio si scrive solo quando c'è.
 - `EngineRuntimeError` separa runtime engine da config; sotto-classi future
   (es. errori I/O di rendering) si appendono qui.
@@ -291,7 +294,7 @@ streams:
 [ERRORE] Csound rendering fallito (exit code 2)
   Comando:      csound -o out.aif /tmp/tmpx3k9.sco
   Output:       error: undefined opcode
-  Hint:         Lo score .sco era temporaneo ed e' stato rimosso: rilancia con `--keep-sco` per conservarlo e rieseguire il comando qui sopra.
+  Hint:         Lo score .sco era temporaneo ed e' stato rimosso, quindi il comando qui sopra non e' piu' rieseguibile: rilancia con `--keep-sco`, che lo score lo conserva su disco, e riesegui il `Comando:` del messaggio che ne esce.
   Stream:       drone_low
   Config:       configs/PGE_test.yml
   Dettagli:     /tmp/engine.log
@@ -299,7 +302,10 @@ streams:
 
 La riga `Hint:` compare solo senza `--keep-sco`: con il flag lo score è già
 sul disco e suggerirlo manderebbe l'utente a cercare un'opzione che ha già
-passato.
+passato. E manda a rieseguire il `Comando:` del messaggio *successivo*, non
+quello mostrato qui: `--keep-sco` non riporta lo score al path temporaneo che
+questa riga nomina — lo scrive in una directory stabile, e senza il flag
+`mkstemp` pesca ogni volta un nome nuovo.
 
 ### SuperCollider subprocess fallito
 Il campo `stage` distingue i due binari, perché hanno rimedi diversi:

--- a/src/pge/cli.py
+++ b/src/pge/cli.py
@@ -539,10 +539,21 @@ def main():
     configure_engine_logger(yaml_name=yaml_basename, log_dir=log_dir)
 
     try:
-        generator = Generator(yaml_file, samples_dir=samples_dir)
+        try:
+            generator = Generator(yaml_file, samples_dir=samples_dir)
 
-        print(f"Caricamento {yaml_file}...")
-        generator.load_yaml()
+            print(f"Caricamento {yaml_file}...")
+            generator.load_yaml()
+        except FileNotFoundError:
+            # L'handler sta qui, non in fondo al try (issue #241): questo e'
+            # l'unico punto che puo' sollevare FileNotFoundError per il
+            # motivo che il messaggio annuncia. In fondo intercettava anche
+            # quelli che risalgono dal rendering -- csound assente su una
+            # macchina senza csound -- e l'utente si sentiva dire che il suo
+            # file di configurazione non esiste, mentre era stato letto e
+            # parsato poche righe sopra.
+            print(f" Errore: file '{yaml_file}' non trovato")
+            sys.exit(1)
 
         print("Generazione streams...")
         generator.create_elements()
@@ -656,9 +667,6 @@ def main():
 
         print(f"Log: {get_clip_log_path()}")
 
-    except FileNotFoundError:
-        print(f" Errore: file '{yaml_file}' non trovato")
-        sys.exit(1)
     except EngineError as e:
         _handle_engine_error(e)
         sys.exit(1)

--- a/src/pge/rendering/csound_renderer.py
+++ b/src/pge/rendering/csound_renderer.py
@@ -230,19 +230,22 @@ class CsoundRenderer(AudioRenderer):
 
         if result.returncode != 0:
             from pge.shared.exceptions import CsoundRenderError
+            # La riga `Comando:` del messaggio invita a rieseguire, ma nomina
+            # uno score che a quel punto non c'e' piu': da quando la
+            # cancellazione sta in un `finally` (PR #256) anche l'exit diverso
+            # da zero ci passa, e prima invece saltava le due righe lasciando
+            # il file in /tmp. Il rimedio esiste ed e' un flag: se il
+            # messaggio non lo dice, la prima azione che suggerisce e' un
+            # no-op. Con `--keep-sco` gia' attivo il rimedio non esiste piu',
+            # e l'hint tace.
+            hint = None if self.sco_dir else (
+                "Lo score .sco era temporaneo ed e' stato rimosso: rilancia "
+                "con `--keep-sco` per conservarlo e rieseguire il comando "
+                "qui sopra."
+            )
             raise CsoundRenderError(
                 returncode=result.returncode,
                 command=cmd,
                 stderr=result.stderr or "",
-                # La riga `Comando:` del messaggio invita a rieseguire, ma
-                # nomina uno score che a quel punto non c'e' piu': da quando
-                # la cancellazione sta in un `finally` (PR #256) anche l'exit
-                # diverso da zero ci passa, e prima invece saltava le due
-                # righe lasciando il file in /tmp. Il rimedio esiste ed e' un
-                # flag: se il messaggio non lo dice, la prima azione che
-                # suggerisce e' un no-op.
-                hint=("Lo score .sco era temporaneo ed e' stato rimosso: "
-                      "rilancia con `--keep-sco` per conservarlo e "
-                      "rieseguire il comando qui sopra.")
-                     if not self.sco_dir else None,
+                hint=hint,
             )

--- a/src/pge/rendering/csound_renderer.py
+++ b/src/pge/rendering/csound_renderer.py
@@ -87,18 +87,7 @@ class CsoundRenderer(AudioRenderer):
                 if not dirty:
                     return output_path
 
-        sco_path = self._write_score(streams=[stream], output_path=output_path, per_stream=True)
-        try:
-            self._run_csound(sco_path, output_path)
-        finally:
-            # Cleanup file temporaneo se non in modalita' keep-sco. Sta nel
-            # `finally` perche' anche i modi di fallire lo lasciano sul disco:
-            # con csound assente (issue #241) era un .sco abbandonato in /tmp
-            # a ogni singolo tentativo, con un nome casuale che l'utente non
-            # ha modo di ritrovare. Chi vuole il .sco di un render fallito ha
-            # --keep-sco, che questo ramo rispetta.
-            if not self.sco_dir and os.path.exists(sco_path):
-                os.unlink(sco_path)
+        self._render([stream], output_path, per_stream=True)
 
         # Aggiorna cache dopo build riuscita
         if self.cache_manager:
@@ -125,17 +114,7 @@ class CsoundRenderer(AudioRenderer):
             CsoundRenderError: se csound esce con errore
             CsoundNotFoundError: se csound non e' installato
         """
-        sco_path = self._write_score(
-            streams=streams,
-            output_path=output_path,
-        )
-        try:
-            self._run_csound(sco_path, output_path)
-        finally:
-            # Cleanup file temporaneo se non in modalita' keep-sco: vedi
-            # render_single_stream, il MIX passa dallo stesso _run_csound.
-            if not self.sco_dir and os.path.exists(sco_path):
-                os.unlink(sco_path)
+        self._render(streams, output_path, per_stream=False)
 
         return output_path
 
@@ -143,34 +122,55 @@ class CsoundRenderer(AudioRenderer):
     # INTERNAL
     # =========================================================================
 
-    def _write_score(self, streams, output_path: str, per_stream: bool = False) -> str:
-        """
-        Scrive il file .sco via ScoreWriter.
+    def _render(self, streams, output_path: str, per_stream: bool) -> None:
+        """Score + csound, con lo score temporaneo che se ne va comunque.
 
-        Se sco_dir e' configurato (--keep-sco), salva in path deterministico
-        basato su output_path. Altrimenti usa un file temporaneo.
+        STEMS e MIX passano di qui, quindi la regola di cancellazione ha una
+        scrittura sola. Il `try` copre anche `write_score`, non la sola
+        chiamata a csound: il file temporaneo lo crea `_score_path`
+        (`mkstemp`) *prima* che ScoreWriter ci scriva, e i grani sono lazy
+        (issue #117) -- si materializzano proprio qui, con tutti i modi di
+        essere invalidi che il parse non ha visto. Uno score che muore
+        scrivendo lasciava un .sco in /tmp esattamente come il csound assente
+        della issue #241, con lo stesso nome casuale che l'utente non ha modo
+        di ritrovare. E' la forma che `SuperColliderRenderer._render` ha da
+        sempre; era questa meta' a non averla.
+
+        Chi il .sco di un render fallito lo vuole ha `--keep-sco`, ed e' la
+        modalita' in cui il file non e' temporaneo: la condizione lo rispetta.
+        """
+        sco_path = self._score_path(output_path)
+        try:
+            self.score_writer.write_score(
+                filepath=sco_path,
+                streams=streams,
+                per_stream=per_stream,
+            )
+            self._run_csound(sco_path, output_path)
+        finally:
+            if not self.sco_dir and os.path.exists(sco_path):
+                os.unlink(sco_path)
+
+    def _score_path(self, output_path: str) -> str:
+        """Path del file .sco.
+
+        Se sco_dir e' configurato (--keep-sco), path deterministico basato su
+        output_path. Altrimenti un file temporaneo, che `mkstemp` crea gia'
+        vuoto sul disco: da quel momento e' compito di `_render` toglierlo.
 
         Args:
-            streams: lista di Stream da includere
             output_path: percorso del file .aif di output (usato per naming)
 
         Returns:
-            Path del file .sco scritto
+            Path del file .sco
         """
         if self.sco_dir:
             base = os.path.splitext(os.path.basename(output_path))[0]
-            sco_path = os.path.join(self.sco_dir, f"{base}.sco")
             os.makedirs(self.sco_dir, exist_ok=True)
-        else:
-            fd, sco_path = tempfile.mkstemp(suffix='.sco')
-            os.close(fd)
+            return os.path.join(self.sco_dir, f"{base}.sco")
 
-        self.score_writer.write_score(
-            filepath=sco_path,
-            streams=streams,
-            per_stream=per_stream,
-        )
-
+        fd, sco_path = tempfile.mkstemp(suffix='.sco')
+        os.close(fd)
         return sco_path
 
     def _run_csound(self, sco_path: str, output_path: str):

--- a/src/pge/rendering/csound_renderer.py
+++ b/src/pge/rendering/csound_renderer.py
@@ -234,4 +234,15 @@ class CsoundRenderer(AudioRenderer):
                 returncode=result.returncode,
                 command=cmd,
                 stderr=result.stderr or "",
+                # La riga `Comando:` del messaggio invita a rieseguire, ma
+                # nomina uno score che a quel punto non c'e' piu': da quando
+                # la cancellazione sta in un `finally` (PR #256) anche l'exit
+                # diverso da zero ci passa, e prima invece saltava le due
+                # righe lasciando il file in /tmp. Il rimedio esiste ed e' un
+                # flag: se il messaggio non lo dice, la prima azione che
+                # suggerisce e' un no-op.
+                hint=("Lo score .sco era temporaneo ed e' stato rimosso: "
+                      "rilancia con `--keep-sco` per conservarlo e "
+                      "rieseguire il comando qui sopra.")
+                     if not self.sco_dir else None,
             )

--- a/src/pge/rendering/csound_renderer.py
+++ b/src/pge/rendering/csound_renderer.py
@@ -74,8 +74,8 @@ class CsoundRenderer(AudioRenderer):
             Il percorso del file .aif prodotto
 
         Raises:
-            RuntimeError: se csound esce con errore
-            FileNotFoundError: se csound non e' installato
+            CsoundRenderError: se csound esce con errore (anche RuntimeError)
+            CsoundNotFoundError: se csound non e' installato
         """
         # Cache check: skip se stream e' clean
         if self.cache_manager:
@@ -168,8 +168,8 @@ class CsoundRenderer(AudioRenderer):
         Costruisce il comando con env vars e flags dalla configurazione.
 
         Raises:
-            RuntimeError: se csound ritorna un codice di errore
-            FileNotFoundError: se csound non e' installato
+            CsoundRenderError: se csound ritorna un codice di errore
+            CsoundNotFoundError: se csound non e' installato
         """
         cmd = ['csound']
 
@@ -197,7 +197,19 @@ class CsoundRenderer(AudioRenderer):
             cmd.append(f'--logfile={log_dir}/{basename}.log')
 
         # Esegui
-        result = subprocess.run(cmd, capture_output=True, text=True)
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True)
+        except FileNotFoundError:
+            # csound non e' nel PATH. Il FileNotFoundError grezzo finiva
+            # nell'handler che la CLI tiene per il file YAML, e l'utente si
+            # sentiva dire che la sua configurazione non esiste (issue #241).
+            from pge.shared.exceptions import CsoundNotFoundError
+            raise CsoundNotFoundError(
+                what=f"binario '{cmd[0]}'",
+                hint=("Installa csound (`make install-system-deps`), oppure "
+                      "usa `--renderer numpy`, che non richiede binari "
+                      "esterni."),
+            ) from None
 
         if result.returncode != 0:
             from pge.shared.exceptions import CsoundRenderError

--- a/src/pge/rendering/csound_renderer.py
+++ b/src/pge/rendering/csound_renderer.py
@@ -238,10 +238,18 @@ class CsoundRenderer(AudioRenderer):
             # messaggio non lo dice, la prima azione che suggerisce e' un
             # no-op. Con `--keep-sco` gia' attivo il rimedio non esiste piu',
             # e l'hint tace.
+            #
+            # Quel flag pero' non riporta lo score al path che il `Comando:`
+            # mostra: `_score_path` con `sco_dir` scrive in una directory
+            # stabile, e senza pesca ogni volta un nome nuovo da `mkstemp`.
+            # Promettere di «rieseguire il comando qui sopra» era lo stesso
+            # rimedio-che-non-fa-nulla riscritto un livello piu' in la': la
+            # riga rieseguibile e' quella del messaggio *successivo*.
             hint = None if self.sco_dir else (
-                "Lo score .sco era temporaneo ed e' stato rimosso: rilancia "
-                "con `--keep-sco` per conservarlo e rieseguire il comando "
-                "qui sopra."
+                "Lo score .sco era temporaneo ed e' stato rimosso, quindi il "
+                "comando qui sopra non e' piu' rieseguibile: rilancia con "
+                "`--keep-sco`, che lo score lo conserva su disco, e riesegui "
+                "il `Comando:` del messaggio che ne esce."
             )
             raise CsoundRenderError(
                 returncode=result.returncode,

--- a/src/pge/rendering/csound_renderer.py
+++ b/src/pge/rendering/csound_renderer.py
@@ -88,11 +88,17 @@ class CsoundRenderer(AudioRenderer):
                     return output_path
 
         sco_path = self._write_score(streams=[stream], output_path=output_path, per_stream=True)
-        self._run_csound(sco_path, output_path)
-
-        # Cleanup file temporaneo se non in modalita' keep-sco
-        if not self.sco_dir and os.path.exists(sco_path):
-            os.unlink(sco_path)
+        try:
+            self._run_csound(sco_path, output_path)
+        finally:
+            # Cleanup file temporaneo se non in modalita' keep-sco. Sta nel
+            # `finally` perche' anche i modi di fallire lo lasciano sul disco:
+            # con csound assente (issue #241) era un .sco abbandonato in /tmp
+            # a ogni singolo tentativo, con un nome casuale che l'utente non
+            # ha modo di ritrovare. Chi vuole il .sco di un render fallito ha
+            # --keep-sco, che questo ramo rispetta.
+            if not self.sco_dir and os.path.exists(sco_path):
+                os.unlink(sco_path)
 
         # Aggiorna cache dopo build riuscita
         if self.cache_manager:
@@ -114,16 +120,22 @@ class CsoundRenderer(AudioRenderer):
 
         Returns:
             Il percorso del file .aif prodotto
+
+        Raises:
+            CsoundRenderError: se csound esce con errore
+            CsoundNotFoundError: se csound non e' installato
         """
         sco_path = self._write_score(
             streams=streams,
             output_path=output_path,
         )
-        self._run_csound(sco_path, output_path)
-
-        # Cleanup file temporaneo se non in modalita' keep-sco
-        if not self.sco_dir and os.path.exists(sco_path):
-            os.unlink(sco_path)
+        try:
+            self._run_csound(sco_path, output_path)
+        finally:
+            # Cleanup file temporaneo se non in modalita' keep-sco: vedi
+            # render_single_stream, il MIX passa dallo stesso _run_csound.
+            if not self.sco_dir and os.path.exists(sco_path):
+                os.unlink(sco_path)
 
         return output_path
 
@@ -206,9 +218,14 @@ class CsoundRenderer(AudioRenderer):
             from pge.shared.exceptions import CsoundNotFoundError
             raise CsoundNotFoundError(
                 what=f"binario '{cmd[0]}'",
-                hint=("Installa csound (`make install-system-deps`), oppure "
-                      "usa `--renderer numpy`, che non richiede binari "
-                      "esterni."),
+                # `make install-system-deps` NON installa csound su
+                # Fedora/RHEL -- non e' nei repo, ne' in RPM Fusion -- ed e'
+                # proprio la macchina da cui viene la issue: un rimedio che
+                # li' e' un no-op vale quanto il messaggio che ha sostituito.
+                hint=("Installa csound (`make install-system-deps`; su "
+                      "Fedora/RHEL non e' nei repo e va compilato dai "
+                      "sorgenti, vedi README), oppure usa `--renderer "
+                      "numpy`, che non richiede binari esterni."),
             ) from None
 
         if result.returncode != 0:

--- a/src/pge/rendering/supercollider_renderer.py
+++ b/src/pge/rendering/supercollider_renderer.py
@@ -217,7 +217,7 @@ class SuperColliderRenderer(AudioRenderer):
 
     def _score_path(self, output_path: str) -> str:
         """Path dello score .osc: deterministico con --keep-osc, temporaneo
-        altrimenti. Stessa logica di CsoundRenderer._write_score."""
+        altrimenti. Stessa logica di CsoundRenderer._score_path."""
         if self.osc_dir:
             base = os.path.splitext(os.path.basename(output_path))[0]
             os.makedirs(self.osc_dir, exist_ok=True)

--- a/src/pge/shared/exceptions.py
+++ b/src/pge/shared/exceptions.py
@@ -273,7 +273,7 @@ class _SubprocessRenderError(EngineRuntimeError, RuntimeError):
     diagnostic_index = 0
 
     def __init__(self, returncode: int, command: list[str], stderr: str,
-                 stdout: str = ""):
+                 stdout: str = "", hint: str | None = None):
         self.returncode = returncode
         self.command = list(command)
         self.stderr = stderr
@@ -281,6 +281,13 @@ class _SubprocessRenderError(EngineRuntimeError, RuntimeError):
         # il backtrace dell'interprete, scsynth li' scrive `FAILURE IN SERVER`.
         # Senza, un refuso nella SynthDef arriva all'utente senza diagnostica.
         self.stdout = stdout
+        # Il rimedio, quando ce n'e' uno che il messaggio da solo non offre.
+        # La riga `Comando:` invita a rieseguire, ma lo score che vi compare
+        # e' temporaneo e il renderer lo cancella prima che il messaggio si
+        # stampi: chi lo vuole ha un flag, e il flag va detto qui. Opzionale
+        # perche' con quel flag gia' attivo il rimedio non esiste piu' --
+        # stessa regola dell'hint di `_BinaryNotFoundError`.
+        self.hint = hint
         super().__init__(
             f"{self.stage} ha fallito con codice {returncode}.\n"
             f"Comando: {' '.join(command)}\n"
@@ -303,6 +310,8 @@ class _SubprocessRenderError(EngineRuntimeError, RuntimeError):
         diagnostic = self.diagnostic_line()
         if diagnostic:
             lines.append(f"  Output:       {diagnostic}")
+        if self.hint:
+            lines.append(f"  Hint:         {self.hint}")
         lines.extend(self._context_lines())
         return "\n".join(lines)
 

--- a/src/pge/shared/exceptions.py
+++ b/src/pge/shared/exceptions.py
@@ -409,22 +409,48 @@ class SuperColliderRenderError(_SubprocessRenderError):
         super().__init__(returncode, command, stderr, stdout=stdout)
 
 
-class SuperColliderNotFoundError(EngineRuntimeError):
-    """Binario SuperCollider o sorgente della SynthDef non trovati (issue #228).
+class _BinaryNotFoundError(EngineRuntimeError):
+    """Un binario esterno -- o un sorgente che serve a produrlo -- non c'e'
+    (issue #228 per SuperCollider, #241 per csound).
 
     NON eredita FileNotFoundError di proposito: la CLI intercetta quel tipo
     per annunciare 'file YAML non trovato', e un binario mancante che
     passasse di li' verrebbe riportato come una configurazione inesistente.
+    Il tipo di un errore serve a chi lo cattura, non a descriverne la causa.
+
+    Le sottoclassi dichiarano `tool`, il nome che apre il messaggio: e'
+    l'unica cosa che le distingue, come per `_SubprocessRenderError`.
     """
+
+    tool = "binario esterno"
 
     def __init__(self, what: str, hint: str | None = None):
         self.what = what
         self.hint = hint
-        super().__init__(f"SuperCollider: {what} non trovato")
+        super().__init__(f"{self.tool}: {what} non trovato")
 
     def user_message(self) -> str:
-        lines = [f"[ERRORE] SuperCollider: {self.what} non trovato"]
+        lines = [f"[ERRORE] {self.tool}: {self.what} non trovato"]
         if self.hint:
             lines.append(f"  Hint:         {self.hint}")
         lines.extend(self._context_lines())
         return "\n".join(lines)
+
+
+class SuperColliderNotFoundError(_BinaryNotFoundError):
+    """Binario SuperCollider o sorgente della SynthDef non trovati (issue #228)."""
+
+    tool = "SuperCollider"
+
+
+class CsoundNotFoundError(_BinaryNotFoundError):
+    """csound non e' nel PATH (issue #241).
+
+    Il subprocess alza FileNotFoundError, che era anche il tipo promesso
+    dalla docstring di `render_single_stream`: la CLI lo intercettava prima
+    di EngineError e diceva all'utente che mancava il suo file YAML -- letto
+    e parsato pochi istanti prima. Qui il guasto prende un tipo suo, con il
+    rimedio scritto dentro.
+    """
+
+    tool = "Csound"

--- a/tests/rendering/test_csound_renderer.py
+++ b/tests/rendering/test_csound_renderer.py
@@ -245,6 +245,49 @@ class TestCsoundRendererErrors:
         with pytest.raises(CsoundNotFoundError):
             renderer.render_merged_streams([mock_stream], '/output/mix.aif')
 
+    @patch('pge.rendering.csound_renderer.subprocess.run')
+    def test_csound_fallito_dice_come_riavere_lo_sco(self, mock_run, renderer, mock_stream):
+        """Il messaggio di CsoundRenderError offre un `Comando:` da rieseguire,
+        ma quel comando nomina il `.sco` che il `finally` ha appena cancellato:
+        senza il flag, la prima azione che il messaggio suggerisce e' un
+        no-op. E' lo stesso metro con cui questa PR ha riscritto l'hint di
+        csound assente. Il rimedio (`--keep-sco`) lo conosce gia'
+        `docs/reference/cli.md`; qui deve stare dentro il messaggio, che e'
+        l'unica cosa che l'utente legge."""
+        from pge.shared.exceptions import CsoundRenderError
+        mock_run.return_value = MagicMock(
+            returncode=2, stderr='error: undefined opcode', stdout='')
+
+        with pytest.raises(CsoundRenderError) as exc:
+            renderer.render_single_stream(mock_stream, '/output/test.aif')
+
+        msg = exc.value.user_message()
+        sco_path = renderer.score_writer.write_score.call_args.kwargs['filepath']
+        assert not os.path.exists(sco_path), \
+            "premessa del test: il finally lo ha cancellato"
+        assert '--keep-sco' in msg
+
+    @patch('pge.rendering.csound_renderer.subprocess.run')
+    def test_con_keep_sco_il_messaggio_non_promette_un_rimedio_gia_attivo(
+        self, mock_run, mock_score_writer, csound_config, mock_stream, tmp_path
+    ):
+        """Con `--keep-sco` lo score e' li': suggerirlo sarebbe un rimedio per
+        un guasto che non c'e', e manderebbe l'utente a cercare un flag che ha
+        gia' passato."""
+        from pge.shared.exceptions import CsoundRenderError
+        mock_run.return_value = MagicMock(
+            returncode=2, stderr='error: undefined opcode', stdout='')
+        renderer = CsoundRenderer(
+            score_writer=mock_score_writer,
+            csound_config=csound_config,
+            sco_dir=str(tmp_path / 'sco'),
+        )
+
+        with pytest.raises(CsoundRenderError) as exc:
+            renderer.render_single_stream(mock_stream, '/out/test.aif')
+
+        assert '--keep-sco' not in exc.value.user_message()
+
     @pytest.mark.parametrize('mode', ['stems', 'mix'])
     @patch('pge.rendering.csound_renderer.subprocess.run')
     def test_il_sco_temporaneo_non_sopravvive_a_un_render_fallito(
@@ -545,6 +588,39 @@ class TestCsoundRendererKeepSco:
         sco_path = call_kwargs['filepath']
         # Deve essere in tempdir, non in 'generated'
         assert 'generated' not in sco_path
+
+    @pytest.mark.parametrize('mode', ['stems', 'mix'])
+    @patch('pge.rendering.csound_renderer.subprocess.run')
+    def test_lo_sco_temporaneo_e_rimosso_anche_dopo_un_render_riuscito(
+        self, mock_run, mock_score_writer, csound_config, mock_stream, mode
+    ):
+        """La regola di cancellazione ha ora una scrittura sola, e il suo ramo
+        piu' battuto e' quello che finisce bene: senza rete, un render che
+        smettesse di ripulire lascerebbe un `.sco` in /tmp a ogni stem, e la
+        suite resterebbe verde. E' il test che
+        `SuperColliderRenderer` ha da sempre (`test_score_scritto_e_poi_rimosso`),
+        e che al ramo csound mancava."""
+        visto = {}
+
+        def spia(cmd, **kwargs):
+            path = mock_score_writer.write_score.call_args.kwargs['filepath']
+            visto['path'] = path
+            visto['esisteva'] = os.path.exists(path)
+            return MagicMock(returncode=0)
+
+        mock_run.side_effect = spia
+        renderer = CsoundRenderer(
+            score_writer=mock_score_writer,
+            csound_config=csound_config,
+        )
+
+        if mode == 'stems':
+            renderer.render_single_stream(mock_stream, '/out/test.aif')
+        else:
+            renderer.render_merged_streams([mock_stream], '/out/mix.aif')
+
+        assert visto['esisteva'], "lo score deve esistere quando csound parte"
+        assert not os.path.exists(visto['path']), "temporaneo non ripulito"
 
     @patch('pge.rendering.csound_renderer.subprocess.run')
     def test_sco_dir_saves_sco_with_deterministic_path(

--- a/tests/rendering/test_csound_renderer.py
+++ b/tests/rendering/test_csound_renderer.py
@@ -257,24 +257,43 @@ class TestCsoundRendererErrors:
         from pge.shared.exceptions import CsoundNotFoundError
         mock_run.side_effect = FileNotFoundError()
 
-        scritti = []
-        vero_write_score = renderer._write_score
-
-        def spia(*args, **kwargs):
-            path = vero_write_score(*args, **kwargs)
-            scritti.append(path)
-            return path
-
-        renderer._write_score = spia
-
         with pytest.raises(CsoundNotFoundError):
             if mode == 'stems':
                 renderer.render_single_stream(mock_stream, '/output/test.aif')
             else:
                 renderer.render_merged_streams([mock_stream], '/output/mix.aif')
 
-        assert scritti, "nessun .sco scritto: il test non sta misurando nulla"
-        assert not os.path.exists(scritti[0])
+        # Il path arriva dalla chiamata a write_score, non da una spia su un
+        # metodo interno: e' il .sco che il renderer ha davvero creato, e
+        # l'asserzione non si rompe se quel metodo cambia nome.
+        assert renderer.score_writer.write_score.call_args, \
+            "nessun .sco scritto: il test non sta misurando nulla"
+        sco_path = renderer.score_writer.write_score.call_args.kwargs['filepath']
+        assert not os.path.exists(sco_path)
+
+    @pytest.mark.parametrize('mode', ['stems', 'mix'])
+    @patch('pge.rendering.csound_renderer.subprocess.run')
+    def test_il_sco_temporaneo_non_sopravvive_a_uno_score_che_fallisce(
+            self, mock_run, renderer, mock_stream, mode):
+        """Il file temporaneo lo crea `mkstemp`, prima che ScoreWriter ci
+        scriva: anche un render che muore *scrivendo* lo score ne lascia uno
+        in /tmp. Non e' un caso di scuola -- i grani sono lazy (issue #117) e
+        si materializzano qui, quindi ogni modo di essere invalidi che il
+        parse non ha visto passa da questa riga. Il `finally` deve coprire
+        anche la scrittura, come in SuperColliderRenderer._render."""
+        from pge.shared.exceptions import FtableError
+        mock_run.return_value = MagicMock(returncode=0)
+        renderer.score_writer.write_score.side_effect = FtableError(
+            key='win_hann', reason='tabella non registrata')
+
+        with pytest.raises(FtableError):
+            if mode == 'stems':
+                renderer.render_single_stream(mock_stream, '/output/test.aif')
+            else:
+                renderer.render_merged_streams([mock_stream], '/output/mix.aif')
+
+        sco_path = renderer.score_writer.write_score.call_args.kwargs['filepath']
+        assert not os.path.exists(sco_path)
 
 
 # =============================================================================
@@ -566,6 +585,44 @@ class TestCsoundRendererKeepSco:
         sco_path = call_kwargs['filepath']
         assert sco_path.startswith(sco_dir)
         assert sco_path.endswith('composition.sco')
+
+    @pytest.mark.parametrize('mode,base', [('stems', 'test'), ('mix', 'mix')])
+    @patch('pge.rendering.csound_renderer.subprocess.run')
+    def test_keep_sco_conserva_lo_score_di_un_render_fallito(
+        self, mock_run, mock_score_writer, csound_config, mock_stream,
+        tmp_path, mode, base
+    ):
+        """--keep-sco serve a ispezionare lo score, e lo score che si vuole
+        ispezionare e' quello del render fallito.
+
+        La cancellazione ora sta in un `finally`, cioe' passa anche di li':
+        prima il ramo dei fallimenti non la eseguiva affatto e la condizione
+        `not self.sco_dir` non aveva modo di sbagliare. Se qualcuno la
+        perdesse, questo flag cancellerebbe il file che promette di tenere --
+        e senza questo test la suite resterebbe verde."""
+        from pge.shared.exceptions import CsoundNotFoundError
+        mock_run.side_effect = FileNotFoundError()
+        sco_dir = str(tmp_path / 'sco')
+
+        # Il ScoreWriter e' un mock e da solo non scrive niente: senza questo
+        # il file non esisterebbe comunque e l'asserzione sarebbe vuota.
+        def scrive_davvero(filepath, **kwargs):
+            open(filepath, 'w').close()
+
+        mock_score_writer.write_score.side_effect = scrive_davvero
+        renderer = CsoundRenderer(
+            score_writer=mock_score_writer,
+            csound_config=csound_config,
+            sco_dir=sco_dir,
+        )
+
+        with pytest.raises(CsoundNotFoundError):
+            if mode == 'stems':
+                renderer.render_single_stream(mock_stream, f'/out/{base}.aif')
+            else:
+                renderer.render_merged_streams([mock_stream], f'/out/{base}.aif')
+
+        assert os.path.exists(os.path.join(sco_dir, f'{base}.sco'))
 
 
 # =============================================================================

--- a/tests/rendering/test_csound_renderer.py
+++ b/tests/rendering/test_csound_renderer.py
@@ -288,6 +288,53 @@ class TestCsoundRendererErrors:
 
         assert '--keep-sco' not in exc.value.user_message()
 
+    @patch('pge.rendering.csound_renderer.subprocess.run')
+    def test_l_hint_non_promette_di_rieseguire_il_comando_del_temporaneo(
+        self, mock_run, mock_score_writer, csound_config, mock_stream, tmp_path
+    ):
+        """`--keep-sco` non ricrea lo score cancellato: lo scrive altrove.
+
+        Il `Comando:` del messaggio nomina il file temporaneo, che il
+        `finally` ha appena rimosso e che nessun rilancio riporta a quel
+        path: con `sco_dir` lo score va in una directory stabile
+        (`generated/` per default, o `--sco-dir`), e senza, `mkstemp` pesca
+        ogni volta un nome nuovo. Un hint che dica «rilancia con
+        `--keep-sco` [...] e riesegui il comando qui sopra» manda quindi a
+        una riga che non tornera' valida mai -- ed e' lo stesso metro con
+        cui questa PR ha riscritto l'hint di csound assente, applicato
+        all'hint che quella riscrittura ha introdotto.
+
+        Il rimedio resta `--keep-sco`; a cambiare e' cosa il messaggio
+        promette del comando che sta mostrando.
+        """
+        from pge.shared.exceptions import CsoundRenderError
+        mock_run.return_value = MagicMock(
+            returncode=2, stderr='error: undefined opcode', stdout='')
+
+        temporaneo = CsoundRenderer(
+            score_writer=mock_score_writer, csound_config=csound_config)
+        with pytest.raises(CsoundRenderError) as exc:
+            temporaneo.render_single_stream(mock_stream, '/out/test.aif')
+        msg = exc.value.user_message()
+        sco_temp = mock_score_writer.write_score.call_args.kwargs['filepath']
+
+        # Premessa, misurata e non dichiarata: il path che il `Comando:`
+        # mostra e' sparito, e il flag che il messaggio suggerisce ne
+        # produce un altro.
+        assert sco_temp in msg
+        assert not os.path.exists(sco_temp)
+        con_flag = CsoundRenderer(
+            score_writer=mock_score_writer, csound_config=csound_config,
+            sco_dir=str(tmp_path / 'sco'))
+        with pytest.raises(CsoundRenderError):
+            con_flag.render_single_stream(mock_stream, '/out/test.aif')
+        assert mock_score_writer.write_score.call_args.kwargs['filepath'] != sco_temp
+
+        # Quindi il messaggio deve dire che quella riga non si riesegue, non
+        # invitare a rieseguirla.
+        assert '--keep-sco' in msg
+        assert "non e' piu' rieseguibile" in msg
+
     @pytest.mark.parametrize('mode', ['stems', 'mix'])
     @patch('pge.rendering.csound_renderer.subprocess.run')
     def test_il_sco_temporaneo_non_sopravvive_a_un_render_fallito(

--- a/tests/rendering/test_csound_renderer.py
+++ b/tests/rendering/test_csound_renderer.py
@@ -206,12 +206,39 @@ class TestCsoundRendererErrors:
             renderer.render_single_stream(mock_stream, '/output/test.aif')
 
     @patch('pge.rendering.csound_renderer.subprocess.run')
-    def test_csound_not_found_raises(self, mock_run, renderer, mock_stream):
-        """Csound non installato solleva FileNotFoundError."""
+    def test_csound_assente_e_un_errore_azionabile(self, mock_run, renderer, mock_stream):
+        """Csound non installato: il messaggio nomina il binario e il rimedio
+        (issue #241). Prima era il FileNotFoundError grezzo del subprocess."""
+        from pge.shared.exceptions import CsoundNotFoundError
         mock_run.side_effect = FileNotFoundError("csound not found")
 
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(CsoundNotFoundError) as exc:
             renderer.render_single_stream(mock_stream, '/output/test.aif')
+
+        msg = exc.value.user_message()
+        assert 'csound' in msg
+        assert '--renderer numpy' in msg
+
+    @patch('pge.rendering.csound_renderer.subprocess.run')
+    def test_csound_assente_non_e_un_FileNotFoundError(self, mock_run, renderer, mock_stream):
+        """Specchio di test_scsynth_assente_non_e_un_FileNotFoundError
+        (issue #241): la CLI intercetta FileNotFoundError per annunciare
+        «file YAML non trovato», e il file YAML qui esiste ed e' gia' stato
+        letto."""
+        mock_run.side_effect = FileNotFoundError()
+
+        with pytest.raises(Exception) as exc:
+            renderer.render_single_stream(mock_stream, '/output/test.aif')
+        assert not isinstance(exc.value, FileNotFoundError)
+
+    @patch('pge.rendering.csound_renderer.subprocess.run')
+    def test_csound_assente_anche_in_mix(self, mock_run, renderer, mock_stream):
+        """Il MIX passa dallo stesso _run_csound: stesso errore."""
+        from pge.shared.exceptions import CsoundNotFoundError
+        mock_run.side_effect = FileNotFoundError()
+
+        with pytest.raises(CsoundNotFoundError):
+            renderer.render_merged_streams([mock_stream], '/output/mix.aif')
 
 
 # =============================================================================

--- a/tests/rendering/test_csound_renderer.py
+++ b/tests/rendering/test_csound_renderer.py
@@ -16,6 +16,8 @@ Coverage:
 6. TestRendererFactoryValidation         - validazione input
 """
 
+import os
+
 import pytest
 from unittest.mock import MagicMock, patch, call
 
@@ -216,7 +218,10 @@ class TestCsoundRendererErrors:
             renderer.render_single_stream(mock_stream, '/output/test.aif')
 
         msg = exc.value.user_message()
-        assert 'csound' in msg
+        # Il binario, non la parola: 'csound' da sola vive gia' nell'hint,
+        # quindi un `what=` svuotato lascerebbe verde l'asserzione che la
+        # docstring dice di fare.
+        assert "binario 'csound'" in msg
         assert '--renderer numpy' in msg
 
     @patch('pge.rendering.csound_renderer.subprocess.run')
@@ -239,6 +244,37 @@ class TestCsoundRendererErrors:
 
         with pytest.raises(CsoundNotFoundError):
             renderer.render_merged_streams([mock_stream], '/output/mix.aif')
+
+    @pytest.mark.parametrize('mode', ['stems', 'mix'])
+    @patch('pge.rendering.csound_renderer.subprocess.run')
+    def test_il_sco_temporaneo_non_sopravvive_a_un_render_fallito(
+            self, mock_run, renderer, mock_stream, mode):
+        """Senza --keep-sco il .sco e' un file temporaneo, e la sua
+        cancellazione stava dopo la chiamata a csound: ogni modo di fallire
+        ne abbandonava uno in /tmp, con un nome che l'utente non puo'
+        ritrovare. Con csound assente (issue #241) era ogni singolo
+        tentativo."""
+        from pge.shared.exceptions import CsoundNotFoundError
+        mock_run.side_effect = FileNotFoundError()
+
+        scritti = []
+        vero_write_score = renderer._write_score
+
+        def spia(*args, **kwargs):
+            path = vero_write_score(*args, **kwargs)
+            scritti.append(path)
+            return path
+
+        renderer._write_score = spia
+
+        with pytest.raises(CsoundNotFoundError):
+            if mode == 'stems':
+                renderer.render_single_stream(mock_stream, '/output/test.aif')
+            else:
+                renderer.render_merged_streams([mock_stream], '/output/mix.aif')
+
+        assert scritti, "nessun .sco scritto: il test non sta misurando nulla"
+        assert not os.path.exists(scritti[0])
 
 
 # =============================================================================

--- a/tests/shared/test_engine_exceptions.py
+++ b/tests/shared/test_engine_exceptions.py
@@ -537,6 +537,48 @@ def test_csound_render_error_context_lines():
 
 
 # =============================================================================
+# Issue #241 — csound assente: un errore azionabile, non un FileNotFoundError
+# =============================================================================
+
+def test_csound_not_found_error_inheritance_and_message():
+    from pge.shared.exceptions import (
+        CsoundNotFoundError, EngineError, EngineRuntimeError,
+    )
+    err = CsoundNotFoundError(
+        what="binario 'csound'",
+        hint="Installa csound, oppure usa --renderer numpy.",
+    )
+    assert isinstance(err, EngineRuntimeError)
+    assert isinstance(err, EngineError)
+    msg = err.user_message()
+    assert "[ERRORE]" in msg
+    assert "Csound" in msg
+    assert "binario 'csound'" in msg
+    assert "--renderer numpy" in msg
+
+
+def test_csound_not_found_error_non_e_un_FileNotFoundError():
+    """La CLI intercetta FileNotFoundError per annunciare «file YAML non
+    trovato»: un binario mancante che passasse di li' verrebbe riportato
+    come una configurazione inesistente (stessa regola di
+    SuperColliderNotFoundError)."""
+    from pge.shared.exceptions import CsoundNotFoundError
+    err = CsoundNotFoundError(what="binario 'csound'")
+    assert not isinstance(err, FileNotFoundError)
+    assert not isinstance(err, OSError)
+
+
+def test_csound_not_found_error_context_lines():
+    from pge.shared.exceptions import CsoundNotFoundError
+    err = CsoundNotFoundError(what="binario 'csound'")
+    err.stream_id = "drone_a"
+    err.config_file = "configs/x.yml"
+    msg = err.user_message()
+    assert "drone_a" in msg
+    assert "configs/x.yml" in msg
+
+
+# =============================================================================
 # Issue #46 — PR1: controllers raises -> EngineError
 # =============================================================================
 

--- a/tests/shared/test_engine_exceptions.py
+++ b/tests/shared/test_engine_exceptions.py
@@ -540,11 +540,18 @@ def test_subprocess_render_error_hint_e_opzionale():
     con = CsoundRenderError(
         returncode=2, command=["csound", "/tmp/x.sco"], stderr="err",
         hint="Rilancia con --keep-sco.")
+    con.stream_id = "drone_a"
+    con.config_file = "configs/x.yml"
     msg = con.user_message()
     assert "  Hint:         Rilancia con --keep-sco." in msg
     # Dopo la diagnostica e prima delle righe di contesto: l'hint e' il
-    # seguito dell'errore, non un'intestazione.
-    assert msg.index("Output:") < msg.index("Hint:")
+    # seguito dell'errore, non un'intestazione -- ed e' la posizione che
+    # `docs/reference/errors.md` mostra nell'esempio del render fallito.
+    # Serve la coppia: `Output: < Hint:` da sola resta vera anche con
+    # l'hint spinto in fondo, sotto Stream e Config, cioe' proprio sul
+    # difetto che il commento dichiara di coprire. Le righe di contesto
+    # vanno quindi materializzate, altrimenti non c'e' un "dopo".
+    assert msg.index("Output:") < msg.index("Hint:") < msg.index("Stream:")
 
 
 def test_csound_render_error_context_lines():
@@ -591,12 +598,17 @@ def test_csound_not_found_error_non_e_un_FileNotFoundError():
 
 def test_csound_not_found_error_context_lines():
     from pge.shared.exceptions import CsoundNotFoundError
-    err = CsoundNotFoundError(what="binario 'csound'")
+    err = CsoundNotFoundError(what="binario 'csound'", hint="Usa --renderer numpy.")
     err.stream_id = "drone_a"
     err.config_file = "configs/x.yml"
     msg = err.user_message()
     assert "drone_a" in msg
     assert "configs/x.yml" in msg
+    # Stessa regola di posizione di `_SubprocessRenderError`, e stesso modo
+    # di sbagliarla: il rimedio precede il contesto, come nell'esempio di
+    # `docs/reference/errors.md`. Senza questa riga, spostare l'hint in
+    # fondo lasciava verdi tutte e due le meta' della gerarchia.
+    assert msg.index("Hint:") < msg.index("Stream:")
 
 
 # =============================================================================

--- a/tests/shared/test_engine_exceptions.py
+++ b/tests/shared/test_engine_exceptions.py
@@ -526,6 +526,27 @@ def test_csound_render_error_inheritance_and_message():
     assert "orch error" in msg
 
 
+def test_subprocess_render_error_hint_e_opzionale():
+    """L'hint del render fallito e' condizionale, non decorativo: dice come
+    riavere lo score temporaneo, e con `--keep-sco` quello score c'e' gia'.
+    Una riga `Hint:` stampata sempre sarebbe un rimedio per un guasto assente
+    -- e' la stessa regola di `_BinaryNotFoundError`, da cui questa base copia
+    il formato della riga."""
+    from pge.shared.exceptions import CsoundRenderError
+    senza = CsoundRenderError(
+        returncode=2, command=["csound", "/tmp/x.sco"], stderr="err")
+    assert "Hint:" not in senza.user_message()
+
+    con = CsoundRenderError(
+        returncode=2, command=["csound", "/tmp/x.sco"], stderr="err",
+        hint="Rilancia con --keep-sco.")
+    msg = con.user_message()
+    assert "  Hint:         Rilancia con --keep-sco." in msg
+    # Dopo la diagnostica e prima delle righe di contesto: l'hint e' il
+    # seguito dell'errore, non un'intestazione.
+    assert msg.index("Output:") < msg.index("Hint:")
+
+
 def test_csound_render_error_context_lines():
     from pge.shared.exceptions import CsoundRenderError
     err = CsoundRenderError(returncode=2, command=["csound"], stderr="x")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -589,6 +589,27 @@ class TestErrorHandling:
                 mocks['main'].main()
         assert exc_info.value.code == 1
 
+    def test_file_not_found_dal_render_non_incolpa_lo_yaml(self, mocks, capsys):
+        """Issue #241: un FileNotFoundError che risale dal rendering non e'
+        il file YAML, che a quel punto e' stato letto e parsato. L'handler
+        della CLI resta attaccato al solo punto che puo' sollevarlo per il
+        motivo che annuncia."""
+        mocks['engine_instance'].render.side_effect = FileNotFoundError()
+        with patch.object(sys, 'argv', ['main.py', 'test.yml', 'out.aif']):
+            with pytest.raises(SystemExit) as exc_info:
+                mocks['main'].main()
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "non trovato" not in out
+
+    def test_file_not_found_dal_render_non_e_scambiato_per_engine_error(self, mocks, capsys):
+        """Il ramo generico resta quello di prima: messaggio + traceback."""
+        mocks['engine_instance'].render.side_effect = FileNotFoundError("csound")
+        with patch.object(sys, 'argv', ['main.py', 'test.yml', 'out.aif']):
+            with pytest.raises(SystemExit):
+                mocks['main'].main()
+        assert "Errore" in capsys.readouterr().out
+
     def test_visualizer_exception_exits_with_1(self, mocks):
         mocks['visualizer_instance'].export_pdf.side_effect = Exception("pdf error")
         with patch.object(sys, 'argv', ['main.py', 'test.yml', 'out.aif', '--visualize']):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -603,12 +603,21 @@ class TestErrorHandling:
         assert "non trovato" not in out
 
     def test_file_not_found_dal_render_non_e_scambiato_per_engine_error(self, mocks, capsys):
-        """Il ramo generico resta quello di prima: messaggio + traceback."""
+        """Il ramo generico resta quello di prima: messaggio + traceback.
+
+        L'asserzione e' sul messaggio *dell'eccezione*, non sulla parola
+        «Errore»: quella la stampava anche il ramo sbagliato («Errore: file
+        'test.yml' non trovato»), quindi cercarla avrebbe lasciato verde
+        proprio il difetto che il test dice di fissare."""
         mocks['engine_instance'].render.side_effect = FileNotFoundError("csound")
         with patch.object(sys, 'argv', ['main.py', 'test.yml', 'out.aif']):
             with pytest.raises(SystemExit):
                 mocks['main'].main()
-        assert "Errore" in capsys.readouterr().out
+        cattura = capsys.readouterr()
+        assert "Errore: csound" in cattura.out
+        assert "file 'test.yml' non trovato" not in cattura.out
+        # Il traceback e' l'altra meta' del ramo generico, e va su stderr.
+        assert "FileNotFoundError" in cattura.err
 
     def test_visualizer_exception_exits_with_1(self, mocks):
         mocks['visualizer_instance'].export_pdf.side_effect = Exception("pdf error")


### PR DESCRIPTION
Chiude #241.

## Il difetto

`CsoundRenderer._run_csound` lasciava salire il `FileNotFoundError` che
`subprocess.run` alza quando `csound` non e' nel PATH. In `cli.main()` quel tipo
aveva il **primo** handler della catena, tenuto per il file di configurazione: su
una macchina senza csound l'utente si sentiva dire che il suo YAML non esiste —
mentre era stato letto e parsato poche righe sopra.

## Il fix

Entrambe le strade proposte nella issue, con la 2 come correzione e la 1 come
rete.

**`CsoundNotFoundError`**, con il rimedio dentro il messaggio:

```
[ERRORE] Csound: binario 'csound' non trovato
  Hint:         Installa csound (`make install-system-deps`; su Fedora/RHEL
                non e' nei repo e va compilato dai sorgenti, vedi README),
                oppure usa `--renderer numpy`, che non richiede binari
                esterni.
```

Non eredita da `FileNotFoundError`, per la stessa ragione per cui non lo fa
`SuperColliderNotFoundError` (#228). Le due classi erano identiche a meno del
nome del tool, quindi ora condividono la base `_BinaryNotFoundError` — come i due
errori di exit code condividono `_SubprocessRenderError`.

**L'handler della CLI si stringe** attorno a `Generator()` + `load_yaml()`,
l'unico punto che puo' sollevare quel tipo per il motivo che annuncia. Il tipo
giusto per chi solleva non basta se chi cattura e' troppo largo: un
`FileNotFoundError` che nessuno ha ancora tradotto finisce ora nel ramo generico
(messaggio + traceback), non in un messaggio falso.

**Nota per chi usa la libreria:** la docstring di `render_single_stream`
prometteva `FileNotFoundError` per csound assente. La promessa *era* il difetto e
cambia con il codice; chi la catturava per nome deve passare a
`CsoundNotFoundError` (o a `EngineError`, che le copre tutte). Dal secondo giro
di review la nota e' una voce `BREAKING` sotto `### Modificato` nel CHANGELOG,
non l'ultimo capoverso di una correzione.

## Secondo giro di review (`6084479`, `fa9ffe6`)

Cinque difetti trovati rileggendo la PR, due nel codice, uno nei test e due nei
doc.

- **Il `.sco` temporaneo sopravviveva a ogni render fallito.** Senza `--keep-sco`
  lo score e' un file temporaneo e la sua cancellazione stava *dopo* la chiamata
  a csound: qualunque modo di fallire saltava le due righe. Con l'errore nuovo di
  questa PR non era piu' un caso raro ma la norma — su una macchina senza csound
  uno per tentativo, con un nome casuale in `/tmp` che l'utente non ha modo di
  ritrovare. Ora la chiamata sta in un `try/finally` in entrambi i chiamanti
  (STEMS e MIX passano dallo stesso `_run_csound`); `--keep-sco` continua a
  valere, la condizione e' rimasta la stessa.
- **L'hint mandava a un rimedio che sulla macchina della issue non fa nulla.**
  Diceva «Installa csound (`make install-system-deps`)», ma su Fedora/RHEL quel
  target installa `python3 sox` e poi stampa che csound non e' nei repo ne' in
  RPM Fusion — ed e' proprio la piattaforma che il CHANGELOG cita come caso
  motivante. Un messaggio azionabile la cui prima azione e' un no-op vale quanto
  quello che ha sostituito.
- **Due asserzioni non potevano fallire sul difetto che dichiaravano.**
  `assert 'csound' in msg` e' soddisfatta dal solo hint, quindi svuotare il
  `what=` lasciava il test verde mentre l'utente perdeva il nome del binario; e
  `assert "Errore" in out` era vera anche per il ramo sbagliato, che stampava
  «Errore: file 'test.yml' non trovato». Stessa forma del difetto gia' corretto
  in `04bc20f`.
- **`render_merged_streams` non aveva la sezione `Raises:`**, benche' la PR
  aggiunga il test che dice che solleva `CsoundNotFoundError`.
- **Tre frontmatter fermi o incompleti.** `architecture.md` era tornato a
  `last_synced_commit: 8e21c03` col merge di main, cioe' a prima della classe che
  il suo corpo descrive; `cli.md` documenta il backend csound senza dichiarare
  `csound_renderer.py` fra le `sources` (pur dichiarando `supercollider_renderer.py`
  per la ragione identica) e `errors.md` descrive l'handler della CLI senza
  dichiarare `cli.py`. Il lint verifica che lo SHA esista, non che sia recente:
  la deriva era invisibile.

## Terzo giro di review (`845f47f`, `05a00ce`)

Due difetti, uno nel codice e uno nella copertura — entrambi sul `try/finally`
introdotto dal giro precedente.

- **Il `.sco` temporaneo sopravviveva ancora allo score che fallisce.** Il
  `try` copriva la sola chiamata a csound, ma il file temporaneo lo crea
  `mkstemp` *prima* che `ScoreWriter` ci scriva: un render che muore
  scrivendo lo score ne lasciava uno in `/tmp` con lo stesso nome casuale del
  caso che il giro precedente dice di aver chiuso. Non e' un caso di scuola —
  i grani sono lazy (#117) e si materializzano proprio li', quindi ogni modo
  di essere invalidi che il parse non ha visto passa da quella riga
  (`FtableError`, bounds di un envelope, un sample che sparisce fra il parse e
  il render). STEMS e MIX passano ora dallo stesso `_render`, che tiene score
  + csound dentro un unico `try`: la regola di cancellazione ha **una**
  scrittura invece di due copie. E' la forma che `SuperColliderRenderer._render`
  ha da sempre — il renderer che questa PR cita come precedente in ogni altro
  punto — ed era il ramo csound a non averla. `_write_score` si separa in
  `_score_path`, che il path lo calcola (e per il temporaneo lo crea) senza
  scrivere: da quel momento e' `_render` a doverlo togliere.
- **Il ramo `--keep-sco` del `finally` non era coperto.** Finche' la
  cancellazione stava dopo la chiamata a csound, il fallimento non la
  eseguiva affatto e la condizione `not self.sco_dir` non aveva modo di
  sbagliare; ora ci passa, e perderla cancellerebbe proprio il `.sco` del
  render fallito — che e' quello che il flag esiste per far ispezionare. Il
  CHANGELOG lo dichiarava («`--keep-sco` continua a valere»), la suite no:
  togliere la condizione restava verde. Ora e' un test su STEMS e MIX,
  verificato rosso col sabotaggio.

Nello stesso giro, il test del caso gia' corretto smette di spiare
`renderer._write_score` (un metodo interno, monkeypatchato) e legge il path
dalla chiamata a `write_score`: misura lo stesso file senza rompersi al
rename che questo giro fa. E `docs/reference/cli.md` dice ora cosa resta sul
disco quando il render fallisce, non solo quando il flag ha effetto.

## Quarto giro di review (`303aad1`)

Tre difetti, tutti nei doc.

- **`architecture.md` diceva una cosa falsa di meta' della coppia.** La riga
  aggiunta dal secondo giro chiudeva con «i due "non trovato" dicono che manca
  il binario del backend», ma `SuperColliderNotFoundError` si solleva anche per
  il *sorgente* della SynthDef assente — come dicono la sua docstring e l'albero
  in `errors.md`, cioe' proprio il documento a cui quella riga rimanda.
- **`architecture.md` era di nuovo indietro sui sorgenti che dichiara**, dopo che
  il terzo giro aveva toccato `src/pge/rendering/`.
- **Il CHANGELOG mostrava un output che il programma non stampa**: rincolonnava
  l'hint su tre righe, mentre `user_message()` non manda a capo.

Nello stesso giro, le due lezioni di #228 e #241 entrano nel passo 3 di
`add-renderer.md`, dove le trova chi aggiunge il backend successivo.

## Quinto giro di review (`1d80252`, `8503a75`)

Tre difetti, due nel codice/copertura e uno nei doc — i primi due sono la
conseguenza del `try/finally` che i giri precedenti hanno introdotto.

- **Il `.sco` dell'exit code diverso da zero non c'e' piu', e il messaggio
  continua a nominarlo.** Finche' la cancellazione stava *dopo* la chiamata a
  csound, un csound uscito non-zero saltava le due righe e il file restava in
  `/tmp`: era la perdita che il secondo giro ha chiuso, ma era anche l'unico
  modo in cui lo score del render fallito sopravviveva — e quello e' proprio
  il caso in cui serve. Ora il `finally` ci passa, e
  `CsoundRenderError.user_message()` offre una riga `Comando:` da rieseguire
  il cui `.sco` e' stato rimosso pochi istanti prima: rieseguirla fallisce
  sempre. E' lo stesso metro con cui questa PR ha riscritto l'hint di csound
  assente, e il rimedio esiste gia' — `docs/reference/cli.md` lo dice, il
  messaggio no, e il messaggio e' l'unica cosa che l'utente legge.
  `_SubprocessRenderError` ha ora un `hint` opzionale (stessa riga e stessa
  regola di `_BinaryNotFoundError`: si scrive solo quando un rimedio c'e'), e
  il ramo csound lo valorizza con `--keep-sco` quando lo score era temporaneo.
  Con il flag gia' attivo l'hint tace: lo score sta sul disco, e suggerire
  quel flag manderebbe l'utente a cercare un'opzione che ha gia' passato.
- **Il ramo che finisce bene non aveva rete.** La regola di cancellazione ha
  ora una scrittura sola, e le due prove del terzo giro stanno entrambe sui
  fallimenti: un `_render` che smettesse di ripulire dopo un render riuscito
  lascerebbe un `.sco` in `/tmp` **per stem** — il difetto di questa PR
  moltiplicato per il numero di stream — e la suite resterebbe verde. E' il
  test che `SuperColliderRenderer` ha da sempre
  (`test_score_scritto_e_poi_rimosso`), qui su STEMS e MIX. Verificato rosso
  col sabotaggio, come gli altri due nuovi.
- **`architecture.md` diceva una cosa falsa dell'altra meta' della coppia.**
  Il quarto giro ha corretto «manca il binario del backend» aggiungendo il
  sorgente della SynthDef, ma scrivendolo come «il sorgente della SynthDef
  *da cui il binario si compila*»: il `.scd` non compila il binario — quello
  si installa — lo compila `sclang` nel `.scsyndef` che lo score carica
  (`supercollider_renderer.py:352-370`, dove `synthdef_dir` e' «dove sta (o va
  scritto) il .scsyndef compilato»). Terza riscrittura della stessa riga, e la
  prima che regge contro entrambi i siti che sollevano
  `SuperColliderNotFoundError`.

Nello stesso giro, `errors.md` mette la regola dell'hint fra quelle di design e
la mostra nell'esempio del render fallito; `cli.md` dice, sotto `--keep-sco`,
che il rimedio e' anche nel messaggio. Frontmatter dei quattro doc che
dichiarano `exceptions.py` o `src/pge/rendering/` fra le `sources`.

Restano fuori, come lavoro separato: **la causa a monte — #257**, cioe' far
sollevare a `Generator.load_yaml` un errore di dominio, cosi' che `cli.main()`
non catturi piu' un builtin e la garanzia non dipenda dall'estensione fisica di
un blocco `try`; un `shutil.which` di pre-volo che eviti di materializzare i
grani prima di scoprire che il binario manca; la terza copia del blocco
`except FileNotFoundError -> <Tool>NotFoundError` (le altre due sono nel renderer
SuperCollider); e l'hint `--keep-osc` sul gemello SuperCollider, che ha lo stesso
`Comando:` con lo stesso score temporaneo — difetto preesistente, non introdotto
qui, e i suoi quattro siti di sollevamento non sono la stessa riga.

## Test

Rossi prima, verdi dopo, quelli che la issue chiedeva piu' gli unit sulla classe:

- `tests/rendering/test_csound_renderer.py` — csound assente da' un errore
  azionabile (nomina il binario e `--renderer numpy`), **non** e' un
  `FileNotFoundError` (specchio di `test_scsynth_assente_non_e_un_FileNotFoundError`),
  vale anche per il MIX, non lascia il `.sco` temporaneo sul disco — ne' quando
  fallisce csound, ne' quando fallisce la scrittura dello score, ne' quando il
  render riesce — e con `--keep-sco` quel `.sco` invece resta; un csound uscito
  non-zero dice come riavere lo score che il `finally` ha appena cancellato, e
  con `--keep-sco` non lo dice;
- `tests/test_main.py` — un `FileNotFoundError` che risale dal rendering non
  produce piu' «non trovato» sul file YAML, e resta un exit 1 dal ramo generico,
  con il messaggio dell'eccezione su stdout e il traceback su stderr;
- `tests/shared/test_engine_exceptions.py` — ereditarieta', `user_message()`,
  righe di contesto della nuova classe; l'hint di `_SubprocessRenderError` e'
  opzionale e sta fra `Output:` e le righe di contesto.

`make tests`: 6242 passed, 10 skipped. `make docs-lint`: OK (22 docs).

## Impatto cross-repo

Nessuno, e verificato invece che dichiarato: `gl-ls` non nomina ne' csound ne' la
gerarchia `EngineError`; `PGE-ui` non parsa i messaggi d'errore del motore (li
inoltra come righe di log), tiene il renderer csound disabilitato nella UI, e i
suoi `FileNotFoundError` sono dei propri subprocess, non del motore. Niente issue
aperte. Il terzo giro non tocca nessuna superficie osservabile (niente YAML,
niente tipi d'errore nuovi, nessun flag), e il quinto nemmeno: aggiunge una riga
`Hint:` gia' prevista dal formato di `user_message()`, che nessuno dei tre repo
legge.

Nessun impatto sugli esempi del paper CIM 2026: cambia solo il tipo dell'errore
quando csound *manca*, non il rendering quando c'e'. Nessun bump del submodule
proposto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FptiRt1z16TVqo91etAsu9