### PR TITLE
Portare al logger i print() puramente diagnostici (#187)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,11 +93,17 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   Nuova doc: [`docs/how-to/print-score-bw.md`](docs/how-to/print-score-bw.md).
 
 - **Diagnostic logger** (`get_diagnostic_logger`, `log_strategy_registration`
-  in `pge.shared.logger`, issue #187). Logger `pge.diagnostics` a livello
-  DEBUG, con il solo `NullHandler`: nessun handler proprio, nessun file,
-  nessuna `./logs` creata di soppiatto — a differenza di
-  `get_engine_logger()`, che si auto-configura. Una libreria non configura il
-  logging del suo ospite.
+  in `pge.shared.logger`, issue #187). Logger `pge.diagnostics` col solo
+  `NullHandler`: nessun handler proprio, nessun file, nessuna `./logs` creata
+  di soppiatto — a differenza di `get_engine_logger()`, che si auto-configura.
+  Una libreria non configura il logging del suo ospite. Il DEBUG e' il livello
+  del **record**, non del logger: `get_diagnostic_logger()` non chiama
+  `setLevel` e il livello effettivo resta quello che decide l'host. Non e'
+  un'omissione: `callHandlers` confronta il record col livello dell'*handler*
+  e non ricontrolla quello del logger, quindi un `setLevel(DEBUG)` qui non
+  renderebbe la diagnostica accendibile ma **accesa** su stderr per chiunque
+  chiami `logging.basicConfig()`. Lo fissa
+  `test_diagnostic_logger_non_impone_un_livello`.
 
 - **`tests/shared/test_stdout_contract.py`** — la classificazione della #178 in
   forma eseguibile. Legge i sorgenti con `ast` e pretende che la riga di
@@ -108,7 +114,19 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   `src/pge/strategies/` non ricompaia nessun `print()`. Il criterio e' la
   forma della riga, non il prefisso: le chiamate sono ricomposte in un
   template (`[CACHE] {}: `), perche' `[CACHE]` da solo lascia passare il
-  riepilogo `[CACHE] <n>/<m> stream da ricompilare` che nessuno parsa.
+  riepilogo `[CACHE] <n>/<m> stream da ricompilare` che nessuno parsa. Quel
+  template e' piu' stretto della regex a valle, di proposito: la guardia
+  difende la riga per stream, non definisce cosa il parser legge.
+
+- **La lista degli emettitori della riga `[CACHE]` e' confrontata con i
+  sorgenti** (`test_la_lista_degli_emettitori_e_completa`). Una lista scritta a
+  mano copre chi c'era quando e' stata scritta: un backend nuovo che dichiara
+  lo stato della cache emette la stessa riga e non ci entra da solo, e la
+  guardia sarebbe rimasta verde sopra un emettitore che nessuno sorveglia —
+  sul canale dove csound e supercollider non hanno altro presidio. Il passo
+  corrispondente e' ora nella checklist di
+  [`docs/how-to/add-renderer.md`](docs/how-to/add-renderer.md), che prima non
+  lo portava benche' `contratto-stdout.md` la indicasse.
 
 - **Test di comportamento sulla riga `[CACHE]` del cache manager**
   (`tests/rendering/test_stream_cache_manager.py`). Era l'unico emettitore
@@ -116,7 +134,15 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   statica.
 
 - **`docs/explanation/contratto-stdout.md`** — protocollo, diagnostica e
-  interfaccia CLI: chi legge cosa, e su quale canale.
+  interfaccia CLI: chi legge cosa, e su quale canale. Compresa la regola che
+  la tabella da sola non lascia dedurre: la regex di PGE-ui e'
+  `^\[CACHE\]\s+(\S+):\s+(.+)$`, e un token *letterale* la soddisfa quanto
+  un id interpolato — `cli.py` stampa gia' `[CACHE] Manifest: <path>` e
+  `[CACHE] GC: ...`, che l'editor matcha e scarta con l'insieme degli id
+  dichiarati dalla richiesta, un filtro inerte quando la richiesta non li
+  dichiara. Ogni riga in quella forma e' quindi protocollo per il solo fatto
+  della forma, e le due di `cli.py` non sono libere di andarsene al logger
+  come fossero diagnostica: la doc lo dichiara invece di lasciarlo intendere.
 
 - **Controprova sulla misura del `NullHandler`**
   (`tests/shared/test_diagnostic_logger.py`). Il test che verifica il mancato

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,12 +102,29 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 - **`tests/shared/test_stdout_contract.py`** — la classificazione della #178 in
   forma eseguibile. Legge i sorgenti con `ast` e pretende che la riga di
   protocollo `[CACHE] <id>: DIRTY|clean` resti un `print(..., flush=True)` in
-  tutti e tre i renderer (per csound e supercollider e' l'unico presidio che
-  quella riga abbia) e che in `src/pge/strategies/` non ricompaia nessun
-  `print()`.
+  tutti e quattro i moduli che la emettono — i tre renderer sul percorso
+  diretto e `StreamCacheManager.get_dirty_stream_dicts`, che e' dove la riga
+  esce sulla pipeline in due stadi (`Generator.write_sco_files`) — e che in
+  `src/pge/strategies/` non ricompaia nessun `print()`. Il criterio e' la
+  forma della riga, non il prefisso: le chiamate sono ricomposte in un
+  template (`[CACHE] {}: `), perche' `[CACHE]` da solo lascia passare il
+  riepilogo `[CACHE] <n>/<m> stream da ricompilare` che nessuno parsa.
+
+- **Test di comportamento sulla riga `[CACHE]` del cache manager**
+  (`tests/rendering/test_stream_cache_manager.py`). Era l'unico emettitore
+  della riga di protocollo senza nessuna asserzione, ne' di comportamento ne'
+  statica.
 
 - **`docs/explanation/contratto-stdout.md`** — protocollo, diagnostica e
   interfaccia CLI: chi legge cosa, e su quale canale.
+
+- **Controprova sulla misura del `NullHandler`**
+  (`tests/shared/test_diagnostic_logger.py`). Il test che verifica il mancato
+  ricorso a `logging.lastResort` neutralizza gli handler che pytest mette sul
+  root e sostituisce `lastResort` con una spia: senza quella neutralizzazione
+  `callHandlers` non arrivava mai a `lastResort` e il test restava verde anche
+  cancellando la riga che dice di difendere. Un secondo test misura la misura,
+  ribaltandone il verdetto su un logger nudo.
 
 
 ### Cambiato

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,18 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   della forma, e le due di `cli.py` non sono libere di andarsene al logger
   come fossero diagnostica: la doc lo dichiara invece di lasciarlo intendere.
 
+- **La guardia della diagnostica non e' piu' scoped per cartella**
+  (`test_la_registrazione_dinamica_non_stampa`,
+  `test_la_lista_dei_punti_di_registrazione_e_completa`). I punti di
+  registrazione dinamica sono sette, non tre, e non stanno tutti in
+  `strategies/`: `register_window_strategy` vive in
+  `controllers/window_selection_strategy.py`, dove vive il registry delle
+  finestre. Una guardia che sorveglia una cartella ne copriva sei, e sul
+  settimo rimettere esattamente la `print()` che la #187 ha tolto lasciava
+  verde la suite intera. Ora il criterio e' la **funzione**
+  `register_*_strategy` ovunque viva, e la lista dei moduli e' confrontata coi
+  sorgenti come quella degli emettitori della riga `[CACHE]`.
+
 - **Controprova sulla misura del `NullHandler`**
   (`tests/shared/test_diagnostic_logger.py`). Il test che verifica il mancato
   ricorso a `logging.lastResort` neutralizza gli handler che pytest mette sul

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ---
 
+## [Unreleased]
+
+### Cambiato
+
+- **Le registrazioni dinamiche di strategy non stampano piu' su stdout**
+  (issue #187, primo scaglione della #178). `register_density_strategy`,
+  `register_variation_strategy` e `register_voice_pan_strategy` passano dal
+  `print()` con la spunta verde al nuovo logger `pge.diagnostics`, via
+  `log_strategy_registration`. Stdout non e' un canale libero: e' il
+  protocollo che `render_pipeline.py` di PGE-ui parsa riga per riga per
+  ricavarne gli eventi NDJSON dell'editor; una conferma che nessuno parsa non
+  ha titolo per attraversarlo. La conferma non e' persa — e' muta finche'
+  l'applicazione ospite non alza il livello di log, e allora esce su stderr.
+
+### Aggiunto
+
+- **Diagnostic logger** (`get_diagnostic_logger`, `log_strategy_registration`
+  in `pge.shared.logger`). Logger `pge.diagnostics` a livello DEBUG, con il
+  solo `NullHandler`: nessun handler proprio, nessun file, nessuna `./logs`
+  creata di soppiatto — a differenza di `get_engine_logger()`, che si
+  auto-configura. Una libreria non configura il logging del suo ospite.
+- **`tests/shared/test_stdout_contract.py`** — la classificazione della #178 in
+  forma eseguibile. Legge i sorgenti con `ast` e pretende che la riga di
+  protocollo `[CACHE] <id>: DIRTY|clean` resti un `print(..., flush=True)` in
+  tutti e tre i renderer (per csound e supercollider e' l'unico presidio che
+  quella riga abbia) e che in `src/pge/strategies/` non ricompaia nessun
+  `print()`.
+- **`docs/explanation/contratto-stdout.md`** — protocollo, diagnostica e
+  interfaccia CLI: chi legge cosa, e su quale canale.
+
+---
+
 ## [v9.0.2] — 2026-08-30
 
 ### Fixed

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,6 +16,7 @@
 |------|--------|------|
 | [architecture](explanation/architecture.md) | stable | architecture, rendering, ocp |
 | [caching](explanation/caching.md) | stable | caching, rendering, csound, supercollider |
+| [contratto-stdout](explanation/contratto-stdout.md) | stable | logging, stdout, protocollo, pge-ui, strategie |
 | [costo-rendering](explanation/costo-rendering.md) | stable | rendering, performance, grains, numpy |
 | [library-vs-cli](explanation/library-vs-cli.md) | stable | api, cli, architecture, refactor |
 | [multi-voice](explanation/multi-voice.md) | stable | voices, strategy, dmx-1000, granular |

--- a/docs/explanation/contratto-stdout.md
+++ b/docs/explanation/contratto-stdout.md
@@ -13,7 +13,8 @@ sources:
   - src/pge/rendering/supercollider_renderer.py
   - src/pge/rendering/stream_cache_manager.py
   - tests/shared/test_stdout_contract.py
-last_synced_commit: db08c65
+  - src/pge/cli.py
+last_synced_commit: 38bfee7
 ---
 
 # Il contratto di stdout — protocollo, diagnostica, interfaccia
@@ -68,12 +69,33 @@ distinzione che conta perche' `stream_cache_manager.py` compare anche fra i
 moduli con `print()` non ancora classificati (sotto): la sua riga per stream e'
 gia' classificata, ed e' protocollo.
 
-Il prefisso `[CACHE]` da solo non identifica il protocollo. Lo stesso metodo
-stampa `[CACHE] <n>/<m> stream da ricompilare` e `Generator` stampa
-`[CACHE] Stream da scrivere: [...]`: nessuna delle due e' parsata, perche' la
-regex di PGE-ui vuole un token *senza spazi* seguito dai due punti. Quel che
-identifica il protocollo e' la forma `[CACHE] <id>: <resto>`, ed e' su quella
-che si regola la guardia.
+Il prefisso `[CACHE]` da solo non identifica il protocollo. La regex a valle e'
+`^\[CACHE\]\s+(\S+):\s+(.+)$`: vuole un token *senza spazi* seguito dai due
+punti. Cadono fuori `[CACHE] <n>/<m> stream da ricompilare` (stesso metodo) e
+`[CACHE] Stream da scrivere: [...]` (`Generator`), che infatti nessuno parsa.
+
+**Ma la forma non basta a identificare il protocollo, e va detto qui perche' e'
+il posto dove si va a cercarlo.** Un token *letterale* soddisfa quella regex
+quanto un id interpolato, e due righe di `cli.py` lo fanno:
+`[CACHE] Manifest: <path>` a ogni render con `--cache`, e
+`[CACHE] GC: rimossi N stream orfani: [...]` quando la GC rimuove qualcosa.
+L'editor le matcha entrambe. A scartarle non e' la loro forma ma l'insieme
+degli id che la richiesta dichiara — e quel filtro e' **inerte** quando la
+richiesta non li dichiara, dove resta il comportamento storico. Il commento di
+`render_pipeline.py` lo dice in prima persona: *«non tutte le righe `[CACHE]`
+sono stream, e la forma non le distingue»*.
+
+Da cui la regola che conta, e che e' piu' stretta di quella che si dedurrebbe
+dalla tabella: **ogni riga nella forma `[CACHE] <token-senza-spazi>: <resto>`
+finisce dentro il parser di PGE-ui, qualunque cosa dica.** Aggiungerne una
+nuova non e' diagnostica ne' interfaccia CLI: e' un'aggiunta al protocollo, e
+va trattata come tale.
+
+La guardia si regola su un criterio piu' stretto ancora — pretende un `{}`
+interpolato in prima posizione (`[CACHE] {}: `) — e non e' una svista: il suo
+mestiere e' difendere la riga *per stream*, non definire cosa il parser legge.
+Cerca cioe' meno di quel che il parser trova, che e' la direzione sicura per
+una guardia che deve dire «questa riga e' sparita».
 
 La **diagnostica** oggi sono le registrazioni dinamiche di strategy
 (`register_density_strategy`, `register_variation_strategy`,
@@ -108,12 +130,20 @@ rendering*, cioe' un prodotto del programma; questa avrebbe configurato il
 logging di chi importa `pge`, che non e' affare di `pge`.
 
 **La classificazione e' un test, non una prosa.** `tests/shared/test_stdout_contract.py`
-legge i sorgenti con `ast` e chiede due cose: che la riga `[CACHE] <id>: ...`
-sia ancora un `print()` flushato in tutti e quattro i moduli che la emettono, e
-che in `src/pge/strategies/` non ci sia nessun `print()`. Il primo e' l'unico
-presidio che csound e supercollider abbiano su quella riga (numpy e il cache
-manager hanno anche un test di comportamento); il secondo e' cio' che impedisce
-alla porta di riaprirsi in silenzio.
+legge i sorgenti con `ast` e chiede tre cose: che la riga `[CACHE] <id>: ...`
+sia ancora un `print()` flushato in tutti e quattro i moduli che la emettono;
+che quei quattro siano **tutti** quelli che la emettono; e che in
+`src/pge/strategies/` non ci sia nessun `print()`. Il primo e' l'unico presidio
+che csound e supercollider abbiano su quella riga (numpy e il cache manager
+hanno anche un test di comportamento); il terzo e' cio' che impedisce alla
+porta di riaprirsi in silenzio.
+
+Il secondo copre il buco che una lista scritta a mano ha per costruzione: un
+backend nuovo che dichiara lo stato della cache emette la stessa riga e non
+entra nella lista da solo, e la guardia sarebbe rimasta verde sopra un
+emettitore che nessuno sorveglia — sul canale dove csound e supercollider non
+hanno altro. La lista e' quindi confrontata con cio' che i sorgenti fanno, e la
+checklist di [[add-renderer]] porta lo stesso passo.
 
 **La guardia riconosce la forma, non il prefisso.** Le chiamate sono
 ricomposte in un *template* — ogni interpolazione di una f-string diventa `{}`,
@@ -133,20 +163,27 @@ discrimine, cosi' che a indebolirlo qualcosa suoni.
   aggiunto a `MODULI_CON_PROTOCOLLO_CACHE` nella guardia. Vedi [[add-renderer]].
 - **Cambi il formato di una riga di protocollo** → e' un cambio di superficie
   pubblica: serve l'analisi d'impatto su PGE-ui e PGE-ls prima, non dopo.
+- **Aggiungi una riga `[CACHE] <token>: ...`** → e' protocollo per il solo
+  fatto della forma, anche se il token e' una parola e non un id. Prima di
+  scriverla, l'analisi d'impatto su PGE-ui.
 - **Il resto dei `print()`** (`engine/generator.py`,
   `rendering/score_visualizer.py`, `rendering/stream_cache_manager.py`,
   `rendering/score_writer.py`, `cli.py`) non e' ancora classificato: sono gli
-  scaglioni successivi. Attenzione a due di quei moduli: non sono omogenei.
+  scaglioni successivi. Attenzione: quei moduli non sono omogenei.
   `stream_cache_manager.py` e `generator.py` contengono *anche* righe gia'
   classificate — la riga per stream del primo e' protocollo e ha la sua
   guardia; quel che resta da classificare li' e' il riepilogo
   `[CACHE] <n>/<m> stream da ricompilare` e `[CACHE] Stream da scrivere: [...]`,
-  che nessun parser legge. `cli.py` concentra la maggioranza del resto ed e'
-  quasi tutto *interfaccia CLI*, cioe' la terza categoria — quella che resta su
-  stdout pur non essendo protocollo. E' anche l'unica dove la scelta non e'
-  meccanica: la riga per stream dei conteggi di grani (#250) la legge un
-  compositore a schermo, non un parser, ma sta sullo stesso canale che un
-  parser attraversa.
+  che nessun parser legge. `cli.py` concentra la maggioranza del resto ed e' in
+  larga parte *interfaccia CLI*, cioe' la terza categoria — quella che resta su
+  stdout pur non essendo protocollo. **Con due eccezioni gia' note**, ed e' bene
+  arrivarci sapendolo: `[CACHE] Manifest: <path>` e `[CACHE] GC: ...` hanno la
+  forma che il parser matcha, quindi non sono libere di andarsene al logger
+  come fosse diagnostica — e la prima esce senza `flush=True`, il che le rende
+  un caso da guardare, non da spostare a occhio. E' anche la categoria dove la
+  scelta non e' meccanica: la riga per stream dei conteggi di grani (#250) la
+  legge un compositore a schermo, non un parser, ma sta sullo stesso canale che
+  un parser attraversa.
 
 ## Vedi anche
 

--- a/docs/explanation/contratto-stdout.md
+++ b/docs/explanation/contratto-stdout.md
@@ -1,0 +1,118 @@
+---
+slug: contratto-stdout
+type: explanation
+status: stable
+tags: [logging, stdout, protocollo, pge-ui, strategie]
+sources:
+  - src/pge/shared/logger.py
+  - src/pge/strategies/strategy_registry.py
+  - src/pge/strategies/variation_registry.py
+  - src/pge/strategies/voice_pan_strategy.py
+  - src/pge/rendering/numpy_audio_renderer.py
+  - tests/shared/test_stdout_contract.py
+last_synced_commit: e57ccec
+---
+
+# Il contratto di stdout — protocollo, diagnostica, interfaccia
+
+**Documenti collegati:** [[INDEX]] · [[caching]] · [[architecture]] · [[add-renderer]]
+
+---
+
+## Problema
+
+PGE ha avuto a lungo due canali diagnostici che non si parlavano: il logger di
+`src/pge/shared/logger.py`, usato da parser, parameter, pointer e window, e i
+`print()` sparsi nel resto del codice. Detta cosi' sembra disordine, ed e' il
+motivo per cui la cosa e' rimasta com'era a lungo.
+
+Non e' disordine. **Stdout non e' un canale libero: e' un'interfaccia.**
+`render_pipeline.py` di PGE-ui legge le righe di `pge` una per una e ne ricava
+gli eventi NDJSON dell'editor — la barra di avanzamento, i pallini di stato dei
+singoli stem, l'indice dei file generati. Le righe che quel parser riconosce
+sono un contratto fra due repository, e nessuno dei due lo dichiara: sta in una
+manciata di regex da una parte e in una manciata di f-string dall'altra.
+
+Da qui il rischio delle due direzioni opposte, che non e' simmetrico:
+
+- portare al logger una riga che PGE-ui parsa **rompe l'interfaccia utente di
+  un altro repository senza far fallire un test di PGE**;
+- lasciare su stdout una riga che nessuno parsa e' materiale che ogni parser a
+  valle deve attraversare — e, il giorno in cui somiglia abbastanza a una riga
+  vera, che deve saper *scartare*.
+
+## Modello
+
+Tre categorie, per destinatario e non per contenuto:
+
+| Categoria | Chi la legge | Canale |
+|---|---|---|
+| **Protocollo** | il parser di PGE-ui | stdout, con quel formato esatto |
+| **Diagnostica** | uno sviluppatore che sta estendendo il motore | logger `pge.diagnostics` |
+| **Interfaccia CLI** | l'utente, a schermo | stdout, ma non e' protocollo |
+
+Il **protocollo** oggi sono le righe `[CACHE] <id>: DIRTY|clean` dei tre
+renderer — da cui l'editor deriva `stream-start` e `stream-done` — e i path del
+blocco riassuntivo. Restano `print(..., flush=True)`: senza flush arriverebbero
+a rendering finito, quando non hanno piu' niente da annunciare.
+
+La **diagnostica** oggi sono le registrazioni dinamiche di strategy
+(`register_density_strategy`, `register_variation_strategy`,
+`register_voice_pan_strategy`). Passano da `log_strategy_registration`, che
+scrive sul logger `pge.diagnostics`. Quel logger e' fatto di due astensioni:
+
+1. **nessun handler proprio oltre a un `NullHandler`.** Una libreria non
+   configura il logging del suo ospite. Qui l'astensione ha anche un effetto
+   concreto: `get_engine_logger()` si auto-configura, e configurarsi vuol dire
+   `os.makedirs('./logs')` — una cartella materializzata sul disco di chi
+   passava di li' solo per registrare una strategy. Il `NullHandler` serve al
+   resto: senza handler, `logging` manda i record da WARNING in su a
+   `lastResort`, che scrive su stderr;
+2. **livello DEBUG.** Sotto il livello di default del root (WARNING) il record
+   non viene nemmeno costruito, quindi la diagnostica muta non costa niente su
+   un percorso caldo. Chi la vuole fa `logging.basicConfig(level=logging.DEBUG)`,
+   e la console di `logging` e' **stderr**: nemmeno accendendola si rientra nel
+   canale che PGE-ui parsa.
+
+## Trade-off
+
+**La conferma di registrazione diventa muta.** Prima, registrare una strategy
+stampava una riga con la spunta verde; ora non stampa niente finche' l'host non
+accende il logging. E' il costo accettato: la registrazione dinamica e'
+un'operazione da sviluppatore che in una pipeline di rendering normale non
+compare mai, e chi la sta facendo e' esattamente la persona in grado di alzare
+un livello di log. Il messaggio non e' andato perso — ha cambiato canale.
+
+**Non c'e' una `configure_diagnostic_logger()`.** Sarebbe stata simmetrica alle
+due che esistono (clip ed engine), ma quelle configurano dei *file di
+rendering*, cioe' un prodotto del programma; questa avrebbe configurato il
+logging di chi importa `pge`, che non e' affare di `pge`.
+
+**La classificazione e' un test, non una prosa.** `tests/shared/test_stdout_contract.py`
+legge i sorgenti con `ast` e chiede due cose: che la riga `[CACHE]` sia ancora
+un `print()` flushato nei tre renderer, e che in `src/pge/strategies/` non ci
+sia nessun `print()`. Il primo e' l'unico presidio di comportamento che csound e
+supercollider abbiano su quella riga (il renderer NumPy ha anche un test vero);
+il secondo e' cio' che impedisce alla porta di riaprirsi in silenzio.
+
+## Implicazioni codice
+
+- **Aggiungi una riga diagnostica** → `get_diagnostic_logger().debug(...)`, con
+  formattazione `%s` pigra. Mai `print()`.
+- **Aggiungi un renderer** → se dichiara lo stato della cache, la riga
+  `[CACHE] <id>: <status>` va su stdout con `flush=True`, e il modulo va
+  aggiunto a `RENDERER_CON_PROTOCOLLO_CACHE` nella guardia. Vedi [[add-renderer]].
+- **Cambi il formato di una riga di protocollo** → e' un cambio di superficie
+  pubblica: serve l'analisi d'impatto su PGE-ui e PGE-ls prima, non dopo.
+- **Il resto dei `print()`** (`engine/generator.py`, `rendering/score_visualizer.py`,
+  `rendering/stream_cache_manager.py`, `rendering/score_writer.py`,
+  `envelopes/time_distribution.py`, `cli.py`) non e' ancora classificato: sono
+  gli scaglioni successivi. `cli.py` in particolare e' quasi tutto *interfaccia
+  CLI*, cioe' la terza categoria — quella che resta su stdout pur non essendo
+  protocollo.
+
+## Vedi anche
+
+- [[caching]] — cosa dichiara la riga `[CACHE]` e perche' esiste
+- [[architecture]] — dove stanno i renderer che la emettono
+- [[add-renderer]] — la checklist di un backend nuovo

--- a/docs/explanation/contratto-stdout.md
+++ b/docs/explanation/contratto-stdout.md
@@ -8,13 +8,14 @@ sources:
   - src/pge/strategies/strategy_registry.py
   - src/pge/strategies/variation_registry.py
   - src/pge/strategies/voice_pan_strategy.py
+  - src/pge/controllers/window_selection_strategy.py
   - src/pge/rendering/numpy_audio_renderer.py
   - src/pge/rendering/csound_renderer.py
   - src/pge/rendering/supercollider_renderer.py
   - src/pge/rendering/stream_cache_manager.py
   - tests/shared/test_stdout_contract.py
   - src/pge/cli.py
-last_synced_commit: 38bfee7
+last_synced_commit: 973cffd
 ---
 
 # Il contratto di stdout — protocollo, diagnostica, interfaccia
@@ -115,6 +116,17 @@ scrive sul logger `pge.diagnostics`. Quel logger e' fatto di due astensioni:
    e la console di `logging` e' **stderr**: nemmeno accendendola si rientra nel
    canale che PGE-ui parsa.
 
+**Ma i punti di registrazione dinamica sono sette, non tre, e non stanno tutti
+in `strategies/`.** La #187 ne ha convertiti tre perche' erano i tre che
+stampavano; gli altri quattro (onset, pointer, pitch, window) erano gia' muti.
+Il settimo, `register_window_strategy`, vive in
+`controllers/window_selection_strategy.py`, dove vive il registry delle
+finestre: una guardia scoped sulla cartella `strategies/` ne copre sei e tace
+sul settimo, che e' la porta da cui la `print()` puo' rientrare senza che nulla
+suoni. Anche quella lista e' quindi dichiarata *e* derivata dai sorgenti, e il
+criterio del test e' la **funzione** `register_*_strategy`, non il modulo che
+la contiene.
+
 ## Trade-off
 
 **La conferma di registrazione diventa muta.** Prima, registrare una strategy
@@ -130,20 +142,26 @@ rendering*, cioe' un prodotto del programma; questa avrebbe configurato il
 logging di chi importa `pge`, che non e' affare di `pge`.
 
 **La classificazione e' un test, non una prosa.** `tests/shared/test_stdout_contract.py`
-legge i sorgenti con `ast` e chiede tre cose: che la riga `[CACHE] <id>: ...`
-sia ancora un `print()` flushato in tutti e quattro i moduli che la emettono;
-che quei quattro siano **tutti** quelli che la emettono; e che in
-`src/pge/strategies/` non ci sia nessun `print()`. Il primo e' l'unico presidio
+legge i sorgenti con `ast` e chiede quattro cose: che la riga
+`[CACHE] <id>: ...` sia ancora un `print()` flushato in tutti e quattro i
+moduli che la emettono; che quei quattro siano **tutti** quelli che la
+emettono; che in `src/pge/strategies/` non ci sia nessun `print()`; e che
+nessun `register_*_strategy` stampi, ovunque viva. Il primo e' l'unico presidio
 che csound e supercollider abbiano su quella riga (numpy e il cache manager
-hanno anche un test di comportamento); il terzo e' cio' che impedisce alla
-porta di riaprirsi in silenzio.
+hanno anche un test di comportamento); il terzo e il quarto sono cio' che
+impedisce alla porta di riaprirsi in silenzio, e sono due perche' uno solo non
+bastava: il terzo guarda una cartella, e il settimo entry point non ci sta
+dentro.
 
-Il secondo copre il buco che una lista scritta a mano ha per costruzione: un
+Il secondo e il quarto coprono il buco che una lista scritta a mano ha per
+costruzione: un
 backend nuovo che dichiara lo stato della cache emette la stessa riga e non
 entra nella lista da solo, e la guardia sarebbe rimasta verde sopra un
 emettitore che nessuno sorveglia — sul canale dove csound e supercollider non
-hanno altro. La lista e' quindi confrontata con cio' che i sorgenti fanno, e la
-checklist di [[add-renderer]] porta lo stesso passo.
+hanno altro; e un registry che sta in un'altra cartella non entra nella guardia
+della diagnostica, che infatti ne sorvegliava sei su sette. Entrambe le liste
+sono quindi confrontate con cio' che i sorgenti fanno, e la checklist di
+[[add-renderer]] porta lo stesso passo.
 
 **La guardia riconosce la forma, non il prefisso.** Le chiamate sono
 ricomposte in un *template* — ogni interpolazione di una f-string diventa `{}`,
@@ -168,10 +186,10 @@ discrimine, cosi' che a indebolirlo qualcosa suoni.
   scriverla, l'analisi d'impatto su PGE-ui.
 - **Il resto dei `print()`** (`engine/generator.py`,
   `rendering/score_visualizer.py`, `rendering/stream_cache_manager.py`,
-  `rendering/score_writer.py`, `cli.py`) non e' ancora classificato: sono gli
-  scaglioni successivi. Attenzione: quei moduli non sono omogenei.
-  `stream_cache_manager.py` e `generator.py` contengono *anche* righe gia'
-  classificate — la riga per stream del primo e' protocollo e ha la sua
+  `rendering/score_writer.py`, `shared/logger.py`, `cli.py`) non e' ancora
+  classificato: sono gli scaglioni successivi. Attenzione: quei moduli non sono
+  omogenei. `stream_cache_manager.py` e `generator.py` contengono *anche* righe
+  gia' classificate — la riga per stream del primo e' protocollo e ha la sua
   guardia; quel che resta da classificare li' e' il riepilogo
   `[CACHE] <n>/<m> stream da ricompilare` e `[CACHE] Stream da scrivere: [...]`,
   che nessun parser legge. `cli.py` concentra la maggioranza del resto ed e' in
@@ -179,11 +197,18 @@ discrimine, cosi' che a indebolirlo qualcosa suoni.
   stdout pur non essendo protocollo. **Con due eccezioni gia' note**, ed e' bene
   arrivarci sapendolo: `[CACHE] Manifest: <path>` e `[CACHE] GC: ...` hanno la
   forma che il parser matcha, quindi non sono libere di andarsene al logger
-  come fosse diagnostica — e la prima esce senza `flush=True`, il che le rende
-  un caso da guardare, non da spostare a occhio. E' anche la categoria dove la
-  scelta non e' meccanica: la riga per stream dei conteggi di grani (#250) la
-  legge un compositore a schermo, non un parser, ma sta sullo stesso canale che
-  un parser attraversa.
+  come fosse diagnostica — e nessuna delle due esce con `flush=True`, il che le
+  rende un caso da guardare, non da spostare a occhio. E' anche la categoria
+  dove la scelta non e' meccanica: la riga per stream dei conteggi di grani
+  (#250) la legge un compositore a schermo, non un parser, ma sta sullo stesso
+  canale che un parser attraversa.
+- **Il meno atteso della lista e' `shared/logger.py`**, che e' poi il modulo
+  dove abita il logger diagnostico: `configure_clip_logger` stampa una riga
+  `Clip log file: <path>` su **stdout**, e la CLI ci passa a ogni render
+  (`file_enabled=True`). Non e' quindi una riga da sviluppatore come le tre che
+  la #187 ha spostato: e' traffico di *ogni* rendering, sul canale che il
+  parser attraversa. L'altra `print()` del modulo scrive gia' su `sys.stderr`
+  e non pone il problema.
 
 ## Vedi anche
 

--- a/docs/explanation/contratto-stdout.md
+++ b/docs/explanation/contratto-stdout.md
@@ -9,6 +9,9 @@ sources:
   - src/pge/strategies/variation_registry.py
   - src/pge/strategies/voice_pan_strategy.py
   - src/pge/rendering/numpy_audio_renderer.py
+  - src/pge/rendering/csound_renderer.py
+  - src/pge/rendering/supercollider_renderer.py
+  - src/pge/rendering/stream_cache_manager.py
   - tests/shared/test_stdout_contract.py
 last_synced_commit: db08c65
 ---
@@ -51,10 +54,26 @@ Tre categorie, per destinatario e non per contenuto:
 | **Diagnostica** | uno sviluppatore che sta estendendo il motore | logger `pge.diagnostics` |
 | **Interfaccia CLI** | l'utente, a schermo | stdout, ma non e' protocollo |
 
-Il **protocollo** oggi sono le righe `[CACHE] <id>: DIRTY|clean` dei tre
-renderer — da cui l'editor deriva `stream-start` e `stream-done` — e i path del
-blocco riassuntivo. Restano `print(..., flush=True)`: senza flush arriverebbero
-a rendering finito, quando non hanno piu' niente da annunciare.
+Il **protocollo** oggi sono le righe `[CACHE] <id>: DIRTY|clean` — da cui
+l'editor deriva `stream-start` e `stream-done` — e i path del blocco
+riassuntivo. Restano `print(..., flush=True)`: senza flush arriverebbero a
+rendering finito, quando non hanno piu' niente da annunciare.
+
+**A emettere quella riga sono quattro moduli, non tre.** I tre renderer la
+stampano sul percorso diretto, uno stream alla volta; la pipeline in due stadi
+non passa di li' — `Generator.write_sco_files` delega a
+`StreamCacheManager.get_dirty_stream_dicts`, ed e' quel metodo a stampare la
+riga per tutti gli stream in blocco, prima che un renderer esista. E' una
+distinzione che conta perche' `stream_cache_manager.py` compare anche fra i
+moduli con `print()` non ancora classificati (sotto): la sua riga per stream e'
+gia' classificata, ed e' protocollo.
+
+Il prefisso `[CACHE]` da solo non identifica il protocollo. Lo stesso metodo
+stampa `[CACHE] <n>/<m> stream da ricompilare` e `Generator` stampa
+`[CACHE] Stream da scrivere: [...]`: nessuna delle due e' parsata, perche' la
+regex di PGE-ui vuole un token *senza spazi* seguito dai due punti. Quel che
+identifica il protocollo e' la forma `[CACHE] <id>: <resto>`, ed e' su quella
+che si regola la guardia.
 
 La **diagnostica** oggi sono le registrazioni dinamiche di strategy
 (`register_density_strategy`, `register_variation_strategy`,
@@ -89,11 +108,21 @@ rendering*, cioe' un prodotto del programma; questa avrebbe configurato il
 logging di chi importa `pge`, che non e' affare di `pge`.
 
 **La classificazione e' un test, non una prosa.** `tests/shared/test_stdout_contract.py`
-legge i sorgenti con `ast` e chiede due cose: che la riga `[CACHE]` sia ancora
-un `print()` flushato nei tre renderer, e che in `src/pge/strategies/` non ci
-sia nessun `print()`. Il primo e' l'unico presidio di comportamento che csound e
-supercollider abbiano su quella riga (il renderer NumPy ha anche un test vero);
-il secondo e' cio' che impedisce alla porta di riaprirsi in silenzio.
+legge i sorgenti con `ast` e chiede due cose: che la riga `[CACHE] <id>: ...`
+sia ancora un `print()` flushato in tutti e quattro i moduli che la emettono, e
+che in `src/pge/strategies/` non ci sia nessun `print()`. Il primo e' l'unico
+presidio che csound e supercollider abbiano su quella riga (numpy e il cache
+manager hanno anche un test di comportamento); il secondo e' cio' che impedisce
+alla porta di riaprirsi in silenzio.
+
+**La guardia riconosce la forma, non il prefisso.** Le chiamate sono
+ricomposte in un *template* — ogni interpolazione di una f-string diventa `{}`,
+senza guardarci dentro — e cio' che si pretende e' `[CACHE] {}: `. Cercare la
+sottostringa `[CACHE]` sarebbe bastato per i renderer e non per il cache
+manager, dove sopravvive comunque un `[CACHE] <n>/<m> stream da ricompilare`
+che nessuno parsa: la guardia sarebbe rimasta verde dopo aver spostato al
+logger l'unica riga che l'editor legge davvero. Due test misurano proprio il
+discrimine, cosi' che a indebolirlo qualcosa suoni.
 
 ## Implicazioni codice
 
@@ -101,17 +130,23 @@ il secondo e' cio' che impedisce alla porta di riaprirsi in silenzio.
   formattazione `%s` pigra. Mai `print()`.
 - **Aggiungi un renderer** → se dichiara lo stato della cache, la riga
   `[CACHE] <id>: <status>` va su stdout con `flush=True`, e il modulo va
-  aggiunto a `RENDERER_CON_PROTOCOLLO_CACHE` nella guardia. Vedi [[add-renderer]].
+  aggiunto a `MODULI_CON_PROTOCOLLO_CACHE` nella guardia. Vedi [[add-renderer]].
 - **Cambi il formato di una riga di protocollo** → e' un cambio di superficie
   pubblica: serve l'analisi d'impatto su PGE-ui e PGE-ls prima, non dopo.
 - **Il resto dei `print()`** (`engine/generator.py`,
   `rendering/score_visualizer.py`, `rendering/stream_cache_manager.py`,
   `rendering/score_writer.py`, `cli.py`) non e' ancora classificato: sono gli
-  scaglioni successivi. `cli.py` ne concentra la maggioranza ed e' quasi tutto
-  *interfaccia CLI*, cioe' la terza categoria — quella che resta su stdout pur
-  non essendo protocollo. E' anche l'unica dove la scelta non e' meccanica: la
-  riga per stream dei conteggi di grani (#250) la legge un compositore a
-  schermo, non un parser, ma sta sullo stesso canale che un parser attraversa.
+  scaglioni successivi. Attenzione a due di quei moduli: non sono omogenei.
+  `stream_cache_manager.py` e `generator.py` contengono *anche* righe gia'
+  classificate — la riga per stream del primo e' protocollo e ha la sua
+  guardia; quel che resta da classificare li' e' il riepilogo
+  `[CACHE] <n>/<m> stream da ricompilare` e `[CACHE] Stream da scrivere: [...]`,
+  che nessun parser legge. `cli.py` concentra la maggioranza del resto ed e'
+  quasi tutto *interfaccia CLI*, cioe' la terza categoria — quella che resta su
+  stdout pur non essendo protocollo. E' anche l'unica dove la scelta non e'
+  meccanica: la riga per stream dei conteggi di grani (#250) la legge un
+  compositore a schermo, non un parser, ma sta sullo stesso canale che un
+  parser attraversa.
 
 ## Vedi anche
 

--- a/docs/how-to/add-renderer.md
+++ b/docs/how-to/add-renderer.md
@@ -9,7 +9,8 @@ sources:
   - src/pge/rendering/supercollider_renderer.py
   - src/pge/api.py
   - src/pge/cli.py
-last_synced_commit: 1d80252
+  - tests/shared/test_stdout_contract.py
+last_synced_commit: 38bfee7
 entry_for: [add-renderer]
 ---
 
@@ -49,11 +50,12 @@ L'ultimo backend aggiunto è SuperCollider (issue #228): è l'esempio lavorato d
      sul solo subprocess lascia uno score orfano a ogni render che muore
      prima
 
-4. Registra in `src/pge/rendering/renderer_factory.py`: aggiungi il nome a `_VALID_TYPES` e il ramo di costruzione in `create()`. `available_types()` è l'unico elenco dei tipi validi — messaggi d'errore e CLI lo chiedono lì
-5. Aggiungi il ramo in `api.build_renderer()`, e una dataclass di opzioni accanto a `CsoundOptions` / `SuperColliderOptions` se il backend ha configurazione propria
-6. Mappa i flag CLI in `cli._build_renderer`: i nomi vanno **dichiarati nella firma** (keyword-only, issue #252), non solo letti nel corpo — uno non dichiarato è un `TypeError` al primo render invece di un no-op silenzioso, e `tests/test_cli_build_renderer_signature.py` confronta la firma col sito di chiamata dentro `main()`. Aggiorna anche la usage string (il golden `tests/test_cli_contract.py` la difende: va aggiornato di proposito)
-7. `make/build.mk` non va toccato se il backend non ha bisogno di flag propri: il ramo generico è `ifneq ($(RENDERER), csound)`
-8. Aggiungi test unit + integrazione + e2e per il nuovo renderer
+4. Se il backend dichiara lo stato della cache, la riga `[CACHE] <id>: <status>` va su stdout con **`print(..., flush=True)`** — non al logger: è protocollo, `render_pipeline.py` di PGE-ui ne ricava `stream-start` e `stream-done`, e portarla al logger lascia la barra di avanzamento dell'editor ferma a zero. Aggiungi il modulo a `MODULI_CON_PROTOCOLLO_CACHE` in `tests/shared/test_stdout_contract.py`: quella guardia deriva la lista dai sorgenti, quindi se te ne dimentichi fallisce lei. Vedi [[contratto-stdout]]
+5. Registra in `src/pge/rendering/renderer_factory.py`: aggiungi il nome a `_VALID_TYPES` e il ramo di costruzione in `create()`. `available_types()` è l'unico elenco dei tipi validi — messaggi d'errore e CLI lo chiedono lì
+6. Aggiungi il ramo in `api.build_renderer()`, e una dataclass di opzioni accanto a `CsoundOptions` / `SuperColliderOptions` se il backend ha configurazione propria
+7. Mappa i flag CLI in `cli._build_renderer`: i nomi vanno **dichiarati nella firma** (keyword-only, issue #252), non solo letti nel corpo — uno non dichiarato è un `TypeError` al primo render invece di un no-op silenzioso, e `tests/test_cli_build_renderer_signature.py` confronta la firma col sito di chiamata dentro `main()`. Aggiorna anche la usage string (il golden `tests/test_cli_contract.py` la difende: va aggiornato di proposito)
+8. `make/build.mk` non va toccato se il backend non ha bisogno di flag propri: il ramo generico è `ifneq ($(RENDERER), csound)`
+9. Aggiungi test unit + integrazione + e2e per il nuovo renderer
 
 ## File toccati
 
@@ -65,6 +67,7 @@ L'ultimo backend aggiunto è SuperCollider (issue #228): è l'esempio lavorato d
 | `src/pge/cli.py` | parsing flag + firma di `_build_renderer` + usage string |
 | `docs/reference/cli.md` · `docs/reference/errors.md` | flag e nuovi errori |
 | `tests/rendering/test_<nome>_renderer.py` | nuovi test |
+| `tests/shared/test_stdout_contract.py` | `MODULI_CON_PROTOCOLLO_CACHE`, se il backend emette la riga `[CACHE]` |
 | `tests/test_cli_contract.py` | golden della usage string |
 
 ## Test da aggiornare
@@ -73,6 +76,7 @@ L'ultimo backend aggiunto è SuperCollider (issue #228): è l'esempio lavorato d
 - Test di integrazione: YAML vero → `Generator` vero → artefatto del backend, senza il motore esterno. È l'unico modo di verificare che i pezzi siano collegati su una macchina che non ha il motore installato
 - E2E `tests/e2e/` con YAML minimo + nuovo renderer, `skipif` sul binario assente. **Se l'e2e si skippa in CI, il DSP del backend non è verificato da nessuno**: aggiungi la dipendenza al job e2e di `.github/workflows/ci.yml`
 - Test fallback / errori (binario assente, exit code, output path non scrivibile)
+- Se il backend stampa `[CACHE] <id>: <status>`, dichiaralo in `tests/shared/test_stdout_contract.py`. **Un test di comportamento sulla riga vale più della guardia statica**: quest'ultima vede la forma della `print()`, non che venga eseguita al momento giusto — csound e supercollider hanno solo quella, ed è un debito, non un modello
 
 ## Verifica
 

--- a/src/pge/shared/logger.py
+++ b/src/pge/shared/logger.py
@@ -223,10 +223,22 @@ def get_engine_log_path() -> str | None:
 #    Il NullHandler serve al resto: senza handler, `logging` manda i record da
 #    WARNING in su a `lastResort`, che scrive su stderr.
 #
-# 2. **Livello DEBUG.** Sotto il livello di default del root (WARNING) il
-#    record non viene nemmeno costruito, quindi la diagnostica muta non costa.
-#    Chi la vuole fa `logging.basicConfig(level=logging.DEBUG)`, e la console
-#    di `logging` e' stderr: nemmeno accendendola si rientra in stdout.
+# 2. **Il record e' DEBUG, il logger resta NOTSET.** Il livello sta sulla
+#    chiamata (`.debug(...)`), non sul logger: `get_diagnostic_logger()` non
+#    chiama `setLevel`, quindi il livello effettivo lo eredita dal root e a
+#    deciderlo e' l'host. Sotto il default del root (WARNING) il record non
+#    viene nemmeno costruito, quindi la diagnostica muta non costa. Chi la
+#    vuole fa `logging.basicConfig(level=logging.DEBUG)`, e la console di
+#    `logging` e' stderr: nemmeno accendendola si rientra in stdout.
+#
+#    Il NOTSET e' la meta' portante, non un dettaglio omesso. Un
+#    `logger.setLevel(logging.DEBUG)` qui non renderebbe la diagnostica
+#    "accendibile": la renderebbe *accesa*. `Logger.callHandlers` confronta il
+#    record col livello dell'**handler**, non ricontrolla quello del logger, e
+#    un `logging.basicConfig()` senza argomenti lascia il suo StreamHandler a
+#    NOTSET: ogni host che lo chiama si troverebbe la diagnostica su stderr
+#    senza averla chiesta. Il livello del logger e' dell'host, e va lasciato
+#    dov'e'. Lo fissa `test_diagnostic_logger_non_impone_un_livello`.
 DIAGNOSTIC_LOGGER_NAME = 'pge.diagnostics'
 
 _diagnostic_logger: logging.Logger | None = None

--- a/src/pge/shared/logger.py
+++ b/src/pge/shared/logger.py
@@ -268,6 +268,7 @@ def log_strategy_registration(domain: str, name: str, strategy_class: type) -> N
         domain, name, strategy_class.__name__,
     )
 
+
 def log_clip_warning(stream_id, param_name, time, raw_value, clipped_value, 
                      min_val, max_val, is_envelope=False):
     """

--- a/src/pge/shared/logger.py
+++ b/src/pge/shared/logger.py
@@ -196,6 +196,78 @@ def get_engine_log_path() -> str | None:
     """Path del file di log engine corrente."""
     return _engine_log_path
 
+
+# =============================================================================
+# DIAGNOSTIC LOGGER (issue #187) — diagnostica di sviluppo, mai su stdout
+# =============================================================================
+# Terzo logger, e con un compito diverso dagli altri due. Clip ed engine
+# raccontano cosa e' successo a un rendering; questo raccoglie le righe che la
+# classificazione della #178 ha marcato come *diagnostica*: nessuno le parsa,
+# nessuno le legge come interfaccia. Oggi sono le registrazioni dinamiche di
+# strategy, un'operazione da sviluppatore che non compare in una pipeline di
+# rendering normale.
+#
+# Il motivo per cui non possono restare `print()` non e' l'ordine: stdout e' un
+# canale di *protocollo*. `render_pipeline.py` di PGE-ui legge le righe di
+# `main.py` una per una e ne ricava gli eventi NDJSON dell'editor — le righe
+# `[CACHE] <id>: DIRTY|clean` dei renderer e i path del blocco riassuntivo. Chi
+# scrive li' scrive dentro l'interfaccia di un altro repository.
+#
+# Due scelte, ed entrambe sono abstention:
+#
+# 1. **Nessun handler proprio oltre al NullHandler.** Una libreria non
+#    configura il logging del suo ospite. Qui l'astensione ha anche un effetto
+#    concreto: `get_engine_logger()` si auto-configura, e configurarsi vuol
+#    dire `os.makedirs('./logs')` — una cartella materializzata sul disco di
+#    chi passava di li' solo per dire che una strategy e' stata registrata.
+#    Il NullHandler serve al resto: senza handler, `logging` manda i record da
+#    WARNING in su a `lastResort`, che scrive su stderr.
+#
+# 2. **Livello DEBUG.** Sotto il livello di default del root (WARNING) il
+#    record non viene nemmeno costruito, quindi la diagnostica muta non costa.
+#    Chi la vuole fa `logging.basicConfig(level=logging.DEBUG)`, e la console
+#    di `logging` e' stderr: nemmeno accendendola si rientra in stdout.
+DIAGNOSTIC_LOGGER_NAME = 'pge.diagnostics'
+
+_diagnostic_logger: logging.Logger | None = None
+
+
+def get_diagnostic_logger() -> logging.Logger:
+    """Logger della diagnostica di sviluppo; muto finche' l'host non lo ascolta.
+
+    Returns:
+        logging.Logger — mai None, a differenza di `get_clip_logger()`: qui non
+        c'e' niente da disabilitare, perche' senza ascoltatori non emette.
+    """
+    global _diagnostic_logger
+
+    if _diagnostic_logger is None:
+        logger = logging.getLogger(DIAGNOSTIC_LOGGER_NAME)
+        # Un solo NullHandler, e solo alla prima chiamata: gli altri handler
+        # sono dell'applicazione ospite e non vanno ne' toccati ne' azzerati,
+        # quindi `handlers = []` (come fa il clip logger, che li possiede
+        # tutti) qui sarebbe un sopruso.
+        logger.addHandler(logging.NullHandler())
+        _diagnostic_logger = logger
+
+    return _diagnostic_logger
+
+
+def log_strategy_registration(domain: str, name: str, strategy_class: type) -> None:
+    """Registrazione dinamica di una strategy: diagnostica, non protocollo.
+
+    Args:
+        domain: dominio del registry ('density', 'variation', 'pan voce')
+        name: chiave con cui la strategy e' stata registrata
+        strategy_class: la classe registrata (se ne logga il `__name__`)
+    """
+    # Formattazione pigra: gli argomenti restano tali finche' un handler non
+    # chiede il messaggio, e con la diagnostica spenta quel momento non arriva.
+    get_diagnostic_logger().debug(
+        "Registrata nuova strategia %s: %s -> %s",
+        domain, name, strategy_class.__name__,
+    )
+
 def log_clip_warning(stream_id, param_name, time, raw_value, clipped_value, 
                      min_val, max_val, is_envelope=False):
     """

--- a/src/pge/strategies/strategy_registry.py
+++ b/src/pge/strategies/strategy_registry.py
@@ -11,6 +11,7 @@ from pge.shared.exceptions import (
     InvalidStrategyConfigError,
     StrategyNotFoundError,
 )
+from pge.shared.logger import log_strategy_registration
 
 # =============================================================================
 # REGISTRI
@@ -32,7 +33,7 @@ DENSITY_STRATEGIES: Dict[str, Type[DensityStrategy]] = {
 def register_density_strategy(param_name: str, strategy_class: Type[DensityStrategy]):
     """Registra una nuova strategia di density."""
     DENSITY_STRATEGIES[param_name] = strategy_class
-    print(f"✅ Registrata nuova strategia density: {param_name} -> {strategy_class.__name__}")
+    log_strategy_registration('density', param_name, strategy_class)
 
 
 # =============================================================================

--- a/src/pge/strategies/variation_registry.py
+++ b/src/pge/strategies/variation_registry.py
@@ -15,6 +15,7 @@ from pge.strategies.variation_strategy import (
     ChoiceVariation
 )
 from pge.shared.exceptions import StrategyNotFoundError
+from pge.shared.logger import log_strategy_registration
 
 # =============================================================================
 # REGISTRY
@@ -43,7 +44,7 @@ def register_variation_strategy(mode_name: str, strategy_class: Type[VariationSt
     - 'biased_gaussian': BiasedGaussianVariation
     """
     VARIATION_STRATEGIES[mode_name] = strategy_class
-    print(f"✅ Registrata nuova strategia variation: {mode_name} -> {strategy_class.__name__}")
+    log_strategy_registration('variation', mode_name, strategy_class)
 
 
 # =============================================================================

--- a/src/pge/strategies/voice_pan_strategy.py
+++ b/src/pge/strategies/voice_pan_strategy.py
@@ -37,6 +37,7 @@ from pge.shared.exceptions import (
     InvalidStrategyConfigError,
     StrategyNotFoundError,
 )
+from pge.shared.logger import log_strategy_registration
 from pge.shared.seeding import voice_rng
 
 
@@ -263,10 +264,7 @@ def register_voice_pan_strategy(
         register_voice_pan_strategy('stereo_spread', MyStereoSpread)
     """
     VOICE_PAN_STRATEGIES[name] = strategy_class
-    print(
-        f"Registrata nuova strategia pan voce: "
-        f"'{name}' -> {strategy_class.__name__}"
-    )
+    log_strategy_registration('pan voce', name, strategy_class)
 
 
 # =============================================================================

--- a/tests/rendering/test_stream_cache_manager.py
+++ b/tests/rendering/test_stream_cache_manager.py
@@ -576,6 +576,34 @@ class TestDirtyStreamFiltering:
         result = manager.get_dirty_stream_dicts([d], aif_dir=str(tmp_path))
         assert result == []
 
+    def test_stampa_la_riga_di_protocollo_per_ogni_stream(
+        self, manager, two_stream_dicts, tmp_path, capsys
+    ):
+        """`[CACHE] <id>: DIRTY|clean` su stdout, uno per stream (issue #187).
+
+        Non e' una riga di servizio: e' quella da cui `parse_render_line` di
+        PGE-ui ricava `stream-start` e `stream-done`. Qui esce prima che un
+        renderer esista — la pipeline in due stadi passa da
+        `Generator.write_sco_files`, che delega a questo metodo. E' anche
+        l'emettitore piu' esposto: gli altri `print()` di questo modulo la
+        #178 non li ha ancora classificati, quindi qualcuno ci ripassera'.
+        Senza questa asserzione una conversione al logger non farebbe fallire
+        niente, e la barra di avanzamento dell'editor resterebbe ferma a zero
+        per tutto il rendering. Vedi `docs/explanation/contratto-stdout.md` e
+        la guardia statica in `tests/shared/test_stdout_contract.py`.
+        """
+        s1, s2 = two_stream_dicts
+
+        # s1 clean: fingerprint nel manifest + .aif presente. s2 dirty.
+        manager.save({'s1': manager.compute_fingerprint(s1)})
+        open(str(tmp_path / 's1.aif'), 'w').close()
+
+        manager.get_dirty_stream_dicts(two_stream_dicts, aif_dir=str(tmp_path))
+
+        righe = capsys.readouterr().out.splitlines()
+        assert '[CACHE] s1: clean' in righe
+        assert '[CACHE] s2: DIRTY' in righe
+
 
 # =============================================================================
 # 5. CACHE UPDATE

--- a/tests/shared/test_diagnostic_logger.py
+++ b/tests/shared/test_diagnostic_logger.py
@@ -1,0 +1,169 @@
+# =============================================================================
+# tests/shared/test_diagnostic_logger.py
+# =============================================================================
+"""
+Test per il diagnostic logger (issue #187, primo scaglione della #178).
+
+Terzo logger accanto a clip ed engine, e con un compito diverso dai loro: le
+righe che nessuno parsa e nessuno legge come interfaccia — la registrazione
+dinamica di una strategy — smettono di essere `print()` e diventano record di
+logging.
+
+Il motivo per cui non possono restare su stdout non e' estetico: stdout e' un
+canale di protocollo. `render_pipeline.py` di PGE-ui lo legge riga per riga e
+ne ricava gli eventi NDJSON dell'editor. Ogni riga che finisce li' e' materiale
+che un parser a valle deve attraversare.
+
+Da qui i due vincoli che questa suite fissa:
+1. muto di default, e muto su *stdout* in ogni caso (il canale della console
+   di `logging` e' stderr);
+2. nessun effetto collaterale sul filesystem — registrare una strategy non
+   deve creare una cartella `logs/`, che e' invece cio' che farebbe
+   `get_engine_logger()`, il quale si auto-configura.
+"""
+import logging
+import os
+
+import pytest
+
+from pge.shared.logger import (
+    DIAGNOSTIC_LOGGER_NAME,
+    get_diagnostic_logger,
+    log_strategy_registration,
+)
+
+
+class _Strategia:
+    """Classe fittizia: al logger interessa solo il suo `__name__`."""
+
+
+# =============================================================================
+# 1. IDENTITA' DEL LOGGER
+# =============================================================================
+
+def test_diagnostic_logger_ha_un_nome_dedicato():
+    """Il logger e' suo, non il root: un host puo' alzarlo o zittirlo da solo."""
+    logger = get_diagnostic_logger()
+
+    assert isinstance(logger, logging.Logger)
+    assert logger.name == DIAGNOSTIC_LOGGER_NAME
+    assert logger is logging.getLogger(DIAGNOSTIC_LOGGER_NAME)
+
+
+def test_diagnostic_logger_e_idempotente():
+    """Chiamate ripetute non impilano handler.
+
+    `get_clip_logger` puo' permettersi di azzerare `handlers` perche' li
+    possiede tutti; qui gli handler sono dell'applicazione ospite e vanno
+    lasciati stare, quindi l'unica difesa contro il duplicato e' non
+    riaggiungere il NullHandler a ogni chiamata.
+    """
+    primo = get_diagnostic_logger()
+    quanti = len(primo.handlers)
+
+    for _ in range(5):
+        get_diagnostic_logger()
+
+    assert len(primo.handlers) == quanti
+
+
+# =============================================================================
+# 2. MUTO DI DEFAULT, E SOPRATTUTTO MUTO SU STDOUT
+# =============================================================================
+
+def test_diagnostic_logger_non_scrive_niente_senza_configurazione(capsys):
+    """Senza configurazione dell'host, nessun byte esce."""
+    logger = get_diagnostic_logger()
+
+    logger.debug("registrata qualcosa")
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_diagnostic_logger_non_ricade_su_lastresort(capsys):
+    """Il NullHandler copre anche i livelli che `logging` stampa da solo.
+
+    Un logger senza handler manda i record da WARNING in su a
+    `logging.lastResort`, che scrive su stderr: la diagnostica sarebbe muta
+    solo finche' resta a DEBUG. Il NullHandler chiude anche quella porta.
+    """
+    logger = get_diagnostic_logger()
+
+    logger.warning("questa non deve comparire da nessuna parte")
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_diagnostic_logger_non_crea_la_cartella_dei_log(tmp_path, monkeypatch):
+    """Nessun effetto collaterale su disco: la diagnostica non configura nulla.
+
+    `get_engine_logger()` si auto-configura e con essa crea `./logs`. Passare
+    di li' avrebbe significato materializzare una cartella per dire che una
+    strategy e' stata registrata.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    get_diagnostic_logger()
+    log_strategy_registration('density', 'pino', _Strategia)
+
+    assert os.listdir(tmp_path) == []
+
+
+# =============================================================================
+# 3. IL RECORD, QUANDO L'HOST LO ASCOLTA
+# =============================================================================
+
+def test_log_strategy_registration_emette_un_record_debug(caplog):
+    """Il messaggio esiste ancora: cambia il canale, non l'informazione."""
+    with caplog.at_level(logging.DEBUG, logger=DIAGNOSTIC_LOGGER_NAME):
+        log_strategy_registration('variation', 'test_mode', _Strategia)
+
+    records = [r for r in caplog.records if r.name == DIAGNOSTIC_LOGGER_NAME]
+    assert len(records) == 1
+
+    record = records[0]
+    assert record.levelno == logging.DEBUG
+    messaggio = record.getMessage()
+    assert 'variation' in messaggio
+    assert 'test_mode' in messaggio
+    assert '_Strategia' in messaggio
+
+
+def test_log_strategy_registration_formatta_pigramente():
+    """Gli argomenti restano tali finche' qualcuno non formatta.
+
+    Con `%s` il costo della stringa lo paga solo chi ascolta davvero — ed e'
+    la ragione per cui una diagnostica muta puo' stare su un percorso caldo
+    senza pesare.
+    """
+    registrati = []
+
+    class _Spia(logging.Handler):
+        def emit(self, record):
+            registrati.append(record)
+
+    logger = get_diagnostic_logger()
+    spia = _Spia()
+    logger.addHandler(spia)
+    livello = logger.level
+    logger.setLevel(logging.DEBUG)
+    try:
+        log_strategy_registration('pan voce', 'stereo_spread', _Strategia)
+    finally:
+        logger.removeHandler(spia)
+        logger.setLevel(livello)
+
+    assert len(registrati) == 1
+    assert registrati[0].args, "il record non porta argomenti: formattazione avida"
+    assert '%s' in registrati[0].msg
+
+
+def test_log_strategy_registration_non_scrive_su_stdout(capsys):
+    """Il punto dell'issue: la riga non entra nel canale che PGE-ui parsa."""
+    log_strategy_registration('density', 'fill_factor', _Strategia)
+
+    assert capsys.readouterr().out == ""

--- a/tests/shared/test_diagnostic_logger.py
+++ b/tests/shared/test_diagnostic_logger.py
@@ -48,6 +48,25 @@ def test_diagnostic_logger_ha_un_nome_dedicato():
     assert logger is logging.getLogger(DIAGNOSTIC_LOGGER_NAME)
 
 
+def test_diagnostic_logger_non_impone_un_livello():
+    """Il livello e' dell'host: qui resta NOTSET, e non e' un'omissione.
+
+    Il DEBUG sta sulla chiamata, non sul logger. Alzarlo qui non renderebbe la
+    diagnostica *accendibile* — la renderebbe accesa: `Logger.callHandlers`
+    confronta il record col livello dell'**handler** e non ricontrolla quello
+    del logger, e un `logging.basicConfig()` senza argomenti lascia il proprio
+    StreamHandler a NOTSET. Con un `setLevel(DEBUG)` qui, ogni host che chiama
+    `basicConfig()` si troverebbe la diagnostica su stderr senza averla
+    chiesta: esattamente l'astensione che questo logger esiste per praticare.
+    """
+    logger = get_diagnostic_logger()
+
+    assert logger.level == logging.NOTSET, (
+        "il diagnostic logger si e' dato un livello: cosi' non e' piu' l'host "
+        "a decidere se ascoltarlo"
+    )
+
+
 def test_diagnostic_logger_e_idempotente():
     """Chiamate ripetute non impilano handler.
 

--- a/tests/shared/test_diagnostic_logger.py
+++ b/tests/shared/test_diagnostic_logger.py
@@ -24,8 +24,6 @@ Da qui i due vincoli che questa suite fissa:
 import logging
 import os
 
-import pytest
-
 from pge.shared.logger import (
     DIAGNOSTIC_LOGGER_NAME,
     get_diagnostic_logger,
@@ -82,20 +80,78 @@ def test_diagnostic_logger_non_scrive_niente_senza_configurazione(capsys):
     assert captured.err == ""
 
 
-def test_diagnostic_logger_non_ricade_su_lastresort(capsys):
+class _SpiaLastResort(logging.Handler):
+    """Handler che si limita a contare: sta al posto di `logging.lastResort`."""
+
+    def __init__(self):
+        super().__init__(level=logging.WARNING)
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+
+def _isola(logger, monkeypatch):
+    """Isola `logger` dagli handler che *l'ambiente* mette sul root.
+
+    Serve perche' l'asserzione qui sotto sia una misura e non una tautologia.
+    `Logger.callHandlers` conta gli handler di **tutta la catena** e ricade su
+    `lastResort` solo se non ne trova nessuno; sotto pytest il root ne porta
+    sempre quattro (`_LiveLoggingNullHandler`, il `_FileHandler` su /dev/null
+    e i due `LogCaptureHandler`), quindi `found` non e' mai zero e la porta che
+    il NullHandler chiude resta chiusa da sola: un test che guardasse solo
+    stderr passerebbe identico dopo aver cancellato la riga che dice di
+    difendere.
+
+    L'isolamento si fa spegnendo `propagate` sul logger in esame, non
+    svuotando `root.handlers`: la lista del root e' condivisa con il plugin di
+    logging di pytest, che alla fine della fase fa `removeHandler` sulla lista
+    che trova: sostituirgliela sotto significa lasciargli l'handler attaccato
+    per il resto della sessione. Cosi' invece l'unico handler in gioco resta
+    quello del logger, che e' esattamente cio' che si vuole misurare.
+
+    Restituisce la spia che prende il posto di `lastResort`.
+    """
+    spia = _SpiaLastResort()
+    monkeypatch.setattr(logging, 'lastResort', spia)
+    monkeypatch.setattr(logger, 'propagate', False)
+    return spia
+
+
+def test_diagnostic_logger_non_ricade_su_lastresort(monkeypatch, capsys):
     """Il NullHandler copre anche i livelli che `logging` stampa da solo.
 
     Un logger senza handler manda i record da WARNING in su a
     `logging.lastResort`, che scrive su stderr: la diagnostica sarebbe muta
-    solo finche' resta a DEBUG. Il NullHandler chiude anche quella porta.
+    solo finche' resta a DEBUG. Il NullHandler chiude anche quella porta —
+    ed e' l'unico a farlo, una volta isolato il logger dall'ambiente.
     """
     logger = get_diagnostic_logger()
+    spia = _isola(logger, monkeypatch)
 
     logger.warning("questa non deve comparire da nessuna parte")
 
+    assert spia.records == [], "record finito su lastResort: manca il NullHandler"
     captured = capsys.readouterr()
     assert captured.out == ""
     assert captured.err == ""
+
+
+def test_la_misura_del_lastresort_e_sensibile(monkeypatch):
+    """Controprova: senza NullHandler, con lo stesso setup, la spia scatta.
+
+    Senza questa meta' il test precedente non dimostra niente — potrebbe
+    essere verde perche' `lastResort` non viene mai raggiunto in nessun caso.
+    Qui l'unica differenza e' un logger nudo, e il verdetto si ribalta.
+    """
+    nudo = logging.getLogger('probe_nuda_senza_handler')
+    assert not nudo.handlers, "la probe deve essere nuda per misurare qualcosa"
+    spia = _isola(nudo, monkeypatch)
+
+    nudo.warning("questa invece deve arrivare a lastResort")
+
+    assert len(spia.records) == 1, \
+        "lastResort non raggiunto nemmeno da un logger nudo: la misura non misura"
 
 
 def test_diagnostic_logger_non_crea_la_cartella_dei_log(tmp_path, monkeypatch):
@@ -142,12 +198,12 @@ def test_log_strategy_registration_formatta_pigramente():
     """
     registrati = []
 
-    class _Spia(logging.Handler):
+    class _SpiaDeiRecord(logging.Handler):
         def emit(self, record):
             registrati.append(record)
 
     logger = get_diagnostic_logger()
-    spia = _Spia()
+    spia = _SpiaDeiRecord()
     logger.addHandler(spia)
     livello = logger.level
     logger.setLevel(logging.DEBUG)

--- a/tests/shared/test_stdout_contract.py
+++ b/tests/shared/test_stdout_contract.py
@@ -19,9 +19,28 @@ Questa suite esiste perche' la classificazione era prosa, e la prosa non si
 accorge di essere stata contraddetta. Le due meta' falliscono in direzioni
 opposte e vanno guardate entrambe: portare al logger una riga di protocollo
 rompe l'interfaccia utente di un altro repository *senza toccare un test di
-PGE* (per csound e supercollider la riga `[CACHE]` non ha oggi nessuna
+PGE* (per csound e supercollider la riga `[CACHE]` non ha nessun'altra
 asserzione di comportamento — solo questa); rimettere un `print()` in
 `strategies/` riapre in silenzio la porta che la #187 ha chiuso.
+
+**Chi emette la riga non e' solo un renderer.** I tre renderer la stampano
+sul percorso diretto (uno stream alla volta), ma la pipeline in due stadi
+passa da `Generator.write_sco_files`, che delega a
+`StreamCacheManager.get_dirty_stream_dicts`: e' li' che la riga esce, per
+tutti gli stream in blocco, prima che un renderer veda alcunche'. E' anche
+l'emettitore piu' esposto: il suo modulo contiene *altri* `print()` che la
+#178 non ha ancora classificato, quindi e' il prossimo su cui passera' un
+giro di conversione al logger, e chi lo fara' avra' sotto gli occhi righe
+`[CACHE]` di due nature diverse. Percio' sta nella lista come gli altri.
+
+**Il criterio e' la forma, non il prefisso.** `[CACHE]` da solo non
+discrimina: lo stesso modulo stampa anche `[CACHE] <n>/<m> stream da
+ricompilare`, che PGE-ui non parsa (la sua regex vuole `<token-senza-spazi>:`
+subito dopo il prefisso). Cercare la sottostringa avrebbe lasciato passare la
+scomparsa della riga vera. Le chiamate sono quindi ricomposte in un
+*template* — ogni `{...}` di una f-string diventa `{}` — e cio' che la
+guardia pretende e' `[CACHE] {}: `, la forma esatta che quella regex
+riconosce.
 """
 import ast
 import os
@@ -31,12 +50,20 @@ import pytest
 SRC_PGE = os.path.abspath(
     os.path.join(os.path.dirname(__file__), '..', '..', 'src', 'pge'))
 
-# I tre renderer che dichiarano lo stato della cache all'editor.
-RENDERER_CON_PROTOCOLLO_CACHE = [
+# I moduli che dichiarano all'editor lo stato della cache, stream per stream.
+# I tre renderer sul percorso diretto; il cache manager sul percorso in due
+# stadi (`Generator.write_sco_files` -> `get_dirty_stream_dicts`), dove la riga
+# esce prima che un renderer esista.
+MODULI_CON_PROTOCOLLO_CACHE = [
     os.path.join('rendering', 'numpy_audio_renderer.py'),
     os.path.join('rendering', 'csound_renderer.py'),
     os.path.join('rendering', 'supercollider_renderer.py'),
+    os.path.join('rendering', 'stream_cache_manager.py'),
 ]
+
+# La forma che `_RE_CACHE_LINE` di PGE-ui riconosce: prefisso, un token senza
+# spazi, i due punti. Il resto della riga non e' vincolato.
+PREFISSO_PROTOCOLLO_CACHE = '[CACHE] {}: '
 
 
 def _sorgente(relpath):
@@ -54,25 +81,45 @@ def _print_calls(tree):
     ]
 
 
-def _testo_letterale(node):
-    """Le parti costanti di un argomento, f-string comprese.
+def _template(node):
+    """Il testo di un argomento con ogni interpolazione ridotta a `{}`.
 
     La riga di protocollo e' una f-string: il prefisso `[CACHE] ` e' un
     `Constant` dentro una `JoinedStr`, e cercarlo come stringa intera non lo
-    troverebbe.
+    troverebbe. Ma raccogliere le costanti con `ast.walk` non basta: l'ordine
+    di visita non e' quello della riga, e le costanti annidate dentro
+    un'interpolazione (`{'DIRTY' if dirty else 'clean'}`, in supercollider)
+    finirebbero nel testo come se fossero letterali. Qui si cammina invece
+    `JoinedStr.values` in ordine, e ogni `FormattedValue` diventa `{}` senza
+    che se ne guardi dentro: quel che resta e' la *forma* della riga, ed e'
+    esattamente cio' su cui la regex di PGE-ui decide.
     """
-    pezzi = []
-    for sotto in ast.walk(node):
-        if isinstance(sotto, ast.Constant) and isinstance(sotto.value, str):
-            pezzi.append(sotto.value)
-    return ''.join(pezzi)
+    if isinstance(node, ast.Constant):
+        return node.value if isinstance(node.value, str) else ''
+    if isinstance(node, ast.JoinedStr):
+        return ''.join(
+            pezzo.value if isinstance(pezzo, ast.Constant)
+            and isinstance(pezzo.value, str)
+            else '{}'
+            for pezzo in node.values
+        )
+    return ''
+
+
+def _print_di_protocollo(tree):
+    """Le `print()` la cui forma e' quella che PGE-ui parsa come stream."""
+    return [
+        c for c in _print_calls(tree)
+        if any(_template(a).startswith(PREFISSO_PROTOCOLLO_CACHE)
+               for a in c.args)
+    ]
 
 
 # =============================================================================
 # 1. PROTOCOLLO — resta su stdout
 # =============================================================================
 
-@pytest.mark.parametrize('relpath', RENDERER_CON_PROTOCOLLO_CACHE)
+@pytest.mark.parametrize('relpath', MODULI_CON_PROTOCOLLO_CACHE)
 def test_la_riga_cache_resta_su_stdout(relpath):
     """`[CACHE] <id>: <status>` e' protocollo: `print()`, non logger.
 
@@ -82,16 +129,14 @@ def test_la_riga_cache_resta_su_stdout(relpath):
     """
     tree = ast.parse(_sorgente(relpath))
 
-    con_cache = [c for c in _print_calls(tree)
-                 if any('[CACHE]' in _testo_letterale(a) for a in c.args)]
-
-    assert con_cache, (
-        f"{relpath}: la riga di protocollo [CACHE] non e' piu' un print(). "
-        "PGE-ui la parsa da stdout: vedi issue #178."
+    assert _print_di_protocollo(tree), (
+        f"{relpath}: la riga di protocollo `{PREFISSO_PROTOCOLLO_CACHE}...` "
+        "non e' piu' un print() con quella forma. PGE-ui la parsa da stdout "
+        "per ricavarne stream-start/stream-done: vedi issue #178."
     )
 
 
-@pytest.mark.parametrize('relpath', RENDERER_CON_PROTOCOLLO_CACHE)
+@pytest.mark.parametrize('relpath', MODULI_CON_PROTOCOLLO_CACHE)
 def test_la_riga_cache_e_flushata(relpath):
     """`flush=True`: l'editor la legge mentre il rendering e' in corso.
 
@@ -100,12 +145,48 @@ def test_la_riga_cache_e_flushata(relpath):
     """
     tree = ast.parse(_sorgente(relpath))
 
-    for chiamata in _print_calls(tree):
-        if not any('[CACHE]' in _testo_letterale(a) for a in chiamata.args):
-            continue
+    for chiamata in _print_di_protocollo(tree):
         flush = [k for k in chiamata.keywords if k.arg == 'flush']
         assert flush and getattr(flush[0].value, 'value', False) is True, \
             f"{relpath}: la riga [CACHE] non e' piu' flushata"
+
+
+# =============================================================================
+# 1b. IL CRITERIO DISCRIMINA — altrimenti la guardia e' verde a vuoto
+# =============================================================================
+# Una guardia che cerca la sottostringa `[CACHE]` non si accorge della
+# sparizione della riga vera finche' nel modulo resta una qualunque altra riga
+# che comincia per `[CACHE]` — e in `stream_cache_manager.py` ce n'e' una
+# (`[CACHE] <n>/<m> stream da ricompilare`, che PGE-ui non parsa). Questi due
+# test misurano il criterio sui casi reali, cosi' che a indebolirlo qualcosa
+# suoni.
+
+def test_il_criterio_riconosce_la_riga_per_stream():
+    """La forma per stream, in tutte le grafie che i moduli usano davvero."""
+    sorgente = (
+        'print(f"[CACHE] {stream.stream_id}: {status}", flush=True)\n'
+        'print(f"[CACHE] {sid}: {\'DIRTY\' if dirty else \'clean\'}",'
+        ' flush=True)\n'
+    )
+
+    assert len(_print_di_protocollo(ast.parse(sorgente))) == 2
+
+
+def test_il_criterio_scarta_le_righe_cache_che_nessuno_parsa():
+    """`[CACHE]` come prefisso non basta: serve `<token-senza-spazi>:`.
+
+    Sono le righe che la regex di PGE-ui lascia cadere. Contarle come
+    protocollo renderebbe la guardia verde anche dopo aver spostato al logger
+    l'unica riga che l'editor legge davvero.
+    """
+    sorgente = (
+        'print(f"[CACHE] {len(dirty)}/{len(tutti)} stream da ricompilare",'
+        ' flush=True)\n'
+        'print(f"[CACHE] Stream da scrivere: {ids}", flush=True)\n'
+        'print("[CACHE] qualcosa di generico", flush=True)\n'
+    )
+
+    assert _print_di_protocollo(ast.parse(sorgente)) == []
 
 
 # =============================================================================

--- a/tests/shared/test_stdout_contract.py
+++ b/tests/shared/test_stdout_contract.py
@@ -33,6 +33,14 @@ l'emettitore piu' esposto: il suo modulo contiene *altri* `print()` che la
 giro di conversione al logger, e chi lo fara' avra' sotto gli occhi righe
 `[CACHE]` di due nature diverse. Percio' sta nella lista come gli altri.
 
+**E i punti di registrazione non stanno tutti in `strategies/`.** Sono sette,
+e il settimo — `register_window_strategy` — vive in
+`controllers/window_selection_strategy.py`, dove vive il registry delle
+finestre. Una guardia scoped per *cartella* ne copre sei e tace sul settimo:
+la `print()` che la #187 ha tolto poteva rientrare da li' lasciando verde la
+suite intera. Anche questa lista e' quindi dichiarata *e* derivata, come
+quella degli emettitori.
+
 **Il criterio e' la forma, non il prefisso.** `[CACHE]` da solo non
 discrimina: lo stesso modulo stampa anche `[CACHE] <n>/<m> stream da
 ricompilare`, che PGE-ui non parsa (la sua regex vuole `<token-senza-spazi>:`
@@ -265,3 +273,79 @@ def test_le_strategie_non_stampano(modulo):
         f"strategies/{modulo}: print() reintrodotto. La diagnostica va a "
         "`log_strategy_registration` (issue #187)."
     )
+
+
+# =============================================================================
+# 2a. LA DIAGNOSTICA NON VIVE SOLO IN `strategies/`
+# =============================================================================
+# Il test qui sopra e' scoped per *cartella*, e la cartella non e' il criterio:
+# il criterio e' essere un punto di registrazione dinamica. I due coincidono per
+# sei entry point su sette, e sul settimo il presidio mancava del tutto —
+# `register_window_strategy` sta in `controllers/`, perche' li' sta il registry
+# delle finestre. Misurato: rimettendo in quella funzione esattamente la
+# `print()` che la #187 ha tolto dalle altre tre, la suite intera resta verde.
+#
+# La lista e' dichiarata *e* derivata, come quella degli emettitori: la
+# dichiarazione dice cosa si sorveglia, il confronto coi sorgenti impedisce che
+# un entry point nuovo — o spostato di cartella — resti fuori in silenzio.
+
+MODULI_CON_REGISTRAZIONE_DINAMICA = [
+    os.path.join('controllers', 'window_selection_strategy.py'),
+    os.path.join('strategies', 'strategy_registry.py'),
+    os.path.join('strategies', 'variation_registry.py'),
+    os.path.join('strategies', 'voice_onset_strategy.py'),
+    os.path.join('strategies', 'voice_pan_strategy.py'),
+    os.path.join('strategies', 'voice_pitch_strategy.py'),
+    os.path.join('strategies', 'voice_pointer_strategy.py'),
+]
+
+
+def _funzioni_di_registrazione(tree):
+    """Le `def register_*_strategy(...)` di livello modulo."""
+    return [
+        node for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name.startswith('register_')
+        and node.name.endswith('_strategy')
+    ]
+
+
+def test_la_lista_dei_punti_di_registrazione_e_completa():
+    """`MODULI_CON_REGISTRAZIONE_DINAMICA` e' confrontata coi sorgenti.
+
+    Un entry point nuovo, o spostato in un'altra cartella, non entra da solo in
+    una lista scritta a mano — ed e' esattamente cosi' che
+    `register_window_strategy` e' rimasto fuori dalla guardia per cartella.
+    """
+    trovati = {
+        rel for rel in _moduli_pge()
+        if _funzioni_di_registrazione(ast.parse(_sorgente(rel)))
+    }
+    dichiarati = set(MODULI_CON_REGISTRAZIONE_DINAMICA)
+
+    assert trovati == dichiarati, (
+        "la lista dei punti di registrazione dinamica non e' piu' allineata ai "
+        f"sorgenti.\n  solo nei sorgenti: {sorted(trovati - dichiarati)}"
+        f"\n  solo nella lista: {sorted(dichiarati - trovati)}\n"
+        "Un `register_*_strategy` nuovo va aggiunto a "
+        "MODULI_CON_REGISTRAZIONE_DINAMICA: la sua conferma e' diagnostica, e "
+        "vedi docs/explanation/contratto-stdout.md."
+    )
+
+
+@pytest.mark.parametrize('relpath', MODULI_CON_REGISTRAZIONE_DINAMICA)
+def test_la_registrazione_dinamica_non_stampa(relpath):
+    """Nessun `print()` dentro un `register_*_strategy`, ovunque viva.
+
+    La conferma di una registrazione dinamica e' diagnostica: va a
+    `log_strategy_registration` (issue #187). Qui il criterio e' la funzione,
+    non la cartella, cosi' che la porta non possa riaprirsi da un registry che
+    sta altrove.
+    """
+    tree = ast.parse(_sorgente(relpath))
+
+    for funzione in _funzioni_di_registrazione(tree):
+        assert not _print_calls(funzione), (
+            f"{relpath}: {funzione.name}() e' tornata a stampare. La conferma "
+            "va a `log_strategy_registration` (issue #187), non su stdout."
+        )

--- a/tests/shared/test_stdout_contract.py
+++ b/tests/shared/test_stdout_contract.py
@@ -1,7 +1,7 @@
 # =============================================================================
 # tests/shared/test_stdout_contract.py
 # =============================================================================
-"""
+r"""
 Il contratto di stdout, in forma eseguibile (issue #178, scaglione #187).
 
 PGE ha due canali diagnostici, e la #178 li ha separati per *destinatario*:
@@ -39,8 +39,18 @@ ricompilare`, che PGE-ui non parsa (la sua regex vuole `<token-senza-spazi>:`
 subito dopo il prefisso). Cercare la sottostringa avrebbe lasciato passare la
 scomparsa della riga vera. Le chiamate sono quindi ricomposte in un
 *template* — ogni `{...}` di una f-string diventa `{}` — e cio' che la
-guardia pretende e' `[CACHE] {}: `, la forma esatta che quella regex
-riconosce.
+guardia pretende e' `[CACHE] {}: `.
+
+**Quel template e' piu' stretto della regex di PGE-ui, di proposito.**
+`_RE_CACHE_LINE` e' `^\[CACHE\]\s+(\S+):\s+(.+)$`, e un token *letterale*
+la soddisfa quanto un id interpolato: `cli.py` stampa `[CACHE] Manifest:
+<path>` e `[CACHE] GC: rimossi N stream orfani: [...]`, e l'editor le matcha
+entrambe — a scartarle e' l'insieme degli id che la richiesta dichiara, non la
+loro forma (`render_pipeline.py` lo dice in prima persona: "non tutte le righe
+`[CACHE]` sono stream, e la forma non le distingue"). Il `{}` obbligatorio in
+prima posizione e' quindi il criterio di *questa* guardia — che difende la riga
+per stream — e non la definizione di cosa il parser a valle legge. Vedi
+`docs/explanation/contratto-stdout.md`.
 """
 import ast
 import os
@@ -149,6 +159,49 @@ def test_la_riga_cache_e_flushata(relpath):
         flush = [k for k in chiamata.keywords if k.arg == 'flush']
         assert flush and getattr(flush[0].value, 'value', False) is True, \
             f"{relpath}: la riga [CACHE] non e' piu' flushata"
+
+
+# =============================================================================
+# 1a. LA LISTA E' COMPLETA — altrimenti la guardia non copre chi arriva dopo
+# =============================================================================
+
+def _moduli_pge():
+    """Tutti i moduli sotto `src/pge/`, path relativo a `SRC_PGE`."""
+    for radice, cartelle, files in os.walk(SRC_PGE):
+        cartelle[:] = [c for c in cartelle if c != '__pycache__']
+        for nome in files:
+            if nome.endswith('.py'):
+                yield os.path.relpath(os.path.join(radice, nome), SRC_PGE)
+
+
+def test_la_lista_degli_emettitori_e_completa():
+    """`MODULI_CON_PROTOCOLLO_CACHE` e' derivato, non solo dichiarato.
+
+    Una lista scritta a mano copre chi c'era quando e' stata scritta. Un
+    backend nuovo che dichiara lo stato della cache emette la stessa riga di
+    protocollo e non entra nella lista da solo: la guardia resterebbe verde
+    sopra un emettitore che nessuno sorveglia, e per csound e supercollider
+    quella guardia e' gia' oggi l'unico presidio che la riga abbia. La lista
+    va quindi confrontata con cio' che i sorgenti fanno davvero.
+
+    Non e' un doppione dei due test qui sotto: quelli chiedono che i moduli
+    *dichiarati* stampino ancora la riga, questo che non ci sia un modulo che
+    la stampa **senza** essere dichiarato. Falliscono in direzioni opposte.
+    """
+    trovati = {
+        rel for rel in _moduli_pge()
+        if _print_di_protocollo(ast.parse(_sorgente(rel)))
+    }
+    dichiarati = set(MODULI_CON_PROTOCOLLO_CACHE)
+
+    assert trovati == dichiarati, (
+        "la lista degli emettitori della riga di protocollo non e' piu' "
+        f"allineata ai sorgenti.\n  solo nei sorgenti: {sorted(trovati - dichiarati)}"
+        f"\n  solo nella lista: {sorted(dichiarati - trovati)}\n"
+        "Se hai aggiunto un renderer che dichiara lo stato della cache, "
+        "aggiungilo a MODULI_CON_PROTOCOLLO_CACHE: vedi "
+        "docs/how-to/add-renderer.md e docs/explanation/contratto-stdout.md."
+    )
 
 
 # =============================================================================

--- a/tests/shared/test_stdout_contract.py
+++ b/tests/shared/test_stdout_contract.py
@@ -1,0 +1,133 @@
+# =============================================================================
+# tests/shared/test_stdout_contract.py
+# =============================================================================
+"""
+Il contratto di stdout, in forma eseguibile (issue #178, scaglione #187).
+
+PGE ha due canali diagnostici, e la #178 li ha separati per *destinatario*:
+
+- **protocollo** — righe che `render_pipeline.py` di PGE-ui parsa riga per riga
+  per ricavarne gli eventi NDJSON dell'editor. Restano su stdout, con quel
+  formato esatto. Sono le `[CACHE] <id>: DIRTY|clean` dei renderer (da cui
+  l'editor deriva `stream-start`/`stream-done`) e i path del blocco
+  riassuntivo;
+- **diagnostica** — righe che nessuno parsa e nessuno legge come interfaccia.
+  Vanno al logger. Sono le registrazioni dinamiche di strategy: operazione da
+  sviluppatore che in una pipeline di rendering normale non compare mai.
+
+Questa suite esiste perche' la classificazione era prosa, e la prosa non si
+accorge di essere stata contraddetta. Le due meta' falliscono in direzioni
+opposte e vanno guardate entrambe: portare al logger una riga di protocollo
+rompe l'interfaccia utente di un altro repository *senza toccare un test di
+PGE* (per csound e supercollider la riga `[CACHE]` non ha oggi nessuna
+asserzione di comportamento — solo questa); rimettere un `print()` in
+`strategies/` riapre in silenzio la porta che la #187 ha chiuso.
+"""
+import ast
+import os
+
+import pytest
+
+SRC_PGE = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', '..', 'src', 'pge'))
+
+# I tre renderer che dichiarano lo stato della cache all'editor.
+RENDERER_CON_PROTOCOLLO_CACHE = [
+    os.path.join('rendering', 'numpy_audio_renderer.py'),
+    os.path.join('rendering', 'csound_renderer.py'),
+    os.path.join('rendering', 'supercollider_renderer.py'),
+]
+
+
+def _sorgente(relpath):
+    with open(os.path.join(SRC_PGE, relpath), encoding='utf-8') as f:
+        return f.read()
+
+
+def _print_calls(tree):
+    """Le chiamate a `print(...)` presenti nell'albero."""
+    return [
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == 'print'
+    ]
+
+
+def _testo_letterale(node):
+    """Le parti costanti di un argomento, f-string comprese.
+
+    La riga di protocollo e' una f-string: il prefisso `[CACHE] ` e' un
+    `Constant` dentro una `JoinedStr`, e cercarlo come stringa intera non lo
+    troverebbe.
+    """
+    pezzi = []
+    for sotto in ast.walk(node):
+        if isinstance(sotto, ast.Constant) and isinstance(sotto.value, str):
+            pezzi.append(sotto.value)
+    return ''.join(pezzi)
+
+
+# =============================================================================
+# 1. PROTOCOLLO — resta su stdout
+# =============================================================================
+
+@pytest.mark.parametrize('relpath', RENDERER_CON_PROTOCOLLO_CACHE)
+def test_la_riga_cache_resta_su_stdout(relpath):
+    """`[CACHE] <id>: <status>` e' protocollo: `print()`, non logger.
+
+    E' la riga da cui `parse_render_line` ricava `stream-start` e
+    `stream-done`. Spostarla al logger lascia la barra di avanzamento
+    dell'editor ferma a zero per tutto il rendering.
+    """
+    tree = ast.parse(_sorgente(relpath))
+
+    con_cache = [c for c in _print_calls(tree)
+                 if any('[CACHE]' in _testo_letterale(a) for a in c.args)]
+
+    assert con_cache, (
+        f"{relpath}: la riga di protocollo [CACHE] non e' piu' un print(). "
+        "PGE-ui la parsa da stdout: vedi issue #178."
+    )
+
+
+@pytest.mark.parametrize('relpath', RENDERER_CON_PROTOCOLLO_CACHE)
+def test_la_riga_cache_e_flushata(relpath):
+    """`flush=True`: l'editor la legge mentre il rendering e' in corso.
+
+    Senza flush la riga resta nel buffer del sottoprocesso e arriva a fine
+    rendering, quando non ha piu' niente da annunciare.
+    """
+    tree = ast.parse(_sorgente(relpath))
+
+    for chiamata in _print_calls(tree):
+        if not any('[CACHE]' in _testo_letterale(a) for a in chiamata.args):
+            continue
+        flush = [k for k in chiamata.keywords if k.arg == 'flush']
+        assert flush and getattr(flush[0].value, 'value', False) is True, \
+            f"{relpath}: la riga [CACHE] non e' piu' flushata"
+
+
+# =============================================================================
+# 2. DIAGNOSTICA — non torna su stdout
+# =============================================================================
+
+def _moduli_strategie():
+    cartella = os.path.join(SRC_PGE, 'strategies')
+    return sorted(f for f in os.listdir(cartella) if f.endswith('.py'))
+
+
+@pytest.mark.parametrize('modulo', _moduli_strategie())
+def test_le_strategie_non_stampano(modulo):
+    """Nessun `print()` in `strategies/`: la registrazione e' diagnostica.
+
+    Non e' una regola di stile. Chi registra una strategy sta estendendo il
+    motore, non rendendo: la sua conferma non ha titolo per attraversare il
+    canale che l'editor parsa.
+    """
+    tree = ast.parse(_sorgente(os.path.join('strategies', modulo)))
+
+    assert not _print_calls(tree), (
+        f"strategies/{modulo}: print() reintrodotto. La diagnostica va a "
+        "`log_strategy_registration` (issue #187)."
+    )

--- a/tests/strategies/test_strategies.py
+++ b/tests/strategies/test_strategies.py
@@ -23,9 +23,12 @@ Copre:
 """
 
 import pytest
+import logging
 import math
 import sys
 import types
+
+from pge.shared.logger import DIAGNOSTIC_LOGGER_NAME
 from unittest.mock import Mock, MagicMock, patch, PropertyMock
 from dataclasses import dataclass
 from typing import Tuple
@@ -818,6 +821,39 @@ class TestRegisterDensityStrategy:
 
         # Cleanup
         del DENSITY_STRATEGIES['weighted_density']
+
+    def test_register_density_logs_instead_of_printing(self, caplog, capsys):
+        """La conferma va al logger diagnostico, non su stdout (issue #187).
+
+        Stdout e' il canale che `render_pipeline.py` di PGE-ui parsa riga per
+        riga; registrare dinamicamente una strategy e' un'operazione da
+        sviluppatore che nessuno parsa, quindi non ha titolo per starci.
+        """
+        class LoggedDensity(DensityStrategy):
+            def __init__(self, param, dist_param):
+                self._param = param
+            def calculate_density(self, elapsed_time, **context):
+                return 1.0
+            @property
+            def name(self):
+                return "logged"
+
+        try:
+            with caplog.at_level(logging.DEBUG, logger=DIAGNOSTIC_LOGGER_NAME):
+                register_density_strategy('logged_density', LoggedDensity)
+
+            messaggi = [r.getMessage() for r in caplog.records
+                        if r.name == DIAGNOSTIC_LOGGER_NAME]
+            assert len(messaggi) == 1
+            assert 'density' in messaggi[0]
+            assert 'logged_density' in messaggi[0]
+            assert 'LoggedDensity' in messaggi[0]
+
+            captured = capsys.readouterr()
+            assert captured.out == ''
+            assert captured.err == ''
+        finally:
+            DENSITY_STRATEGIES.pop('logged_density', None)
 
 
 # =============================================================================

--- a/tests/strategies/test_variation_registry.py
+++ b/tests/strategies/test_variation_registry.py
@@ -14,7 +14,7 @@ Dipendenze:
 Organizzazione:
   1. VARIATION_STRATEGIES Registry - completezza, tipi, struttura
   2. Registry Integrity - invarianti strutturali del dizionario
-  3. register_variation_strategy() - registrazione dinamica, sovrascrittura, print
+  3. register_variation_strategy() - registrazione dinamica, sovrascrittura, log
   4. VariationFactory.create() - creazione valida per ogni modo
   5. VariationFactory.create() - gestione errori (ValueError)
   6. Factory Output Type Validation - isinstance checks sulle istanze
@@ -23,8 +23,12 @@ Organizzazione:
   9. Cleanup e Isolamento - ripristino stato registry tra test
 """
 
+import logging
+
 import pytest
 from typing import Dict, Type
+
+from pge.shared.logger import DIAGNOSTIC_LOGGER_NAME
 
 from pge.shared.distribution_strategy import DistributionStrategy
 from pge.strategies.variation_strategy import (
@@ -251,29 +255,38 @@ class TestRegisterVariationStrategy:
         assert VARIATION_STRATEGIES['additive'] is CustomAdditive
         assert VARIATION_STRATEGIES['additive'] is not original_class
 
-    def test_register_prints_confirmation(self, capsys):
-        """La registrazione stampa messaggio di conferma."""
+    def test_register_logs_confirmation(self, caplog):
+        """La conferma esiste ancora, ma come record di logging (issue #187)."""
         class TestVariation(VariationStrategy):
             def apply(self, base, mod_range, distribution):
                 return base
 
-        register_variation_strategy('test_mode', TestVariation)
-        captured = capsys.readouterr()
+        with caplog.at_level(logging.DEBUG, logger=DIAGNOSTIC_LOGGER_NAME):
+            register_variation_strategy('test_mode', TestVariation)
 
-        assert 'test_mode' in captured.out
-        assert 'TestVariation' in captured.out
+        messaggi = [r.getMessage() for r in caplog.records
+                    if r.name == DIAGNOSTIC_LOGGER_NAME]
+        assert len(messaggi) == 1
+        assert 'variation' in messaggi[0]
+        assert 'test_mode' in messaggi[0]
+        assert 'TestVariation' in messaggi[0]
 
-    def test_register_print_contains_emoji(self, capsys):
-        """Il messaggio di conferma contiene l'emoji di check."""
+    def test_register_does_not_write_to_stdout(self, capsys):
+        """Registrare non sporca stdout, che e' il canale di protocollo.
+
+        `render_pipeline.py` di PGE-ui parsa le righe di stdout una per una:
+        la registrazione dinamica di una strategy e' diagnostica da
+        sviluppatore e non ha titolo per passare di li'.
+        """
         class DemoVariation(VariationStrategy):
             def apply(self, base, mod_range, distribution):
                 return base
 
         register_variation_strategy('demo', DemoVariation)
-        captured = capsys.readouterr()
 
-        # Il codice di produzione usa questo formato specifico
-        assert captured.out.startswith('\u2705')  # emoji check verde
+        captured = capsys.readouterr()
+        assert captured.out == ''
+        assert captured.err == ''
 
     def test_register_multiple_strategies(self):
         """Registrazione multipla aggiunge tutte le strategie."""

--- a/tests/strategies/test_voice_pan_strategy.py
+++ b/tests/strategies/test_voice_pan_strategy.py
@@ -36,7 +36,11 @@ Organizzazione:
   13. StochasticPanStrategy — seed riproducibile (issue #81)
 """
 
+import logging
+
 import pytest
+
+from pge.shared.logger import DIAGNOSTIC_LOGGER_NAME
 
 
 # =============================================================================
@@ -506,6 +510,40 @@ class TestRegisterFunction:
     def test_register_function_has_docstring(self):
         _, _, _, _, _, register_voice_pan_strategy, _ = _get_module()
         assert register_voice_pan_strategy.__doc__ is not None
+
+    def test_register_logs_instead_of_printing(self, caplog, capsys):
+        """La conferma va al logger diagnostico, non su stdout (issue #187).
+
+        Stdout e' il canale di protocollo che `render_pipeline.py` di PGE-ui
+        parsa riga per riga; una registrazione dinamica di strategy e'
+        diagnostica da sviluppatore, e nessuno la parsa.
+        """
+        VoicePanStrategy, _, _, _, registry, register_voice_pan_strategy, _ = _get_module()
+
+        class LoggedPan(VoicePanStrategy):
+            def get_pan_offset(self, voice_index, num_voices, time):
+                return 0.0
+
+            @property
+            def name(self):
+                return 'logged'
+
+        try:
+            with caplog.at_level(logging.DEBUG, logger=DIAGNOSTIC_LOGGER_NAME):
+                register_voice_pan_strategy('logged_pan', LoggedPan)
+
+            messaggi = [r.getMessage() for r in caplog.records
+                        if r.name == DIAGNOSTIC_LOGGER_NAME]
+            assert len(messaggi) == 1
+            assert 'pan' in messaggi[0]
+            assert 'logged_pan' in messaggi[0]
+            assert 'LoggedPan' in messaggi[0]
+
+            captured = capsys.readouterr()
+            assert captured.out == ''
+            assert captured.err == ''
+        finally:
+            registry.pop('logged_pan', None)
 
 
 # =============================================================================


### PR DESCRIPTION
Closes #187. Refs #178.

## Il punto

Stdout non è un canale libero: è un'interfaccia. `render_pipeline.py` di PGE-ui lo legge riga per riga e ne ricava gli eventi NDJSON dell'editor. Le righe che nessuno parsa non hanno titolo per attraversarlo; quelle che qualcuno parsa non possono uscirne.

## Classificazione (la #178 è ancora aperta, quindi l'ho fatta per le righe toccate)

Ho letto `render_pipeline.py` di PGE-ui. Il parser riconosce due forme: `[CACHE] <id>: <status>` e i path del blocco riassuntivo.

| Riga | Categoria | Esito |
|---|---|---|
| `register_density_strategy` → `Registrata nuova strategia density: …` | diagnostica | → logger |
| `register_variation_strategy` → `Registrata nuova strategia variation: …` | diagnostica | → logger |
| `register_voice_pan_strategy` → `Registrata nuova strategia pan voce: …` | diagnostica | → logger |
| `numpy_audio_renderer` → `[CACHE] <id>: DIRTY\|clean` | **protocollo** | **invariata** |
| `csound_renderer` → idem | **protocollo** | **invariata** |
| `supercollider_renderer` → idem | **protocollo** | **invariata** |

L'issue lasciava aperta la sorte dei `print()` dei renderer ("se la classificazione li ha messi qui"): non ci stanno. Sono esattamente le righe da cui l'editor deriva `stream-start` e `stream-done` — spostarle lascia la barra di avanzamento ferma a zero per tutto il rendering. Restano dove sono.

Nota: #185 non è ancora chiusa, quindi i tre registry sono ancora tre e i `print()` erano tre distinti.

## Cosa cambia

**Un terzo logger**, `pge.diagnostics`, accanto a clip ed engine — `get_diagnostic_logger()` e `log_strategy_registration()` in `pge.shared.logger`. È fatto di due astensioni:

1. **Nessun handler proprio oltre a un `NullHandler`.** Una libreria non configura il logging del suo ospite, e qui l'astensione ha anche un effetto concreto: `get_engine_logger()` si auto-configura, e configurarsi vuol dire `os.makedirs('./logs')` — una cartella materializzata sul disco di chi passava di lì solo per registrare una strategy. Il `NullHandler` copre il resto: senza handler, `logging` manda i record da WARNING in su a `lastResort`, che scrive su stderr.
2. **Livello DEBUG.** Sotto il default del root il record non viene nemmeno costruito. Chi lo vuole fa `logging.basicConfig(level=logging.DEBUG)` — e la console di `logging` è stderr, quindi nemmeno accendendolo si rientra nel canale che PGE-ui parsa.

**I tre `register_*`** passano da `log_strategy_registration`. Sparisce anche l'asimmetria fra i messaggi (uno quotava il nome, gli altri no; due portavano una spunta verde): il livello del record dice quel che diceva l'emoji.

## Il costo, dichiarato

**La conferma di registrazione diventa muta** finché l'host non alza il livello di log. È il costo accettato: chi registra dinamicamente una strategy sta estendendo il motore, ed è esattamente la persona in grado di accendere un logger. Il messaggio non è perso, ha cambiato canale.

Non ho aggiunto una `configure_diagnostic_logger()` simmetrica alle altre due: quelle configurano un *prodotto* del programma (i file di log di un rendering), questa avrebbe configurato il logging di chi importa `pge`.

## La classificazione smette di essere prosa

`tests/shared/test_stdout_contract.py` legge i sorgenti con `ast` e chiede due cose che falliscono in direzioni opposte:

- la riga `[CACHE]` è ancora un `print(..., flush=True)` in tutti e tre i renderer — **per csound e supercollider è l'unico presidio che quella riga abbia** (solo il renderer NumPy aveva un test di comportamento);
- in `src/pge/strategies/` non c'è nessun `print()`.

Il testo letterale è ricomposto camminando la `JoinedStr`: la riga di protocollo è una f-string, e cercare `[CACHE] ` come stringa intera non la troverebbe. Ho verificato che entrambe le metà mordano, sabotandole una per volta.

## Impatto cross-repo

**Nessuno.** Non cambia sintassi YAML, gerarchia errori, CLI, flag o formati di output. Le tre righe rimosse da stdout non sono parsate da PGE-ui (verificato: `render_pipeline.py` riconosce solo `[CACHE]` e i path riassuntivi; nessuna occorrenza di `Registrata` nel repo) e non compaiono in una pipeline di rendering normale — la registrazione dinamica è un'operazione da sviluppatore. Nessuna issue aperta su PGE-ui né su PGE-ls.

Il paper CIM 2026 non è toccato: nulla di ciò che `render_example.py` esercita passa di qui.

## Merge di `main`

Il branch era partito da `e57ccec` mentre `main` era già a `db08c65`. Merge fatto, con tre risoluzioni oltre all'automatico:

- **`CHANGELOG.md`** — `main` aveva già una sezione `[Non rilasciato]`, io ne avevo aperta una concorrente intitolata `[Unreleased]`. Le mie voci entrano nella sua, sotto `Aggiunto` e una nuova `Cambiato`;
- **`docs/INDEX.md`** — rigenerato con `make docs-index`, non risolto a mano: è auto-generato e il merge testuale non ne conosce l'ordinamento;
- **`docs/explanation/contratto-stdout.md`** — elencava `envelopes/time_distribution.py` fra i moduli con `print()` non ancora classificati. Nel frattempo `main` li ha rimossi tutti, quindi la riga era falsa già al momento del merge. Al suo posto il caso che `main` ha invece *aggiunto*: la riga per stream dei conteggi di grani (#250), interfaccia CLI sullo stesso canale che un parser attraversa.

## Test

`make tests`: **6250 passed, 10 skipped**, dopo il merge di `main`. I 26 test nuovi sono le due guardie del contratto, i test del logger diagnostico e le metà mancanti sui tre registry. Nessun fallimento.

## Criteri d'accettazione

- [x] Le righe classificate come diagnostica passano da `print()` al logger
- [x] Nessuna riga di protocollo è stata toccata — e ora una guardia lo verifica
- [x] `make tests` verde

## Cosa resta alla #178

`engine/generator.py`, `rendering/score_visualizer.py`, `rendering/stream_cache_manager.py`, `rendering/score_writer.py` e `cli.py` non sono classificati. `cli.py` ne concentra la maggioranza (40 su 66) ed è quasi tutto *interfaccia CLI* — la terza categoria, quella che resta su stdout pur non essendo protocollo. È anche l'unica dove la scelta non è meccanica, e #250 ne è l'esempio fresco: una riga che legge un compositore a schermo, sullo stesso canale che un parser attraversa. La documentazione lo dichiara aperto invece di lasciarlo intendere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDcsxcm6aWf7MrC2vGWhAk