### PR TITLE
fix(api): la dichiarazione "nessun print" non descriveva questa libreria (#189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,9 +211,18 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   `tests/test_api_stdout.py` lo verifica **su output vero, senza mock**, e
   chiude il censimento in due direzioni: nessuna riga su stdout fuori
   elenco, nessuna voce in elenco che in `src/pge/` non abbia più un
-  `print()` che la emetta. Quando #187/#188 sposteranno una di quelle righe
-  il test diventerà rosso — non è un falso allarme, è la dichiarazione che
-  va aggiornata insieme al comportamento.
+  `print()` **su stdout** che la emetta. Quando #187/#188 sposteranno una di
+  quelle righe il test diventerà rosso — non è un falso allarme, è la
+  dichiarazione che va aggiornata insieme al comportamento.
+
+  Quel «su stdout» è la condizione, non un rafforzativo: la prova che una
+  voce è ancora viva deve stare sullo stesso canale che la voce dichiara.
+  Senza guardare il `file=` bastava aggiungere `file=sys.stderr` a una riga
+  censita per toglierla da stdout lasciando verdi entrambe le direzioni —
+  lo stesso buco del `  - ` e del `[CACHE]`, spostato dal prefisso al
+  canale, e peggiore lì dove la direzione statica è l'unica guardia che
+  c'è: `✓ Score generato` e `  - ` stanno sul ramo Csound, che nessun test
+  esercita a runtime.
 
   Il censimento è di **stdout**, e lo dice: letto come inventario completo
   rifarebbe lo stesso errore un piano sotto. Gli avvisi del clip logger

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,47 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
 
 ### Corretto
 
+- **`api.py` prometteva un silenzio che non ha mai avuto** (issue #189).
+  L'intestazione dichiarava «nessun print» come primo punto del contratto
+  del modulo, e la dichiarazione era falsa: nessuna funzione di `api.py`
+  contiene un `print()`, ma le funzioni orchestrano `Generator`, i renderer
+  e `ScoreVisualizer`, che stampano. Chiamare `load_generator` scrive su
+  stdout `[SEED] ...`, `🔇 N stream muted`, `Creazione di N stream...` e una
+  riga per stream; `render` con un `cache_manifest_path` scrive `[CACHE]
+  <id>: DIRTY|clean`; `export_score_pdf` fa parlare il visualizer. Per una
+  libreria che qualcun altro incorpora non è cosmesi: è output non richiesto
+  sullo stdout del processo ospite.
+
+  Il piano da cui il contratto viene diceva «non stampa (nel proprio
+  modulo)» — la parentesi si era persa nella trascrizione, e con lei tutta
+  la differenza.
+
+  I test che sembravano difendere la dichiarazione non potevano
+  contraddirla: gli undici `test_no_print` di `tests/test_api.py` girano con
+  `Generator`, `RenderingEngine` e `ScoreVisualizer` montati come MagicMock,
+  quindi il `capsys` vuoto misurava il silenzio dei mock. Restano validi su
+  ciò che dicono davvero (api.py non stampa di suo) e il loro docstring ora
+  lo dice.
+
+  La dichiarazione è riscritta come **censimento**: quali righe si vedono
+  chiamando quale funzione, chi le emette, e perché restano (sono il
+  contratto stdout della CLI: `[CACHE] <id>: DIRTY|clean` la parsa PGE-ui
+  per l'avanzamento per stream dell'editor, delle altre non risulta nessun
+  consumatore — accertarlo è la #178, portarle al logger le #187/#188). Il
+  nuovo
+  `tests/test_api_stdout.py` lo verifica **su output vero, senza mock**, e
+  chiude il censimento in due direzioni: nessuna riga su stdout fuori
+  elenco, nessuna voce in elenco che in `src/pge/` non abbia più un
+  `print()` che la emetta. Quando #187/#188 sposteranno una di quelle righe
+  il test diventerà rosso — non è un falso allarme, è la dichiarazione che
+  va aggiornata insieme al comportamento.
+
+  Chi incorpora e ha bisogno di silenzio: `contextlib.redirect_stdout`, e
+  `configure_clip_logger`/`configure_engine_logger` prima di
+  `load_generator`. Documentato in
+  [`docs/how-to/use-as-library.md`](docs/how-to/use-as-library.md) e
+  [`docs/explanation/library-vs-cli.md`](docs/explanation/library-vs-cli.md).
+
 - **`cli._build_renderer` ingoiava in silenzio ogni kwarg sconosciuto**
   (issue #252). La funzione raccoglieva tutto in `**kwargs` e poi pescava
   una chiave per volta con `.get()`: non c'era nessun punto in cui un nome

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,7 +129,17 @@ Versioning semantico: [SemVer](https://semver.org/lang/it/).
   il test diventerà rosso — non è un falso allarme, è la dichiarazione che
   va aggiornata insieme al comportamento.
 
-  Chi incorpora e ha bisogno di silenzio: `contextlib.redirect_stdout`, e
+  Il censimento è di **stdout**, e lo dice: letto come inventario completo
+  rifarebbe lo stesso errore un piano sotto. Gli avvisi del clip logger
+  passano da stderr (`⚠️  CLIP: ...` dall'handler console, `CLIP: ...`
+  dall'avviso di migrazione `loop_unit` della #222, che stampa proprio
+  quando quella console è spenta), quindi `contextlib.redirect_stdout` da
+  solo non è silenzio: servono entrambe le redirezioni, e la
+  `redirect_stderr` va entrata prima che il clip logger si costruisca
+  (`logging.StreamHandler()` cattura `sys.stderr` alla costruzione).
+
+  Chi incorpora e ha bisogno di silenzio: `contextlib.redirect_stdout` +
+  `contextlib.redirect_stderr`, e
   `configure_clip_logger`/`configure_engine_logger` prima di
   `load_generator`. Documentato in
   [`docs/how-to/use-as-library.md`](docs/how-to/use-as-library.md) e

--- a/docs/explanation/library-vs-cli.md
+++ b/docs/explanation/library-vs-cli.md
@@ -4,7 +4,7 @@ type: explanation
 status: stable
 tags: [api, cli, architecture, refactor]
 sources: [src/pge/api.py, src/pge/cli.py, src/main.py]
-last_synced_commit: 638f9d6
+last_synced_commit: 5285c17
 entry_for: [usare PGE come libreria, capire la divisione API/CLI]
 ---
 

--- a/docs/explanation/library-vs-cli.md
+++ b/docs/explanation/library-vs-cli.md
@@ -26,10 +26,10 @@ Dal refactor library/CLI (plans/2026-07-08-001) il sistema ha due strati:
   `collect_cache_orphans`, `collect_grain_counts`, `render`, `render_file`,
   `export_*`, con le dataclass `CsoundOptions` (input), `RenderResult`
   (output) e `StreamGrainCount` (dentro `RenderResult`). Contratto:
-  nessun `print`, nessun `sys.exit`, nessuna lettura di `sys.argv`; errori
-  come eccezioni (`EngineError` e sottoclassi, `ValueError`); ogni default
-  filesystem è un parametro esplicito (`samples_dir`,
-  `cache_manifest_path`, ...).
+  nessun `print` **nel proprio modulo**, nessun `sys.exit`, nessuna lettura
+  di `sys.argv`; errori come eccezioni (`EngineError` e sottoclassi,
+  `ValueError`); ogni default filesystem è un parametro esplicito
+  (`samples_dir`, `cache_manifest_path`, ...).
 - **`pge.cli`** — shell sottile: parsing argv a mano (byte-identico allo
   storico), print, exit code, derivazione dei nomi file. Delega tutta
   l'orchestrazione all'API. `src/main.py` è lo shim permanente; il console
@@ -60,9 +60,25 @@ Divisione delle policy (chi decide cosa):
 
 ## Implicazioni codice
 
-- I print interni preesistenti (`Generator._create_streams`, `[SEED]`,
-  `[CACHE]` nei renderer) fanno parte del contratto stdout della CLI e
-  restano; migrarli a logging è un follow-up dichiarato.
+- **`pge.api` non stampa, la libreria sì**, ed è una distinzione che conta
+  per chi la incorpora (issue #189). Nessuna funzione di `api.py` contiene
+  un `print()`; i componenti che orchestra ne contengono, e scrivono su
+  stdout mentre lavorano: `Generator` (`[SEED]`, `Creazione di N
+  stream...`, `  → Stream '<id>'`, `🔇 N stream muted`), i renderer
+  (`[CACHE] <id>: DIRTY|clean`, solo con `cache_manifest_path`),
+  `ScoreWriter` sul ramo Csound (`✓ Score generato`), `ScoreVisualizer` da
+  `export_score_pdf` (`Analisi completata`, `Esportazione PDF`, ...) e il
+  clip logger alla prima inizializzazione (`📝 Clip log file`). Il
+  censimento completo, con chi emette cosa, sta nell'intestazione di
+  `api.py`; `tests/test_api_stdout.py` lo verifica su output vero, in
+  entrambe le direzioni.
+- Quelle righe restano perché fanno parte del contratto stdout della CLI, e
+  una almeno è interfaccia vera: `[CACHE] <id>: DIRTY|clean` la parsa PGE-ui
+  (`render_pipeline.py`) per gli eventi NDJSON `stream-start`/`stream-done`,
+  cioè per l'avanzamento per stream che l'editor mostra durante un render.
+  Delle altre non risulta nessun consumatore — accertarlo è la issue #178,
+  portarle al logger le #187/#188. Quando succederà, il censimento in
+  `api.py` va aggiornato insieme al codice, ed è il test a chiederlo.
 - Il GC della cache è una funzione separata (`collect_cache_orphans`)
   perché la CLI deve stamparne l'esito PRIMA del render (ordine stdout);
   `render_file` lo esegue da sé col default `run_cache_gc=True`.

--- a/docs/explanation/library-vs-cli.md
+++ b/docs/explanation/library-vs-cli.md
@@ -4,7 +4,7 @@ type: explanation
 status: stable
 tags: [api, cli, architecture, refactor]
 sources: [src/pge/api.py, src/pge/cli.py, src/main.py]
-last_synced_commit: be716c9
+last_synced_commit: 638f9d6
 entry_for: [usare PGE come libreria, capire la divisione API/CLI]
 ---
 
@@ -72,6 +72,13 @@ Divisione delle policy (chi decide cosa):
   censimento completo, con chi emette cosa, sta nell'intestazione di
   `api.py`; `tests/test_api_stdout.py` lo verifica su output vero, in
   entrambe le direzioni.
+- **Il censimento è di stdout, e c'è anche stderr.** Gli avvisi del clip
+  logger passano di là (`⚠️  CLIP: ...` dall'handler console, `CLIP: ...`
+  dall'avviso di migrazione `loop_unit` della #222, che parla proprio quando
+  quella console è spenta), quindi `redirect_stdout` da solo non è silenzio:
+  per chi incorpora servono entrambe le redirezioni. Dirlo fa parte del
+  punto — un censimento di stdout letto come inventario completo rifà
+  l'errore della #189 un piano sotto.
 - Quelle righe restano perché fanno parte del contratto stdout della CLI, e
   una almeno è interfaccia vera: `[CACHE] <id>: DIRTY|clean` la parsa PGE-ui
   (`render_pipeline.py`) per gli eventi NDJSON `stream-start`/`stream-done`,

--- a/docs/how-to/use-as-library.md
+++ b/docs/how-to/use-as-library.md
@@ -4,7 +4,7 @@ type: how-to
 status: stable
 tags: [api, library, install, render]
 sources: [src/pge/api.py, pyproject.toml]
-last_synced_commit: be716c9
+last_synced_commit: 638f9d6
 entry_for: [renderizzare da Python, integrare PGE in un altro progetto]
 ---
 
@@ -57,19 +57,32 @@ passare dalla CLI né monkey-patchare i globali.
    riga per riga e con chi la emette, sta nell'intestazione di
    `src/pge/api.py`. Fanno parte del contratto stdout della CLI (la riga
    `[CACHE]` la parsa PGE-ui per l'avanzamento per stream), quindi non
-   spariranno da sole: servendo silenzio, la via è
-   `contextlib.redirect_stdout`.
+   spariranno da sole.
+
+4. Stderr: **`redirect_stdout` da solo non è silenzio.** Il censimento in
+   `api.py` è di stdout; gli avvisi del clip logger passano da stderr, da
+   qualunque percorso che costruisca envelope — `⚠️  CLIP: ...`
+   dall'handler console (attivo di default) e `CLIP: ...` dall'avviso di
+   migrazione `loop_unit` (#222), che stampa proprio *quando* la console del
+   clip logger è spenta. Spegnere la console non zittisce quell'ultimo: lo
+   sposta.
+
+   Chiudere entrambi i canali vuole entrambe le redirezioni, e la
+   `redirect_stderr` va entrata **prima** che il clip logger si costruisca:
+   `logging.StreamHandler()` cattura `sys.stderr` alla costruzione, non alla
+   scrittura, quindi un handler già vivo continua a scrivere sullo stderr
+   vero.
 
    ```python
    import contextlib, io
 
-   silenzio = io.StringIO()
-   with contextlib.redirect_stdout(silenzio):
+   fuori, errori = io.StringIO(), io.StringIO()
+   with contextlib.redirect_stdout(fuori), contextlib.redirect_stderr(errori):
        result = api.render_file('scena.yml', 'out/scena.aif',
                                 renderer='numpy', samples_dir='refs/')
    ```
 
-4. Logging: i singleton restano; configurarli PRIMA di `load_generator`
+5. Logging: i singleton restano; configurarli PRIMA di `load_generator`
    (altrimenti il primo Stream inizializza il clip logger coi default di
    modulo, file in `./logs` + la riga `📝 Clip log file: ...` su stdout):
 
@@ -80,15 +93,15 @@ passare dalla CLI né monkey-patchare i globali.
    configure_engine_logger(yaml_name='mio_progetto', log_dir='out/logs')
    ```
 
-5. Errori: catturare `pge.EngineError` (gerarchia con `user_message()`);
+6. Errori: catturare `pge.EngineError` (gerarchia con `user_message()`);
    argomenti API invalidi sollevano `ValueError` (es. `audio_format`
    stringa ignota), file YAML mancante `FileNotFoundError`.
 
-6. Csound: `renderer='csound'` con knob raggruppati in
+7. Csound: `renderer='csound'` con knob raggruppati in
    `api.CsoundOptions(orc_path=..., ssdir=..., sco_dir=...)`;
    `ssdir=None` eredita `samples_dir`.
 
-7. Quanti grani ha prodotto ogni stream: `result.grain_counts`, una voce per
+8. Quanti grani ha prodotto ogni stream: `result.grain_counts`, una voce per
    stream nell'ordine di `generator.streams`.
 
    ```python

--- a/docs/how-to/use-as-library.md
+++ b/docs/how-to/use-as-library.md
@@ -48,9 +48,30 @@ passare dalla CLI né monkey-patchare i globali.
    api.export_score_pdf(gen, 'out/scena.pdf', samples_dir='refs/')
    ```
 
-3. Logging: i singleton restano; configurarli PRIMA di `load_generator`
+3. Stdout: **la libreria non è silenziosa.** `pge.api` non stampa di suo,
+   ma i componenti che orchestra sì, e chi incorpora se li ritrova sul
+   proprio stdout: `Generator` annuncia il seed di sessione (`[SEED] ...`),
+   quanti stream costruisce e uno per riga; i renderer scrivono `[CACHE]
+   <id>: DIRTY|clean` quando c'è un `cache_manifest_path`;
+   `export_score_pdf` fa parlare `ScoreVisualizer`. Il censimento completo,
+   riga per riga e con chi la emette, sta nell'intestazione di
+   `src/pge/api.py`. Fanno parte del contratto stdout della CLI (la riga
+   `[CACHE]` la parsa PGE-ui per l'avanzamento per stream), quindi non
+   spariranno da sole: servendo silenzio, la via è
+   `contextlib.redirect_stdout`.
+
+   ```python
+   import contextlib, io
+
+   silenzio = io.StringIO()
+   with contextlib.redirect_stdout(silenzio):
+       result = api.render_file('scena.yml', 'out/scena.aif',
+                                renderer='numpy', samples_dir='refs/')
+   ```
+
+4. Logging: i singleton restano; configurarli PRIMA di `load_generator`
    (altrimenti il primo Stream inizializza il clip logger coi default di
-   modulo, file in `./logs` + print):
+   modulo, file in `./logs` + la riga `📝 Clip log file: ...` su stdout):
 
    ```python
    from pge import configure_clip_logger, configure_engine_logger
@@ -59,15 +80,15 @@ passare dalla CLI né monkey-patchare i globali.
    configure_engine_logger(yaml_name='mio_progetto', log_dir='out/logs')
    ```
 
-4. Errori: catturare `pge.EngineError` (gerarchia con `user_message()`);
+5. Errori: catturare `pge.EngineError` (gerarchia con `user_message()`);
    argomenti API invalidi sollevano `ValueError` (es. `audio_format`
    stringa ignota), file YAML mancante `FileNotFoundError`.
 
-5. Csound: `renderer='csound'` con knob raggruppati in
+6. Csound: `renderer='csound'` con knob raggruppati in
    `api.CsoundOptions(orc_path=..., ssdir=..., sco_dir=...)`;
    `ssdir=None` eredita `samples_dir`.
 
-6. Quanti grani ha prodotto ogni stream: `result.grain_counts`, una voce per
+7. Quanti grani ha prodotto ogni stream: `result.grain_counts`, una voce per
    stream nell'ordine di `generator.streams`.
 
    ```python
@@ -92,7 +113,9 @@ codice di integrazione (es. `engine_bridge.py` in granulation-studies).
 ## Test da aggiornare
 
 Nel progetto ospite: i test del proprio wrapper. In PGE l'API è coperta da
-`tests/test_api.py` e il layout da `tests/test_package_layout.py`.
+`tests/test_api.py` (superficie e kwargs, componenti mockati),
+`tests/test_api_stdout.py` (cosa arriva davvero su stdout, componenti veri)
+e il layout da `tests/test_package_layout.py`.
 
 ## Verifica
 

--- a/docs/how-to/use-as-library.md
+++ b/docs/how-to/use-as-library.md
@@ -4,7 +4,7 @@ type: how-to
 status: stable
 tags: [api, library, install, render]
 sources: [src/pge/api.py, pyproject.toml]
-last_synced_commit: 638f9d6
+last_synced_commit: 5285c17
 entry_for: [renderizzare da Python, integrare PGE in un altro progetto]
 ---
 

--- a/src/pge/api.py
+++ b/src/pge/api.py
@@ -61,8 +61,24 @@
 # va aggiornato: il test lo verifica in entrambe le direzioni (nessuna riga
 # fuori elenco, nessuna voce in elenco che nessuno emette piu').
 #
-# Chi incorpora e ha bisogno di silenzio: contextlib.redirect_stdout, e
-# configure_clip_logger/configure_engine_logger PRIMA di load_generator --
+# --- e stderr, che il censimento qui sopra non copre ---
+#
+# L'elenco e' di stdout, e dirlo per intero fa parte del punto: letto come
+# inventario completo rifarebbe l'errore della #189 un piano sotto. Sullo
+# stderr scrivono gli avvisi del clip logger, da qualunque percorso che
+# costruisca envelope:
+#     `⚠️  CLIP: ...`   l'handler console del clip logger (attivo di default)
+#     `CLIP: ...`       log_loop_unit_migration_warning, che stampa proprio
+#                       quando la console del clip logger e' spenta (#222):
+#                       spegnerla non zittisce quell'avviso, lo sposta
+#
+# Chi incorpora e ha bisogno di silenzio: contextlib.redirect_stdout NON
+# basta -- copre l'elenco qui sopra e nient'altro. Servono anche
+# redirect_stderr (da entrare PRIMA che il clip logger si costruisca:
+# logging.StreamHandler() cattura sys.stderr alla costruzione, non alla
+# scrittura) oppure configure_clip_logger(console_enabled=False), tenendo
+# conto che l'avviso #222 resta. E configure_clip_logger /
+# configure_engine_logger vanno chiamate PRIMA di load_generator --
 # altrimenti il primo Stream inizializza il clip logger coi default di
 # modulo, che scrivono in ./logs (docs/how-to/use-as-library.md).
 #

--- a/src/pge/api.py
+++ b/src/pge/api.py
@@ -3,13 +3,68 @@
 #
 # Contratto del modulo
 # (docs/plans/done/2026-07-08-001-refactor-pge-library-cli-plan.md, sez. B.1):
-# - nessun print, nessun sys.exit, nessuna lettura di sys.argv;
+# - nessun sys.exit, nessuna lettura di sys.argv;
 # - errori -> eccezioni (EngineError e sottoclassi, FileNotFoundError,
 #   ValueError per argomenti API invalidi);
 # - import lazy dei moduli pesanti dentro le funzioni (stesso stile di
 #   main.py): mantiene mockabile via sys.modules e non paga matplotlib
 #   all'import;
 # - ogni default filesystem e' un parametro esplicito overridabile.
+#
+# Stdout: questo modulo non stampa -- nessuna funzione qui sotto contiene un
+# print() -- ma la libreria NON e' silenziosa, e la differenza conta per chi
+# la incorpora. Le funzioni orchestrano Generator, i renderer e
+# ScoreVisualizer, e sono quei componenti a scrivere su stdout mentre
+# lavorano. Il piano diceva "non stampa (nel proprio modulo)"; la parentesi
+# si era persa strada facendo, e senza di essa la dichiarazione prometteva un
+# silenzio che non c'e' mai stato (issue #189).
+#
+# --- righe su stdout (censimento verificato da tests/test_api_stdout.py) ---
+#
+#   da load_generator(), tutte da Generator:
+#     `[SEED]`              create_elements, quando lo YAML non ha `seed:`
+#     `🔇`                  _filter_solo_mute, quanti stream sono muted
+#     `⚡ SOLO MODE`        _filter_solo_mute, in modalita' solo
+#     `Creazione di`        _create_streams, quanti stream sta costruendo
+#     `  → Stream`          _create_streams, una riga per stream
+#     `⚠️  Warning: impossibile valutare`  espressione matematica nello YAML
+#
+#   da render(), solo con `cache_manifest_path` (senza manifest non c'e'
+#   nessuna riga di cache):
+#     `[CACHE]`             il renderer, DIRTY/clean per stream
+#
+#   da render(renderer='csound'), da ScoreWriter mentre scrive il .sco:
+#     `✓ Score generato`    il path del .sco
+#     `  - `                tre righe di riepilogo (tables, stream, grani)
+#
+#   da export_score_pdf(), da ScoreVisualizer:
+#     `Analisi completata`  pagine e durata totale
+#     `  Rendering pagina`  una riga per pagina
+#     `Esportazione PDF`    inizio esportazione
+#     `✓ PDF esportato`     fine esportazione
+#     `⚠️  Impossibile caricare waveform`  sample illeggibile per la partitura
+#
+#   alla prima inizializzazione del clip logger, da qualunque percorso che
+#   costruisca envelope (load_generator, render, export_score_pdf):
+#     `📝 Clip log file`    il path del log, che il logger crea in ./logs
+#
+# --- fine censimento ---
+#
+# Perche' restano: fanno parte del contratto stdout della CLI, e almeno una
+# e' interfaccia vera. `[CACHE] <id>: DIRTY|clean` la parsa PGE-ui
+# (render_pipeline.py, _RE_CACHE_LINE) per costruirne gli eventi NDJSON
+# `stream-start`/`stream-done`: spostarla al logger rompe l'avanzamento per
+# stream nell'editor dell'altro repo. Le altre nessuno le parsa, per quanto
+# se ne sa -- ma "per quanto se ne sa" e' esattamente cio' che la issue #178
+# deve accertare (protocollo / diagnostica / interfaccia CLI) prima che le
+# #187/#188 le portino al logger. Quando succedera', il censimento qui sopra
+# va aggiornato: il test lo verifica in entrambe le direzioni (nessuna riga
+# fuori elenco, nessuna voce in elenco che nessuno emette piu').
+#
+# Chi incorpora e ha bisogno di silenzio: contextlib.redirect_stdout, e
+# configure_clip_logger/configure_engine_logger PRIMA di load_generator --
+# altrimenti il primo Stream inizializza il clip logger coi default di
+# modulo, che scrivono in ./logs (docs/how-to/use-as-library.md).
 #
 # Divisione delle policy: l'API sceglie default deterministici e senza
 # dipendenze esterne (jobs=1, renderer='numpy', path manifest esplicito);

--- a/src/pge/cli.py
+++ b/src/pge/cli.py
@@ -67,7 +67,10 @@ def _build_renderer(
     Adapter CLI -> API (Fase 1 refactor library/CLI): mappa i kwargs storici
     della CLI (use_cache/cache_dir/yaml_basename, orc_path/incdir/...) sulla
     firma keyword-only dell'API e conserva qui il print `[CACHE] Manifest:`
-    (i print sono policy CLI, l'API non stampa).
+    (quella riga e' policy CLI: api.build_renderer non la emette). Il che
+    non vuol dire che chiamare l'API sia silenzioso -- i componenti che
+    orchestra stampano, e il censimento sta nell'intestazione di api.py
+    (issue #189).
 
     La firma e' esplicita e keyword-only (issue #252). Con `**kwargs` +
     `.get()` un nome fuori elenco non era ne' un errore ne' un warning: era

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,7 +4,8 @@ Test unit per src/api.py — l'API programmatica estratta da main.py
 (Fase 1 del refactor library/CLI).
 
 Contratto del modulo api (piano, sez. B.1):
-- nessun print, nessun sys.exit, nessuna lettura di sys.argv;
+- nessun print NEL PROPRIO MODULO, nessun sys.exit, nessuna lettura di
+  sys.argv;
 - errori -> eccezioni (EngineError e sottoclassi, ValueError);
 - lazy import dei moduli pesanti dentro le funzioni.
 
@@ -12,6 +13,15 @@ Stessa tecnica di mock ai confini di test_main.py (fixture condivisa in
 tests/main_mocks.py), ma senza argv e senza SystemExit: le asserzioni sono
 sui kwargs esatti verso RendererFactory/RenderingEngine/engine.render, sui
 campi di RenderResult, su capsys vuoto e sulle eccezioni propagate.
+
+Cosa misurano davvero i `test_no_print` di questo file (issue #189): qui
+Generator, RenderingEngine e ScoreVisualizer sono MagicMock, quindi un
+capsys vuoto dice che *api.py* non stampa di suo -- ed e' vero, ed e' la
+meta' del contratto che vale la pena blindare qui. Non dice niente su cosa
+vede chi chiama l'API con i componenti veri: quelli stampano, e per anni la
+dichiarazione in api.py ha promesso il contrario proprio perche' i mock non
+potevano contraddirla. L'altra meta' sta in tests/test_api_stdout.py, che
+lavora su output vero e senza mock in mezzo.
 """
 
 import sys

--- a/tests/test_api_stdout.py
+++ b/tests/test_api_stdout.py
@@ -23,6 +23,13 @@ Il censimento chiude in due direzioni, e servono entrambe:
 
 La prima direzione da sola lascerebbe crescere l'elenco all'infinito; la
 seconda da sola non vedrebbe mai una riga nuova.
+
+Entrambe le direzioni confrontano il token con l'inizio di una riga --
+`riga.startswith(token)` a runtime, `prefisso_emesso.startswith(token)` da
+sorgente. La relazione dev'essere la stessa nelle due, o l'elenco significa
+due cose diverse a seconda di chi lo legge: con `token.strip() in
+ast.unparse(node)` due voci su quindici non discriminavano piu' niente (vedi
+il docstring di `_library_prints` e quello del test statico).
 """
 
 import ast
@@ -46,6 +53,26 @@ _END = '--- fine censimento'
 # La CLI e' l'altro lato del contratto: i suoi print sono policy sua e non
 # c'entrano con cosa vede chi importa la libreria.
 _NOT_LIBRARY = {'cli.py'}
+
+# I print che `src/pge/` contiene ma che dall'API non si raggiungono. Non
+# possono valere come prova che una voce del censimento sia ancora viva:
+# senza questo elenco il token `[CACHE]` restava verde anche togliendo la
+# riga per stream da tutti e tre i renderer -- cioe' proprio nello scenario
+# #187/#188 che questo file dichiara di sorvegliare, sulla riga che PGE-ui
+# parsa. Sono nominati per (modulo, funzione) e non per prefisso, perche' il
+# prefisso e' identico a quello delle righe vive.
+#
+# L'elenco e' verificato, non trascritto: `test_le_esclusioni_sono_ancora_vere`
+# chiede che ognuna esista ancora e che ogni sua chiamata in `src/pge/` stia
+# dentro una funzione a sua volta esclusa -- il giorno che una diventa
+# raggiungibile l'esclusione e' sbagliata e il test lo dice.
+_UNREACHABLE = {
+    # Generator.generate_score_files_per_stream: nessun chiamante in src/pge/
+    ('generator.py', 'generate_score_files_per_stream'),
+    # StreamCacheManager.get_dirty_stream_dicts: chiamata solo dalla
+    # precedente, quindi irraggiungibile per la stessa ragione.
+    ('stream_cache_manager.py', 'get_dirty_stream_dicts'),
+}
 
 
 def _census_tokens():
@@ -76,23 +103,109 @@ def _census_tokens():
     return tokens
 
 
-def _library_print_sources():
-    """Il testo di ogni `print(...)` di `src/pge/`, CLI esclusa."""
+def _emitted_prefix(node):
+    """Il testo che il print emette PRIMA della prima interpolazione.
+
+    E' la sola meta' della riga che si puo' leggere staticamente, ed e'
+    quella che il censimento elenca: `[CACHE] {stream_id}: {status}` comincia
+    per `[CACHE] `. Ritorna None per un print il cui primo argomento non e'
+    una stringa (nessun prefisso da confrontare).
+    """
+    if not node.args:
+        return None
+    arg = node.args[0]
+    if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+        return arg.value
+    if isinstance(arg, ast.JoinedStr):
+        head = []
+        for part in arg.values:
+            if isinstance(part, ast.Constant) and isinstance(part.value, str):
+                head.append(part.value)
+            else:
+                break
+        return ''.join(head) if head else ''
+    return None
+
+
+def _iter_prints(path):
+    """(funzione che lo contiene, nodo) per ogni `print(...)` del file."""
+    tree = ast.parse(open(path, encoding='utf-8').read())
+    trovati = []
+
+    def walk(node, func):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            func = node.name
+        if (isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == 'print'):
+            trovati.append((func, node))
+        for child in ast.iter_child_nodes(node):
+            walk(child, func)
+
+    walk(tree, None)
+    return trovati
+
+
+def _library_prints(*, skip_unreachable=True):
+    """Ogni `print(...)` di `src/pge/`, CLI esclusa, come record.
+
+    Record: (modulo, funzione, prefisso emesso, sorgente). Il confronto col
+    censimento e' sul **prefisso emesso**, non sul testo della chiamata: con
+    `needle in ast.unparse(node)` il token `  - ` si riduceva a `-` dopo lo
+    strip e veniva soddisfatto dalle frecce `->` dei print di
+    `register_*_strategy`, cosi' che cancellare tutte e tre le righe di
+    riepilogo dello ScoreWriter lasciava il test verde.
+    """
     out = []
     for root, _dirs, files in os.walk(SRC_PGE):
         if '__pycache__' in root:
             continue
-        for name in files:
+        for name in sorted(files):
             if not name.endswith('.py') or name in _NOT_LIBRARY:
+                continue
+            for func, node in _iter_prints(os.path.join(root, name)):
+                if skip_unreachable and (name, func) in _UNREACHABLE:
+                    continue
+                out.append((name, func, _emitted_prefix(node),
+                            ast.unparse(node)))
+    return out
+
+
+def _library_call_sites():
+    """(modulo, funzione chiamante, nome chiamato) per ogni call di src/pge/.
+
+    Il chiamante serve quanto il chiamato: `get_dirty_stream_dicts` ha un
+    chiamante, ed e' `generate_score_files_per_stream` -- che a sua volta
+    non ne ha. Senza il chiamante non si distingue "raggiungibile" da
+    "raggiungibile solo da codice a sua volta irraggiungibile".
+    """
+    sites = []
+    for root, _dirs, files in os.walk(SRC_PGE):
+        if '__pycache__' in root:
+            continue
+        for name in sorted(files):
+            if not name.endswith('.py'):
                 continue
             path = os.path.join(root, name)
             tree = ast.parse(open(path, encoding='utf-8').read())
-            for node in ast.walk(tree):
-                if (isinstance(node, ast.Call)
-                        and isinstance(node.func, ast.Name)
-                        and node.func.id == 'print'):
-                    out.append((path, ast.unparse(node)))
-    return out
+
+            def walk(node, func):
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    func = node.name
+                if isinstance(node, ast.Call):
+                    fn = node.func
+                    called = None
+                    if isinstance(fn, ast.Name):
+                        called = fn.id
+                    elif isinstance(fn, ast.Attribute):
+                        called = fn.attr
+                    if called is not None:
+                        sites.append((name, func, called))
+                for child in ast.iter_child_nodes(node):
+                    walk(child, func)
+
+            walk(tree, None)
+    return sites
 
 
 def _write_sample(tmp_path, name='probe.wav', dur=1.0, sr=48000):
@@ -154,30 +267,78 @@ class TestCensimento:
             "libreria che dichiara cosa stampa deve dire cosa")
 
     def test_api_non_dichiara_piu_silenzio_assoluto(self):
-        """La riga che la #189 ha trovato falsa non deve tornare."""
+        """La riga che la #189 ha trovato falsa non deve tornare.
+
+        Falsa e' la forma **assoluta**: "nessun print". Qualificata --
+        "nessun print nel proprio modulo", che e' la parola del piano e
+        quella che `docs/explanation/library-vs-cli.md` e `tests/test_api.py`
+        usano -- e' vera, e questo test non deve punirla: vietare la
+        sottostringa e basta rendeva rosso il modo corretto di dirlo.
+        """
         header = []
         for line in open(API_PATH, encoding='utf-8'):
             if not line.startswith('#'):
                 break
             header.append(line)
         header = ''.join(header)
-        assert 'nessun print' not in header, (
-            "api.py torna a dichiarare 'nessun print': i componenti che "
-            "orchestra stampano ancora (vedi gli altri test di questo file)")
+        for match in re.finditer(r'nessun print', header):
+            coda = header[match.end():match.end() + 60]
+            coda = ' '.join(coda.replace('#', ' ').split())
+            assert coda.startswith('nel proprio modulo'), (
+                "api.py torna a dichiarare 'nessun print' senza qualificarlo "
+                "'nel proprio modulo': i componenti che orchestra stampano "
+                "ancora (vedi gli altri test di questo file)")
+
+    def test_le_esclusioni_sono_ancora_vere(self):
+        """`_UNREACHABLE` e' verificato, non trascritto.
+
+        Ogni esclusione deve (a) esistere ancora -- altrimenti descrive un
+        print che non c'e' piu' e resta li' a nascondere il prossimo -- e
+        (b) restare irraggiungibile, cioe' ogni sua chiamata in `src/pge/`
+        deve stare dentro una funzione a sua volta esclusa. Il giorno che una
+        diventa raggiungibile, l'esclusione e' sbagliata e va tolta.
+        """
+        vivi = {(mod, func)
+                for mod, func, _pref, _src in _library_prints(
+                    skip_unreachable=False)}
+        esclusi = {func for _mod, func in _UNREACHABLE}
+        siti = _library_call_sites()
+        for mod, func in sorted(_UNREACHABLE):
+            assert (mod, func) in vivi, (
+                f"_UNREACHABLE elenca {mod}:{func}(), ma li' non c'e' piu' "
+                f"nessun print(): togli la voce")
+            fuori = [(m, chiamante) for m, chiamante, chiamato in siti
+                     if chiamato == func and chiamante not in esclusi]
+            assert not fuori, (
+                f"_UNREACHABLE dichiara {mod}:{func}() irraggiungibile, ma "
+                f"in src/pge/ la chiamano da {fuori}: le sue righe finiscono "
+                f"su stdout e vanno censite, non escluse")
 
     def test_ogni_prefisso_elencato_esiste_ancora_come_print(self):
         """Direzione statica: l'elenco non sopravvive a chi lo svuota.
+
+        Il confronto e' `prefisso_emesso.startswith(token)` -- la stessa
+        relazione della direzione runtime (`riga.startswith(token)`), su cio'
+        che il print emette davvero. Con `token.strip() in ast.unparse(node)`
+        due voci su quindici non discriminavano nulla: `  - ` si riduceva a
+        `-` e lo soddisfacevano le frecce `->` dei `register_*_strategy`
+        (tolte tutte e tre le righe di riepilogo dello ScoreWriter, verde), e
+        `[CACHE]` restava soddisfatto dalle righe irraggiungibili di
+        `generator.py` / `stream_cache_manager.py` (tolta la riga per stream
+        da tutti e tre i renderer, verde -- cioe' cieco proprio allo
+        scenario qui sotto).
 
         Rosso previsto quando #187/#188 porteranno una di queste righe al
         logger. Non e' un falso allarme: e' la dichiarazione che va
         aggiornata insieme al comportamento.
         """
-        sources = _library_print_sources()
+        prints = _library_prints()
         for token in _census_tokens():
-            needle = token.strip()
-            assert any(needle in text for _path, text in sources), (
+            assert any(pref is not None and pref.startswith(token)
+                       for _mod, _func, pref, _src in prints), (
                 f"il censimento di api.py elenca {token!r}, ma in src/pge/ "
-                f"nessun print() lo emette piu': aggiorna l'elenco")
+                f"nessun print() emette una riga che cominci cosi': "
+                f"aggiorna l'elenco")
 
 
 # =============================================================================
@@ -257,7 +418,10 @@ class TestStdoutReale:
         # chdir: il clip logger scrive ./logs alla prima inizializzazione,
         # e un test non sporca la root del repo.
         monkeypatch.chdir(probe['dir'])
-        monkeypatch.setenv('MPLBACKEND', 'Agg')
+        # matplotlib.use() e non MPLBACKEND: la variabile d'ambiente la legge
+        # matplotlib all'import, che l'importorskip qui sopra ha gia' fatto.
+        import matplotlib
+        matplotlib.use('Agg')
         pdf = str(probe['dir'] / 'census.pdf')
         _p, lines = _capture(lambda: api.export_score_pdf(
             gen, pdf, samples_dir=probe['samples']))
@@ -268,10 +432,37 @@ class TestStdoutReale:
         assert not _undocumented(lines, _census_tokens()), (
             f"righe non censite: {_undocumented(lines, _census_tokens())}")
 
-    def test_le_funzioni_pure_restano_silenziose(self, probe):
-        """parameter_bounds/renderer_types e gli export non-partitura non
-        stampano: il censimento riguarda chi orchestra, non tutta l'API."""
+    def test_le_funzioni_pure_restano_silenziose(self):
+        """parameter_bounds/renderer_types non stampano: il censimento
+        riguarda chi orchestra, non tutta l'API."""
         from pge import api
         for fn in (api.parameter_bounds, api.renderer_types):
             _r, lines = _capture(fn)
             assert lines == [], f"{fn.__name__} ha stampato: {lines}"
+
+    def test_gli_export_non_partitura_restano_silenziosi(self, probe):
+        """L'altra meta' della frase qui sopra, che prima era solo scritta.
+
+        `export_score_pdf` fa parlare il visualizer; reaper, sv e grain json
+        no, ed e' una differenza che il censimento afferma (li' compare solo
+        il PDF). Un `print()` aggiunto a uno di questi tre passava sotto
+        silenzio: il docstring li nominava, il ciclo no.
+        """
+        from pge import api
+        gen, _ = _capture(
+            lambda: api.load_generator(probe['yml'],
+                                       samples_dir=probe['samples']))
+        audio = str(probe['dir'] / 'probe.wav')
+        casi = (
+            ('export_reaper',
+             lambda: api.export_reaper(gen, [audio],
+                                       str(probe['dir'] / 'p.rpp'))),
+            ('export_sv',
+             lambda: api.export_sv(gen, audio,
+                                   str(probe['dir'] / 'p.sv'))),
+            ('export_grain_json',
+             lambda: api.export_grain_json(gen, str(probe['dir']), 'p')),
+        )
+        for nome, fn in casi:
+            _r, lines = _capture(fn)
+            assert lines == [], f"{nome} ha stampato: {lines}"

--- a/tests/test_api_stdout.py
+++ b/tests/test_api_stdout.py
@@ -1,0 +1,277 @@
+# tests/test_api_stdout.py
+"""
+Il contratto stdout di `pge.api`, verificato su output vero (issue #189).
+
+L'intestazione di `api.py` dichiarava "nessun print". La dichiarazione era
+falsa, e i test che sembravano difenderla non potevano accorgersene:
+`tests/test_api.py` monta `Generator`, `RenderingEngine` e `ScoreVisualizer`
+come MagicMock, quindi il `capsys` vuoto dei suoi `test_no_print` misura il
+silenzio dei mock, non quello della libreria. Quei test restano veri su cio'
+che dicono davvero -- nessuna funzione di `api.py` contiene un `print()` --
+e questo file copre l'altra meta': cosa vede su stdout chi chiama l'API con
+i componenti veri, che e' la domanda di chi la incorpora.
+
+Il censimento chiude in due direzioni, e servono entrambe:
+
+- **runtime** -- ogni riga che un render vero scrive su stdout deve essere
+  una di quelle che il censimento in `api.py` elenca. Un `print()` nuovo che
+  arriva fino all'API senza passare dalla dichiarazione e' rosso.
+- **statico** -- ogni prefisso elencato deve esistere ancora come `print()`
+  dentro `src/pge/`. Quando #187/#188 porteranno quelle righe al logger,
+  l'elenco diventera' stale: qui diventa rosso, invece di restare a
+  descrivere un comportamento che non c'e' piu'.
+
+La prima direzione da sola lascerebbe crescere l'elenco all'infinito; la
+seconda da sola non vedrebbe mai una riga nuova.
+"""
+
+import ast
+import io
+import os
+import re
+import contextlib
+
+import pytest
+
+SRC_PGE = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', 'src', 'pge')
+)
+API_PATH = os.path.join(SRC_PGE, 'api.py')
+
+# Delimitatori del blocco censimento nell'intestazione di api.py. Sono la
+# ragione per cui l'estrazione non deve indovinare dove finisce la prosa.
+_BEGIN = '--- righe su stdout'
+_END = '--- fine censimento'
+
+# La CLI e' l'altro lato del contratto: i suoi print sono policy sua e non
+# c'entrano con cosa vede chi importa la libreria.
+_NOT_LIBRARY = {'cli.py'}
+
+
+def _census_tokens():
+    """I prefissi backtickati elencati nel censimento di `api.py`."""
+    lines = open(API_PATH, encoding='utf-8').read().splitlines()
+    start = end = None
+    for i, line in enumerate(lines):
+        if _BEGIN in line:
+            start = i
+        elif _END in line and start is not None:
+            end = i
+            break
+    assert start is not None and end is not None, (
+        f"blocco censimento non trovato in {API_PATH}: servono le righe "
+        f"'{_BEGIN}' e '{_END}'"
+    )
+    # Una voce del censimento e' una riga che APRE con il prefisso
+    # backtickato; i backtick che compaiono piu' avanti sono prosa (un nome
+    # di parametro, una chiave YAML) e non righe di stdout.
+    tokens = []
+    for line in lines[start:end]:
+        body = line.lstrip('#').strip()
+        if not body.startswith('`'):
+            continue
+        match = re.match(r'`([^`]+)`', body)
+        if match:
+            tokens.append(match.group(1))
+    return tokens
+
+
+def _library_print_sources():
+    """Il testo di ogni `print(...)` di `src/pge/`, CLI esclusa."""
+    out = []
+    for root, _dirs, files in os.walk(SRC_PGE):
+        if '__pycache__' in root:
+            continue
+        for name in files:
+            if not name.endswith('.py') or name in _NOT_LIBRARY:
+                continue
+            path = os.path.join(root, name)
+            tree = ast.parse(open(path, encoding='utf-8').read())
+            for node in ast.walk(tree):
+                if (isinstance(node, ast.Call)
+                        and isinstance(node.func, ast.Name)
+                        and node.func.id == 'print'):
+                    out.append((path, ast.unparse(node)))
+    return out
+
+
+def _write_sample(tmp_path, name='probe.wav', dur=1.0, sr=48000):
+    """Un wav vero in tmp_path: `refs/` in un checkout pulito e' vuota."""
+    import numpy as np
+    import soundfile as sf
+    sf.write(str(tmp_path / name),
+             np.zeros(int(dur * sr), dtype='float32'), sr)
+    return name
+
+
+_YAML = """\
+composition:
+  title: "stdout census"
+
+streams:
+  - stream_id: "s1"
+    onset: 0.0
+    duration: 0.3
+    sample: "probe.wav"
+  - stream_id: "s2"
+    onset: 0.3
+    duration: 0.3
+    sample: "probe.wav"
+    mute: true
+"""
+
+
+@pytest.fixture
+def probe(tmp_path):
+    """YAML + sample veri; niente `seed:`, cosi' la riga [SEED] si vede."""
+    _write_sample(tmp_path)
+    yml = tmp_path / 'census.yml'
+    yml.write_text(_YAML)
+    return {'yml': str(yml), 'samples': str(tmp_path), 'dir': tmp_path}
+
+
+def _capture(fn):
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        result = fn()
+    return result, [ln for ln in buf.getvalue().splitlines() if ln.strip()]
+
+
+def _undocumented(lines, tokens):
+    return [ln for ln in lines
+            if not any(ln.startswith(t) for t in tokens)]
+
+
+# =============================================================================
+# Il censimento esiste, ed e' fatto di prefissi veri
+# =============================================================================
+
+class TestCensimento:
+
+    def test_il_blocco_esiste_e_non_e_vuoto(self):
+        assert _census_tokens(), (
+            "il censimento di api.py non elenca nessun prefisso: una "
+            "libreria che dichiara cosa stampa deve dire cosa")
+
+    def test_api_non_dichiara_piu_silenzio_assoluto(self):
+        """La riga che la #189 ha trovato falsa non deve tornare."""
+        header = []
+        for line in open(API_PATH, encoding='utf-8'):
+            if not line.startswith('#'):
+                break
+            header.append(line)
+        header = ''.join(header)
+        assert 'nessun print' not in header, (
+            "api.py torna a dichiarare 'nessun print': i componenti che "
+            "orchestra stampano ancora (vedi gli altri test di questo file)")
+
+    def test_ogni_prefisso_elencato_esiste_ancora_come_print(self):
+        """Direzione statica: l'elenco non sopravvive a chi lo svuota.
+
+        Rosso previsto quando #187/#188 porteranno una di queste righe al
+        logger. Non e' un falso allarme: e' la dichiarazione che va
+        aggiornata insieme al comportamento.
+        """
+        sources = _library_print_sources()
+        for token in _census_tokens():
+            needle = token.strip()
+            assert any(needle in text for _path, text in sources), (
+                f"il censimento di api.py elenca {token!r}, ma in src/pge/ "
+                f"nessun print() lo emette piu': aggiorna l'elenco")
+
+
+# =============================================================================
+# Direzione runtime: cosa stampa davvero l'API con i componenti veri
+# =============================================================================
+
+class TestStdoutReale:
+
+    def test_load_generator_non_e_silenzioso(self, probe):
+        """Il cuore della #189: la libreria non tace, e questo lo prova
+        senza mock in mezzo."""
+        from pge import api
+        _gen, lines = _capture(
+            lambda: api.load_generator(probe['yml'],
+                                       samples_dir=probe['samples']))
+        assert lines, (
+            "load_generator non ha stampato niente: se e' diventato vero, "
+            "la dichiarazione in api.py va riscritta di conseguenza")
+
+    def test_ogni_riga_di_load_generator_e_censita(self, probe):
+        from pge import api
+        _gen, lines = _capture(
+            lambda: api.load_generator(probe['yml'],
+                                       samples_dir=probe['samples']))
+        assert not _undocumented(lines, _census_tokens()), (
+            f"righe su stdout che il censimento di api.py non elenca: "
+            f"{_undocumented(lines, _census_tokens())}")
+
+    def test_le_righe_del_generator_ci_sono_tutte(self, probe):
+        """Il test precedente da solo passerebbe anche su stdout vuoto."""
+        from pge import api
+        _gen, lines = _capture(
+            lambda: api.load_generator(probe['yml'],
+                                       samples_dir=probe['samples']))
+        blob = '\n'.join(lines)
+        for atteso in ('[SEED]', '🔇', 'Creazione di', '→ Stream'):
+            assert atteso in blob, f"manca la riga {atteso!r}: {lines}"
+
+    def test_render_stampa_lo_stato_della_cache(self, probe):
+        """`[CACHE] <id>: DIRTY|clean`, una riga per stream, dal renderer."""
+        from pge import api
+        gen, _ = _capture(
+            lambda: api.load_generator(probe['yml'],
+                                       samples_dir=probe['samples']))
+        manifest = str(probe['dir'] / 'manifest.json')
+        out = str(probe['dir'] / 'stem.wav')
+        _res, lines = _capture(lambda: api.render(
+            gen, out, renderer='numpy', per_stream=True,
+            samples_dir=probe['samples'], cache_manifest_path=manifest))
+
+        assert any(ln.startswith('[CACHE]') for ln in lines), lines
+        assert not _undocumented(lines, _census_tokens()), (
+            f"righe non censite: {_undocumented(lines, _census_tokens())}")
+
+    def test_senza_manifest_non_c_e_riga_di_cache(self, probe):
+        """`[CACHE]` e' condizionata a `cache_manifest_path`, e il
+        censimento lo dice: senza manifest quella riga non esiste."""
+        from pge import api
+        gen, _ = _capture(
+            lambda: api.load_generator(probe['yml'],
+                                       samples_dir=probe['samples']))
+        out = str(probe['dir'] / 'mix.wav')
+        _res, lines = _capture(lambda: api.render(
+            gen, out, renderer='numpy', samples_dir=probe['samples']))
+
+        assert not [ln for ln in lines if ln.startswith('[CACHE]')], lines
+        assert not _undocumented(lines, _census_tokens()), (
+            f"righe non censite: {_undocumented(lines, _census_tokens())}")
+
+    def test_export_score_pdf_stampa_la_partitura(self, probe, monkeypatch):
+        """ScoreVisualizer e' la terza fonte, e la piu' loquace."""
+        pytest.importorskip('matplotlib')
+        from pge import api
+        gen, _ = _capture(
+            lambda: api.load_generator(probe['yml'],
+                                       samples_dir=probe['samples']))
+        # chdir: il clip logger scrive ./logs alla prima inizializzazione,
+        # e un test non sporca la root del repo.
+        monkeypatch.chdir(probe['dir'])
+        monkeypatch.setenv('MPLBACKEND', 'Agg')
+        pdf = str(probe['dir'] / 'census.pdf')
+        _p, lines = _capture(lambda: api.export_score_pdf(
+            gen, pdf, samples_dir=probe['samples']))
+
+        blob = '\n'.join(lines)
+        assert 'Esportazione PDF' in blob, lines
+        assert '✓ PDF esportato' in blob, lines
+        assert not _undocumented(lines, _census_tokens()), (
+            f"righe non censite: {_undocumented(lines, _census_tokens())}")
+
+    def test_le_funzioni_pure_restano_silenziose(self, probe):
+        """parameter_bounds/renderer_types e gli export non-partitura non
+        stampano: il censimento riguarda chi orchestra, non tutta l'API."""
+        from pge import api
+        for fn in (api.parameter_bounds, api.renderer_types):
+            _r, lines = _capture(fn)
+            assert lines == [], f"{fn.__name__} ha stampato: {lines}"

--- a/tests/test_api_stdout.py
+++ b/tests/test_api_stdout.py
@@ -133,8 +133,41 @@ def _emitted_prefix(node):
     return None
 
 
+def _va_su_stdout(node):
+    """True se la riga che questo `print()` emette finisce su stdout.
+
+    Il censimento e' **di stdout**, quindi un print che scrive altrove non
+    puo' valere come prova che una sua voce sia ancora viva. Senza guardare
+    il `file=` il buco era lo stesso gia' trovato due volte -- il `  - ` e il
+    `[CACHE]` -- spostato dal prefisso al canale: aggiungere `file=sys.stderr`
+    a una riga censita la toglieva da stdout lasciando verdi entrambe le
+    direzioni. Misurato per sabotaggio su `✓ Score generato`, che e' anche il
+    caso peggiore: quella voce e il `  - ` stanno sul ramo csound, che nessun
+    test esercita a runtime, quindi per loro la direzione statica e' l'unica
+    guardia che c'e'.
+
+    `file=` assente o `sys.stdout` sono stdout; ogni altra cosa -- stderr, un
+    file, un'espressione che non si sa leggere -- no. L'incertezza va nella
+    direzione sicura: la voce risulta non piu' emessa e il test lo dice,
+    invece di dare per stdout un canale che non e' stato letto.
+    """
+    for kw in node.keywords:
+        if kw.arg != 'file':
+            continue
+        target = kw.value
+        return (isinstance(target, ast.Attribute)
+                and target.attr == 'stdout'
+                and isinstance(target.value, ast.Name)
+                and target.value.id == 'sys')
+    return True
+
+
 def _iter_prints(path):
-    """(funzione che lo contiene, nodo) per ogni `print(...)` del file."""
+    """(funzione che lo contiene, nodo) per ogni `print(...)` su stdout.
+
+    Chi scrive altrove (`_va_su_stdout`) resta fuori: e' un print del file,
+    ma non una riga di stdout, e il censimento censisce quelle.
+    """
     tree = ast.parse(open(path, encoding='utf-8').read())
     trovati = []
 
@@ -143,7 +176,8 @@ def _iter_prints(path):
             func = node.name
         if (isinstance(node, ast.Call)
                 and isinstance(node.func, ast.Name)
-                and node.func.id == 'print'):
+                and node.func.id == 'print'
+                and _va_su_stdout(node)):
             trovati.append((func, node))
         for child in ast.iter_child_nodes(node):
             walk(child, func)
@@ -153,14 +187,20 @@ def _iter_prints(path):
 
 
 def _library_prints(*, skip_unreachable=True):
-    """Ogni `print(...)` di `src/pge/`, CLI esclusa, come record.
+    """Ogni `print(...)` su stdout di `src/pge/`, CLI esclusa, come record.
 
     Record: (modulo, funzione, prefisso emesso, sorgente). Il confronto col
     censimento e' sul **prefisso emesso**, non sul testo della chiamata: con
     `needle in ast.unparse(node)` il token `  - ` si riduceva a `-` dopo lo
     strip e veniva soddisfatto dalle frecce `->` dei print di
     `register_*_strategy`, cosi' che cancellare tutte e tre le righe di
-    riepilogo dello ScoreWriter lasciava il test verde.
+    riepilogo dello ScoreWriter lasciava il test verde. (Quei print non
+    esistono piu': la #187 li ha portati al logger. Il sabotaggio non e'
+    piu' riproducibile cosi', ma la relazione giusta e' quella, ed e' cio'
+    che tiene il token `  - ` legato alle tre righe che lo emettono.)
+
+    "Su stdout" e' parte della definizione, non un dettaglio: vedi
+    `_va_su_stdout`.
     """
     out = []
     for root, _dirs, files in os.walk(SRC_PGE):
@@ -345,6 +385,36 @@ class TestCensimento:
                 f"il censimento di api.py elenca {token!r}, ma in src/pge/ "
                 f"nessun print() emette una riga che cominci cosi': "
                 f"aggiorna l'elenco")
+
+
+    def test_la_prova_di_una_voce_dev_essere_su_stdout(self):
+        """Chi scrive su stderr non tiene in vita una voce del censimento.
+
+        Il buco che questo chiude e' quello del `  - ` e del `[CACHE]`
+        spostato dal prefisso al canale: la direzione statica non guardava il
+        `file=`, quindi mettere `file=sys.stderr` su una riga censita la
+        toglieva da stdout lasciando verdi entrambe le direzioni (misurato su
+        `✓ Score generato`, che sta sul ramo csound e a runtime non e'
+        esercitato da nessuno: per lui la statica e' l'unica guardia).
+
+        Il caso vero e' misurato, non inventato: `log_loop_unit_migration_warning`
+        e' l'unico `print()` di `src/pge/` con un `file=`, scrive su stderr, ed
+        e' proprio uno dei due writer che l'intestazione di `api.py` nomina
+        **fuori** censimento -- deve stare fuori anche dal bacino delle prove.
+        L'altra meta' dell'asserzione tiene il filtro dall'essere troppo largo:
+        un predicato che scartasse tutto renderebbe questo test verde e la
+        direzione statica un no-op.
+        """
+        pool = _library_prints(skip_unreachable=False)
+        assert ('logger.py', 'log_loop_unit_migration_warning') not in {
+            (mod, func) for mod, func, _pref, _src in pool}, (
+            "un print con file=sys.stderr conta come prova che una voce del "
+            "censimento e' ancora su stdout: il censimento e' di stdout, "
+            "quella prova non lo e' (vedi _va_su_stdout)")
+        assert ('generator.py', 'create_elements') in {
+            (mod, func) for mod, func, _pref, _src in pool}, (
+            "il filtro su stdout ha scartato anche i print senza file=: "
+            "cosi' la direzione statica non prova piu' niente")
 
 
 # =============================================================================

--- a/tests/test_api_stdout.py
+++ b/tests/test_api_stdout.py
@@ -30,6 +30,12 @@ sorgente. La relazione dev'essere la stessa nelle due, o l'elenco significa
 due cose diverse a seconda di chi lo legge: con `token.strip() in
 ast.unparse(node)` due voci su quindici non discriminavano piu' niente (vedi
 il docstring di `_library_prints` e quello del test statico).
+
+E c'e' una terza classe, che il censimento non copre ed e' per questo che il
+censimento deve dichiarare il proprio perimetro: **stderr**. `TestStderr`
+tiene fermo che i clip warning passano di la' e che l'intestazione di
+`api.py` lo dica -- un elenco di stdout letto come inventario completo
+rifarebbe l'errore della #189 un piano sotto.
 """
 
 import ast
@@ -466,3 +472,46 @@ class TestStdoutReale:
         for nome, fn in casi:
             _r, lines = _capture(fn)
             assert lines == [], f"{nome} ha stampato: {lines}"
+
+
+# =============================================================================
+# Lo stderr e' un canale a parte, e redirect_stdout non lo tocca
+# =============================================================================
+
+class TestStderr:
+    """Il censimento e' di **stdout**, e dirlo per intero fa parte del punto.
+
+    La #189 nasce da una dichiarazione che prometteva piu' silenzio di
+    quanto ne consegnasse. Un censimento di stdout letto come inventario
+    completo rifa' lo stesso errore un piano sotto: chi incorpora la libreria
+    e mette `redirect_stdout` non ha silenziato niente di cio' che passa da
+    qui.
+    """
+
+    def test_i_clip_warning_vanno_su_stderr_non_su_stdout(self, tmp_path):
+        from pge.shared import logger as clip
+
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            clip.configure_clip_logger(log_dir=str(tmp_path / 'logs'))
+            clip.log_clip_warning('s1', 'volume', 0.0, 5.0, 1.0, 0.0, 1.0)
+
+        assert 'CLIP' in err.getvalue(), (
+            f"il clip warning non e' su stderr: out={out.getvalue()!r} "
+            f"err={err.getvalue()!r}")
+        assert 'CLIP' not in out.getvalue(), (
+            "il clip warning e' finito su stdout: se il canale e' cambiato, "
+            "il censimento di api.py va aggiornato")
+
+    def test_il_censimento_dichiara_di_essere_di_stdout(self):
+        """Non basta che sia vero: deve dirlo, o si rilegge come completo."""
+        header = []
+        for line in open(API_PATH, encoding='utf-8'):
+            if not line.startswith('#'):
+                break
+            header.append(line)
+        header = ''.join(header)
+        assert 'stderr' in header, (
+            "l'intestazione di api.py censisce stdout senza dire che stderr "
+            "esiste: redirect_stdout si legge allora come 'silenzio', e non "
+            "lo e' (issue #189)")

--- a/tests/test_api_stdout.py
+++ b/tests/test_api_stdout.py
@@ -289,6 +289,38 @@ def probe(tmp_path):
     return {'yml': str(yml), 'samples': str(tmp_path), 'dir': tmp_path}
 
 
+@pytest.fixture
+def clip_logger_ripristinato():
+    """Rimette a posto lo stato globale del clip logger dopo il test.
+
+    `configure_clip_logger` + `log_clip_warning` scrivono su tre globali di
+    `pge.shared.logger`, e l'handler console che ne nasce cattura
+    `sys.stderr` **alla costruzione** -- qui dentro una `redirect_stderr`,
+    cioe' lo StringIO del test. Senza ripristino quel logger resta il
+    singleton del processo: ogni clip warning dei test successivi finisce in
+    un buffer morto invece che sullo stderr vero (verificato: la seconda
+    chiamata, fuori dalla redirezione, atterra ancora nello StringIO), e
+    `log_dir` continua a puntare a una `tmp_path` gia' rimossa.
+
+    E' la stessa `reset_logger_state` autouse di `tests/shared/test_logger.py`,
+    ristretta a chi quello stato lo tocca davvero: renderla autouse di modulo
+    riazzererebbe il logger prima di ogni test di questo file, e la riga
+    `📝 Clip log file` tornerebbe a nascere -- con la sua `./logs` -- nella
+    root del repo, che solo il test del PDF evita con la `chdir`.
+    """
+    from pge.shared import logger as clip
+    config = dict(clip.CLIP_LOG_CONFIG)
+    yield
+    if clip._clip_logger is not None:
+        for handler in clip._clip_logger.handlers[:]:
+            handler.close()
+            clip._clip_logger.removeHandler(handler)
+    clip._clip_logger = None
+    clip._clip_logger_initialized = False
+    clip.CLIP_LOG_CONFIG.clear()
+    clip.CLIP_LOG_CONFIG.update(config)
+
+
 def _capture(fn):
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
@@ -558,7 +590,8 @@ class TestStderr:
     qui.
     """
 
-    def test_i_clip_warning_vanno_su_stderr_non_su_stdout(self, tmp_path):
+    def test_i_clip_warning_vanno_su_stderr_non_su_stdout(
+            self, tmp_path, clip_logger_ripristinato):
         from pge.shared import logger as clip
 
         out, err = io.StringIO(), io.StringIO()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -756,7 +756,9 @@ class TestRendererFlag:
 
     def test_cache_manifest_composed_from_cache_dir_and_yaml(self, mocks, capsys):
         """--cache: la CLI compone cache_dir/{yaml_basename}.json e stampa
-        [CACHE] Manifest: (policy CLI, l'API non stampa)."""
+        [CACHE] Manifest: (policy CLI: quella riga api.build_renderer non la
+        emette -- cio' che l'API stampa via i suoi componenti e' censito in
+        api.py e verificato da tests/test_api_stdout.py)."""
         import os
         build_mock, _, _ = self._run_delegated(
             mocks,


### PR DESCRIPTION
Closes #189.

## Delle due l'una: resta falsa

La issue diceva di chiuderla per ultima, dopo #188, perché a quel punto si sarebbe visto se la dichiarazione era diventata vera. #178, #187 e #188 sono tutte ancora aperte, quindi vale il secondo ramo: **la dichiarazione è falsa e va riscritta per dire cosa succede davvero**.

Falsa non per poco. Verificato eseguendo l'API con i componenti veri:

```
>>> api.load_generator('census.yml', samples_dir='refs/')
[SEED] Nessun seed nello YAML: seed di sessione 561870528. Per riprodurre...
🔇 1 stream muted
Creazione di 1 stream...
  → Stream 's1': Stream(id=s1, onset=0.0, dur=0.5, mode=fill_factor, grains=lazy)

>>> api.render(gen, out, per_stream=True, cache_manifest_path=manifest)
[CACHE] s1: DIRTY

>>> api.export_score_pdf(gen, pdf)
Esportazione PDF: .../census.pdf
Analisi completata: 1 pagine, durata totale 0.50s
  Rendering pagina 1/1...
📝 Clip log file: ./logs/envelope_clips_20260905_123913.log
✓ PDF esportato: .../census.pdf
```

Il piano da cui il contratto viene ([`2026-07-08-001`, R5](docs/plans/done/2026-07-08-001-refactor-pge-library-cli-plan.md)) diceva «non stampa **(nel proprio modulo)**». La parentesi si è persa nella trascrizione in `api.py`, e con lei tutta la differenza: `api.py` non contiene un `print()`, ma le sue funzioni orchestrano `Generator`, i renderer e `ScoreVisualizer`, che stampano sullo stdout del processo ospite.

## Perché il difetto è sopravvissuto

`tests/test_api.py` ha **undici** `test_no_print` che asseriscono `capsys.readouterr().out == ''`. Girano tutti con `Generator`, `RenderingEngine` e `ScoreVisualizer` montati come `MagicMock`: quel capsys vuoto misura il silenzio dei mock, non quello della libreria. Il presidio non poteva contraddire la dichiarazione che sembrava difendere.

Quei test restano — sono veri su ciò che dicono davvero — e il loro docstring ora lo dichiara.

## Cosa cambia

**`src/pge/api.py`** — la dichiarazione diventa un **censimento**: quali righe, da quale funzione, emesse da chi, delimitato da marker così che sia estraibile. Più la ragione per cui restano, con l'attribuzione precisa: `[CACHE] <id>: DIRTY|clean` la parsa PGE-ui (`render_pipeline.py`, `_RE_CACHE_LINE`) per gli eventi NDJSON `stream-start`/`stream-done`; delle altre non risulta nessun consumatore, ed è esattamente ciò che #178 deve accertare prima che #187/#188 le portino al logger. Dichiara il proprio perimetro — è un censimento **di stdout** — e nomina i due writer su stderr che restano fuori. Chiude con la via al silenzio per chi incorpora: entrambe le redirezioni (`redirect_stdout` da solo non basta) più `configure_clip_logger`.

**`tests/test_api_stdout.py`** (nuovo, 14 test) — la dichiarazione diventa eseguibile, **su output vero e senza mock in mezzo**. Il censimento chiude in due direzioni, e servono entrambe:

| direzione | cosa cattura | come |
|---|---|---|
| runtime | un `print()` nuovo che arriva all'API senza passare dalla dichiarazione | render vero (YAML + wav in `tmp_path`), ogni riga catturata dev'essere in elenco |
| statico | un elenco che descrive righe non più emesse | ogni prefisso in elenco dev'essere ancora l'inizio di una riga che un `print()` di `src/pge/` emette, letto dall'AST |

La prima da sola lascerebbe crescere l'elenco all'infinito; la seconda da sola non vedrebbe mai una riga nuova. Entrambe usano la **stessa relazione** — il token è il prefisso di una riga: `riga.startswith(token)` a runtime, `prefisso_emesso.startswith(token)` da sorgente. Entrambe provate per sabotaggio: aggiungere un `print()` in `generator.py` accende la prima, sostituirne uno con `pass` accende la seconda.

**Rosso previsto quando #187/#188 sposteranno una di quelle righe al logger.** Non è un falso allarme: è la dichiarazione che va aggiornata insieme al comportamento — il difetto che questa PR chiude è esattamente prosa e comportamento che divergono in silenzio.

**Le altre copie della stessa frase** — `docs/explanation/library-vs-cli.md` (contratto + implicazioni), `docs/how-to/use-as-library.md` (nuovi passi su stdout e stderr), `src/pge/cli.py` e `tests/test_main.py` (dove «l'API non stampa» diceva una cosa giusta — il `[CACHE] Manifest:` è policy CLI — con parole che ne affermavano una falsa).

## Acceptance criteria

- [x] La dichiarazione in `api.py` corrisponde al comportamento reale — verificato per esecuzione, non per lettura
- [x] Se resta dell'output, il documento dice quale e perché — censimento in `api.py`, riscritto nei due doc Diátaxis
- [x] `make tests` verde — 6238 passed, 10 skipped; `make docs-lint` OK (22 docs)

## Giro di review (commit `3ad758c`, `5285c17`)

Cinque finding, tutti verificati per esecuzione.

**1. La direzione statica era cieca su due voci su quindici.** Il confronto era `token.strip()` come sottostringa di `ast.unparse(print_node)`.

- `  - ` si riduceva a `-` dopo lo strip, e lo soddisfacevano le frecce `->` dei print di `register_*_strategy`. Cancellate tutte e tre le righe di riepilogo dello ScoreWriter, il test restava verde — e quella voce non aveva copertura runtime (nessun test renderizza csound): cieca in entrambe le direzioni.
- `[CACHE]` restava soddisfatto dalle righe irraggiungibili di `generator.py` e `stream_cache_manager.py`, cioè proprio quelle che la nota in fondo dichiara fuori censimento. Portata la riga per stream al logger in tutti e tre i renderer — lo scenario #187/#188 che il file dichiara di sorvegliare, sulla riga che PGE-ui parsa — il test statico restava verde.

Ora le due direzioni usano la stessa relazione (prefisso di riga, ricavando dall'AST il testo che il `print` emette prima della prima interpolazione), e i print irraggiungibili sono esclusi per `(modulo, funzione)` e non per prefisso, che è identico a quello delle righe vive. L'esclusione è a sua volta verificata e non trascritta: ognuna deve esistere ancora e ogni sua chiamata deve stare dentro una funzione a sua volta esclusa (`get_dirty_stream_dicts` un chiamante ce l'ha, ed è `generate_score_files_per_stream`, che non ne ha). Entrambi i sabotaggi ora sono rossi.

**2. Un test che puniva la formulazione corretta.** `test_api_non_dichiara_piu_silenzio_assoluto` vietava la sottostringa `nessun print`, quindi sarebbe diventato rosso anche sulla forma *qualificata* — «nessun print nel proprio modulo» — che è vera, è la parola del piano ed è quella che questa PR stessa adotta in `library-vs-cli.md` e `test_api.py`. Ora chiede la qualificazione invece di vietare la frase.

**3. Docstring più largo del ciclo.** `test_le_funzioni_pure_restano_silenziose` prometteva «e gli export non-partitura», ma girava solo su `parameter_bounds`/`renderer_types`, e chiedeva una fixture che non usava. Reaper, sv e grain json hanno ora un test loro.

**4. `redirect_stdout` non è silenzio** — il difetto della #189 rifatto un piano sotto. Il censimento non dichiarava il proprio perimetro, e la via al silenzio che indicava lascia parlare un canale intero: `⚠️  CLIP: ...` dall'handler console del clip logger (attivo per default: `logging.StreamHandler()` senza argomenti scrive su stderr) e `CLIP: ...` da `log_loop_unit_migration_warning`, che stampa proprio *quando* quella console è spenta (#222) — spegnerla non zittisce l'avviso, lo sposta. Misurato, non dedotto. Il censimento ora dice di essere di stdout e nomina i due writer; la via corretta vuole entrambe le redirezioni, con `redirect_stderr` entrata **prima** che il clip logger si costruisca (`logging.StreamHandler()` cattura `sys.stderr` alla costruzione, non alla scrittura). `TestStderr` tiene ferme le due premesse.

**5. `last_synced_commit` non bumpato** nei due doc modificati sostanzialmente: restava a `be716c9`, anteriore alla modifica che ora descrivono — esattamente il drift che quel campo esiste per far vedere. Salito a `638f9d6`. È la convenzione del repo: i due commit precedenti su questi stessi file (`e9502f3`, `481e7dd`) lo bumpano.

Minore, sistemato di passaggio: il `monkeypatch.setenv('MPLBACKEND', ...)` del test PDF era inerte (matplotlib legge quella variabile all'import, che l'`importorskip` sopra ha già fatto) → `matplotlib.use('Agg')`.

**Non erano difetti**, verificati: i subprocess csound e sclang usano `capture_output=True`, i worker del pool NumPy non stampano, `generate_score_files_per_stream` e `get_dirty_stream_dicts` sono davvero irraggiungibili, `export_png` non è esposto. Il censimento è accurato su stdout.

## Impatto cross-repo

**Nessuno.** La modifica non tocca la superficie osservabile: nessun `print()` spostato o riformulato, nessun cambio di sintassi YAML, errori, CLI o formati. Solo intestazioni, documentazione e un test nuovo. Niente issue su `PGE-ls` / `PGE-ui`.

**Submodule CIM 2026:** nessun bump. Gli esempi del paper non esercitano nulla di ciò che cambia qui — rendering, score visualizer e la superficie usata da `render_example.py` sono invariati byte per byte.

## Nota per chi rivede

Il censimento è verificato, non trascritto: `[CACHE] Stream da scrivere:` e `[CACHE] N/M stream da ricompilare` **non** sono in elenco, perché passano da `Generator.generate_score_files_per_stream`, che nessuno in `src/pge/` chiama — irraggiungibili dall'API. Stessa ragione per cui `export_png` del visualizer non c'è: `api.py` espone solo `export_score_pdf`. Dal giro di review quell'irraggiungibilità non è più solo scritta: `_UNREACHABLE` in `tests/test_api_stdout.py` la nomina, e un test chiede che regga.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011QyReCmVabuaYsb1eagZec

Giro di review: https://claude.ai/code/session_01PjZsCVoE3tLkZEQaHpbiVE

---
_Generated by [Claude Code](https://claude.ai/code/session_011QyReCmVabuaYsb1eagZec)_